### PR TITLE
Add customer-specific pricing engine

### DIFF
--- a/.github/workflows/customer-specific-pricing-validation.yml
+++ b/.github/workflows/customer-specific-pricing-validation.yml
@@ -1,0 +1,71 @@
+name: Customer-specific Pricing Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "app/api/customers/**/pricing/**"
+      - "app/api/work-orders/**/customer-pricing/**"
+      - "app/api/quotes/send/route.ts"
+      - "features/customers/components/CustomerPricingPanel.tsx"
+      - "features/customers/components/CustomerAccountDetails.tsx"
+      - "features/pricing/**"
+      - "features/work-orders/quote-review/QuoteReviewView.tsx"
+      - "supabase/migrations/20260812022359_customer_specific_pricing_engine.sql"
+      - "tests/customer-specific-pricing-engine.test.ts"
+      - "tests/pricing/customer-specific-pricing.runtime.sql"
+      - ".github/workflows/customer-specific-pricing-validation.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: customer-specific-pricing-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.8.1
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Pricing source and resolver tests
+        run: >-
+          pnpm exec vitest run
+          features/pricing/lib/customerPricing.test.ts
+          tests/customer-specific-pricing-engine.test.ts
+      - name: Pricing lint
+        run: >-
+          pnpm exec eslint
+          app/api/customers/[id]/pricing/route.ts
+          app/api/work-orders/[id]/customer-pricing/route.ts
+          features/customers/components/CustomerPricingPanel.tsx
+          features/customers/components/CustomerAccountDetails.tsx
+          features/pricing/lib/customerPricing.ts
+          features/pricing/lib/customerPricing.test.ts
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v2
+        with:
+          version: 2.101.0
+          github-token: ${{ github.token }}
+      - name: Start clean local database
+        run: supabase db start
+      - name: Run customer pricing runtime
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: >-
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1
+          -f tests/pricing/customer-specific-pricing.runtime.sql
+      - name: Stop local Supabase
+        if: always()
+        run: supabase stop --no-backup || true

--- a/app/api/customers/[id]/pricing/route.ts
+++ b/app/api/customers/[id]/pricing/route.ts
@@ -1,0 +1,268 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function boundedText(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized && normalized.length <= maxLength ? normalized : null;
+}
+
+function optionalText(value: unknown, maxLength: number): string | null {
+  if (value == null || value === "") return null;
+  return boundedText(value, maxLength);
+}
+
+function optionalDate(value: unknown): string | null {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  return value;
+}
+
+function moneyOrNull(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  const numberValue = typeof value === "number" ? value : Number(value);
+  if (
+    !Number.isFinite(numberValue) ||
+    numberValue < 0 ||
+    Math.round(numberValue * 100) / 100 !== numberValue
+  ) {
+    return null;
+  }
+  return numberValue;
+}
+
+function percent(value: unknown): number | null {
+  const numberValue = moneyOrNull(value ?? 0);
+  return numberValue != null && numberValue <= 100 ? numberValue : null;
+}
+
+function errorMessage(error: {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+}): string {
+  return [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+}
+
+function statusForError(message: string): number {
+  if (message.includes("not found")) return 404;
+  if (message.includes("ROLE_REQUIRED") || message.includes("access denied")) {
+    return 403;
+  }
+  if (message.includes("CONFLICT") || message.includes("linked active Fleet")) {
+    return 409;
+  }
+  return 400;
+}
+
+async function customerId(context: RouteContext): Promise<string | null> {
+  const { id } = await context.params;
+  return UUID_PATTERN.test(id.trim()) ? id.trim() : null;
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canAuthorizeQuotes",
+  });
+  if (!access.ok) return access.response;
+
+  const id = await customerId(context);
+  if (!id) {
+    return NextResponse.json(
+      { error: "Invalid customer id." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await access.supabase.rpc(
+    "get_customer_pricing_account_summary" as never,
+    {
+      p_shop_id: access.profile.shop_id,
+      p_customer_id: id,
+      p_at: new Date().toISOString(),
+    } as never,
+  );
+
+  if (error) {
+    const message = errorMessage(error);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: statusForError(message) },
+    );
+  }
+
+  return NextResponse.json(
+    data && typeof data === "object" ? data : { ok: true, agreements: [] },
+  );
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canEditPricing",
+    allowRoles: ["owner", "admin", "manager"],
+  });
+  if (!access.ok) return access.response;
+
+  const id = await customerId(context);
+  if (!id) {
+    return NextResponse.json(
+      { error: "Invalid customer id." },
+      { status: 400 },
+    );
+  }
+
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const sourceType = boundedText(body?.sourceType, 40);
+  const name = boundedText(body?.name, 120);
+  const currency = boundedText(body?.currency, 3)?.toUpperCase() ?? "CAD";
+  const laborRate = moneyOrNull(body?.laborRate);
+  const laborDiscountPercent = percent(body?.laborDiscountPercent);
+  const partsDiscountPercent = percent(body?.partsDiscountPercent);
+  const effectiveFrom = optionalDate(body?.effectiveFrom);
+  const effectiveUntil = optionalDate(body?.effectiveUntil);
+  const approvalReason = boundedText(body?.approvalReason, 500);
+  const notes = optionalText(body?.notes, 2000);
+  const operationKey = boundedText(
+    body?.operationKey ?? request.headers.get("idempotency-key"),
+    200,
+  );
+
+  if (
+    !sourceType ||
+    !["customer_specific", "customer_contract", "fleet_contract"].includes(
+      sourceType,
+    ) ||
+    !name ||
+    !["CAD", "USD"].includes(currency) ||
+    laborDiscountPercent == null ||
+    partsDiscountPercent == null ||
+    !effectiveFrom ||
+    (body?.effectiveUntil && !effectiveUntil) ||
+    !approvalReason ||
+    !operationKey
+  ) {
+    return NextResponse.json(
+      {
+        error: "Customer pricing agreement details are incomplete or invalid.",
+      },
+      { status: 400 },
+    );
+  }
+  if (body?.laborRate != null && body.laborRate !== "" && laborRate == null) {
+    return NextResponse.json(
+      { error: "Labor rate must be a non-negative amount with two decimals." },
+      { status: 400 },
+    );
+  }
+  if (laborRate != null && laborDiscountPercent > 0) {
+    return NextResponse.json(
+      { error: "Choose a fixed labor rate or a labor discount, not both." },
+      { status: 400 },
+    );
+  }
+  if (
+    laborRate == null &&
+    laborDiscountPercent === 0 &&
+    partsDiscountPercent === 0
+  ) {
+    return NextResponse.json(
+      { error: "At least one customer pricing adjustment is required." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await access.supabase.rpc(
+    "create_customer_pricing_agreement_atomic" as never,
+    {
+      p_shop_id: access.profile.shop_id,
+      p_customer_id: id,
+      p_source_type: sourceType,
+      p_name: name,
+      p_currency: currency,
+      p_labor_rate: laborRate,
+      p_labor_discount_percent: laborDiscountPercent,
+      p_parts_discount_percent: partsDiscountPercent,
+      p_effective_from: effectiveFrom,
+      p_effective_until: effectiveUntil,
+      p_approval_reason: approvalReason,
+      p_notes: notes,
+      p_operation_key: operationKey,
+      p_actor_user_id: access.authUserId,
+      p_at: new Date().toISOString(),
+    } as never,
+  );
+
+  if (error) {
+    const message = errorMessage(error);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: statusForError(message) },
+    );
+  }
+
+  return NextResponse.json(
+    data && typeof data === "object" ? data : { ok: true },
+  );
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canEditPricing",
+    allowRoles: ["owner", "admin", "manager"],
+  });
+  if (!access.ok) return access.response;
+
+  const id = await customerId(context);
+  if (!id) {
+    return NextResponse.json(
+      { error: "Invalid customer id." },
+      { status: 400 },
+    );
+  }
+
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const agreementId = boundedText(body?.agreementId, 50);
+  const reason = boundedText(body?.reason, 500);
+  if (!agreementId || !UUID_PATTERN.test(agreementId) || !reason) {
+    return NextResponse.json(
+      { error: "Agreement id and retirement reason are required." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await access.supabase.rpc(
+    "retire_customer_pricing_agreement_atomic" as never,
+    {
+      p_shop_id: access.profile.shop_id,
+      p_agreement_id: agreementId,
+      p_actor_user_id: access.authUserId,
+      p_reason: reason,
+      p_at: new Date().toISOString(),
+    } as never,
+  );
+
+  if (error) {
+    const message = errorMessage(error);
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: statusForError(message) },
+    );
+  }
+
+  return NextResponse.json(
+    data && typeof data === "object" ? data : { ok: true },
+  );
+}

--- a/app/api/quotes/send/route.ts
+++ b/app/api/quotes/send/route.ts
@@ -806,6 +806,36 @@ export async function POST(req: Request) {
       : body?.quoteTotal;
     let sendableQuoteLineIds: string[] = [];
 
+    const { error: customerPricingError } = await supabaseAdmin.rpc(
+      "apply_customer_pricing_to_quote_atomic" as never,
+      {
+        p_shop_id: wo.shop_id,
+        p_work_order_id: workOrderId,
+        p_quote_line_ids: [],
+        p_actor_user_id: access.authUserId,
+        p_at: new Date().toISOString(),
+      } as never,
+    );
+    if (customerPricingError) {
+      const detail = [
+        customerPricingError.message,
+        customerPricingError.details,
+        customerPricingError.hint,
+      ]
+        .filter(Boolean)
+        .join(" — ");
+      return NextResponse.json(
+        {
+          ok: false,
+          trace,
+          error:
+            "Customer-specific pricing could not be frozen for this quote.",
+          detail,
+        },
+        { status: 409 },
+      );
+    }
+
     const { data: quoteLineRowsRaw, error: quoteLinesErr } = await supabaseAdmin
       .from("work_order_quote_lines")
       .select(

--- a/app/api/work-orders/[id]/customer-pricing/route.ts
+++ b/app/api/work-orders/[id]/customer-pricing/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function stringIds(value: unknown): string[] | null {
+  if (value == null) return [];
+  if (!Array.isArray(value) || value.length > 100) return null;
+  const ids = [...new Set(value.map((item) => String(item).trim()))];
+  return ids.every((id) => UUID_PATTERN.test(id)) ? ids : null;
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canAuthorizeQuotes",
+  });
+  if (!access.ok) return access.response;
+
+  const { id: rawId } = await context.params;
+  const workOrderId = rawId.trim();
+  if (!UUID_PATTERN.test(workOrderId)) {
+    return NextResponse.json(
+      { error: "Invalid work order id." },
+      { status: 400 },
+    );
+  }
+
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const quoteLineIds = stringIds(body?.quoteLineIds);
+  if (quoteLineIds == null) {
+    return NextResponse.json(
+      { error: "Quote line ids must be valid UUIDs." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await access.supabase.rpc(
+    "apply_customer_pricing_to_quote_atomic" as never,
+    {
+      p_shop_id: access.profile.shop_id,
+      p_work_order_id: workOrderId,
+      p_quote_line_ids: quoteLineIds,
+      p_actor_user_id: access.authUserId,
+      p_at: new Date().toISOString(),
+    } as never,
+  );
+
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    const status = message.includes("not found")
+      ? 404
+      : message.includes("LOCKED") || message.includes("protected")
+        ? 409
+        : 400;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+
+  return NextResponse.json(
+    data && typeof data === "object" ? data : { ok: true },
+  );
+}

--- a/features/customers/components/CustomerAccountDetails.tsx
+++ b/features/customers/components/CustomerAccountDetails.tsx
@@ -5,6 +5,7 @@ import { Building2, Loader2, MapPin, Plus, UserRound } from "lucide-react";
 import { toast } from "sonner";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@/features/shared/types/types/supabase";
+import { CustomerPricingPanel } from "@/features/customers/components/CustomerPricingPanel";
 
 type Contact = Database["public"]["Tables"]["customer_contacts"]["Row"];
 type Location = Database["public"]["Tables"]["customer_locations"]["Row"];
@@ -136,7 +137,9 @@ export function CustomerAccountDetails({ customerId, shopId }: Props) {
   }
 
   return (
-    <section className="rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
+    <div className="space-y-4">
+      <CustomerPricingPanel customerId={customerId} />
+      <section className="rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
       <div className="flex items-start justify-between gap-3">
         <div>
           <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper)]">
@@ -409,6 +412,7 @@ export function CustomerAccountDetails({ customerId, shopId }: Props) {
           </div>
         </div>
       </div>
-    </section>
+      </section>
+    </div>
   );
 }

--- a/features/customers/components/CustomerPricingPanel.tsx
+++ b/features/customers/components/CustomerPricingPanel.tsx
@@ -1,0 +1,660 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  BadgeDollarSign,
+  CalendarRange,
+  Check,
+  History,
+  Loader2,
+  Plus,
+  ShieldCheck,
+} from "lucide-react";
+import { toast } from "sonner";
+
+type AgreementSource =
+  | "customer_specific"
+  | "customer_contract"
+  | "fleet_contract";
+
+type PricingAgreement = {
+  id: string;
+  source_type: AgreementSource;
+  name: string;
+  status: "active" | "superseded" | "retired";
+  currency: "CAD" | "USD";
+  labor_rate: number | null;
+  labor_discount_percent: number;
+  parts_discount_percent: number;
+  effective_from: string;
+  effective_until: string | null;
+  approval_reason: string;
+  notes: string | null;
+  retired_reason: string | null;
+  created_at: string;
+};
+
+type PricingSummary = {
+  ok: boolean;
+  account_type: string | null;
+  is_fleet: boolean;
+  has_linked_fleet: boolean;
+  can_manage: boolean;
+  effective_agreement: PricingAgreement | null;
+  agreements: PricingAgreement[];
+};
+
+type Props = {
+  customerId: string;
+};
+
+type Draft = {
+  sourceType: AgreementSource;
+  name: string;
+  currency: "CAD" | "USD";
+  laborStrategy: "fixed" | "discount" | "none";
+  laborRate: string;
+  laborDiscountPercent: string;
+  partsDiscountPercent: string;
+  effectiveFrom: string;
+  effectiveUntil: string;
+  approvalReason: string;
+  notes: string;
+};
+
+const inputClass =
+  "w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] outline-none focus:border-[var(--accent-copper)] focus:ring-2 focus:ring-[var(--accent-copper-soft)]";
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function emptyDraft(sourceType: AgreementSource): Draft {
+  return {
+    sourceType,
+    name: "",
+    currency: "CAD",
+    laborStrategy: "fixed",
+    laborRate: "",
+    laborDiscountPercent: "",
+    partsDiscountPercent: "",
+    effectiveFrom: today(),
+    effectiveUntil: "",
+    approvalReason: "",
+    notes: "",
+  };
+}
+
+function sourceLabel(source: AgreementSource): string {
+  if (source === "fleet_contract") return "Fleet contract";
+  if (source === "customer_contract") return "Business contract";
+  return "Customer-specific rate";
+}
+
+function agreementTerms(agreement: PricingAgreement): string[] {
+  const terms: string[] = [];
+  if (agreement.labor_rate != null) {
+    terms.push(
+      `${agreement.currency} $${agreement.labor_rate.toFixed(2)}/hr labor`,
+    );
+  } else if (agreement.labor_discount_percent > 0) {
+    terms.push(`${agreement.labor_discount_percent}% off labor rate`);
+  }
+  if (agreement.parts_discount_percent > 0) {
+    terms.push(`${agreement.parts_discount_percent}% off parts sell price`);
+  }
+  return terms;
+}
+
+function effectiveWindow(agreement: PricingAgreement): string {
+  return agreement.effective_until
+    ? `${agreement.effective_from} – ${agreement.effective_until}`
+    : `${agreement.effective_from} onward`;
+}
+
+export function CustomerPricingPanel({ customerId }: Props) {
+  const [summary, setSummary] = useState<PricingSummary | null>(null);
+  const [available, setAvailable] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [retiringId, setRetiringId] = useState<string | null>(null);
+  const [retirementReason, setRetirementReason] = useState("");
+  const [draft, setDraft] = useState<Draft>(() =>
+    emptyDraft("customer_specific"),
+  );
+
+  const defaultSource = useMemo<AgreementSource>(() => {
+    if (summary?.has_linked_fleet) return "fleet_contract";
+    if (
+      summary?.account_type === "business" ||
+      summary?.account_type === "enterprise"
+    ) {
+      return "customer_contract";
+    }
+    return "customer_specific";
+  }, [summary?.account_type, summary?.has_linked_fleet]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/customers/${customerId}/pricing`, {
+        cache: "no-store",
+      });
+      if (response.status === 401 || response.status === 403) {
+        setAvailable(false);
+        return;
+      }
+      const payload = (await response.json().catch(() => null)) as
+        | (PricingSummary & { error?: string })
+        | null;
+      if (!response.ok || !payload) {
+        throw new Error(
+          payload?.error ?? "Customer pricing could not be loaded.",
+        );
+      }
+      setSummary(payload);
+      setAvailable(true);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Customer pricing could not be loaded.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [customerId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!showForm) setDraft(emptyDraft(defaultSource));
+  }, [defaultSource, showForm]);
+
+  async function saveAgreement(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (saving) return;
+    setSaving(true);
+    try {
+      const response = await fetch(`/api/customers/${customerId}/pricing`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": crypto.randomUUID(),
+        },
+        body: JSON.stringify({
+          sourceType: draft.sourceType,
+          name: draft.name,
+          currency: draft.currency,
+          laborRate: draft.laborStrategy === "fixed" ? draft.laborRate : null,
+          laborDiscountPercent:
+            draft.laborStrategy === "discount"
+              ? Number(draft.laborDiscountPercent || 0)
+              : 0,
+          partsDiscountPercent: Number(draft.partsDiscountPercent || 0),
+          effectiveFrom: draft.effectiveFrom,
+          effectiveUntil: draft.effectiveUntil || null,
+          approvalReason: draft.approvalReason,
+          notes: draft.notes || null,
+          operationKey: crypto.randomUUID(),
+        }),
+      });
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      if (!response.ok) {
+        throw new Error(
+          payload?.error ?? "Pricing agreement could not be saved.",
+        );
+      }
+      toast.success("Customer pricing agreement activated.");
+      setShowForm(false);
+      await load();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Pricing agreement could not be saved.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function retireAgreement(agreementId: string) {
+    if (saving || retirementReason.trim().length < 3) return;
+    setSaving(true);
+    try {
+      const response = await fetch(`/api/customers/${customerId}/pricing`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agreementId,
+          reason: retirementReason,
+        }),
+      });
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      if (!response.ok) {
+        throw new Error(
+          payload?.error ?? "Pricing agreement could not be retired.",
+        );
+      }
+      toast.success(
+        "Pricing agreement retired. Existing sent quotes are unchanged.",
+      );
+      setRetiringId(null);
+      setRetirementReason("");
+      await load();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Pricing agreement could not be retired.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!available) return null;
+
+  const effective = summary?.effective_agreement ?? null;
+  const agreements = summary?.agreements ?? [];
+
+  return (
+    <section className="overflow-hidden rounded-2xl border border-[color:var(--accent-copper-soft)]/45 bg-[radial-gradient(circle_at_top_right,rgba(197,122,74,0.16),transparent_38%),color:var(--desktop-panel-bg-soft)] shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
+      <div className="border-b border-[color:var(--desktop-border)] p-4 sm:p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <div className="rounded-2xl border border-[var(--accent-copper-soft)]/50 bg-[var(--accent-copper)]/10 p-2.5 text-[var(--accent-copper)]">
+              <BadgeDollarSign className="h-5 w-5" />
+            </div>
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper)]">
+                Dedicated pricing
+              </div>
+              <h2 className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                Customer labor & parts terms
+              </h2>
+              <p className="mt-1 max-w-2xl text-xs text-[color:var(--theme-text-secondary)]">
+                Shop-owned pricing resolves automatically on editable quotes.
+                Sent approvals and invoices keep their original snapshot.
+              </p>
+            </div>
+          </div>
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin text-[var(--accent-copper)]" />
+          ) : summary?.can_manage ? (
+            <button
+              type="button"
+              onClick={() => setShowForm((current) => !current)}
+              className="inline-flex items-center gap-1.5 rounded-xl bg-[var(--accent-copper)] px-3 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] hover:brightness-110"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              New agreement
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="grid gap-4 p-4 sm:p-5 xl:grid-cols-[1.15fr_0.85fr]">
+        <div className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+            <ShieldCheck className="h-4 w-4 text-emerald-400" />
+            Effective now
+          </div>
+          {effective ? (
+            <div className="mt-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="text-base font-semibold text-[color:var(--theme-text-primary)]">
+                  {effective.name}
+                </h3>
+                <span className="rounded-full border border-emerald-300/35 bg-emerald-400/10 px-2.5 py-1 text-[11px] font-semibold text-emerald-100">
+                  {sourceLabel(effective.source_type)}
+                </span>
+              </div>
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                {agreementTerms(effective).map((term) => (
+                  <div
+                    key={term}
+                    className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3 text-sm font-semibold text-[color:var(--theme-text-primary)]"
+                  >
+                    <Check className="mr-1.5 inline h-4 w-4 text-emerald-400" />
+                    {term}
+                  </div>
+                ))}
+              </div>
+              <div className="mt-3 flex items-center gap-1.5 text-xs text-[color:var(--theme-text-secondary)]">
+                <CalendarRange className="h-3.5 w-3.5" />
+                {effectiveWindow(effective)}
+              </div>
+              <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
+                Approved because: {effective.approval_reason}
+              </p>
+            </div>
+          ) : (
+            <div className="mt-3 rounded-xl border border-dashed border-[color:var(--desktop-border)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+              Shop defaults apply. Add a customer rate or contract when this
+              account receives negotiated pricing.
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-4">
+          <div className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+            Fixed precedence
+          </div>
+          <ol className="mt-3 space-y-2 text-xs text-[color:var(--theme-text-secondary)]">
+            {[
+              "Approved manual override",
+              "Fleet or business contract",
+              "Customer-specific rate",
+              "Shop default",
+            ].map((label, index) => (
+              <li key={label} className="flex items-center gap-2">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full border border-[var(--accent-copper-soft)]/45 bg-[var(--accent-copper)]/10 font-bold text-[var(--accent-copper)]">
+                  {index + 1}
+                </span>
+                {label}
+              </li>
+            ))}
+          </ol>
+          <p className="mt-3 text-[11px] leading-relaxed text-[color:var(--theme-text-muted)]">
+            Staff cannot invent priority numbers. The engine selects one winner,
+            records the original values, and exposes the resolved source on the
+            quote.
+          </p>
+        </div>
+      </div>
+
+      {showForm && summary?.can_manage ? (
+        <form
+          onSubmit={saveAgreement}
+          className="border-t border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-4 sm:p-5"
+        >
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Agreement type
+              <select
+                value={draft.sourceType}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    sourceType: event.target.value as AgreementSource,
+                  }))
+                }
+                className={`mt-1 ${inputClass}`}
+              >
+                <option value="customer_specific">
+                  Customer-specific rate
+                </option>
+                <option value="customer_contract">Business contract</option>
+                {summary.has_linked_fleet ? (
+                  <option value="fleet_contract">Fleet contract</option>
+                ) : null}
+              </select>
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)] md:col-span-1 xl:col-span-2">
+              Agreement name
+              <input
+                required
+                maxLength={120}
+                value={draft.name}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    name: event.target.value,
+                  }))
+                }
+                placeholder="Example: Northside Fleet 2026"
+                className={`mt-1 ${inputClass}`}
+              />
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Currency
+              <select
+                value={draft.currency}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    currency: event.target.value as "CAD" | "USD",
+                  }))
+                }
+                className={`mt-1 ${inputClass}`}
+              >
+                <option value="CAD">CAD</option>
+                <option value="USD">USD</option>
+              </select>
+            </label>
+          </div>
+
+          <div className="mt-3 grid gap-3 md:grid-cols-3">
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Labor treatment
+              <select
+                value={draft.laborStrategy}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    laborStrategy: event.target.value as Draft["laborStrategy"],
+                  }))
+                }
+                className={`mt-1 ${inputClass}`}
+              >
+                <option value="fixed">Fixed hourly rate</option>
+                <option value="discount">Percent off shop rate</option>
+                <option value="none">No labor adjustment</option>
+              </select>
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              {draft.laborStrategy === "discount"
+                ? "Labor discount %"
+                : "Fixed labor rate"}
+              <input
+                required={draft.laborStrategy !== "none"}
+                disabled={draft.laborStrategy === "none"}
+                inputMode="decimal"
+                value={
+                  draft.laborStrategy === "discount"
+                    ? draft.laborDiscountPercent
+                    : draft.laborRate
+                }
+                onChange={(event) =>
+                  setDraft((current) =>
+                    current.laborStrategy === "discount"
+                      ? {
+                          ...current,
+                          laborDiscountPercent: event.target.value,
+                        }
+                      : { ...current, laborRate: event.target.value },
+                  )
+                }
+                placeholder={
+                  draft.laborStrategy === "discount" ? "10" : "125.00"
+                }
+                className={`mt-1 ${inputClass} disabled:opacity-45`}
+              />
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Parts sell discount %
+              <input
+                inputMode="decimal"
+                value={draft.partsDiscountPercent}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    partsDiscountPercent: event.target.value,
+                  }))
+                }
+                placeholder="5"
+                className={`mt-1 ${inputClass}`}
+              />
+            </label>
+          </div>
+
+          <div className="mt-3 grid gap-3 md:grid-cols-2">
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Effective from
+              <input
+                required
+                type="date"
+                value={draft.effectiveFrom}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    effectiveFrom: event.target.value,
+                  }))
+                }
+                className={`mt-1 ${inputClass}`}
+              />
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Ends (optional)
+              <input
+                type="date"
+                min={draft.effectiveFrom}
+                value={draft.effectiveUntil}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    effectiveUntil: event.target.value,
+                  }))
+                }
+                className={`mt-1 ${inputClass}`}
+              />
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)] md:col-span-2">
+              Approval reason
+              <input
+                required
+                minLength={3}
+                maxLength={500}
+                value={draft.approvalReason}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    approvalReason: event.target.value,
+                  }))
+                }
+                placeholder="Signed fleet agreement, volume commitment, preferred customer…"
+                className={`mt-1 ${inputClass}`}
+              />
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)] md:col-span-2">
+              Internal notes (optional)
+              <textarea
+                maxLength={2000}
+                value={draft.notes}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    notes: event.target.value,
+                  }))
+                }
+                rows={2}
+                className={`mt-1 ${inputClass}`}
+              />
+            </label>
+          </div>
+
+          <div className="mt-4 flex flex-wrap justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setShowForm(false)}
+              className="rounded-xl border border-[color:var(--desktop-border)] px-4 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)]"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="inline-flex items-center gap-1.5 rounded-xl bg-[var(--accent-copper)] px-4 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-55"
+            >
+              {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+              Activate agreement
+            </button>
+          </div>
+        </form>
+      ) : null}
+
+      {agreements.length > 0 ? (
+        <div className="border-t border-[color:var(--desktop-border)] p-4 sm:p-5">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+            <History className="h-4 w-4" /> Agreement history
+          </div>
+          <div className="mt-3 space-y-2">
+            {agreements.map((agreement) => (
+              <div
+                key={agreement.id}
+                className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                        {agreement.name}
+                      </span>
+                      <span className="rounded-full border border-[color:var(--desktop-border)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--theme-text-secondary)]">
+                        {agreement.status}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                      {sourceLabel(agreement.source_type)} ·{" "}
+                      {agreementTerms(agreement).join(" · ")} ·{" "}
+                      {effectiveWindow(agreement)}
+                    </div>
+                    {agreement.retired_reason ? (
+                      <div className="mt-1 text-[11px] text-[color:var(--theme-text-muted)]">
+                        {agreement.retired_reason}
+                      </div>
+                    ) : null}
+                  </div>
+                  {summary?.can_manage && agreement.status === "active" ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setRetiringId(
+                          retiringId === agreement.id ? null : agreement.id,
+                        );
+                        setRetirementReason("");
+                      }}
+                      className="rounded-lg border border-amber-300/35 bg-amber-400/10 px-2.5 py-1.5 text-xs font-semibold text-amber-100"
+                    >
+                      Retire
+                    </button>
+                  ) : null}
+                </div>
+                {retiringId === agreement.id ? (
+                  <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+                    <input
+                      autoFocus
+                      value={retirementReason}
+                      onChange={(event) =>
+                        setRetirementReason(event.target.value)
+                      }
+                      placeholder="Why is this agreement ending?"
+                      className={inputClass}
+                    />
+                    <button
+                      type="button"
+                      disabled={saving || retirementReason.trim().length < 3}
+                      onClick={() => void retireAgreement(agreement.id)}
+                      className="rounded-xl border border-amber-300/40 bg-amber-400/15 px-3 py-2 text-xs font-bold text-amber-50 disabled:opacity-45"
+                    >
+                      Confirm retirement
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/features/pricing/lib/customerPricing.test.ts
+++ b/features/pricing/lib/customerPricing.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  CUSTOMER_PRICING_PRECEDENCE,
+  resolveCustomerPricing,
+  selectEffectiveCustomerPricingAgreement,
+  type CustomerPricingAgreement,
+} from "./customerPricing";
+
+const customerRate: CustomerPricingAgreement = {
+  id: "customer-rate",
+  sourceType: "customer_specific",
+  status: "active",
+  currency: "CAD",
+  laborRate: 120,
+  laborDiscountPercent: 0,
+  partsDiscountPercent: 5,
+  effectiveFrom: "2026-01-01",
+  effectiveUntil: null,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+describe("customer pricing precedence", () => {
+  it("chooses a contract over a newer simple customer rate", () => {
+    const agreement = selectEffectiveCustomerPricingAgreement({
+      agreements: [
+        customerRate,
+        {
+          ...customerRate,
+          id: "fleet-contract",
+          sourceType: "fleet_contract",
+          laborRate: 105,
+          createdAt: "2025-12-01T00:00:00Z",
+        },
+      ],
+      at: "2026-08-12T00:00:00Z",
+    });
+
+    expect(agreement?.id).toBe("fleet-contract");
+  });
+
+  it("ignores retired, future, and expired agreements", () => {
+    const agreement = selectEffectiveCustomerPricingAgreement({
+      agreements: [
+        { ...customerRate, id: "retired", status: "retired" },
+        {
+          ...customerRate,
+          id: "future",
+          effectiveFrom: "2026-09-01",
+        },
+        {
+          ...customerRate,
+          id: "expired",
+          effectiveUntil: "2026-07-31",
+        },
+      ],
+      at: "2026-08-12T00:00:00Z",
+    });
+
+    expect(agreement).toBeNull();
+  });
+
+  it("applies fixed labor and parts discounts without touching cost", () => {
+    const resolution = resolveCustomerPricing({
+      agreements: [customerRate],
+      at: "2026-08-12T00:00:00Z",
+      currency: "CAD",
+      laborHours: 2.5,
+      baseLaborRate: 150,
+      basePartsTotal: 400,
+    });
+
+    expect(resolution).toMatchObject({
+      sourceType: "customer_specific",
+      precedenceRank: CUSTOMER_PRICING_PRECEDENCE.customer_specific,
+      resolvedLaborRate: 120,
+      resolvedLaborTotal: 300,
+      resolvedPartsTotal: 380,
+    });
+  });
+
+  it("accepts only an approved and attributed manual override", () => {
+    const unapproved = resolveCustomerPricing({
+      agreements: [customerRate],
+      manualOverride: {
+        approved: true,
+        approvedBy: null,
+        reason: "Goodwill",
+        laborRate: 80,
+      },
+      at: "2026-08-12T00:00:00Z",
+      currency: "CAD",
+      laborHours: 2,
+      baseLaborRate: 150,
+      basePartsTotal: 100,
+    });
+    const approved = resolveCustomerPricing({
+      agreements: [customerRate],
+      manualOverride: {
+        approved: true,
+        approvedBy: "owner-user-id",
+        reason: "Written contract exception",
+        laborRate: 80,
+        partsTotal: 70,
+      },
+      at: "2026-08-12T00:00:00Z",
+      currency: "CAD",
+      laborHours: 2,
+      baseLaborRate: 150,
+      basePartsTotal: 100,
+    });
+
+    expect(unapproved.sourceType).toBe("customer_specific");
+    expect(approved).toMatchObject({
+      sourceType: "manual_override",
+      precedenceRank: CUSTOMER_PRICING_PRECEDENCE.manual_override,
+      resolvedLaborRate: 80,
+      resolvedLaborTotal: 160,
+      resolvedPartsTotal: 70,
+    });
+  });
+});

--- a/features/pricing/lib/customerPricing.ts
+++ b/features/pricing/lib/customerPricing.ts
@@ -1,0 +1,192 @@
+export const CUSTOMER_PRICING_PRECEDENCE = {
+  manual_override: 1000,
+  fleet_contract: 800,
+  customer_contract: 800,
+  customer_specific: 700,
+  shop_default: 100,
+} as const;
+
+export type CustomerPricingSource = keyof typeof CUSTOMER_PRICING_PRECEDENCE;
+
+export type CustomerPricingAgreement = {
+  id: string;
+  sourceType: Exclude<
+    CustomerPricingSource,
+    "manual_override" | "shop_default"
+  >;
+  status: "active" | "superseded" | "retired";
+  currency: "CAD" | "USD";
+  laborRate: number | null;
+  laborDiscountPercent: number;
+  partsDiscountPercent: number;
+  effectiveFrom: string;
+  effectiveUntil: string | null;
+  createdAt: string;
+};
+
+export type ApprovedManualPricingOverride = {
+  approved: boolean;
+  approvedBy: string | null;
+  reason: string | null;
+  laborRate?: number | null;
+  laborTotal?: number | null;
+  partsTotal?: number | null;
+};
+
+export type CustomerPricingResolution = {
+  sourceType: CustomerPricingSource;
+  precedenceRank: number;
+  agreementId: string | null;
+  currency: "CAD" | "USD";
+  baseLaborRate: number;
+  resolvedLaborRate: number;
+  baseLaborTotal: number;
+  resolvedLaborTotal: number;
+  basePartsTotal: number;
+  resolvedPartsTotal: number;
+  laborDiscountPercent: number;
+  partsDiscountPercent: number;
+};
+
+function money(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function nonNegative(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+}
+
+function dateOnly(value: string): string {
+  return value.slice(0, 10);
+}
+
+function isEffective(agreement: CustomerPricingAgreement, at: string): boolean {
+  const day = dateOnly(at);
+  return (
+    agreement.status === "active" &&
+    agreement.effectiveFrom <= day &&
+    (!agreement.effectiveUntil || agreement.effectiveUntil >= day)
+  );
+}
+
+export function selectEffectiveCustomerPricingAgreement(input: {
+  agreements: CustomerPricingAgreement[];
+  at: string;
+}): CustomerPricingAgreement | null {
+  return (
+    input.agreements
+      .filter((agreement) => isEffective(agreement, input.at))
+      .sort((left, right) => {
+        const rankDelta =
+          CUSTOMER_PRICING_PRECEDENCE[right.sourceType] -
+          CUSTOMER_PRICING_PRECEDENCE[left.sourceType];
+        if (rankDelta !== 0) return rankDelta;
+        const effectiveDelta = right.effectiveFrom.localeCompare(
+          left.effectiveFrom,
+        );
+        if (effectiveDelta !== 0) return effectiveDelta;
+        const createdDelta = right.createdAt.localeCompare(left.createdAt);
+        if (createdDelta !== 0) return createdDelta;
+        return right.id.localeCompare(left.id);
+      })[0] ?? null
+  );
+}
+
+function isApprovedManualOverride(
+  override: ApprovedManualPricingOverride | null | undefined,
+): override is ApprovedManualPricingOverride {
+  return Boolean(
+    override?.approved &&
+    override.approvedBy?.trim() &&
+    override.reason?.trim(),
+  );
+}
+
+export function resolveCustomerPricing(input: {
+  agreements: CustomerPricingAgreement[];
+  manualOverride?: ApprovedManualPricingOverride | null;
+  at: string;
+  currency: "CAD" | "USD";
+  laborHours: number;
+  baseLaborRate: number;
+  basePartsTotal: number;
+}): CustomerPricingResolution {
+  const laborHours = nonNegative(input.laborHours);
+  const baseLaborRate = money(nonNegative(input.baseLaborRate));
+  const basePartsTotal = money(nonNegative(input.basePartsTotal));
+  const baseLaborTotal = money(laborHours * baseLaborRate);
+
+  if (isApprovedManualOverride(input.manualOverride)) {
+    const resolvedLaborRate = money(
+      nonNegative(input.manualOverride.laborRate ?? baseLaborRate),
+    );
+    const resolvedLaborTotal = money(
+      nonNegative(
+        input.manualOverride.laborTotal ?? laborHours * resolvedLaborRate,
+      ),
+    );
+    const resolvedPartsTotal = money(
+      nonNegative(input.manualOverride.partsTotal ?? basePartsTotal),
+    );
+    return {
+      sourceType: "manual_override",
+      precedenceRank: CUSTOMER_PRICING_PRECEDENCE.manual_override,
+      agreementId: null,
+      currency: input.currency,
+      baseLaborRate,
+      resolvedLaborRate,
+      baseLaborTotal,
+      resolvedLaborTotal,
+      basePartsTotal,
+      resolvedPartsTotal,
+      laborDiscountPercent: 0,
+      partsDiscountPercent: 0,
+    };
+  }
+
+  const agreement = selectEffectiveCustomerPricingAgreement({
+    agreements: input.agreements,
+    at: input.at,
+  });
+  if (!agreement) {
+    return {
+      sourceType: "shop_default",
+      precedenceRank: CUSTOMER_PRICING_PRECEDENCE.shop_default,
+      agreementId: null,
+      currency: input.currency,
+      baseLaborRate,
+      resolvedLaborRate: baseLaborRate,
+      baseLaborTotal,
+      resolvedLaborTotal: baseLaborTotal,
+      basePartsTotal,
+      resolvedPartsTotal: basePartsTotal,
+      laborDiscountPercent: 0,
+      partsDiscountPercent: 0,
+    };
+  }
+
+  const laborDiscountPercent = nonNegative(agreement.laborDiscountPercent);
+  const partsDiscountPercent = nonNegative(agreement.partsDiscountPercent);
+  const resolvedLaborRate = money(
+    agreement.laborRate == null
+      ? baseLaborRate * (1 - laborDiscountPercent / 100)
+      : nonNegative(agreement.laborRate),
+  );
+
+  return {
+    sourceType: agreement.sourceType,
+    precedenceRank: CUSTOMER_PRICING_PRECEDENCE[agreement.sourceType],
+    agreementId: agreement.id,
+    currency: agreement.currency,
+    baseLaborRate,
+    resolvedLaborRate,
+    baseLaborTotal,
+    resolvedLaborTotal: money(laborHours * resolvedLaborRate),
+    basePartsTotal,
+    resolvedPartsTotal: money(
+      basePartsTotal * (1 - partsDiscountPercent / 100),
+    ),
+    laborDiscountPercent,
+    partsDiscountPercent,
+  };
+}

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -3063,6 +3063,113 @@ export type Database = {
           },
         ]
       }
+      customer_pricing_agreements: {
+        Row: {
+          approval_reason: string
+          approved_by: string
+          created_at: string
+          created_by: string
+          currency: string
+          customer_id: string
+          effective_from: string
+          effective_until: string | null
+          id: string
+          labor_discount_percent: number
+          labor_rate: number | null
+          name: string
+          notes: string | null
+          operation_key: string
+          parts_discount_percent: number
+          retired_at: string | null
+          retired_by: string | null
+          retired_reason: string | null
+          shop_id: string
+          source_type: string
+          status: string
+          supersedes_agreement_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          approval_reason: string
+          approved_by: string
+          created_at?: string
+          created_by: string
+          currency?: string
+          customer_id: string
+          effective_from?: string
+          effective_until?: string | null
+          id?: string
+          labor_discount_percent?: number
+          labor_rate?: number | null
+          name: string
+          notes?: string | null
+          operation_key: string
+          parts_discount_percent?: number
+          retired_at?: string | null
+          retired_by?: string | null
+          retired_reason?: string | null
+          shop_id: string
+          source_type: string
+          status?: string
+          supersedes_agreement_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          approval_reason?: string
+          approved_by?: string
+          created_at?: string
+          created_by?: string
+          currency?: string
+          customer_id?: string
+          effective_from?: string
+          effective_until?: string | null
+          id?: string
+          labor_discount_percent?: number
+          labor_rate?: number | null
+          name?: string
+          notes?: string | null
+          operation_key?: string
+          parts_discount_percent?: number
+          retired_at?: string | null
+          retired_by?: string | null
+          retired_reason?: string | null
+          shop_id?: string
+          source_type?: string
+          status?: string
+          supersedes_agreement_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "customer_pricing_agreements_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_pricing_agreements_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_pricing_agreements_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_pricing_agreements_supersedes_agreement_id_fkey"
+            columns: ["supersedes_agreement_id"]
+            isOneToOne: false
+            referencedRelation: "customer_pricing_agreements"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       customer_quotes: {
         Row: {
           created_at: string | null
@@ -13315,6 +13422,168 @@ export type Database = {
           },
           {
             foreignKeyName: "portal_notifications_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "work_orders"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      pricing_resolution_snapshots: {
+        Row: {
+          agreement_id: string | null
+          base_labor_rate: number
+          base_labor_total: number
+          base_parts_total: number
+          created_at: string
+          currency: string
+          customer_id: string
+          id: string
+          input_snapshot: Json
+          labor_discount_percent: number
+          part_prices: Json
+          parts_discount_percent: number
+          precedence_rank: number
+          quote_line_id: string
+          resolution_hash: string
+          resolved_at: string
+          resolved_by: string
+          resolved_labor_rate: number
+          resolved_labor_total: number
+          resolved_parts_total: number
+          result_snapshot: Json
+          shop_id: string
+          source_type: string
+          supersedes_snapshot_id: string | null
+          work_order_id: string
+        }
+        Insert: {
+          agreement_id?: string | null
+          base_labor_rate: number
+          base_labor_total: number
+          base_parts_total: number
+          created_at?: string
+          currency: string
+          customer_id: string
+          id?: string
+          input_snapshot?: Json
+          labor_discount_percent: number
+          part_prices?: Json
+          parts_discount_percent: number
+          precedence_rank: number
+          quote_line_id: string
+          resolution_hash: string
+          resolved_at?: string
+          resolved_by: string
+          resolved_labor_rate: number
+          resolved_labor_total: number
+          resolved_parts_total: number
+          result_snapshot?: Json
+          shop_id: string
+          source_type: string
+          supersedes_snapshot_id?: string | null
+          work_order_id: string
+        }
+        Update: {
+          agreement_id?: string | null
+          base_labor_rate?: number
+          base_labor_total?: number
+          base_parts_total?: number
+          created_at?: string
+          currency?: string
+          customer_id?: string
+          id?: string
+          input_snapshot?: Json
+          labor_discount_percent?: number
+          part_prices?: Json
+          parts_discount_percent?: number
+          precedence_rank?: number
+          quote_line_id?: string
+          resolution_hash?: string
+          resolved_at?: string
+          resolved_by?: string
+          resolved_labor_rate?: number
+          resolved_labor_total?: number
+          resolved_parts_total?: number
+          result_snapshot?: Json
+          shop_id?: string
+          source_type?: string
+          supersedes_snapshot_id?: string | null
+          work_order_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pricing_resolution_snapshots_agreement_id_fkey"
+            columns: ["agreement_id"]
+            isOneToOne: false
+            referencedRelation: "customer_pricing_agreements"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pricing_resolution_snapshots_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pricing_resolution_snapshots_quote_line_id_fkey"
+            columns: ["quote_line_id"]
+            isOneToOne: false
+            referencedRelation: "work_order_quote_lines"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pricing_resolution_snapshots_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pricing_resolution_snapshots_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pricing_resolution_snapshots_supersedes_snapshot_id_fkey"
+            columns: ["supersedes_snapshot_id"]
+            isOneToOne: false
+            referencedRelation: "pricing_resolution_snapshots"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "pricing_resolution_snapshots_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "v_portal_invoices"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "pricing_resolution_snapshots_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "v_work_order_board_cards_fleet"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "pricing_resolution_snapshots_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "v_work_order_board_cards_portal"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "pricing_resolution_snapshots_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "v_work_order_board_cards_shop"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "pricing_resolution_snapshots_work_order_id_fkey"
             columns: ["work_order_id"]
             isOneToOne: false
             referencedRelation: "work_orders"
@@ -24288,6 +24557,7 @@ export type Database = {
           converted_at: string | null
           created_at: string
           created_by: string | null
+          customer_pricing_snapshot_id: string | null
           decision: string | null
           decline_reason: string | null
           declined_at: string | null
@@ -24337,6 +24607,7 @@ export type Database = {
           converted_at?: string | null
           created_at?: string
           created_by?: string | null
+          customer_pricing_snapshot_id?: string | null
           decision?: string | null
           decline_reason?: string | null
           declined_at?: string | null
@@ -24386,6 +24657,7 @@ export type Database = {
           converted_at?: string | null
           created_at?: string
           created_by?: string | null
+          customer_pricing_snapshot_id?: string | null
           decision?: string | null
           decline_reason?: string | null
           declined_at?: string | null
@@ -24427,6 +24699,13 @@ export type Database = {
           work_order_line_id?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "work_order_quote_lines_customer_pricing_snapshot_id_fkey"
+            columns: ["customer_pricing_snapshot_id"]
+            isOneToOne: false
+            referencedRelation: "pricing_resolution_snapshots"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "work_order_quote_lines_shop_id_fkey"
             columns: ["shop_id"]
@@ -26211,6 +26490,16 @@ export type Database = {
         }
         Returns: Json
       }
+      apply_customer_pricing_to_quote_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_at?: string
+          p_quote_line_ids: string[]
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
       apply_customer_quote_decision_atomic: {
         Args: {
           p_actor_user_id: string
@@ -26795,6 +27084,26 @@ export type Database = {
         }
         Returns: string
       }
+      create_customer_pricing_agreement_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_approval_reason: string
+          p_at?: string
+          p_currency: string
+          p_customer_id: string
+          p_effective_from: string
+          p_effective_until: string
+          p_labor_discount_percent: number
+          p_labor_rate: number
+          p_name: string
+          p_notes: string
+          p_operation_key: string
+          p_parts_discount_percent: number
+          p_shop_id: string
+          p_source_type: string
+        }
+        Returns: Json
+      }
       create_estimate_atomic: {
         Args: {
           p_customer: Json
@@ -27224,6 +27533,10 @@ export type Database = {
       }
       first_segment_uuid: { Args: { p: string }; Returns: string }
       fleet_defect_descriptor: { Args: { p_key: string }; Returns: Json }
+      get_customer_pricing_account_summary: {
+        Args: { p_at?: string; p_customer_id: string; p_shop_id: string }
+        Returns: Json
+      }
       get_fleet_defect_queue: { Args: { p_fleet_id?: string }; Returns: Json }
       get_invoice_net_issued_parts: {
         Args: { p_shop_id: string; p_work_order_id: string }
@@ -28234,6 +28547,16 @@ export type Database = {
           p_clarification_id: string
           p_evidence: Json
           p_response_text: string
+        }
+        Returns: Json
+      }
+      retire_customer_pricing_agreement_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_agreement_id: string
+          p_at?: string
+          p_reason: string
+          p_shop_id: string
         }
         Returns: Json
       }

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -73,6 +73,7 @@ type QuoteMetadata = {
   parts?: Json;
   parts_quote?: Json;
   labor_rate?: Json;
+  customer_pricing?: Json;
   technician_notes?: Json;
   tech_notes?: Json;
 };
@@ -256,6 +257,46 @@ function partsQuoteSummary(line: Pick<QuoteLine, "metadata">): {
     partsTotal: jsonNumber(record.parts_total),
     ...sanitization,
   };
+}
+
+function customerPricingSummary(line: Pick<QuoteLine, "metadata">): {
+  sourceType: string;
+  agreementName: string | null;
+  baseLaborRate: number | null;
+  resolvedLaborRate: number | null;
+  laborDiscountPercent: number;
+  partsDiscountPercent: number;
+} | null {
+  const value = quoteMetadata(line).customer_pricing;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, Json>;
+  const sourceType = jsonString(record.source_type);
+  if (!sourceType || sourceType === "shop_default") return null;
+  return {
+    sourceType,
+    agreementName: jsonString(record.agreement_name) || null,
+    baseLaborRate: jsonNumber(record.base_labor_rate),
+    resolvedLaborRate: jsonNumber(record.resolved_labor_rate),
+    laborDiscountPercent: jsonNumber(record.labor_discount_percent) ?? 0,
+    partsDiscountPercent: jsonNumber(record.parts_discount_percent) ?? 0,
+  };
+}
+
+function customerPricingLabel(summary: NonNullable<ReturnType<typeof customerPricingSummary>>): string {
+  const source = summary.sourceType.replaceAll("_", " ");
+  const terms = [
+    summary.resolvedLaborRate != null &&
+    summary.baseLaborRate != null &&
+    summary.resolvedLaborRate !== summary.baseLaborRate
+      ? `labor ${fmt(summary.resolvedLaborRate)}/hr`
+      : summary.laborDiscountPercent > 0
+        ? `${summary.laborDiscountPercent}% labor`
+        : null,
+    summary.partsDiscountPercent > 0
+      ? `${summary.partsDiscountPercent}% parts`
+      : null,
+  ].filter(Boolean);
+  return `${summary.agreementName || source}${terms.length > 0 ? ` · ${terms.join(" · ")}` : ""}`;
 }
 
 function partsWorkflowLabel(line: EditableQuoteLine): { label: string; tone: "warn" | "ok" | "info" } | null {
@@ -509,6 +550,23 @@ export default function QuoteReviewView(props: {
     const shopId = woRow?.shop_id ?? null;
 
     if (shopId) {
+      const pricingResponse = await fetch(
+        `/api/work-orders/${woId}/customer-pricing`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ quoteLineIds: [] }),
+        },
+      );
+      if (!pricingResponse.ok && pricingResponse.status !== 403) {
+        const pricingPayload = (await pricingResponse
+          .json()
+          .catch(() => null)) as { error?: string } | null;
+        toast.error(
+          pricingPayload?.error ?? "Customer pricing could not be resolved.",
+        );
+      }
+
       const [{ data: shopRow, error: shopErr }, { data: qRows, error: qErr }, { data: wlRows, error: wlErr }] = await Promise.all([
         supabase.from("shops").select("*").eq("id", shopId).maybeSingle(),
         supabase
@@ -731,6 +789,7 @@ export default function QuoteReviewView(props: {
           notes: line.notes,
           est_labor_hours: line.est_labor_hours,
           labor_hours: laborHours,
+          labor_rate: quoteLineLaborRate(line, laborRate),
           labor_total: laborTotal,
           parts_total: partsTotal,
           subtotal,
@@ -748,6 +807,23 @@ export default function QuoteReviewView(props: {
           .eq("shop_id", wo.shop_id)
           .eq("work_order_id", woId);
         if (error) throw error;
+      }
+
+      const pricingResponse = await fetch(
+        `/api/work-orders/${woId}/customer-pricing`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ quoteLineIds: dirty.map((line) => line.id) }),
+        },
+      );
+      const pricingPayload = (await pricingResponse.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      if (!pricingResponse.ok) {
+        throw new Error(
+          pricingPayload?.error ?? "Customer pricing could not be resolved.",
+        );
       }
 
       toast.success("Quote lines saved.");
@@ -1008,6 +1084,7 @@ export default function QuoteReviewView(props: {
                     const finalDecision = isFinalDecision(line);
                     const pricingQuarantined =
                       partsSummary?.customerPricingQuarantined === true;
+                    const dedicatedPricing = customerPricingSummary(line);
                     const commercialEditingDisabled =
                       finalDecision || pricingQuarantined;
                     const finalizedLineTotalUnavailable =
@@ -1025,6 +1102,7 @@ export default function QuoteReviewView(props: {
                                 <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">Quote line {index + 1}</div>
                                 <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${badgeClass(workflow.tone)}`}>{workflow.label}</span>
                                 {partsWorkflow ? <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${badgeClass(partsWorkflow.tone)}`}>{partsWorkflow.label}</span> : null}
+                                {dedicatedPricing ? <span className="rounded-full border border-emerald-300/35 bg-emerald-400/10 px-2.5 py-1 text-[11px] font-semibold capitalize text-emerald-100">{customerPricingLabel(dedicatedPricing)}</span> : null}
                                 {line._dirty ? <span className="rounded-full border border-amber-300/40 bg-amber-400/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100">Unsaved</span> : null}
                               </div>
                               <h3 className="mt-2 text-base font-semibold text-[color:var(--theme-text-primary)]">{safeTrim(line.description) || "Untitled quote line"}</h3>

--- a/supabase/migrations/20260812022359_customer_specific_pricing_engine.sql
+++ b/supabase/migrations/20260812022359_customer_specific_pricing_engine.sql
@@ -1,0 +1,1364 @@
+begin;
+
+set local lock_timeout = '10s';
+set local statement_timeout = '120s';
+
+create table public.customer_pricing_agreements (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete restrict,
+  customer_id uuid not null references public.customers(id) on delete restrict,
+  source_type text not null check (
+    source_type in ('customer_specific', 'customer_contract', 'fleet_contract')
+  ),
+  name text not null check (length(btrim(name)) between 1 and 120),
+  status text not null default 'active' check (
+    status in ('active', 'superseded', 'retired')
+  ),
+  currency text not null default 'CAD' check (currency in ('CAD', 'USD')),
+  labor_rate numeric(12,2),
+  labor_discount_percent numeric(5,2) not null default 0,
+  parts_discount_percent numeric(5,2) not null default 0,
+  effective_from date not null default current_date,
+  effective_until date,
+  approval_reason text not null check (
+    length(btrim(approval_reason)) between 3 and 500
+  ),
+  notes text,
+  operation_key text not null check (length(btrim(operation_key)) between 1 and 200),
+  supersedes_agreement_id uuid references public.customer_pricing_agreements(id) on delete restrict,
+  approved_by uuid not null references auth.users(id) on delete restrict,
+  retired_by uuid references auth.users(id) on delete restrict,
+  retired_at timestamptz,
+  retired_reason text,
+  created_by uuid not null references auth.users(id) on delete restrict,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint customer_pricing_agreements_labor_rate_nonnegative
+    check (labor_rate is null or labor_rate >= 0),
+  constraint customer_pricing_agreements_labor_discount_range
+    check (labor_discount_percent between 0 and 100),
+  constraint customer_pricing_agreements_parts_discount_range
+    check (parts_discount_percent between 0 and 100),
+  constraint customer_pricing_agreements_single_labor_strategy
+    check (labor_rate is null or labor_discount_percent = 0),
+  constraint customer_pricing_agreements_has_adjustment
+    check (
+      labor_rate is not null
+      or labor_discount_percent > 0
+      or parts_discount_percent > 0
+    ),
+  constraint customer_pricing_agreements_effective_window
+    check (effective_until is null or effective_until >= effective_from),
+  constraint customer_pricing_agreements_retirement_shape
+    check (
+      (status = 'active' and retired_at is null and retired_by is null)
+      or (
+        status in ('superseded', 'retired')
+        and retired_at is not null
+        and retired_by is not null
+        and length(btrim(coalesce(retired_reason, ''))) >= 3
+      )
+    ),
+  unique (shop_id, operation_key)
+);
+
+create index customer_pricing_agreements_customer_lookup_idx
+  on public.customer_pricing_agreements (
+    shop_id,
+    customer_id,
+    status,
+    source_type,
+    effective_from desc,
+    created_at desc
+  );
+
+create index customer_pricing_agreements_effective_until_idx
+  on public.customer_pricing_agreements (shop_id, effective_until)
+  where status = 'active' and effective_until is not null;
+
+create table public.pricing_resolution_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete restrict,
+  customer_id uuid not null references public.customers(id) on delete restrict,
+  work_order_id uuid not null references public.work_orders(id) on delete restrict,
+  quote_line_id uuid not null references public.work_order_quote_lines(id) on delete restrict,
+  agreement_id uuid references public.customer_pricing_agreements(id) on delete restrict,
+  supersedes_snapshot_id uuid references public.pricing_resolution_snapshots(id) on delete restrict,
+  source_type text not null check (
+    source_type in (
+      'manual_override',
+      'fleet_contract',
+      'customer_contract',
+      'customer_specific',
+      'shop_default'
+    )
+  ),
+  precedence_rank integer not null check (precedence_rank between 100 and 1000),
+  currency text not null check (currency in ('CAD', 'USD')),
+  base_labor_rate numeric(12,2) not null check (base_labor_rate >= 0),
+  resolved_labor_rate numeric(12,2) not null check (resolved_labor_rate >= 0),
+  labor_discount_percent numeric(5,2) not null check (
+    labor_discount_percent between 0 and 100
+  ),
+  base_labor_total numeric(12,2) not null check (base_labor_total >= 0),
+  resolved_labor_total numeric(12,2) not null check (resolved_labor_total >= 0),
+  base_parts_total numeric(12,2) not null check (base_parts_total >= 0),
+  resolved_parts_total numeric(12,2) not null check (resolved_parts_total >= 0),
+  parts_discount_percent numeric(5,2) not null check (
+    parts_discount_percent between 0 and 100
+  ),
+  part_prices jsonb not null default '[]'::jsonb check (
+    jsonb_typeof(part_prices) = 'array'
+  ),
+  input_snapshot jsonb not null default '{}'::jsonb check (
+    jsonb_typeof(input_snapshot) = 'object'
+  ),
+  result_snapshot jsonb not null default '{}'::jsonb check (
+    jsonb_typeof(result_snapshot) = 'object'
+  ),
+  resolution_hash text not null check (resolution_hash ~ '^[0-9a-f]{64}$'),
+  resolved_by uuid not null references auth.users(id) on delete restrict,
+  resolved_at timestamptz not null default now(),
+  created_at timestamptz not null default now()
+);
+
+create index pricing_resolution_snapshots_quote_line_idx
+  on public.pricing_resolution_snapshots (shop_id, quote_line_id, resolved_at desc);
+
+create index pricing_resolution_snapshots_work_order_idx
+  on public.pricing_resolution_snapshots (shop_id, work_order_id, resolved_at desc);
+
+create index pricing_resolution_snapshots_customer_idx
+  on public.pricing_resolution_snapshots (shop_id, customer_id, resolved_at desc);
+
+alter table public.work_order_quote_lines
+  add column customer_pricing_snapshot_id uuid;
+
+alter table public.work_order_quote_lines
+  add constraint work_order_quote_lines_customer_pricing_snapshot_id_fkey
+  foreign key (customer_pricing_snapshot_id)
+  references public.pricing_resolution_snapshots(id)
+  on delete restrict;
+
+create index work_order_quote_lines_customer_pricing_snapshot_idx
+  on public.work_order_quote_lines (customer_pricing_snapshot_id)
+  where customer_pricing_snapshot_id is not null;
+
+alter table public.customer_pricing_agreements enable row level security;
+alter table public.pricing_resolution_snapshots enable row level security;
+
+create policy customer_pricing_agreements_staff_select
+  on public.customer_pricing_agreements
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles profile
+      where profile.shop_id = customer_pricing_agreements.shop_id
+        and (
+          profile.id = (select auth.uid())
+          or profile.user_id = (select auth.uid())
+        )
+        and public.canonical_shop_membership_role(profile.role::text) in (
+          'owner', 'admin', 'manager', 'advisor', 'service', 'foreman'
+        )
+    )
+  );
+
+create policy pricing_resolution_snapshots_staff_select
+  on public.pricing_resolution_snapshots
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles profile
+      where profile.shop_id = pricing_resolution_snapshots.shop_id
+        and (
+          profile.id = (select auth.uid())
+          or profile.user_id = (select auth.uid())
+        )
+        and public.canonical_shop_membership_role(profile.role::text) in (
+          'owner', 'admin', 'manager', 'advisor', 'service', 'foreman'
+        )
+    )
+  );
+
+revoke all on table public.customer_pricing_agreements
+  from public, anon, authenticated;
+grant select on table public.customer_pricing_agreements to authenticated;
+grant all on table public.customer_pricing_agreements to service_role;
+
+revoke all on table public.pricing_resolution_snapshots
+  from public, anon, authenticated;
+grant select on table public.pricing_resolution_snapshots to authenticated;
+grant all on table public.pricing_resolution_snapshots to service_role;
+
+create or replace function private.guard_customer_pricing_agreement_history()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if tg_op = 'DELETE' then
+    raise exception using
+      errcode = '55000',
+      message = 'CUSTOMER_PRICING_AGREEMENT_HISTORY_IS_APPEND_ONLY';
+  end if;
+
+  if old.status <> 'active' then
+    raise exception using
+      errcode = '55000',
+      message = 'CUSTOMER_PRICING_AGREEMENT_TERMINAL_STATE_IS_IMMUTABLE';
+  end if;
+
+  if new.status not in ('superseded', 'retired')
+     or new.shop_id is distinct from old.shop_id
+     or new.customer_id is distinct from old.customer_id
+     or new.source_type is distinct from old.source_type
+     or new.name is distinct from old.name
+     or new.currency is distinct from old.currency
+     or new.labor_rate is distinct from old.labor_rate
+     or new.labor_discount_percent is distinct from old.labor_discount_percent
+     or new.parts_discount_percent is distinct from old.parts_discount_percent
+     or new.effective_from is distinct from old.effective_from
+     or new.effective_until is distinct from old.effective_until
+     or new.approval_reason is distinct from old.approval_reason
+     or new.notes is distinct from old.notes
+     or new.operation_key is distinct from old.operation_key
+     or new.supersedes_agreement_id is distinct from old.supersedes_agreement_id
+     or new.approved_by is distinct from old.approved_by
+     or new.created_by is distinct from old.created_by
+     or new.created_at is distinct from old.created_at then
+    raise exception using
+      errcode = '55000',
+      message = 'CUSTOMER_PRICING_AGREEMENT_TERMS_REQUIRE_A_NEW_VERSION';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function private.guard_customer_pricing_agreement_history()
+  from public, anon, authenticated, service_role;
+
+create trigger guard_customer_pricing_agreement_history
+before update or delete on public.customer_pricing_agreements
+for each row execute function private.guard_customer_pricing_agreement_history();
+
+create or replace function private.guard_pricing_resolution_snapshot_history()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  raise exception using
+    errcode = '55000',
+    message = 'PRICING_RESOLUTION_SNAPSHOTS_ARE_IMMUTABLE';
+end;
+$$;
+
+revoke all on function private.guard_pricing_resolution_snapshot_history()
+  from public, anon, authenticated, service_role;
+
+create trigger guard_pricing_resolution_snapshot_history
+before update or delete on public.pricing_resolution_snapshots
+for each row execute function private.guard_pricing_resolution_snapshot_history();
+
+create or replace function public.create_customer_pricing_agreement_atomic(
+  p_shop_id uuid,
+  p_customer_id uuid,
+  p_source_type text,
+  p_name text,
+  p_currency text,
+  p_labor_rate numeric,
+  p_labor_discount_percent numeric,
+  p_parts_discount_percent numeric,
+  p_effective_from date,
+  p_effective_until date,
+  p_approval_reason text,
+  p_notes text,
+  p_operation_key text,
+  p_actor_user_id uuid,
+  p_at timestamptz default now()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor_role text;
+  v_existing public.customer_pricing_agreements%rowtype;
+  v_superseded_id uuid;
+  v_created public.customer_pricing_agreements%rowtype;
+  v_now timestamptz := coalesce(p_at, now());
+  v_source_type text := lower(btrim(coalesce(p_source_type, '')));
+  v_currency text := upper(btrim(coalesce(p_currency, 'CAD')));
+  v_labor_rate numeric := case
+    when p_labor_rate is null then null
+    else round(p_labor_rate, 2)
+  end;
+  v_labor_discount numeric := round(coalesce(p_labor_discount_percent, 0), 2);
+  v_parts_discount numeric := round(coalesce(p_parts_discount_percent, 0), 2);
+begin
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'PRICING_ACTOR_MISMATCH';
+  end if;
+
+  select public.canonical_shop_membership_role(profile.role::text)
+    into v_actor_role
+  from public.profiles profile
+  where profile.shop_id = p_shop_id
+    and (profile.id = p_actor_user_id or profile.user_id = p_actor_user_id)
+  order by case when profile.user_id = p_actor_user_id then 0 else 1 end
+  limit 1;
+
+  if coalesce(v_actor_role, '') not in ('owner', 'admin', 'manager') then
+    raise exception using errcode = '42501', message = 'PRICING_MANAGER_ROLE_REQUIRED';
+  end if;
+
+  select agreement.*
+    into v_existing
+  from public.customer_pricing_agreements agreement
+  where agreement.shop_id = p_shop_id
+    and agreement.operation_key = btrim(coalesce(p_operation_key, ''));
+
+  if found then
+    if v_existing.customer_id is distinct from p_customer_id
+       or v_existing.source_type is distinct from v_source_type
+       or v_existing.name is distinct from btrim(coalesce(p_name, ''))
+       or v_existing.currency is distinct from v_currency
+       or v_existing.labor_rate is distinct from v_labor_rate
+       or v_existing.labor_discount_percent is distinct from v_labor_discount
+       or v_existing.parts_discount_percent is distinct from v_parts_discount
+       or v_existing.effective_from is distinct from coalesce(p_effective_from, v_now::date)
+       or v_existing.effective_until is distinct from p_effective_until
+       or v_existing.approval_reason is distinct from btrim(coalesce(p_approval_reason, '')) then
+      raise exception using errcode = '22023', message = 'PRICING_OPERATION_KEY_CONFLICT';
+    end if;
+    return jsonb_build_object(
+      'ok', true,
+      'idempotent', true,
+      'agreement', to_jsonb(v_existing)
+    );
+  end if;
+
+  if nullif(btrim(coalesce(p_operation_key, '')), '') is null
+     or length(btrim(p_operation_key)) > 200 then
+    raise exception using errcode = '22023', message = 'A valid pricing operation key is required.';
+  end if;
+  if v_source_type not in ('customer_specific', 'customer_contract', 'fleet_contract') then
+    raise exception using errcode = '22023', message = 'Unsupported customer pricing source.';
+  end if;
+  if v_currency not in ('CAD', 'USD') then
+    raise exception using errcode = '22023', message = 'Pricing currency must be CAD or USD.';
+  end if;
+  if length(btrim(coalesce(p_name, ''))) not between 1 and 120 then
+    raise exception using errcode = '22023', message = 'Agreement name is required and must be 120 characters or fewer.';
+  end if;
+  if length(btrim(coalesce(p_approval_reason, ''))) not between 3 and 500 then
+    raise exception using errcode = '22023', message = 'Approval reason must be between 3 and 500 characters.';
+  end if;
+  if v_labor_rate < 0
+     or v_labor_discount not between 0 and 100
+     or v_parts_discount not between 0 and 100 then
+    raise exception using errcode = '22023', message = 'Pricing values are outside the supported range.';
+  end if;
+  if v_labor_rate is not null and v_labor_discount > 0 then
+    raise exception using errcode = '22023', message = 'Choose a fixed labor rate or a labor discount, not both.';
+  end if;
+  if v_labor_rate is null and v_labor_discount = 0 and v_parts_discount = 0 then
+    raise exception using errcode = '22023', message = 'At least one customer pricing adjustment is required.';
+  end if;
+  if p_effective_until is not null
+     and p_effective_until < coalesce(p_effective_from, v_now::date) then
+    raise exception using errcode = '22023', message = 'Agreement end date cannot be before its start date.';
+  end if;
+  if not exists (
+    select 1
+    from public.customers customer
+    where customer.id = p_customer_id
+      and customer.shop_id = p_shop_id
+      and coalesce(customer.active, true)
+  ) then
+    raise exception using errcode = 'P0002', message = 'Customer account not found for shop.';
+  end if;
+  if v_source_type = 'fleet_contract'
+     and not exists (
+       select 1
+       from public.fleets fleet
+       where fleet.shop_id = p_shop_id
+         and fleet.customer_id = p_customer_id
+         and coalesce(fleet.active, true)
+     ) then
+    raise exception using errcode = '23514', message = 'Fleet contract pricing requires a linked active Fleet account.';
+  end if;
+
+  select agreement.id
+    into v_superseded_id
+  from public.customer_pricing_agreements agreement
+  where agreement.shop_id = p_shop_id
+    and agreement.customer_id = p_customer_id
+    and agreement.status = 'active'
+    and (
+      agreement.source_type = v_source_type
+      or (
+        agreement.source_type in ('customer_contract', 'fleet_contract')
+        and v_source_type in ('customer_contract', 'fleet_contract')
+      )
+    )
+  order by agreement.effective_from desc, agreement.created_at desc, agreement.id desc
+  limit 1
+  for update;
+
+  update public.customer_pricing_agreements agreement
+  set status = 'superseded',
+      retired_by = p_actor_user_id,
+      retired_at = v_now,
+      retired_reason = 'Superseded by a newer pricing agreement.',
+      updated_at = v_now
+  where agreement.shop_id = p_shop_id
+    and agreement.customer_id = p_customer_id
+    and agreement.status = 'active'
+    and (
+      agreement.source_type = v_source_type
+      or (
+        agreement.source_type in ('customer_contract', 'fleet_contract')
+        and v_source_type in ('customer_contract', 'fleet_contract')
+      )
+    );
+
+  insert into public.customer_pricing_agreements (
+    shop_id,
+    customer_id,
+    source_type,
+    name,
+    status,
+    currency,
+    labor_rate,
+    labor_discount_percent,
+    parts_discount_percent,
+    effective_from,
+    effective_until,
+    approval_reason,
+    notes,
+    operation_key,
+    supersedes_agreement_id,
+    approved_by,
+    created_by,
+    created_at,
+    updated_at
+  ) values (
+    p_shop_id,
+    p_customer_id,
+    v_source_type,
+    btrim(p_name),
+    'active',
+    v_currency,
+    v_labor_rate,
+    v_labor_discount,
+    v_parts_discount,
+    coalesce(p_effective_from, v_now::date),
+    p_effective_until,
+    btrim(p_approval_reason),
+    nullif(btrim(coalesce(p_notes, '')), ''),
+    btrim(p_operation_key),
+    v_superseded_id,
+    p_actor_user_id,
+    p_actor_user_id,
+    v_now,
+    v_now
+  )
+  returning * into v_created;
+
+  insert into public.operational_events (
+    shop_id,
+    event_type,
+    actor_user_id,
+    actor_role,
+    entity_type,
+    entity_id,
+    source,
+    idempotency_key,
+    metadata
+  ) values (
+    p_shop_id,
+    'customer_pricing.agreement_created',
+    p_actor_user_id,
+    v_actor_role,
+    'customer_pricing_agreement',
+    v_created.id,
+    'customer_pricing_engine',
+    'customer-pricing-agreement:' || btrim(p_operation_key),
+    jsonb_build_object(
+      'customer_id', p_customer_id,
+      'source_type', v_source_type,
+      'supersedes_agreement_id', v_superseded_id,
+      'effective_from', v_created.effective_from,
+      'effective_until', v_created.effective_until
+    )
+  )
+  on conflict (shop_id, idempotency_key) where idempotency_key is not null
+  do nothing;
+
+  return jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'agreement', to_jsonb(v_created)
+  );
+end;
+$$;
+
+revoke all on function public.create_customer_pricing_agreement_atomic(
+  uuid, uuid, text, text, text, numeric, numeric, numeric, date, date,
+  text, text, text, uuid, timestamptz
+) from public, anon;
+grant execute on function public.create_customer_pricing_agreement_atomic(
+  uuid, uuid, text, text, text, numeric, numeric, numeric, date, date,
+  text, text, text, uuid, timestamptz
+) to authenticated, service_role;
+
+create or replace function public.retire_customer_pricing_agreement_atomic(
+  p_shop_id uuid,
+  p_agreement_id uuid,
+  p_actor_user_id uuid,
+  p_reason text,
+  p_at timestamptz default now()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor_role text;
+  v_agreement public.customer_pricing_agreements%rowtype;
+  v_now timestamptz := coalesce(p_at, now());
+begin
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'PRICING_ACTOR_MISMATCH';
+  end if;
+
+  select public.canonical_shop_membership_role(profile.role::text)
+    into v_actor_role
+  from public.profiles profile
+  where profile.shop_id = p_shop_id
+    and (profile.id = p_actor_user_id or profile.user_id = p_actor_user_id)
+  order by case when profile.user_id = p_actor_user_id then 0 else 1 end
+  limit 1;
+
+  if coalesce(v_actor_role, '') not in ('owner', 'admin', 'manager') then
+    raise exception using errcode = '42501', message = 'PRICING_MANAGER_ROLE_REQUIRED';
+  end if;
+  if length(btrim(coalesce(p_reason, ''))) not between 3 and 500 then
+    raise exception using errcode = '22023', message = 'Retirement reason must be between 3 and 500 characters.';
+  end if;
+
+  select agreement.*
+    into v_agreement
+  from public.customer_pricing_agreements agreement
+  where agreement.id = p_agreement_id
+    and agreement.shop_id = p_shop_id
+  for update;
+
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Pricing agreement not found for shop.';
+  end if;
+  if v_agreement.status <> 'active' then
+    return jsonb_build_object(
+      'ok', true,
+      'idempotent', true,
+      'agreement', to_jsonb(v_agreement)
+    );
+  end if;
+
+  update public.customer_pricing_agreements
+  set status = 'retired',
+      retired_by = p_actor_user_id,
+      retired_at = v_now,
+      retired_reason = btrim(p_reason),
+      updated_at = v_now
+  where id = p_agreement_id
+    and shop_id = p_shop_id
+  returning * into v_agreement;
+
+  insert into public.operational_events (
+    shop_id,
+    event_type,
+    actor_user_id,
+    actor_role,
+    entity_type,
+    entity_id,
+    source,
+    metadata
+  ) values (
+    p_shop_id,
+    'customer_pricing.agreement_retired',
+    p_actor_user_id,
+    v_actor_role,
+    'customer_pricing_agreement',
+    p_agreement_id,
+    'customer_pricing_engine',
+    jsonb_build_object(
+      'customer_id', v_agreement.customer_id,
+      'reason', btrim(p_reason)
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'agreement', to_jsonb(v_agreement)
+  );
+end;
+$$;
+
+revoke all on function public.retire_customer_pricing_agreement_atomic(
+  uuid, uuid, uuid, text, timestamptz
+) from public, anon;
+grant execute on function public.retire_customer_pricing_agreement_atomic(
+  uuid, uuid, uuid, text, timestamptz
+) to authenticated, service_role;
+
+create or replace function public.get_customer_pricing_account_summary(
+  p_shop_id uuid,
+  p_customer_id uuid,
+  p_at timestamptz default now()
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_actor_role text;
+  v_customer public.customers%rowtype;
+  v_effective public.customer_pricing_agreements%rowtype;
+  v_agreements jsonb := '[]'::jsonb;
+  v_has_fleet boolean := false;
+begin
+  if (select auth.uid()) is null then
+    raise exception using errcode = '42501', message = 'Authentication required.';
+  end if;
+
+  select public.canonical_shop_membership_role(profile.role::text)
+    into v_actor_role
+  from public.profiles profile
+  where profile.shop_id = p_shop_id
+    and (
+      profile.id = (select auth.uid())
+      or profile.user_id = (select auth.uid())
+    )
+  order by case when profile.user_id = (select auth.uid()) then 0 else 1 end
+  limit 1;
+
+  if coalesce(v_actor_role, '') not in (
+    'owner', 'admin', 'manager', 'advisor', 'service', 'foreman'
+  ) then
+    raise exception using errcode = '42501', message = 'Customer pricing access denied.';
+  end if;
+
+  select customer.*
+    into v_customer
+  from public.customers customer
+  where customer.id = p_customer_id
+    and customer.shop_id = p_shop_id;
+
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Customer account not found for shop.';
+  end if;
+
+  select exists (
+    select 1
+    from public.fleets fleet
+    where fleet.shop_id = p_shop_id
+      and fleet.customer_id = p_customer_id
+      and coalesce(fleet.active, true)
+  ) into v_has_fleet;
+
+  select coalesce(
+    jsonb_agg(to_jsonb(agreement) order by
+      case agreement.status when 'active' then 0 else 1 end,
+      agreement.effective_from desc,
+      agreement.created_at desc,
+      agreement.id desc
+    ),
+    '[]'::jsonb
+  )
+  into v_agreements
+  from public.customer_pricing_agreements agreement
+  where agreement.shop_id = p_shop_id
+    and agreement.customer_id = p_customer_id;
+
+  select agreement.*
+    into v_effective
+  from public.customer_pricing_agreements agreement
+  where agreement.shop_id = p_shop_id
+    and agreement.customer_id = p_customer_id
+    and agreement.status = 'active'
+    and agreement.effective_from <= coalesce(p_at, now())::date
+    and (
+      agreement.effective_until is null
+      or agreement.effective_until >= coalesce(p_at, now())::date
+    )
+  order by
+    case agreement.source_type
+      when 'fleet_contract' then 800
+      when 'customer_contract' then 800
+      when 'customer_specific' then 700
+      else 100
+    end desc,
+    agreement.effective_from desc,
+    agreement.created_at desc,
+    agreement.id desc
+  limit 1;
+
+  return jsonb_build_object(
+    'ok', true,
+    'customer_id', p_customer_id,
+    'account_type', v_customer.account_type,
+    'is_fleet', coalesce(v_customer.is_fleet, false),
+    'has_linked_fleet', v_has_fleet,
+    'can_manage', v_actor_role in ('owner', 'admin', 'manager'),
+    'precedence', jsonb_build_array(
+      'manual_override',
+      'fleet_or_customer_contract',
+      'customer_specific',
+      'shop_default'
+    ),
+    'effective_agreement', case
+      when v_effective.id is null then null
+      else to_jsonb(v_effective)
+    end,
+    'agreements', v_agreements
+  );
+end;
+$$;
+
+revoke all on function public.get_customer_pricing_account_summary(
+  uuid, uuid, timestamptz
+) from public, anon;
+grant execute on function public.get_customer_pricing_account_summary(
+  uuid, uuid, timestamptz
+) to authenticated, service_role;
+
+create or replace function public.apply_customer_pricing_to_quote_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_quote_line_ids uuid[],
+  p_actor_user_id uuid,
+  p_at timestamptz default now()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor_role text;
+  v_work_order public.work_orders%rowtype;
+  v_agreement public.customer_pricing_agreements%rowtype;
+  v_line public.work_order_quote_lines%rowtype;
+  v_previous public.pricing_resolution_snapshots%rowtype;
+  v_item public.part_request_items%rowtype;
+  v_snapshot public.pricing_resolution_snapshots%rowtype;
+  v_now timestamptz := coalesce(p_at, now());
+  v_shop_labor_rate numeric := 0;
+  v_currency text := 'CAD';
+  v_source_type text;
+  v_precedence_rank integer;
+  v_labor_discount numeric := 0;
+  v_parts_discount numeric := 0;
+  v_current_labor_rate numeric := 0;
+  v_base_labor_rate numeric := 0;
+  v_resolved_labor_rate numeric := 0;
+  v_labor_hours numeric := 0;
+  v_base_labor_total numeric := 0;
+  v_resolved_labor_total numeric := 0;
+  v_current_sell numeric;
+  v_base_sell numeric;
+  v_resolved_sell numeric;
+  v_qty numeric;
+  v_previous_part jsonb;
+  v_part_prices jsonb;
+  v_base_parts_total numeric;
+  v_resolved_parts_total numeric;
+  v_line_metadata jsonb;
+  v_input_snapshot jsonb;
+  v_result_snapshot jsonb;
+  v_resolution_hash text;
+  v_changed boolean;
+  v_item_count integer;
+  v_applied jsonb := '[]'::jsonb;
+  v_unchanged jsonb := '[]'::jsonb;
+  v_skipped jsonb := '[]'::jsonb;
+begin
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'PRICING_ACTOR_MISMATCH';
+  end if;
+
+  select public.canonical_shop_membership_role(profile.role::text)
+    into v_actor_role
+  from public.profiles profile
+  where profile.shop_id = p_shop_id
+    and (profile.id = p_actor_user_id or profile.user_id = p_actor_user_id)
+  order by case when profile.user_id = p_actor_user_id then 0 else 1 end
+  limit 1;
+
+  if coalesce(v_actor_role, '') not in (
+    'owner', 'admin', 'manager', 'advisor', 'service', 'foreman'
+  ) then
+    raise exception using errcode = '42501', message = 'QUOTE_PRICING_ROLE_REQUIRED';
+  end if;
+
+  select work_order.*
+    into v_work_order
+  from public.work_orders work_order
+  where work_order.id = p_work_order_id
+    and work_order.shop_id = p_shop_id
+  for update;
+
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Work order not found for shop.';
+  end if;
+  if v_work_order.customer_id is null then
+    return jsonb_build_object(
+      'ok', true,
+      'agreement', null,
+      'applied', v_applied,
+      'unchanged', v_unchanged,
+      'skipped', jsonb_build_array(jsonb_build_object('reason', 'no_customer'))
+    );
+  end if;
+  if public.work_order_is_financially_locked(p_shop_id, p_work_order_id) then
+    raise exception using errcode = '55000', message = 'FINANCIALLY_LOCKED: customer pricing cannot change after invoice finalization.';
+  end if;
+
+  if coalesce(cardinality(p_quote_line_ids), 0) > 0
+     and (
+       select count(distinct quote_line.id)
+       from public.work_order_quote_lines quote_line
+       where quote_line.shop_id = p_shop_id
+         and quote_line.work_order_id = p_work_order_id
+         and quote_line.id = any(p_quote_line_ids)
+     ) <> (
+       select count(distinct requested.id)
+       from unnest(p_quote_line_ids) requested(id)
+       where requested.id is not null
+     ) then
+    raise exception using errcode = 'P0002', message = 'One or more quote lines were not found for this work order.';
+  end if;
+
+  select
+    coalesce(shop.labor_rate, 0),
+    case when upper(coalesce(shop.country, 'CA')) in ('US', 'USA') then 'USD' else 'CAD' end
+  into v_shop_labor_rate, v_currency
+  from public.shops shop
+  where shop.id = p_shop_id;
+
+  select agreement.*
+    into v_agreement
+  from public.customer_pricing_agreements agreement
+  where agreement.shop_id = p_shop_id
+    and agreement.customer_id = v_work_order.customer_id
+    and agreement.status = 'active'
+    and agreement.effective_from <= v_now::date
+    and (agreement.effective_until is null or agreement.effective_until >= v_now::date)
+  order by
+    case agreement.source_type
+      when 'fleet_contract' then 800
+      when 'customer_contract' then 800
+      when 'customer_specific' then 700
+      else 100
+    end desc,
+    agreement.effective_from desc,
+    agreement.created_at desc,
+    agreement.id desc
+  limit 1;
+
+  if found then
+    v_source_type := v_agreement.source_type;
+    v_precedence_rank := case v_agreement.source_type
+      when 'fleet_contract' then 800
+      when 'customer_contract' then 800
+      when 'customer_specific' then 700
+      else 100
+    end;
+    v_labor_discount := v_agreement.labor_discount_percent;
+    v_parts_discount := v_agreement.parts_discount_percent;
+    v_currency := v_agreement.currency;
+  else
+    v_agreement := null;
+    v_source_type := 'shop_default';
+    v_precedence_rank := 100;
+    v_labor_discount := 0;
+    v_parts_discount := 0;
+  end if;
+
+  for v_line in
+    select quote_line.*
+    from public.work_order_quote_lines quote_line
+    where quote_line.shop_id = p_shop_id
+      and quote_line.work_order_id = p_work_order_id
+      and (
+        coalesce(cardinality(p_quote_line_ids), 0) = 0
+        or quote_line.id = any(p_quote_line_ids)
+      )
+    order by quote_line.created_at, quote_line.id
+    for update
+  loop
+    if public.quote_line_pricing_is_protected(
+      v_line.status::text,
+      v_line.stage::text,
+      v_line.sent_to_customer_at,
+      v_line.sent_at,
+      v_line.approved_at,
+      v_line.declined_at,
+      v_line.deferred_at,
+      v_line.converted_at,
+      v_line.work_order_line_id
+    ) then
+      v_skipped := v_skipped || jsonb_build_array(jsonb_build_object(
+        'quote_line_id', v_line.id,
+        'reason', 'protected_quote_line_state'
+      ));
+      continue;
+    end if;
+
+    v_previous := null;
+    if v_line.customer_pricing_snapshot_id is not null then
+      select snapshot.*
+        into v_previous
+      from public.pricing_resolution_snapshots snapshot
+      where snapshot.id = v_line.customer_pricing_snapshot_id
+        and snapshot.shop_id = p_shop_id
+        and snapshot.quote_line_id = v_line.id;
+    end if;
+
+    if v_agreement.id is null and v_previous.id is null then
+      v_skipped := v_skipped || jsonb_build_array(jsonb_build_object(
+        'quote_line_id', v_line.id,
+        'reason', 'shop_default_already_applies'
+      ));
+      continue;
+    end if;
+
+    v_line_metadata := case
+      when jsonb_typeof(v_line.metadata) = 'object' then v_line.metadata
+      else '{}'::jsonb
+    end;
+    v_current_labor_rate := coalesce(
+      v_line.labor_rate,
+      case
+        when coalesce(v_line_metadata ->> 'labor_rate', '') ~ '^[0-9]+([.][0-9]+)?$'
+          then (v_line_metadata ->> 'labor_rate')::numeric
+        else null
+      end,
+      v_shop_labor_rate,
+      0
+    );
+    v_base_labor_rate := case
+      when v_previous.id is not null
+        and round(v_current_labor_rate, 2) = v_previous.resolved_labor_rate
+        then v_previous.base_labor_rate
+      else round(v_current_labor_rate, 2)
+    end;
+    v_resolved_labor_rate := case
+      when v_agreement.id is not null and v_agreement.labor_rate is not null
+        then v_agreement.labor_rate
+      else round(v_base_labor_rate * (1 - v_labor_discount / 100), 2)
+    end;
+    v_labor_hours := greatest(
+      coalesce(v_line.labor_hours, 0),
+      coalesce(v_line.est_labor_hours, 0),
+      0
+    );
+    v_base_labor_total := round(v_labor_hours * v_base_labor_rate, 2);
+    v_resolved_labor_total := round(v_labor_hours * v_resolved_labor_rate, 2);
+    v_base_parts_total := 0;
+    v_resolved_parts_total := 0;
+    v_part_prices := '[]'::jsonb;
+    v_item_count := 0;
+    v_changed := round(v_current_labor_rate, 2) is distinct from v_resolved_labor_rate
+      or round(coalesce(v_line.labor_total, 0), 2) is distinct from v_resolved_labor_total;
+
+    for v_item in
+      select item.*
+      from public.part_request_items item
+      join public.part_requests request on request.id = item.request_id
+      where item.shop_id = p_shop_id
+        and item.work_order_id = p_work_order_id
+        and item.quote_line_id = v_line.id
+        and request.shop_id = item.shop_id
+        and lower(coalesce(request.status::text, 'requested')) not in (
+          'cancelled', 'canceled', 'rejected', 'declined', 'voided'
+        )
+        and lower(coalesce(item.status::text, 'requested')) not in (
+          'cancelled', 'canceled', 'rejected', 'declined', 'voided'
+        )
+      order by request.created_at, request.id, item.id
+      for update of item
+    loop
+      v_qty := greatest(
+        coalesce(v_item.qty, 0),
+        coalesce(v_item.qty_requested, 0),
+        coalesce(v_item.qty_approved, 0),
+        0
+      );
+      v_current_sell := case
+        when v_item.quoted_price is not null and v_item.quoted_price >= 0
+          then v_item.quoted_price
+        when v_item.unit_price is not null and v_item.unit_price >= 0
+          then v_item.unit_price
+        else null
+      end;
+
+      if v_qty <= 0 or v_current_sell is null then
+        continue;
+      end if;
+
+      v_previous_part := null;
+      if v_previous.id is not null then
+        select part.value
+          into v_previous_part
+        from jsonb_array_elements(v_previous.part_prices) part(value)
+        where part.value ->> 'request_item_id' = v_item.id::text
+        limit 1;
+      end if;
+
+      v_base_sell := case
+        when v_previous_part is not null
+          and coalesce(v_previous_part ->> 'resolved_unit_price', '') ~ '^[0-9]+([.][0-9]+)?$'
+          and round(v_current_sell, 2) = (v_previous_part ->> 'resolved_unit_price')::numeric
+          and coalesce(v_previous_part ->> 'base_unit_price', '') ~ '^[0-9]+([.][0-9]+)?$'
+          then (v_previous_part ->> 'base_unit_price')::numeric
+        else round(v_current_sell, 2)
+      end;
+      v_resolved_sell := round(v_base_sell * (1 - v_parts_discount / 100), 2);
+
+      if round(v_current_sell, 2) is distinct from v_resolved_sell then
+        if v_item.work_order_line_id is not null
+           or coalesce(v_item.qty_ordered, 0) > 0
+           or coalesce(v_item.qty_received, 0) > 0
+           or coalesce(v_item.qty_reserved, 0) > 0
+           or coalesce(v_item.qty_consumed, 0) > 0
+           or coalesce(v_item.qty_returned, 0) > 0
+           or v_item.po_id is not null then
+          raise exception using
+            errcode = '55000',
+            message = 'CUSTOMER_PRICING_PART_LIFECYCLE_LOCKED',
+            detail = format('Part request item %s has operational activity.', v_item.id);
+        end if;
+
+        update public.part_request_items
+        set quoted_price = v_resolved_sell,
+            unit_price = v_resolved_sell,
+            updated_at = v_now
+        where id = v_item.id
+          and shop_id = p_shop_id;
+        v_changed := true;
+      end if;
+
+      v_base_parts_total := round(v_base_parts_total + v_qty * v_base_sell, 2);
+      v_resolved_parts_total := round(
+        v_resolved_parts_total + v_qty * v_resolved_sell,
+        2
+      );
+      v_item_count := v_item_count + 1;
+      v_part_prices := v_part_prices || jsonb_build_array(jsonb_build_object(
+        'request_item_id', v_item.id,
+        'request_id', v_item.request_id,
+        'description', v_item.description,
+        'quantity', v_qty,
+        'base_unit_price', v_base_sell,
+        'resolved_unit_price', v_resolved_sell,
+        'base_line_total', round(v_qty * v_base_sell, 2),
+        'resolved_line_total', round(v_qty * v_resolved_sell, 2)
+      ));
+    end loop;
+
+    if v_item_count = 0 then
+      v_base_parts_total := case
+        when v_previous.id is not null
+          and round(coalesce(v_line.parts_total, 0), 2) = v_previous.resolved_parts_total
+          then v_previous.base_parts_total
+        else round(coalesce(v_line.parts_total, 0), 2)
+      end;
+      v_resolved_parts_total := round(
+        v_base_parts_total * (1 - v_parts_discount / 100),
+        2
+      );
+      if v_base_parts_total > 0 and v_parts_discount > 0 then
+        raise exception using
+          errcode = '55000',
+          message = 'CUSTOMER_PRICING_REQUIRES_CANONICAL_PART_ITEMS',
+          detail = format(
+            'Quote line %s has an aggregate parts total without canonical request-item sell prices.',
+            v_line.id
+          );
+      end if;
+      v_changed := v_changed
+        or round(coalesce(v_line.parts_total, 0), 2) is distinct from v_resolved_parts_total;
+    end if;
+
+    if v_previous.id is not null
+       and v_previous.agreement_id is not distinct from v_agreement.id
+       and v_previous.source_type = v_source_type
+       and v_previous.precedence_rank = v_precedence_rank
+       and v_previous.currency = v_currency
+       and v_previous.base_labor_rate = v_base_labor_rate
+       and v_previous.resolved_labor_rate = v_resolved_labor_rate
+       and v_previous.labor_discount_percent = v_labor_discount
+       and v_previous.base_labor_total = v_base_labor_total
+       and v_previous.resolved_labor_total = v_resolved_labor_total
+       and v_previous.base_parts_total = v_base_parts_total
+       and v_previous.resolved_parts_total = v_resolved_parts_total
+       and v_previous.parts_discount_percent = v_parts_discount
+       and v_previous.part_prices = v_part_prices
+       and not v_changed then
+      v_unchanged := v_unchanged || jsonb_build_array(jsonb_build_object(
+        'quote_line_id', v_line.id,
+        'snapshot_id', v_previous.id,
+        'source_type', v_source_type
+      ));
+      continue;
+    end if;
+
+    v_line_metadata := jsonb_set(
+      v_line_metadata,
+      '{labor_rate}',
+      to_jsonb(v_resolved_labor_rate),
+      true
+    );
+    v_line_metadata := jsonb_set(
+      v_line_metadata,
+      '{customer_pricing}',
+      jsonb_strip_nulls(jsonb_build_object(
+        'agreement_id', v_agreement.id,
+        'agreement_name', v_agreement.name,
+        'source_type', v_source_type,
+        'precedence_rank', v_precedence_rank,
+        'currency', v_currency,
+        'base_labor_rate', v_base_labor_rate,
+        'resolved_labor_rate', v_resolved_labor_rate,
+        'labor_discount_percent', v_labor_discount,
+        'base_parts_total', v_base_parts_total,
+        'resolved_parts_total', v_resolved_parts_total,
+        'parts_discount_percent', v_parts_discount,
+        'resolved_at', v_now,
+        'resolved_by', p_actor_user_id
+      )),
+      true
+    );
+
+    update public.work_order_quote_lines
+    set labor_rate = v_resolved_labor_rate,
+        labor_total = v_resolved_labor_total,
+        parts_total = v_resolved_parts_total,
+        subtotal = round(v_resolved_labor_total + v_resolved_parts_total, 2),
+        grand_total = round(
+          v_resolved_labor_total
+          + v_resolved_parts_total
+          + coalesce(v_line.tax_total, 0),
+          2
+        ),
+        metadata = v_line_metadata,
+        updated_at = v_now
+    where id = v_line.id
+      and shop_id = p_shop_id;
+
+    if v_item_count > 0 then
+      perform public.sync_quote_line_pricing_from_parts(p_shop_id, v_line.id);
+    end if;
+
+    select quote_line.*
+      into v_line
+    from public.work_order_quote_lines quote_line
+    where quote_line.id = v_line.id
+      and quote_line.shop_id = p_shop_id;
+
+    v_input_snapshot := jsonb_build_object(
+      'shop_id', p_shop_id,
+      'customer_id', v_work_order.customer_id,
+      'work_order_id', p_work_order_id,
+      'quote_line_id', v_line.id,
+      'agreement_id', v_agreement.id,
+      'source_type', v_source_type,
+      'labor_hours', v_labor_hours,
+      'base_labor_rate', v_base_labor_rate,
+      'base_parts_total', v_base_parts_total,
+      'part_prices', v_part_prices
+    );
+    v_result_snapshot := jsonb_build_object(
+      'resolved_labor_rate', v_resolved_labor_rate,
+      'resolved_labor_total', v_resolved_labor_total,
+      'resolved_parts_total', v_resolved_parts_total,
+      'subtotal', round(v_resolved_labor_total + v_resolved_parts_total, 2),
+      'grand_total', v_line.grand_total,
+      'labor_discount_percent', v_labor_discount,
+      'parts_discount_percent', v_parts_discount,
+      'precedence_rank', v_precedence_rank
+    );
+    v_resolution_hash := encode(
+      extensions.digest(
+        convert_to(
+          jsonb_build_object(
+            'input', v_input_snapshot,
+            'result', v_result_snapshot,
+            'currency', v_currency
+          )::text,
+          'UTF8'
+        ),
+        'sha256'
+      ),
+      'hex'
+    );
+
+    insert into public.pricing_resolution_snapshots (
+      shop_id,
+      customer_id,
+      work_order_id,
+      quote_line_id,
+      agreement_id,
+      supersedes_snapshot_id,
+      source_type,
+      precedence_rank,
+      currency,
+      base_labor_rate,
+      resolved_labor_rate,
+      labor_discount_percent,
+      base_labor_total,
+      resolved_labor_total,
+      base_parts_total,
+      resolved_parts_total,
+      parts_discount_percent,
+      part_prices,
+      input_snapshot,
+      result_snapshot,
+      resolution_hash,
+      resolved_by,
+      resolved_at,
+      created_at
+    ) values (
+      p_shop_id,
+      v_work_order.customer_id,
+      p_work_order_id,
+      v_line.id,
+      v_agreement.id,
+      v_previous.id,
+      v_source_type,
+      v_precedence_rank,
+      v_currency,
+      v_base_labor_rate,
+      v_resolved_labor_rate,
+      v_labor_discount,
+      v_base_labor_total,
+      v_resolved_labor_total,
+      v_base_parts_total,
+      v_resolved_parts_total,
+      v_parts_discount,
+      v_part_prices,
+      v_input_snapshot,
+      v_result_snapshot,
+      v_resolution_hash,
+      p_actor_user_id,
+      v_now,
+      v_now
+    )
+    returning * into v_snapshot;
+
+    update public.work_order_quote_lines
+    set customer_pricing_snapshot_id = v_snapshot.id,
+        metadata = jsonb_set(
+          metadata,
+          '{customer_pricing,snapshot_id}',
+          to_jsonb(v_snapshot.id),
+          true
+        ),
+        updated_at = v_now
+    where id = v_line.id
+      and shop_id = p_shop_id;
+
+    v_applied := v_applied || jsonb_build_array(jsonb_build_object(
+      'quote_line_id', v_line.id,
+      'snapshot_id', v_snapshot.id,
+      'agreement_id', v_agreement.id,
+      'source_type', v_source_type,
+      'base_labor_rate', v_base_labor_rate,
+      'resolved_labor_rate', v_resolved_labor_rate,
+      'base_parts_total', v_base_parts_total,
+      'resolved_parts_total', v_resolved_parts_total
+    ));
+  end loop;
+
+  insert into public.operational_events (
+    shop_id,
+    event_type,
+    actor_user_id,
+    actor_role,
+    entity_type,
+    entity_id,
+    source,
+    metadata
+  )
+  select
+    p_shop_id,
+    'customer_pricing.resolved',
+    p_actor_user_id,
+    v_actor_role,
+    'work_order',
+    p_work_order_id,
+    'customer_pricing_engine',
+    jsonb_build_object(
+      'customer_id', v_work_order.customer_id,
+      'agreement_id', v_agreement.id,
+      'source_type', v_source_type,
+      'applied', v_applied,
+      'unchanged', v_unchanged,
+      'skipped', v_skipped
+    )
+  where jsonb_array_length(v_applied) > 0;
+
+  return jsonb_build_object(
+    'ok', true,
+    'agreement', case
+      when v_agreement.id is null then null
+      else to_jsonb(v_agreement)
+    end,
+    'source_type', v_source_type,
+    'precedence_rank', v_precedence_rank,
+    'applied', v_applied,
+    'unchanged', v_unchanged,
+    'skipped', v_skipped
+  );
+end;
+$$;
+
+revoke all on function public.apply_customer_pricing_to_quote_atomic(
+  uuid, uuid, uuid[], uuid, timestamptz
+) from public, anon;
+grant execute on function public.apply_customer_pricing_to_quote_atomic(
+  uuid, uuid, uuid[], uuid, timestamptz
+) to authenticated, service_role;
+
+comment on table public.customer_pricing_agreements is
+  'Shop-owned, versioned pricing terms for customer and Fleet accounts. Terms are replaced by creating a new version, never edited in place.';
+
+comment on table public.pricing_resolution_snapshots is
+  'Immutable quote pricing provenance. Each row records the fixed-precedence winner, base values, and customer-facing resolved values.';
+
+comment on function public.apply_customer_pricing_to_quote_atomic(
+  uuid, uuid, uuid[], uuid, timestamptz
+) is
+  'Applies the fixed customer pricing precedence to editable quote lines and canonical part sell prices, then records immutable resolution snapshots.';
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/customer-specific-pricing-engine.test.ts
+++ b/tests/customer-specific-pricing-engine.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260812022359_customer_specific_pricing_engine.sql",
+  "utf8",
+);
+const quoteReview = readFileSync(
+  "features/work-orders/quote-review/QuoteReviewView.tsx",
+  "utf8",
+);
+const quoteSend = readFileSync("app/api/quotes/send/route.ts", "utf8");
+
+describe("customer-specific pricing engine contracts", () => {
+  it("keeps precedence fixed and agreement history versioned", () => {
+    expect(migration).toContain("when 'fleet_contract' then 800");
+    expect(migration).toContain("when 'customer_contract' then 800");
+    expect(migration).toContain("when 'customer_specific' then 700");
+    expect(migration).not.toContain("priority integer");
+    expect(migration).toContain(
+      "CUSTOMER_PRICING_AGREEMENT_TERMS_REQUIRE_A_NEW_VERSION",
+    );
+  });
+
+  it("freezes labor and canonical part sell prices without using cost", () => {
+    expect(migration).toContain("set quoted_price = v_resolved_sell");
+    expect(migration).toContain("unit_price = v_resolved_sell");
+    expect(migration).not.toContain("unit_cost = v_resolved_sell");
+    expect(migration).toContain(
+      "CUSTOMER_PRICING_REQUIRES_CANONICAL_PART_ITEMS",
+    );
+    expect(migration).toContain("PRICING_RESOLUTION_SNAPSHOTS_ARE_IMMUTABLE");
+  });
+
+  it("resolves before staff review saves and before quote delivery", () => {
+    expect(quoteReview).toContain(
+      "`/api/work-orders/${woId}/customer-pricing`",
+    );
+    expect(quoteSend).toContain("apply_customer_pricing_to_quote_atomic");
+    expect(
+      quoteSend.indexOf("apply_customer_pricing_to_quote_atomic"),
+    ).toBeLessThan(quoteSend.indexOf('from("work_order_quote_lines")'));
+  });
+});

--- a/tests/pricing/customer-specific-pricing.runtime.sql
+++ b/tests/pricing/customer-specific-pricing.runtime.sql
@@ -1,0 +1,447 @@
+\set ON_ERROR_STOP on
+
+-- @regression-flow pricing.customer-specific
+begin;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values
+  (
+    '51100000-0000-4000-8000-000000000001',
+    'pricing-owner-a@example.com',
+    '{"full_name":"Pricing Owner A"}'::jsonb
+  ),
+  (
+    '51100000-0000-4000-8000-000000000002',
+    'pricing-owner-b@example.com',
+    '{"full_name":"Pricing Owner B"}'::jsonb
+  ),
+  (
+    '51100000-0000-4000-8000-000000000011',
+    'pricing-owner-a-profile@example.com',
+    '{"full_name":"Pricing Owner A Profile"}'::jsonb
+  )
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name)
+values
+  (
+    '51100000-0000-4000-8000-000000000011',
+    '51100000-0000-4000-8000-000000000001',
+    'owner',
+    'Pricing Owner A'
+  ),
+  (
+    '51100000-0000-4000-8000-000000000002',
+    '51100000-0000-4000-8000-000000000002',
+    'owner',
+    'Pricing Owner B'
+  )
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name;
+
+update public.profiles
+set user_id = '51100000-0000-4000-8000-000000000001'
+where id = '51100000-0000-4000-8000-000000000011';
+
+insert into public.shops (id, owner_id, business_name, name, labor_rate, country)
+values
+  (
+    '51200000-0000-4000-8000-000000000001',
+    '51100000-0000-4000-8000-000000000011',
+    'Customer Pricing Shop A',
+    'Customer Pricing Shop A',
+    150,
+    'CA'
+  ),
+  (
+    '51200000-0000-4000-8000-000000000002',
+    '51100000-0000-4000-8000-000000000002',
+    'Customer Pricing Shop B',
+    'Customer Pricing Shop B',
+    160,
+    'CA'
+  );
+
+update public.profiles
+set shop_id = case id
+  when '51100000-0000-4000-8000-000000000011'::uuid
+    then '51200000-0000-4000-8000-000000000001'::uuid
+  else '51200000-0000-4000-8000-000000000002'::uuid
+end
+where id in (
+  '51100000-0000-4000-8000-000000000011',
+  '51100000-0000-4000-8000-000000000002'
+);
+
+insert into public.customers (
+  id,
+  shop_id,
+  name,
+  business_name,
+  account_type,
+  active
+) values (
+  '51300000-0000-4000-8000-000000000001',
+  '51200000-0000-4000-8000-000000000001',
+  'Northside Transport',
+  'Northside Transport',
+  'business',
+  true
+);
+
+insert into public.work_orders (
+  id,
+  shop_id,
+  customer_id,
+  status,
+  type,
+  record_type
+) values (
+  '51400000-0000-4000-8000-000000000001',
+  '51200000-0000-4000-8000-000000000001',
+  '51300000-0000-4000-8000-000000000001',
+  'in_progress',
+  'repair',
+  'work_order'
+);
+
+insert into public.work_order_quote_lines (
+  id,
+  shop_id,
+  work_order_id,
+  description,
+  job_type,
+  status,
+  stage,
+  labor_hours,
+  est_labor_hours,
+  labor_rate,
+  labor_total,
+  parts_total,
+  subtotal,
+  grand_total,
+  metadata
+) values (
+  '51500000-0000-4000-8000-000000000001',
+  '51200000-0000-4000-8000-000000000001',
+  '51400000-0000-4000-8000-000000000001',
+  'Customer pricing runtime repair',
+  'repair',
+  'quoted',
+  'ready_to_send',
+  2,
+  2,
+  150,
+  300,
+  200,
+  500,
+  500,
+  jsonb_build_object('labor_rate', 150)
+);
+
+insert into public.parts (
+  id,
+  shop_id,
+  name,
+  part_number,
+  sku,
+  cost,
+  price
+) values (
+  '51600000-0000-4000-8000-000000000001',
+  '51200000-0000-4000-8000-000000000001',
+  'Pricing runtime part',
+  'PRICE-RUNTIME',
+  'PRICE-RUNTIME',
+  100,
+  200
+);
+
+insert into public.part_requests (
+  id,
+  shop_id,
+  work_order_id,
+  quote_line_id,
+  requested_by,
+  status
+) values (
+  '51700000-0000-4000-8000-000000000001',
+  '51200000-0000-4000-8000-000000000001',
+  '51400000-0000-4000-8000-000000000001',
+  '51500000-0000-4000-8000-000000000001',
+  '51100000-0000-4000-8000-000000000001',
+  'requested'
+);
+
+insert into public.part_request_items (
+  id,
+  request_id,
+  shop_id,
+  work_order_id,
+  quote_line_id,
+  part_id,
+  description,
+  qty,
+  qty_requested,
+  unit_cost,
+  unit_price,
+  quoted_price,
+  status
+) values (
+  '51800000-0000-4000-8000-000000000001',
+  '51700000-0000-4000-8000-000000000001',
+  '51200000-0000-4000-8000-000000000001',
+  '51400000-0000-4000-8000-000000000001',
+  '51500000-0000-4000-8000-000000000001',
+  '51600000-0000-4000-8000-000000000001',
+  'Pricing runtime part',
+  1,
+  1,
+  100,
+  200,
+  200,
+  'requested'
+);
+
+select public.create_customer_pricing_agreement_atomic(
+  '51200000-0000-4000-8000-000000000001',
+  '51300000-0000-4000-8000-000000000001',
+  'customer_specific',
+  'Preferred customer rate',
+  'CAD',
+  130,
+  0,
+  5,
+  current_date,
+  null,
+  'Approved preferred customer terms',
+  null,
+  'pricing-runtime-customer-rate',
+  '51100000-0000-4000-8000-000000000001',
+  now()
+);
+
+select public.create_customer_pricing_agreement_atomic(
+  '51200000-0000-4000-8000-000000000001',
+  '51300000-0000-4000-8000-000000000001',
+  'customer_contract',
+  'Northside volume contract',
+  'CAD',
+  110,
+  0,
+  10,
+  current_date,
+  null,
+  'Signed annual volume agreement',
+  null,
+  'pricing-runtime-contract',
+  '51100000-0000-4000-8000-000000000001',
+  now()
+);
+
+select public.apply_customer_pricing_to_quote_atomic(
+  '51200000-0000-4000-8000-000000000001',
+  '51400000-0000-4000-8000-000000000001',
+  array['51500000-0000-4000-8000-000000000001'::uuid],
+  '51100000-0000-4000-8000-000000000001',
+  now()
+);
+
+do $$
+declare
+  v_line public.work_order_quote_lines%rowtype;
+  v_item public.part_request_items%rowtype;
+  v_snapshot public.pricing_resolution_snapshots%rowtype;
+begin
+  select * into strict v_line
+  from public.work_order_quote_lines
+  where id = '51500000-0000-4000-8000-000000000001';
+
+  select * into strict v_item
+  from public.part_request_items
+  where id = '51800000-0000-4000-8000-000000000001';
+
+  select * into strict v_snapshot
+  from public.pricing_resolution_snapshots
+  where id = v_line.customer_pricing_snapshot_id;
+
+  if v_line.labor_rate is distinct from 110::numeric
+     or v_line.labor_total is distinct from 220::numeric
+     or v_line.parts_total is distinct from 180::numeric
+     or v_line.subtotal is distinct from 400::numeric
+     or v_line.grand_total is distinct from 400::numeric then
+    raise exception 'Contract pricing did not resolve expected quote totals: %', row_to_json(v_line);
+  end if;
+  if v_item.unit_cost is distinct from 100::numeric
+     or v_item.unit_price is distinct from 180::numeric
+     or v_item.quoted_price is distinct from 180::numeric then
+    raise exception 'Parts sell discount changed acquisition cost or missed sell fields: %', row_to_json(v_item);
+  end if;
+  if v_snapshot.source_type is distinct from 'customer_contract'
+     or v_snapshot.precedence_rank is distinct from 800
+     or v_snapshot.base_labor_rate is distinct from 150::numeric
+     or v_snapshot.resolved_labor_rate is distinct from 110::numeric
+     or v_snapshot.base_parts_total is distinct from 200::numeric
+     or v_snapshot.resolved_parts_total is distinct from 180::numeric then
+    raise exception 'Pricing provenance snapshot is incorrect: %', row_to_json(v_snapshot);
+  end if;
+end;
+$$;
+
+-- A replay must not compound discounts or manufacture duplicate history.
+select public.apply_customer_pricing_to_quote_atomic(
+  '51200000-0000-4000-8000-000000000001',
+  '51400000-0000-4000-8000-000000000001',
+  array['51500000-0000-4000-8000-000000000001'::uuid],
+  '51100000-0000-4000-8000-000000000001',
+  now()
+);
+
+do $$
+begin
+  if (
+    select count(*)
+    from public.pricing_resolution_snapshots
+    where quote_line_id = '51500000-0000-4000-8000-000000000001'
+  ) <> 1 then
+    raise exception 'Idempotent pricing replay created duplicate snapshots.';
+  end if;
+  if (
+    select quoted_price
+    from public.part_request_items
+    where id = '51800000-0000-4000-8000-000000000001'
+  ) is distinct from 180::numeric then
+    raise exception 'Idempotent pricing replay compounded the parts discount.';
+  end if;
+end;
+$$;
+
+select public.retire_customer_pricing_agreement_atomic(
+  '51200000-0000-4000-8000-000000000001',
+  (
+    select id
+    from public.customer_pricing_agreements
+    where customer_id = '51300000-0000-4000-8000-000000000001'
+      and source_type = 'customer_contract'
+  ),
+  '51100000-0000-4000-8000-000000000001',
+  'Annual contract ended',
+  now()
+);
+
+select public.apply_customer_pricing_to_quote_atomic(
+  '51200000-0000-4000-8000-000000000001',
+  '51400000-0000-4000-8000-000000000001',
+  array['51500000-0000-4000-8000-000000000001'::uuid],
+  '51100000-0000-4000-8000-000000000001',
+  now()
+);
+
+do $$
+declare
+  v_line public.work_order_quote_lines%rowtype;
+  v_snapshot public.pricing_resolution_snapshots%rowtype;
+begin
+  select * into strict v_line
+  from public.work_order_quote_lines
+  where id = '51500000-0000-4000-8000-000000000001';
+  select * into strict v_snapshot
+  from public.pricing_resolution_snapshots
+  where id = v_line.customer_pricing_snapshot_id;
+
+  if v_line.labor_rate is distinct from 130::numeric
+     or v_line.parts_total is distinct from 190::numeric
+     or v_snapshot.source_type is distinct from 'customer_specific'
+     or v_snapshot.base_labor_rate is distinct from 150::numeric
+     or v_snapshot.base_parts_total is distinct from 200::numeric then
+    raise exception 'Contract retirement did not fall back to the un-compounded customer rate.';
+  end if;
+end;
+$$;
+
+-- Cross-shop staff cannot create or apply Shop A pricing.
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"51100000-0000-4000-8000-000000000002","role":"authenticated"}',
+  true
+);
+
+do $$
+declare
+  v_denied boolean := false;
+begin
+  begin
+    perform public.create_customer_pricing_agreement_atomic(
+      '51200000-0000-4000-8000-000000000001',
+      '51300000-0000-4000-8000-000000000001',
+      'customer_specific',
+      'Cross-shop probe',
+      'CAD',
+      50,
+      0,
+      0,
+      current_date,
+      null,
+      'Cross-shop probe should fail',
+      null,
+      'pricing-runtime-cross-shop',
+      '51100000-0000-4000-8000-000000000002',
+      now()
+    );
+  exception when insufficient_privilege then
+    v_denied := true;
+  end;
+  if not v_denied then
+    raise exception 'Cross-shop actor created a customer pricing agreement.';
+  end if;
+end;
+$$;
+
+reset role;
+select set_config('request.jwt.claims', '', true);
+select set_config('request.jwt.claim.role', '', true);
+
+-- Agreement and resolution history are append-only even for privileged SQL.
+do $$
+declare
+  v_snapshot_id uuid;
+  v_agreement_id uuid;
+  v_snapshot_blocked boolean := false;
+  v_agreement_blocked boolean := false;
+begin
+  select id into strict v_snapshot_id
+  from public.pricing_resolution_snapshots
+  where quote_line_id = '51500000-0000-4000-8000-000000000001'
+  order by resolved_at
+  limit 1;
+
+  select id into strict v_agreement_id
+  from public.customer_pricing_agreements
+  where customer_id = '51300000-0000-4000-8000-000000000001'
+    and source_type = 'customer_contract';
+
+  begin
+    update public.pricing_resolution_snapshots
+    set resolved_labor_rate = 1
+    where id = v_snapshot_id;
+  exception when object_not_in_prerequisite_state then
+    v_snapshot_blocked := true;
+  end;
+
+  begin
+    delete from public.customer_pricing_agreements
+    where id = v_agreement_id;
+  exception when object_not_in_prerequisite_state then
+    v_agreement_blocked := true;
+  end;
+
+  if not v_snapshot_blocked or not v_agreement_blocked then
+    raise exception 'Customer pricing history was not immutable.';
+  end if;
+end;
+$$;
+
+rollback;


### PR DESCRIPTION
## What changed

- adds shop-owned, versioned customer, business-contract, and Fleet-contract pricing agreements
- fixes pricing precedence in code/database: approved manual override, contract, customer-specific rate, then shop default
- applies resolved labor and canonical part sell prices atomically to editable quote lines
- records immutable pricing resolution snapshots and preserves sent/approved quote pricing
- adds a premium customer pricing panel with effective terms, history, replacement, and retirement controls
- resolves pricing in Quote Review and again immediately before quote delivery
- adds a dedicated clean-database runtime for tenant isolation, non-compounding discounts, contract fallback, and append-only history

## Validation

- Agent PR Checks: full type-check, changed-file lint, complete test suite, and production build passed
- Customer-specific Pricing Validation passed, including its clean-database SQL runtime
- Supabase Clean Replay Validation passed on final head `40061a877398a978e8a05d396c185c7a31bc5f00`
- Phase 2, Phase 4, Phase 8, and Stripe identity compatibility checks passed
- Supabase preview migration, seeding, database, services, and APIs completed

## Production migration

- reviewed SQL from `20260812022359_customer_specific_pricing_engine.sql` applied successfully to canonical production `scjjkmuwadwkaaqjoigx`
- production schema verified: tables, quote snapshot FK, RLS, policies, RPC signatures, and restricted direct-write grants
- production ledger reconciled to exact repository version/name: `20260812022359_customer_specific_pricing_engine`
- stored production SQL remains byte-for-byte identical to the reviewed migration (46,552 bytes; SHA-256 `c9555094c3b53774f2fc0363036e73b25939cbf2a0fc655506195924298dd7be`)

## Advisor review

- security advisor reports the three authenticated `SECURITY DEFINER` write RPCs; this is intentional because table writes are denied and each RPC enforces actor identity, shop membership, role, and tenant scope
- performance advisor reports informational FK/index observations; tenant query paths use the task-owned shop-scoped composite indexes
