### PR TITLE
Add customer account foundation and Fleet linking

### DIFF
--- a/app/api/portal/fleet/invites/route.ts
+++ b/app/api/portal/fleet/invites/route.ts
@@ -16,7 +16,10 @@ function siteUrl(): string {
     : "http://localhost:3000";
 }
 
-export async function GET() {
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function GET(req: Request) {
   const access = await requireShopScopedApiAccess({
     requiredCapability: "canInviteFleetMembers",
   });
@@ -24,7 +27,7 @@ export async function GET() {
   const [fleetsResult, invitesResult] = await Promise.all([
     supabaseAdmin
       .from("fleets")
-      .select("id, name")
+      .select("id, name, customer_id")
       .eq("shop_id", access.profile.shop_id)
       .order("name"),
     supabaseAdmin
@@ -42,10 +45,38 @@ export async function GET() {
       { status: 500 },
     );
   }
+
+  const customerId = new URL(req.url).searchParams.get("customerId")?.trim();
+  if (customerId && !UUID_PATTERN.test(customerId)) {
+    return NextResponse.json(
+      { error: "Customer reference is invalid." },
+      { status: 400 },
+    );
+  }
+  const customerCandidate = customerId
+    ? await supabaseAdmin
+        .from("customers")
+        .select(
+          "id, name, business_name, first_name, last_name, email, account_type",
+        )
+        .eq("id", customerId)
+        .eq("shop_id", access.profile.shop_id)
+        .maybeSingle()
+    : null;
+  if (customerCandidate?.error) {
+    return NextResponse.json(
+      { error: "Customer relationship could not be loaded." },
+      { status: 500 },
+    );
+  }
+  if (customerId && !customerCandidate?.data) {
+    return NextResponse.json({ error: "Customer not found." }, { status: 404 });
+  }
   return NextResponse.json({
     ok: true,
     fleets: fleetsResult.data ?? [],
     invites: invitesResult.data ?? [],
+    customerCandidate: customerCandidate?.data ?? null,
   });
 }
 
@@ -62,12 +93,49 @@ export async function POST(req: Request) {
     name?: string;
     contactName?: string;
     contactEmail?: string;
+    customerId?: string;
   } | null;
 
   if (body?.action === "create_fleet") {
-    const name = String(body.name ?? "").trim();
-    const contactName = String(body.contactName ?? "").trim();
-    const contactEmail = String(body.contactEmail ?? "")
+    const customerId = String(body.customerId ?? "").trim();
+    if (customerId && !UUID_PATTERN.test(customerId)) {
+      return NextResponse.json(
+        { error: "Customer reference is invalid." },
+        { status: 400 },
+      );
+    }
+
+    const customerResult = customerId
+      ? await supabaseAdmin
+          .from("customers")
+          .select("id, name, business_name, first_name, last_name, email")
+          .eq("id", customerId)
+          .eq("shop_id", access.profile.shop_id)
+          .maybeSingle()
+      : null;
+    if (customerResult?.error) {
+      return NextResponse.json(
+        { error: "Customer relationship could not be verified." },
+        { status: 500 },
+      );
+    }
+    if (customerId && !customerResult?.data) {
+      return NextResponse.json(
+        { error: "Customer not found." },
+        { status: 404 },
+      );
+    }
+
+    const customer = customerResult?.data ?? null;
+    const name =
+      String(body.name ?? "").trim() ||
+      customer?.business_name?.trim() ||
+      customer?.name?.trim() ||
+      "";
+    const contactName =
+      String(body.contactName ?? "").trim() ||
+      [customer?.first_name, customer?.last_name].filter(Boolean).join(" ");
+    const contactEmail = String(body.contactEmail ?? customer?.email ?? "")
       .trim()
       .toLowerCase();
     if (!name || name.length > 120) {
@@ -89,6 +157,7 @@ export async function POST(req: Request) {
       .from("fleets")
       .insert({
         shop_id: access.profile.shop_id,
+        ...(customerId ? { customer_id: customerId } : {}),
         name,
         contact_name: contactName || null,
         contact_email: contactEmail || null,

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -15,6 +15,7 @@ import { format } from "date-fns";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { CustomerCsvImportCard } from "@/features/customers/components/CustomerCsvImportCard";
+import { CustomerAccountDetails } from "@/features/customers/components/CustomerAccountDetails";
 import { ImportedHistoryRecordCard } from "@/features/work-orders/components/ImportedHistoryRecordCard";
 import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
@@ -66,9 +67,17 @@ type CustomerSearchRow = Pick<
   | "phone_number"
   | "created_at"
   | "customer_since"
+  | "account_type"
+  | "is_fleet"
+  | "active"
 >;
 
-type NewCustomerType = "individual" | "business" | "fleet";
+type NewCustomerType = "individual" | "business" | "fleet" | "enterprise";
+type CustomerDirectoryFilter = "all" | NewCustomerType;
+type FleetConnection = Pick<
+  DB["public"]["Tables"]["fleets"]["Row"],
+  "id" | "name" | "active"
+>;
 
 type NewCustomerDraft = {
   customerType: NewCustomerType;
@@ -175,6 +184,27 @@ function customerSearchHaystack(c: CustomerSearchRow): string {
     )
     .join(" ")
     .toLowerCase();
+}
+
+const CUSTOMER_TYPE_LABELS: Record<NewCustomerType, string> = {
+  individual: "Individual",
+  business: "Business",
+  fleet: "Fleet",
+  enterprise: "Enterprise",
+};
+
+function customerAccountType(
+  customer: Pick<Customer, "account_type" | "is_fleet" | "business_name">,
+): NewCustomerType {
+  if (customer.is_fleet) return "fleet";
+  if (
+    customer.account_type === "business" ||
+    customer.account_type === "fleet" ||
+    customer.account_type === "enterprise"
+  ) {
+    return customer.account_type;
+  }
+  return customer.business_name?.trim() ? "business" : "individual";
 }
 
 function sortCustomerRows(rows: CustomerSearchRow[]): CustomerSearchRow[] {
@@ -519,7 +549,9 @@ function TopBar({
         </span>
         Back
       </button>
-      <div className="text-[10px] text-[color:var(--theme-text-muted)]">{rightLabel}</div>
+      <div className="text-[10px] text-[color:var(--theme-text-muted)]">
+        {rightLabel}
+      </div>
     </div>
   );
 }
@@ -633,6 +665,8 @@ export default function CustomerProfilePage(): JSX.Element {
   const [searching, setSearching] = useState<boolean>(false);
   const [results, setResults] = useState<CustomerSearchRow[]>([]);
   const [directoryRows, setDirectoryRows] = useState<CustomerSearchRow[]>([]);
+  const [directoryFilter, setDirectoryFilter] =
+    useState<CustomerDirectoryFilter>("all");
   const [directoryLoaded, setDirectoryLoaded] = useState(false);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -648,6 +682,9 @@ export default function CustomerProfilePage(): JSX.Element {
   ] = useState(false);
   const [newCustomer, setNewCustomer] =
     useState<NewCustomerDraft>(EMPTY_NEW_CUSTOMER);
+  const [fleetConnections, setFleetConnections] = useState<FleetConnection[]>(
+    [],
+  );
   const { updateActiveTab } = useTabs();
 
   useEffect(() => {
@@ -729,7 +766,7 @@ export default function CustomerProfilePage(): JSX.Element {
         const { data: cust, error: custErr } = await supabase
           .from("customers")
           .select(
-            "id, shop_id, first_name, last_name, name, business_name, email, phone, phone_number, created_at, customer_since, address, city, province, postal_code",
+            "id, shop_id, first_name, last_name, name, business_name, email, phone, phone_number, created_at, customer_since, address, city, province, postal_code, account_type, is_fleet, active",
           )
           .eq("id", customerId)
           .maybeSingle();
@@ -744,12 +781,22 @@ export default function CustomerProfilePage(): JSX.Element {
           setImportedHistory([]);
           setRawVehicleMedia([]);
           setMedia([]);
+          setFleetConnections([]);
           setViewError("Customer not found / not visible.");
           setLoading(false);
           return;
         }
 
         setCustomer(cust as Customer);
+
+        const { data: connectedFleets, error: connectedFleetsError } =
+          await supabase
+            .from("fleets")
+            .select("id, name, active")
+            .eq("customer_id", customerId)
+            .order("name");
+        if (connectedFleetsError) throw connectedFleetsError;
+        setFleetConnections((connectedFleets ?? []) as FleetConnection[]);
 
         const { data: vs, error: vsErr } = await supabase
           .from("vehicles")
@@ -1044,7 +1091,8 @@ export default function CustomerProfilePage(): JSX.Element {
     const businessName = strOrNull(newCustomer.businessName);
     const isBusinessLike =
       newCustomer.customerType === "business" ||
-      newCustomer.customerType === "fleet";
+      newCustomer.customerType === "fleet" ||
+      newCustomer.customerType === "enterprise";
     const displayName = isBusinessLike ? businessName : customerName;
 
     if (!displayName) {
@@ -1073,7 +1121,9 @@ export default function CustomerProfilePage(): JSX.Element {
 
       const insertRecord: DB["public"]["Tables"]["customers"]["Insert"] = {
         shop_id: shopId,
-        user_id: user.id,
+        user_id: null,
+        created_by: user.id,
+        account_type: newCustomer.customerType,
         is_fleet: newCustomer.customerType === "fleet",
         name: displayName,
         business_name: isBusinessLike ? businessName : null,
@@ -1137,7 +1187,7 @@ export default function CustomerProfilePage(): JSX.Element {
       const { data, error } = await supabase
         .from("customers")
         .select(
-          "id, shop_id, first_name, last_name, name, business_name, email, phone, phone_number, created_at, customer_since",
+          "id, shop_id, first_name, last_name, name, business_name, email, phone, phone_number, created_at, customer_since, account_type, is_fleet, active",
         )
         .eq("shop_id", shopId);
 
@@ -1163,11 +1213,17 @@ export default function CustomerProfilePage(): JSX.Element {
 
   const runSearch = useCallback(() => {
     const q = query.trim().toLowerCase();
+    const typedRows =
+      directoryFilter === "all"
+        ? directoryRows
+        : directoryRows.filter(
+            (row) => customerAccountType(row) === directoryFilter,
+          );
     const rows = q
-      ? directoryRows.filter((row) => customerSearchHaystack(row).includes(q))
-      : directoryRows;
+      ? typedRows.filter((row) => customerSearchHaystack(row).includes(q))
+      : typedRows;
     setResults(sortCustomerRows(rows).slice(0, 20));
-  }, [directoryRows, query]);
+  }, [directoryFilter, directoryRows, query]);
 
   // Optional: prime query from ?q= ONCE (do not keep syncing, avoids focus/typing weirdness)
   useEffect(() => {
@@ -1195,7 +1251,7 @@ export default function CustomerProfilePage(): JSX.Element {
     }, 150);
 
     return () => window.clearTimeout(t);
-  }, [query, isDirectoryMode, sp, directoryLoaded, runSearch]);
+  }, [query, directoryFilter, isDirectoryMode, sp, directoryLoaded, runSearch]);
 
   // ------------------ Upload ------------------
   const handleUpload = useCallback(
@@ -1279,6 +1335,7 @@ export default function CustomerProfilePage(): JSX.Element {
         typeof r["business_name"] === "string"
           ? (r["business_name"] as string)
           : "",
+      account_type: customerAccountType(customer),
       email: customer.email ?? null,
       phone: customer.phone ?? null,
       phone_number: customer.phone_number ?? null,
@@ -1313,6 +1370,11 @@ export default function CustomerProfilePage(): JSX.Element {
         typeof custDraft["business_name"] === "string"
           ? (custDraft["business_name"] as string) || null
           : null,
+      account_type:
+        typeof custDraft["account_type"] === "string"
+          ? custDraft["account_type"]
+          : "individual",
+      is_fleet: custDraft["account_type"] === "fleet",
       email: typeof custDraft["email"] === "string" ? custDraft["email"] : null,
       phone: typeof custDraft["phone"] === "string" ? custDraft["phone"] : null,
       phone_number:
@@ -1656,7 +1718,9 @@ export default function CustomerProfilePage(): JSX.Element {
           >
             ← Back
           </button>
-          <div className="text-xs text-[color:var(--theme-text-muted)]">Customers</div>
+          <div className="text-xs text-[color:var(--theme-text-muted)]">
+            Customers
+          </div>
         </div>
 
         <GuidedPageStepPanel
@@ -1753,9 +1817,34 @@ export default function CustomerProfilePage(): JSX.Element {
             </div>
           </div>
 
+          <div
+            className="mt-4 flex flex-wrap gap-2"
+            aria-label="Filter customer files by account type"
+          >
+            {(
+              ["all", "individual", "business", "fleet", "enterprise"] as const
+            ).map((filter) => (
+              <button
+                key={filter}
+                type="button"
+                aria-pressed={directoryFilter === filter}
+                onClick={() => setDirectoryFilter(filter)}
+                className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                  directoryFilter === filter
+                    ? "border-[var(--accent-copper)] bg-[var(--accent-copper)] text-[color:var(--theme-text-on-accent)]"
+                    : "border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-[color:var(--theme-text-secondary)] hover:border-[var(--accent-copper-soft)]"
+                }`}
+              >
+                {filter === "all" ? "All" : CUSTOMER_TYPE_LABELS[filter]}
+              </button>
+            ))}
+          </div>
+
           <div className="mt-4">
             {results.length === 0 ? (
-              <div className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}>
+              <div
+                className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}
+              >
                 {searching
                   ? "Searching…"
                   : directoryRows.length === 0
@@ -1776,6 +1865,11 @@ export default function CustomerProfilePage(): JSX.Element {
                         <div className="min-w-0">
                           <div className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
                             {bestCustomerDisplayName(r)}
+                          </div>
+                          <div className="mt-1">
+                            <span className="inline-flex rounded-full border border-[var(--accent-copper-soft)]/45 bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.14em] text-[var(--accent-copper)]">
+                              {CUSTOMER_TYPE_LABELS[customerAccountType(r)]}
+                            </span>
                           </div>
                           <div className="mt-0.5 truncate text-[11px] text-[color:var(--theme-text-secondary)]">
                             {r.business_name?.trim() &&
@@ -1866,6 +1960,9 @@ export default function CustomerProfilePage(): JSX.Element {
                   <option value="individual">Individual</option>
                   <option value="business">Business</option>
                   <option value="fleet">Fleet</option>
+                  <option value="enterprise">
+                    Enterprise / multi-location
+                  </option>
                 </select>
               </label>
 
@@ -2102,6 +2199,23 @@ export default function CustomerProfilePage(): JSX.Element {
                           {title}
                         </h1>
 
+                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                          <span className="inline-flex rounded-full border border-[var(--accent-copper-soft)]/45 bg-[color:var(--theme-surface-inset)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--accent-copper)]">
+                            {
+                              CUSTOMER_TYPE_LABELS[
+                                customerAccountType(customer)
+                              ]
+                            }
+                          </span>
+                          {fleetConnections.length > 0 ? (
+                            <span className="inline-flex rounded-full border border-emerald-500/35 bg-emerald-950/25 px-2.5 py-1 text-[10px] font-semibold text-emerald-200">
+                              {fleetConnections.length === 1
+                                ? `Fleet connected · ${fleetConnections[0]?.name}`
+                                : `${fleetConnections.length} Fleet workspaces connected`}
+                            </span>
+                          ) : null}
+                        </div>
+
                         {biz && (customer.first_name || customer.last_name) ? (
                           <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
                             {fmtName(customer)}
@@ -2158,6 +2272,23 @@ export default function CustomerProfilePage(): JSX.Element {
                 </div>
 
                 <div className="flex flex-wrap items-center gap-2">
+                  {customerAccountType(customer) !== "individual" ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        router.push(
+                          fleetConnections[0]?.id
+                            ? `/dashboard/owner/fleet-access?fleetId=${fleetConnections[0].id}`
+                            : `/dashboard/owner/fleet-access?customerId=${customer.id}`,
+                        )
+                      }
+                      className="rounded-xl border border-[var(--accent-copper-soft)]/55 bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] hover:border-[var(--accent-copper)]"
+                    >
+                      {fleetConnections.length > 0
+                        ? "Manage Fleet access"
+                        : "Connect Fleet workspace"}
+                    </button>
+                  ) : null}
                   <button
                     type="button"
                     onClick={() => setEditCustomerOpen(true)}
@@ -2184,6 +2315,12 @@ export default function CustomerProfilePage(): JSX.Element {
                 </div>
               </div>
             </div>
+            {customer.shop_id ? (
+              <CustomerAccountDetails
+                customerId={customer.id}
+                shopId={customer.shop_id}
+              />
+            ) : null}
             {/* Vehicles */}
             <div className={`${CARD_BASE} p-4`}>
               <div className="flex flex-wrap items-start justify-between gap-3">
@@ -2662,11 +2799,15 @@ export default function CustomerProfilePage(): JSX.Element {
         }
       >
         {!viewerItem ? (
-          <div className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}>
+          <div
+            className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}
+          >
             No file selected.
           </div>
         ) : !viewerItem.displayUrl ? (
-          <div className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}>
+          <div
+            className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}
+          >
             This file doesn’t have a viewable URL yet (likely a private bucket
             without a signed URL).
           </div>
@@ -2678,7 +2819,9 @@ export default function CustomerProfilePage(): JSX.Element {
             className="w-full rounded-xl"
           />
         ) : (
-          <div className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}>
+          <div
+            className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}
+          >
             Document ready. Use “Open in new tab”.
           </div>
         )}
@@ -2708,6 +2851,26 @@ export default function CustomerProfilePage(): JSX.Element {
           </>
         }
       >
+        <div className="mb-3 space-y-1">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+            Account type
+          </div>
+          <select
+            value={String(custDraft["account_type"] ?? "individual")}
+            onChange={(event) =>
+              setCustDraft((draft) => ({
+                ...draft,
+                account_type: event.target.value,
+              }))
+            }
+            className="w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
+          >
+            <option value="individual">Individual</option>
+            <option value="business">Business</option>
+            <option value="fleet">Fleet</option>
+            <option value="enterprise">Enterprise / multi-location</option>
+          </select>
+        </div>
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
           {(
             [
@@ -2765,7 +2928,9 @@ export default function CustomerProfilePage(): JSX.Element {
         }
       >
         {!selectedVehicle ? (
-          <div className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}>
+          <div
+            className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}
+          >
             No vehicle selected.
           </div>
         ) : (
@@ -2854,7 +3019,9 @@ export default function CustomerProfilePage(): JSX.Element {
         }
       >
         {!customer ? (
-          <div className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}>
+          <div
+            className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}
+          >
             No customer loaded.
           </div>
         ) : (

--- a/features/customers/components/CustomerAccountDetails.tsx
+++ b/features/customers/components/CustomerAccountDetails.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Building2, Loader2, MapPin, Plus, UserRound } from "lucide-react";
+import { toast } from "sonner";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import type { Database } from "@/features/shared/types/types/supabase";
+
+type Contact = Database["public"]["Tables"]["customer_contacts"]["Row"];
+type Location = Database["public"]["Tables"]["customer_locations"]["Row"];
+
+type Props = {
+  customerId: string;
+  shopId: string;
+};
+
+const inputClass =
+  "w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]";
+
+export function CustomerAccountDetails({ customerId, shopId }: Props) {
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const [contacts, setContacts] = useState<Contact[]>([]);
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [showContactForm, setShowContactForm] = useState(false);
+  const [showLocationForm, setShowLocationForm] = useState(false);
+  const [contact, setContact] = useState({
+    displayName: "",
+    email: "",
+    phone: "",
+    role: "primary",
+  });
+  const [location, setLocation] = useState({
+    name: "",
+    locationType: "service",
+    address: "",
+    city: "",
+    province: "",
+    postalCode: "",
+  });
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const [contactsResult, locationsResult] = await Promise.all([
+      supabase
+        .from("customer_contacts")
+        .select("*")
+        .eq("customer_id", customerId)
+        .eq("active", true)
+        .order("is_primary", { ascending: false })
+        .order("created_at"),
+      supabase
+        .from("customer_locations")
+        .select("*")
+        .eq("customer_id", customerId)
+        .eq("active", true)
+        .order("is_primary", { ascending: false })
+        .order("created_at"),
+    ]);
+
+    if (contactsResult.error || locationsResult.error) {
+      toast.error("Customer contacts and locations could not be loaded.");
+    } else {
+      setContacts(contactsResult.data ?? []);
+      setLocations(locationsResult.data ?? []);
+    }
+    setLoading(false);
+  }, [customerId, supabase]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function addContact(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaving(true);
+    const { data: auth } = await supabase.auth.getUser();
+    const { error } = await supabase.from("customer_contacts").insert({
+      shop_id: shopId,
+      customer_id: customerId,
+      display_name: contact.displayName.trim() || null,
+      email: contact.email.trim().toLowerCase() || null,
+      phone: contact.phone.trim() || null,
+      role: contact.role,
+      is_primary: contacts.length === 0,
+      can_approve: contact.role === "approver",
+      can_view_billing: contact.role === "billing",
+      created_by: auth.user?.id ?? null,
+    });
+
+    if (error) {
+      toast.error(error.message);
+    } else {
+      setContact({ displayName: "", email: "", phone: "", role: "primary" });
+      setShowContactForm(false);
+      await load();
+      toast.success("Customer contact added.");
+    }
+    setSaving(false);
+  }
+
+  async function addLocation(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaving(true);
+    const { data: auth } = await supabase.auth.getUser();
+    const { error } = await supabase.from("customer_locations").insert({
+      shop_id: shopId,
+      customer_id: customerId,
+      name: location.name.trim(),
+      location_type: location.locationType,
+      address: location.address.trim() || null,
+      city: location.city.trim() || null,
+      province: location.province.trim() || null,
+      postal_code: location.postalCode.trim() || null,
+      is_primary: locations.length === 0,
+      created_by: auth.user?.id ?? null,
+    });
+
+    if (error) {
+      toast.error(error.message);
+    } else {
+      setLocation({
+        name: "",
+        locationType: "service",
+        address: "",
+        city: "",
+        province: "",
+        postalCode: "",
+      });
+      setShowLocationForm(false);
+      await load();
+      toast.success("Customer location added.");
+    }
+    setSaving(false);
+  }
+
+  return (
+    <section className="rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper)]">
+            Account details
+          </div>
+          <h2 className="mt-1 text-lg font-semibold">Contacts & locations</h2>
+          <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+            Keep service, approval, billing, and branch details on one customer
+            file.
+          </p>
+        </div>
+        {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+      </div>
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-2">
+        <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <UserRound className="h-4 w-4 text-[var(--accent-copper)]" />
+              Contacts
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowContactForm((current) => !current)}
+              className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--accent-copper)] hover:underline"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add
+            </button>
+          </div>
+
+          {showContactForm ? (
+            <form onSubmit={addContact} className="mt-3 space-y-2">
+              <input
+                required
+                value={contact.displayName}
+                onChange={(event) =>
+                  setContact((draft) => ({
+                    ...draft,
+                    displayName: event.target.value,
+                  }))
+                }
+                placeholder="Contact name"
+                aria-label="Contact name"
+                className={inputClass}
+              />
+              <div className="grid gap-2 sm:grid-cols-2">
+                <input
+                  type="email"
+                  value={contact.email}
+                  onChange={(event) =>
+                    setContact((draft) => ({
+                      ...draft,
+                      email: event.target.value,
+                    }))
+                  }
+                  placeholder="Email"
+                  aria-label="Contact email"
+                  className={inputClass}
+                />
+                <input
+                  value={contact.phone}
+                  onChange={(event) =>
+                    setContact((draft) => ({
+                      ...draft,
+                      phone: event.target.value,
+                    }))
+                  }
+                  placeholder="Phone"
+                  aria-label="Contact phone"
+                  className={inputClass}
+                />
+              </div>
+              <select
+                value={contact.role}
+                onChange={(event) =>
+                  setContact((draft) => ({
+                    ...draft,
+                    role: event.target.value,
+                  }))
+                }
+                aria-label="Contact role"
+                className={inputClass}
+              >
+                <option value="primary">Primary</option>
+                <option value="service">Service</option>
+                <option value="billing">Billing</option>
+                <option value="approver">Approver</option>
+                <option value="other">Other</option>
+              </select>
+              <button
+                type="submit"
+                disabled={saving}
+                className="w-full rounded-xl bg-[var(--accent-copper)] px-3 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-60"
+              >
+                Save contact
+              </button>
+            </form>
+          ) : null}
+
+          <div className="mt-3 space-y-2">
+            {contacts.length === 0 ? (
+              <p className="text-xs text-[color:var(--theme-text-muted)]">
+                No additional contacts yet. The existing customer contact stays
+                available above.
+              </p>
+            ) : (
+              contacts.map((item) => (
+                <div
+                  key={item.id}
+                  className="rounded-lg bg-[color:var(--theme-surface-inset)] p-2.5 text-xs"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-semibold">
+                      {item.display_name ||
+                        [item.first_name, item.last_name]
+                          .filter(Boolean)
+                          .join(" ") ||
+                        "Contact"}
+                    </span>
+                    <span className="capitalize text-[var(--accent-copper)]">
+                      {item.role}
+                    </span>
+                  </div>
+                  <div className="mt-1 text-[color:var(--theme-text-secondary)]">
+                    {[item.email, item.phone].filter(Boolean).join(" · ") ||
+                      "No contact method"}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <Building2 className="h-4 w-4 text-[var(--accent-copper)]" />
+              Locations
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowLocationForm((current) => !current)}
+              className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--accent-copper)] hover:underline"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add
+            </button>
+          </div>
+
+          {showLocationForm ? (
+            <form onSubmit={addLocation} className="mt-3 space-y-2">
+              <div className="grid gap-2 sm:grid-cols-2">
+                <input
+                  required
+                  value={location.name}
+                  onChange={(event) =>
+                    setLocation((draft) => ({
+                      ...draft,
+                      name: event.target.value,
+                    }))
+                  }
+                  placeholder="Location name"
+                  aria-label="Location name"
+                  className={inputClass}
+                />
+                <select
+                  value={location.locationType}
+                  onChange={(event) =>
+                    setLocation((draft) => ({
+                      ...draft,
+                      locationType: event.target.value,
+                    }))
+                  }
+                  aria-label="Location type"
+                  className={inputClass}
+                >
+                  <option value="service">Service</option>
+                  <option value="billing">Billing</option>
+                  <option value="branch">Branch</option>
+                  <option value="other">Other</option>
+                </select>
+              </div>
+              <input
+                value={location.address}
+                onChange={(event) =>
+                  setLocation((draft) => ({
+                    ...draft,
+                    address: event.target.value,
+                  }))
+                }
+                placeholder="Street address"
+                aria-label="Location street address"
+                className={inputClass}
+              />
+              <div className="grid gap-2 sm:grid-cols-3">
+                <input
+                  value={location.city}
+                  onChange={(event) =>
+                    setLocation((draft) => ({
+                      ...draft,
+                      city: event.target.value,
+                    }))
+                  }
+                  placeholder="City"
+                  aria-label="Location city"
+                  className={inputClass}
+                />
+                <input
+                  value={location.province}
+                  onChange={(event) =>
+                    setLocation((draft) => ({
+                      ...draft,
+                      province: event.target.value,
+                    }))
+                  }
+                  placeholder="Province"
+                  aria-label="Location province"
+                  className={inputClass}
+                />
+                <input
+                  value={location.postalCode}
+                  onChange={(event) =>
+                    setLocation((draft) => ({
+                      ...draft,
+                      postalCode: event.target.value,
+                    }))
+                  }
+                  placeholder="Postal code"
+                  aria-label="Location postal code"
+                  className={inputClass}
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={saving}
+                className="w-full rounded-xl bg-[var(--accent-copper)] px-3 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-60"
+              >
+                Save location
+              </button>
+            </form>
+          ) : null}
+
+          <div className="mt-3 space-y-2">
+            {locations.length === 0 ? (
+              <p className="text-xs text-[color:var(--theme-text-muted)]">
+                No additional locations yet. The existing customer address stays
+                available above.
+              </p>
+            ) : (
+              locations.map((item) => (
+                <div
+                  key={item.id}
+                  className="rounded-lg bg-[color:var(--theme-surface-inset)] p-2.5 text-xs"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-1 font-semibold">
+                      <MapPin className="h-3.5 w-3.5" /> {item.name}
+                    </span>
+                    <span className="capitalize text-[var(--accent-copper)]">
+                      {item.location_type}
+                    </span>
+                  </div>
+                  <div className="mt-1 text-[color:var(--theme-text-secondary)]">
+                    {[item.address, item.city, item.province, item.postal_code]
+                      .filter(Boolean)
+                      .join(", ") || "Address not entered"}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/features/fleet/components/FleetPortalAccessManager.tsx
+++ b/features/fleet/components/FleetPortalAccessManager.tsx
@@ -7,6 +7,16 @@ import { toast } from "sonner";
 type Fleet = {
   id: string;
   name: string;
+  customer_id: string;
+};
+
+type CustomerCandidate = {
+  id: string;
+  name: string | null;
+  business_name: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
 };
 
 type InviteRole = "viewer" | "approver" | "manager";
@@ -26,6 +36,7 @@ type InvitePayload = {
   fleets?: Fleet[];
   fleet?: Fleet;
   invites?: Invite[];
+  customerCandidate?: CustomerCandidate | null;
   error?: string;
 };
 
@@ -43,13 +54,21 @@ export default function FleetPortalAccessManager() {
   const [fleetContactName, setFleetContactName] = useState("");
   const [fleetContactEmail, setFleetContactEmail] = useState("");
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [customerCandidate, setCustomerCandidate] =
+    useState<CustomerCandidate | null>(null);
 
   const load = useCallback(async (preferredFleetId?: string) => {
     setLoading(true);
     setLoadError(null);
 
     try {
-      const response = await fetch("/api/portal/fleet/invites", {
+      const requestedCustomerId = new URLSearchParams(
+        window.location.search,
+      ).get("customerId");
+      const endpoint = requestedCustomerId
+        ? `/api/portal/fleet/invites?customerId=${encodeURIComponent(requestedCustomerId)}`
+        : "/api/portal/fleet/invites";
+      const response = await fetch(endpoint, {
         cache: "no-store",
       });
       const payload = (await response
@@ -65,12 +84,37 @@ export default function FleetPortalAccessManager() {
       const nextFleets = payload?.fleets ?? [];
       setFleets(nextFleets);
       setInvites(payload?.invites ?? []);
+      setCustomerCandidate(payload?.customerCandidate ?? null);
+
+      const connectedFleet = requestedCustomerId
+        ? nextFleets.find((fleet) => fleet.customer_id === requestedCustomerId)
+        : null;
+      if (payload?.customerCandidate && !connectedFleet) {
+        const candidate = payload.customerCandidate;
+        setFleetName(
+          candidate.business_name?.trim() || candidate.name?.trim() || "",
+        );
+        setFleetContactName(
+          [candidate.first_name, candidate.last_name]
+            .filter(Boolean)
+            .join(" ") ||
+            candidate.name?.trim() ||
+            "",
+        );
+        setFleetContactEmail(candidate.email ?? "");
+        setShowCreateFleet(true);
+      }
 
       const requestedFleetId = new URLSearchParams(window.location.search).get(
         "fleetId",
       );
       setFleetId((current) => {
-        const preferred = preferredFleetId || current || requestedFleetId || "";
+        const preferred =
+          preferredFleetId ||
+          connectedFleet?.id ||
+          current ||
+          requestedFleetId ||
+          "";
         return nextFleets.some((fleet) => fleet.id === preferred)
           ? preferred
           : (nextFleets[0]?.id ?? "");
@@ -132,6 +176,7 @@ export default function FleetPortalAccessManager() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           action: "create_fleet",
+          customerId: customerCandidate?.id,
           name: fleetName,
           contactName: fleetContactName,
           contactEmail: fleetContactEmail,
@@ -234,6 +279,17 @@ export default function FleetPortalAccessManager() {
                   This establishes the Shop connection. Workspace details,
                   users, assets, and maintenance are managed inside Fleet.
                 </p>
+                {customerCandidate ? (
+                  <p className="mt-2 rounded-lg border border-[var(--accent-copper-soft)]/45 bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs text-[color:var(--theme-text-primary)]">
+                    Connecting the existing customer file for{" "}
+                    <span className="font-semibold">
+                      {customerCandidate.business_name ||
+                        customerCandidate.name ||
+                        "this customer"}
+                    </span>
+                    . No duplicate customer will be created.
+                  </p>
+                ) : null}
               </div>
               <label className="block text-xs font-semibold text-[color:var(--theme-text-secondary)]">
                 Fleet name

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -2787,6 +2787,164 @@ export type Database = {
         }
         Relationships: []
       }
+      customer_contacts: {
+        Row: {
+          active: boolean
+          can_approve: boolean
+          can_view_billing: boolean
+          created_at: string
+          created_by: string | null
+          customer_id: string
+          display_name: string | null
+          email: string | null
+          first_name: string | null
+          id: string
+          is_primary: boolean
+          last_name: string | null
+          phone: string | null
+          portal_user_id: string | null
+          role: string
+          shop_id: string
+          updated_at: string
+        }
+        Insert: {
+          active?: boolean
+          can_approve?: boolean
+          can_view_billing?: boolean
+          created_at?: string
+          created_by?: string | null
+          customer_id: string
+          display_name?: string | null
+          email?: string | null
+          first_name?: string | null
+          id?: string
+          is_primary?: boolean
+          last_name?: string | null
+          phone?: string | null
+          portal_user_id?: string | null
+          role?: string
+          shop_id: string
+          updated_at?: string
+        }
+        Update: {
+          active?: boolean
+          can_approve?: boolean
+          can_view_billing?: boolean
+          created_at?: string
+          created_by?: string | null
+          customer_id?: string
+          display_name?: string | null
+          email?: string | null
+          first_name?: string | null
+          id?: string
+          is_primary?: boolean
+          last_name?: string | null
+          phone?: string | null
+          portal_user_id?: string | null
+          role?: string
+          shop_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "customer_contacts_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_contacts_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_contacts_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      customer_locations: {
+        Row: {
+          active: boolean
+          address: string | null
+          city: string | null
+          country: string
+          created_at: string
+          created_by: string | null
+          customer_id: string
+          id: string
+          is_primary: boolean
+          location_type: string
+          name: string
+          postal_code: string | null
+          province: string | null
+          shop_id: string
+          updated_at: string
+        }
+        Insert: {
+          active?: boolean
+          address?: string | null
+          city?: string | null
+          country?: string
+          created_at?: string
+          created_by?: string | null
+          customer_id: string
+          id?: string
+          is_primary?: boolean
+          location_type?: string
+          name: string
+          postal_code?: string | null
+          province?: string | null
+          shop_id: string
+          updated_at?: string
+        }
+        Update: {
+          active?: boolean
+          address?: string | null
+          city?: string | null
+          country?: string
+          created_at?: string
+          created_by?: string | null
+          customer_id?: string
+          id?: string
+          is_primary?: boolean
+          location_type?: string
+          name?: string
+          postal_code?: string | null
+          province?: string | null
+          shop_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "customer_locations_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_locations_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_locations_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       customer_portal_invites: {
         Row: {
           acceptance_metadata: Json
@@ -2993,11 +3151,15 @@ export type Database = {
       }
       customers: {
         Row: {
+          account_type: string
+          active: boolean
           address: string | null
           business_name: string | null
           city: string | null
           created_at: string | null
+          created_by: string | null
           customer_since: string | null
+          default_bill_to_customer_id: string | null
           email: string | null
           external_id: string | null
           first_name: string | null
@@ -3008,6 +3170,7 @@ export type Database = {
           last_name: string | null
           name: string | null
           notes: string | null
+          parent_customer_id: string | null
           phone: string | null
           phone_number: string | null
           postal_code: string | null
@@ -3021,11 +3184,15 @@ export type Database = {
           vehicle: string | null
         }
         Insert: {
+          account_type?: string
+          active?: boolean
           address?: string | null
           business_name?: string | null
           city?: string | null
           created_at?: string | null
+          created_by?: string | null
           customer_since?: string | null
+          default_bill_to_customer_id?: string | null
           email?: string | null
           external_id?: string | null
           first_name?: string | null
@@ -3036,6 +3203,7 @@ export type Database = {
           last_name?: string | null
           name?: string | null
           notes?: string | null
+          parent_customer_id?: string | null
           phone?: string | null
           phone_number?: string | null
           postal_code?: string | null
@@ -3049,11 +3217,15 @@ export type Database = {
           vehicle?: string | null
         }
         Update: {
+          account_type?: string
+          active?: boolean
           address?: string | null
           business_name?: string | null
           city?: string | null
           created_at?: string | null
+          created_by?: string | null
           customer_since?: string | null
+          default_bill_to_customer_id?: string | null
           email?: string | null
           external_id?: string | null
           first_name?: string | null
@@ -3064,6 +3236,7 @@ export type Database = {
           last_name?: string | null
           name?: string | null
           notes?: string | null
+          parent_customer_id?: string | null
           phone?: string | null
           phone_number?: string | null
           postal_code?: string | null
@@ -3077,6 +3250,20 @@ export type Database = {
           vehicle?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "customers_default_bill_to_customer_id_fkey"
+            columns: ["default_bill_to_customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customers_parent_customer_id_fkey"
+            columns: ["parent_customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "customers_shop_id_fkey"
             columns: ["shop_id"]
@@ -25964,7 +26151,11 @@ export type Database = {
       }
       agent_can_start: { Args: never; Returns: boolean }
       agent_reject_action: {
-        Args: { p_action_id: string; p_reason?: string; p_rejected_by?: string }
+        Args: {
+          p_action_id: string
+          p_reason?: string
+          p_rejected_by?: string
+        }
         Returns: {
           approved_at: string | null
           approved_by: string | null
@@ -26826,7 +27017,11 @@ export type Database = {
         Returns: Json
       }
       dispatch_can_execute: {
-        Args: { p_actor_user_id: string; p_shop_id: string; p_visit_id: string }
+        Args: {
+          p_actor_user_id: string
+          p_shop_id: string
+          p_visit_id: string
+        }
         Returns: boolean
       }
       dispatch_can_manage: {
@@ -26920,7 +27115,11 @@ export type Database = {
         Returns: Json
       }
       dispatch_visit_history: {
-        Args: { p_actor_user_id: string; p_shop_id: string; p_visit_id: string }
+        Args: {
+          p_actor_user_id: string
+          p_shop_id: string
+          p_visit_id: string
+        }
         Returns: Json
       }
       dispatch_visit_snapshot: { Args: { p_visit_id: string }; Returns: Json }
@@ -27201,7 +27400,11 @@ export type Database = {
         Returns: Json
       }
       match_learned_job_templates: {
-        Args: { p_embedding: string; p_match_count?: number; p_shop_id: string }
+        Args: {
+          p_embedding: string
+          p_match_count?: number
+          p_shop_id: string
+        }
         Returns: {
           confidence_score: number
           default_labor_hours: number
@@ -27215,7 +27418,11 @@ export type Database = {
         }[]
       }
       match_work_order_intelligence: {
-        Args: { p_embedding: string; p_match_count?: number; p_shop_id: string }
+        Args: {
+          p_embedding: string
+          p_match_count?: number
+          p_shop_id: string
+        }
         Returns: {
           cause: string
           complaint: string
@@ -29220,4 +29427,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -26151,11 +26151,7 @@ export type Database = {
       }
       agent_can_start: { Args: never; Returns: boolean }
       agent_reject_action: {
-        Args: {
-          p_action_id: string
-          p_reason?: string
-          p_rejected_by?: string
-        }
+        Args: { p_action_id: string; p_reason?: string; p_rejected_by?: string }
         Returns: {
           approved_at: string | null
           approved_by: string | null
@@ -27017,11 +27013,7 @@ export type Database = {
         Returns: Json
       }
       dispatch_can_execute: {
-        Args: {
-          p_actor_user_id: string
-          p_shop_id: string
-          p_visit_id: string
-        }
+        Args: { p_actor_user_id: string; p_shop_id: string; p_visit_id: string }
         Returns: boolean
       }
       dispatch_can_manage: {
@@ -27115,11 +27107,7 @@ export type Database = {
         Returns: Json
       }
       dispatch_visit_history: {
-        Args: {
-          p_actor_user_id: string
-          p_shop_id: string
-          p_visit_id: string
-        }
+        Args: { p_actor_user_id: string; p_shop_id: string; p_visit_id: string }
         Returns: Json
       }
       dispatch_visit_snapshot: { Args: { p_visit_id: string }; Returns: Json }
@@ -27400,11 +27388,7 @@ export type Database = {
         Returns: Json
       }
       match_learned_job_templates: {
-        Args: {
-          p_embedding: string
-          p_match_count?: number
-          p_shop_id: string
-        }
+        Args: { p_embedding: string; p_match_count?: number; p_shop_id: string }
         Returns: {
           confidence_score: number
           default_labor_hours: number
@@ -27418,11 +27402,7 @@ export type Database = {
         }[]
       }
       match_work_order_intelligence: {
-        Args: {
-          p_embedding: string
-          p_match_count?: number
-          p_shop_id: string
-        }
+        Args: { p_embedding: string; p_match_count?: number; p_shop_id: string }
         Returns: {
           cause: string
           complaint: string
@@ -29427,3 +29407,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/supabase/migrations/20260811232403_customer_account_foundation.sql
+++ b/supabase/migrations/20260811232403_customer_account_foundation.sql
@@ -1,0 +1,313 @@
+-- Expand the canonical customer record without replacing any existing
+-- customer, vehicle, work-order, portal, or Fleet relationship.
+
+alter table public.customers
+  add column if not exists account_type text not null default 'individual',
+  add column if not exists created_by uuid references auth.users(id) on delete set null,
+  add column if not exists parent_customer_id uuid references public.customers(id) on delete set null,
+  add column if not exists default_bill_to_customer_id uuid references public.customers(id) on delete set null,
+  add column if not exists active boolean not null default true;
+
+update public.customers c
+set account_type = case
+  when c.is_fleet or exists (
+    select 1 from public.fleets f where f.customer_id = c.id
+  ) then 'fleet'
+  when nullif(trim(coalesce(c.business_name, '')), '') is not null then 'business'
+  else 'individual'
+end;
+
+alter table public.customers
+  drop constraint if exists customers_account_type_check;
+alter table public.customers
+  add constraint customers_account_type_check
+  check (account_type in ('individual', 'business', 'fleet', 'enterprise'))
+  not valid;
+alter table public.customers validate constraint customers_account_type_check;
+
+create index if not exists customers_shop_account_type_idx
+  on public.customers (shop_id, account_type)
+  where active;
+create index if not exists customers_parent_customer_idx
+  on public.customers (parent_customer_id)
+  where parent_customer_id is not null;
+create index if not exists customers_default_bill_to_idx
+  on public.customers (default_bill_to_customer_id)
+  where default_bill_to_customer_id is not null;
+
+create or replace function public.enforce_customer_account_boundary()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if new.is_fleet then
+    new.account_type := 'fleet';
+  elsif new.account_type = 'fleet' then
+    new.is_fleet := true;
+  elsif new.account_type = 'individual'
+    and nullif(trim(coalesce(new.business_name, '')), '') is not null then
+    new.account_type := 'business';
+  end if;
+
+  if new.parent_customer_id = new.id then
+    raise exception 'A customer cannot be its own parent account';
+  end if;
+  if new.default_bill_to_customer_id = new.id then
+    raise exception 'A customer cannot bill to itself through an override';
+  end if;
+
+  if new.parent_customer_id is not null and not exists (
+    select 1
+    from public.customers parent
+    where parent.id = new.parent_customer_id
+      and parent.shop_id = new.shop_id
+  ) then
+    raise exception 'Parent customer account must belong to the same shop';
+  end if;
+
+  if new.default_bill_to_customer_id is not null and not exists (
+    select 1
+    from public.customers bill_to
+    where bill_to.id = new.default_bill_to_customer_id
+      and bill_to.shop_id = new.shop_id
+  ) then
+    raise exception 'Bill-to customer account must belong to the same shop';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.enforce_customer_account_boundary()
+  from public, anon, authenticated;
+
+drop trigger if exists enforce_customer_account_boundary_trigger
+  on public.customers;
+create trigger enforce_customer_account_boundary_trigger
+before insert or update of
+  shop_id,
+  account_type,
+  is_fleet,
+  business_name,
+  parent_customer_id,
+  default_bill_to_customer_id
+on public.customers
+for each row execute function public.enforce_customer_account_boundary();
+
+create table if not exists public.customer_contacts (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  customer_id uuid not null references public.customers(id) on delete cascade,
+  first_name text,
+  last_name text,
+  display_name text,
+  email text,
+  phone text,
+  role text not null default 'other'
+    check (role in ('primary', 'service', 'billing', 'approver', 'other')),
+  portal_user_id uuid references auth.users(id) on delete set null,
+  is_primary boolean not null default false,
+  can_approve boolean not null default false,
+  can_view_billing boolean not null default false,
+  active boolean not null default true,
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint customer_contacts_identity_check check (
+    nullif(trim(coalesce(display_name, '')), '') is not null
+    or nullif(trim(coalesce(first_name, '')), '') is not null
+    or nullif(trim(coalesce(last_name, '')), '') is not null
+    or nullif(trim(coalesce(email, '')), '') is not null
+    or nullif(trim(coalesce(phone, '')), '') is not null
+  )
+);
+
+create index if not exists customer_contacts_customer_idx
+  on public.customer_contacts (customer_id, active);
+create index if not exists customer_contacts_shop_email_idx
+  on public.customer_contacts (shop_id, lower(email))
+  where email is not null and active;
+create unique index if not exists customer_contacts_one_primary_idx
+  on public.customer_contacts (customer_id)
+  where is_primary and active;
+
+create table if not exists public.customer_locations (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  customer_id uuid not null references public.customers(id) on delete cascade,
+  name text not null,
+  location_type text not null default 'service'
+    check (location_type in ('billing', 'service', 'branch', 'other')),
+  address text,
+  city text,
+  province text,
+  postal_code text,
+  country text not null default 'CA',
+  is_primary boolean not null default false,
+  active boolean not null default true,
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists customer_locations_customer_idx
+  on public.customer_locations (customer_id, active);
+create unique index if not exists customer_locations_one_primary_idx
+  on public.customer_locations (customer_id)
+  where is_primary and active;
+
+create or replace function public.enforce_customer_child_shop_boundary()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if not exists (
+    select 1
+    from public.customers c
+    where c.id = new.customer_id
+      and c.shop_id = new.shop_id
+  ) then
+    raise exception 'Customer contact or location must belong to the same shop';
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.enforce_customer_child_shop_boundary()
+  from public, anon, authenticated;
+
+drop trigger if exists customer_contacts_shop_boundary_trigger
+  on public.customer_contacts;
+create trigger customer_contacts_shop_boundary_trigger
+before insert or update of shop_id, customer_id on public.customer_contacts
+for each row execute function public.enforce_customer_child_shop_boundary();
+
+drop trigger if exists customer_locations_shop_boundary_trigger
+  on public.customer_locations;
+create trigger customer_locations_shop_boundary_trigger
+before insert or update of shop_id, customer_id on public.customer_locations
+for each row execute function public.enforce_customer_child_shop_boundary();
+
+drop trigger if exists customer_contacts_set_updated_at
+  on public.customer_contacts;
+create trigger customer_contacts_set_updated_at
+before update on public.customer_contacts
+for each row execute function public.set_updated_at();
+
+drop trigger if exists customer_locations_set_updated_at
+  on public.customer_locations;
+create trigger customer_locations_set_updated_at
+before update on public.customer_locations
+for each row execute function public.set_updated_at();
+
+alter table public.customer_contacts enable row level security;
+alter table public.customer_locations enable row level security;
+
+create policy customer_contacts_staff_select
+on public.customer_contacts for select to authenticated
+using (public.is_staff_for_shop(shop_id));
+create policy customer_contacts_staff_insert
+on public.customer_contacts for insert to authenticated
+with check (public.is_staff_for_shop(shop_id));
+create policy customer_contacts_staff_update
+on public.customer_contacts for update to authenticated
+using (public.is_staff_for_shop(shop_id))
+with check (public.is_staff_for_shop(shop_id));
+create policy customer_contacts_staff_delete
+on public.customer_contacts for delete to authenticated
+using (public.is_staff_for_shop(shop_id));
+
+create policy customer_locations_staff_select
+on public.customer_locations for select to authenticated
+using (public.is_staff_for_shop(shop_id));
+create policy customer_locations_staff_insert
+on public.customer_locations for insert to authenticated
+with check (public.is_staff_for_shop(shop_id));
+create policy customer_locations_staff_update
+on public.customer_locations for update to authenticated
+using (public.is_staff_for_shop(shop_id))
+with check (public.is_staff_for_shop(shop_id));
+create policy customer_locations_staff_delete
+on public.customer_locations for delete to authenticated
+using (public.is_staff_for_shop(shop_id));
+
+grant select, insert, update, delete on table public.customer_contacts
+  to authenticated, service_role;
+grant select, insert, update, delete on table public.customer_locations
+  to authenticated, service_role;
+
+-- Keep the established Fleet compatibility flag and new account type aligned
+-- for both explicitly linked and automatically created Fleet customers.
+create or replace function public.ensure_fleet_customer_account()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_customer_id uuid;
+begin
+  if new.customer_id is not null then
+    if not exists (
+      select 1
+      from public.customers c
+      where c.id = new.customer_id
+        and c.shop_id = new.shop_id
+    ) then
+      raise exception 'Fleet customer account must belong to the same shop';
+    end if;
+    update public.customers
+    set is_fleet = true,
+        account_type = 'fleet',
+        business_name = coalesce(nullif(business_name, ''), new.name),
+        name = coalesce(nullif(name, ''), new.contact_name, new.name),
+        email = coalesce(nullif(email, ''), new.contact_email),
+        updated_at = now()
+    where id = new.customer_id;
+    return new;
+  end if;
+
+  if nullif(trim(coalesce(new.contact_email, '')), '') is not null then
+    select c.id into v_customer_id
+    from public.customers c
+    where c.shop_id = new.shop_id
+      and lower(trim(c.email)) = lower(trim(new.contact_email))
+    order by c.created_at, c.id
+    limit 1;
+  end if;
+
+  if v_customer_id is null then
+    insert into public.customers (
+      shop_id, name, business_name, email, is_fleet, account_type, notes, updated_at
+    ) values (
+      new.shop_id,
+      coalesce(nullif(trim(coalesce(new.contact_name, '')), ''), new.name),
+      new.name,
+      nullif(trim(coalesce(new.contact_email, '')), ''),
+      true,
+      'fleet',
+      'Canonical customer account for Fleet portal billing and history.',
+      now()
+    )
+    returning id into v_customer_id;
+  else
+    update public.customers
+    set is_fleet = true,
+        account_type = 'fleet',
+        business_name = coalesce(nullif(business_name, ''), new.name),
+        name = coalesce(nullif(name, ''), new.contact_name, new.name),
+        updated_at = now()
+    where id = v_customer_id;
+  end if;
+
+  new.customer_id := v_customer_id;
+  return new;
+end;
+$$;
+
+revoke all on function public.ensure_fleet_customer_account()
+  from public, anon, authenticated;

--- a/tests/customer-account-foundation.test.ts
+++ b/tests/customer-account-foundation.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const migration = read(
+  "supabase/migrations/20260811232403_customer_account_foundation.sql",
+);
+const customerPage = read("features/customers/app/customers/[id]/page.tsx");
+const fleetRoute = read("app/api/portal/fleet/invites/route.ts");
+
+describe("customer account foundation", () => {
+  it("expands customer accounts without replacing canonical customer records", () => {
+    expect(migration).toContain("add column if not exists account_type text");
+    expect(migration).toContain(
+      "'individual', 'business', 'fleet', 'enterprise'",
+    );
+    expect(migration).toContain(
+      "parent_customer_id uuid references public.customers",
+    );
+    expect(migration).toContain(
+      "default_bill_to_customer_id uuid references public.customers",
+    );
+    expect(migration).not.toMatch(/drop table|delete from public\.customers/i);
+  });
+
+  it("keeps contacts and locations inside the authenticated Shop boundary", () => {
+    expect(migration).toContain(
+      "create table if not exists public.customer_contacts",
+    );
+    expect(migration).toContain(
+      "create table if not exists public.customer_locations",
+    );
+    expect(migration).toContain("public.is_staff_for_shop(shop_id)");
+    expect(migration).toContain(
+      "Customer contact or location must belong to the same shop",
+    );
+    expect(migration).toContain("to authenticated, service_role");
+  });
+
+  it("separates a staff creator from the customer portal identity", () => {
+    expect(customerPage).toContain("user_id: null");
+    expect(customerPage).toContain("created_by: user.id");
+    expect(customerPage).toContain("account_type: newCustomer.customerType");
+  });
+
+  it("links Fleet to an explicitly verified existing customer", () => {
+    expect(fleetRoute).toContain(
+      'const customerId = String(body.customerId ?? "").trim()',
+    );
+    expect(fleetRoute).toContain('.eq("shop_id", access.profile.shop_id)');
+    expect(fleetRoute).toContain(
+      "...(customerId ? { customer_id: customerId } : {})",
+    );
+  });
+});

--- a/tests/fleet-invite-relationship-api.test.ts
+++ b/tests/fleet-invite-relationship-api.test.ts
@@ -9,6 +9,17 @@ const fixture = vi.hoisted(() => ({
     } | null,
     error: null as { code?: string } | null,
   },
+  customerResult: {
+    data: {
+      id: "11111111-1111-4111-8111-111111111111",
+      name: "Northside Transport",
+      business_name: "Northside Transport",
+      first_name: "Morgan",
+      last_name: "Lee",
+      email: "fleet@example.com",
+    } as Record<string, string | null> | null,
+    error: null as { code?: string } | null,
+  },
 }));
 
 vi.mock("@/features/shared/lib/server/admin-access", () => ({
@@ -24,6 +35,18 @@ vi.mock("@/features/shared/lib/server/admin-access", () => ({
 vi.mock("@/features/shared/lib/supabase/admin", () => ({
   supabaseAdmin: {
     from: vi.fn((table: string) => {
+      if (table === "customers") {
+        const builder = {
+          select() {
+            return builder;
+          },
+          eq() {
+            return builder;
+          },
+          maybeSingle: async () => fixture.customerResult,
+        };
+        return builder;
+      }
       if (table !== "fleets") throw new Error(`Unexpected table: ${table}`);
       return {
         insert(payload: Record<string, unknown>) {
@@ -66,6 +89,17 @@ describe("Fleet relationship creation", () => {
       data: { id: "fleet-1", name: "Northside Transport" },
       error: null,
     };
+    fixture.customerResult = {
+      data: {
+        id: "11111111-1111-4111-8111-111111111111",
+        name: "Northside Transport",
+        business_name: "Northside Transport",
+        first_name: "Morgan",
+        last_name: "Lee",
+        email: "fleet@example.com",
+      },
+      error: null,
+    };
   });
 
   it("uses the authenticated Shop scope and ignores client tenant claims", async () => {
@@ -99,6 +133,38 @@ describe("Fleet relationship creation", () => {
     );
 
     expect(response.status).toBe(400);
+    expect(fixture.insertPayload).toBeNull();
+  });
+
+  it("links a same-Shop customer without creating a duplicate customer", async () => {
+    const customerId = "11111111-1111-4111-8111-111111111111";
+    const response = await POST(
+      createRequest({
+        action: "create_fleet",
+        customerId,
+        name: "",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(fixture.insertPayload).toMatchObject({
+      shop_id: "shop-1",
+      customer_id: customerId,
+      name: "Northside Transport",
+    });
+  });
+
+  it("rejects a customer outside the authenticated Shop scope", async () => {
+    fixture.customerResult = { data: null, error: null };
+    const response = await POST(
+      createRequest({
+        action: "create_fleet",
+        customerId: "22222222-2222-4222-8222-222222222222",
+        name: "Foreign Fleet",
+      }),
+    );
+
+    expect(response.status).toBe(404);
     expect(fixture.insertPayload).toBeNull();
   });
 


### PR DESCRIPTION
## What changed

- adds explicit Individual, Business, Fleet, and Enterprise customer account types while preserving every existing customer ID and `is_fleet` compatibility path
- fixes directory-created customers so the signed-in staff user is recorded as `created_by`, not as the customer portal identity
- adds tenant-scoped customer contacts and service/billing/branch locations with RLS, same-Shop trigger enforcement, and explicit Data API grants
- adds optional same-Shop parent-account and bill-to relationships for later enterprise hierarchy and pricing work
- adds Customer directory account filters, account badges, contact/location management, and Fleet connection status
- lets authorized shop staff connect an existing Business/Fleet/Enterprise customer to a Fleet workspace without creating a duplicate customer
- keeps Create Work Order as the primary customer intake path

## Why

The previous customer record mixed individuals, businesses, and fleets behind `business_name` and `is_fleet`. Directory creation also assigned the staff user's auth ID to `customers.user_id`, even though that field is used as the customer portal identity. That made role separation ambiguous and blocked a safe path from an existing customer file into Fleet.

## Safety and deployment

- additive forward migration only; no tables or customer records are deleted
- existing `customer_id`, vehicle, work-order, history, portal, and Fleet relationships remain intact
- legacy creation/import paths continue to work because the database derives account type from existing business/Fleet fields
- all new child records enforce the same Shop at both RLS and trigger layers
- migration `20260811232403_customer_account_foundation.sql` was applied to canonical ProFixIQ production project `scjjkmuwadwkaaqjoigx`
- the connector's temporary execution-time history alias was repaired to repository version `20260811232403`; migration history, repository filename, and deployed schema now agree
- post-apply verification confirmed both new tables, RLS, all eight staff policies, explicit grants, validated constraints, zero cross-Shop violations, and zero Fleet/account-type mismatches
- post-apply security advisors reported no findings attributable to this migration
- performance advisors reported informational missing-FK-index notices; those are deferred to a small additive follow-up migration rather than changing this validated production migration
- deploy order is migration first, then application

This PR intentionally does not change independent Fleet subscription tenancy or apply customer-specific pricing to work orders. It creates the canonical customer/account boundary those later slices need.

## Validation

Final head: `1d9c573c4af241e8cc037975a94bd931109595f1`

- Agent PR Checks: passed
- Supabase Clean Replay Validation: passed, including generated types, second full replay, and runtime database integrations
- Fleet Premier Workspace Validation: passed
- Phase 7 Customer Portal Validation: passed
- P0-006 Stripe Identity Validation: passed
- strict TypeScript: passed
- changed-file ESLint: passed
- full Vitest suite: 369 files passed, 2,119 tests passed; 1 DB integration file skipped by its existing environment gate
- API route audit: completed
- regression inventory: 0 new errors
- production migration and history reconciliation: verified
