### PR TITLE
Build unified Customer Account Center

### DIFF
--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -10,6 +10,7 @@ on:
       - "tests/parts/*.runtime.sql"
       - "tests/parts/*.runtime.sh"
       - "tests/security/*.runtime.sql"
+      - "tests/customers/*.runtime.sql"
       - "db/sql/schema.sql"
       - "features/shared/types/types/supabase.ts"
       - "package.json"
@@ -165,6 +166,20 @@ jobs:
           psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
             -f tests/security/quote-review-cost-and-sell.runtime.sql \
             2>&1 | tee quote-review-cost-and-sell-runtime.log
+
+      - name: Execute Customer Account Center runtime integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/customers/unified-customer-account-center.runtime.sql \
+            2>&1 | tee customer-account-center-runtime.log
 
       - name: Execute P0 relation-boundary runtime integration
         shell: bash

--- a/app/api/customers/[id]/account/route.ts
+++ b/app/api/customers/[id]/account/route.ts
@@ -1,0 +1,210 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PAYMENT_TERMS = new Set([
+  "due_on_receipt",
+  "net_7",
+  "net_15",
+  "net_30",
+  "net_45",
+  "net_60",
+  "custom",
+]);
+const ACCOUNT_STATUSES = new Set([
+  "good_standing",
+  "credit_hold",
+  "account_hold",
+]);
+
+function optionalText(value: unknown, maxLength: number): string | null {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized && normalized.length <= maxLength ? normalized : null;
+}
+
+function requiredText(value: unknown, maxLength: number): string | null {
+  return optionalText(value, maxLength);
+}
+
+function uuid(value: unknown): string | null {
+  const candidate = optionalText(value, 50);
+  return candidate && UUID_PATTERN.test(candidate) ? candidate : null;
+}
+
+function errorMessage(error: {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+}): string {
+  return [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+}
+
+function statusFor(message: string): number {
+  if (/not found/i.test(message)) return 404;
+  if (/ROLE_REQUIRED|ACTOR_MISMATCH|access denied/i.test(message)) return 403;
+  if (/conflict|Fleet workspace|portal identities/i.test(message)) return 409;
+  return 400;
+}
+
+async function routeCustomerId(context: RouteContext): Promise<string | null> {
+  const { id } = await context.params;
+  return uuid(id);
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
+  if (!access.ok) return access.response;
+  const customerId = await routeCustomerId(context);
+  if (!customerId) {
+    return NextResponse.json(
+      { error: "Invalid customer id." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await access.supabase.rpc(
+    "get_customer_account_center" as never,
+    {
+      p_shop_id: access.profile.shop_id,
+      p_customer_id: customerId,
+      p_actor_user_id: access.authUserId,
+    } as never,
+  );
+  if (error) {
+    const message = errorMessage(error);
+    return NextResponse.json(
+      { error: message },
+      { status: statusFor(message) },
+    );
+  }
+  return NextResponse.json(data ?? { ok: true });
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
+  if (!access.ok) return access.response;
+  const customerId = await routeCustomerId(context);
+  if (!customerId) {
+    return NextResponse.json(
+      { error: "Invalid customer id." },
+      { status: 400 },
+    );
+  }
+
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const action = optionalText(body?.action, 40);
+  const operationKey =
+    requiredText(body?.operationKey, 200) ??
+    requiredText(request.headers.get("idempotency-key"), 200);
+  if (!action || !operationKey) {
+    return NextResponse.json(
+      { error: "Account action and operation key are required." },
+      { status: 400 },
+    );
+  }
+
+  let rpcName = "";
+  let rpcArgs: Record<string, unknown> = {};
+
+  if (action === "update_commercial_controls") {
+    const paymentTerms = optionalText(body?.paymentTerms, 40)?.toLowerCase();
+    const accountStatus = optionalText(body?.accountStatus, 40)?.toLowerCase();
+    const paymentTermsDays = Number(body?.paymentTermsDays ?? 0);
+    if (
+      !paymentTerms ||
+      !PAYMENT_TERMS.has(paymentTerms) ||
+      !accountStatus ||
+      !ACCOUNT_STATUSES.has(accountStatus) ||
+      !Number.isInteger(paymentTermsDays) ||
+      paymentTermsDays < 0 ||
+      paymentTermsDays > 365
+    ) {
+      return NextResponse.json(
+        { error: "Commercial controls are incomplete or invalid." },
+        { status: 400 },
+      );
+    }
+    rpcName = "update_customer_commercial_controls_atomic";
+    rpcArgs = {
+      p_shop_id: access.profile.shop_id,
+      p_customer_id: customerId,
+      p_primary_billing_contact_id: uuid(body?.primaryBillingContactId),
+      p_primary_approval_contact_id: uuid(body?.primaryApprovalContactId),
+      p_po_required: body?.poRequired === true,
+      p_payment_terms: paymentTerms,
+      p_payment_terms_days: paymentTermsDays,
+      p_tax_exempt: body?.taxExempt === true,
+      p_tax_exemption_reference: optionalText(body?.taxExemptionReference, 300),
+      p_account_status: accountStatus,
+      p_account_hold_reason: optionalText(body?.accountHoldReason, 500),
+      p_billing_notes: optionalText(body?.billingNotes, 4000),
+      p_customer_reference: optionalText(body?.customerReference, 500),
+      p_actor_user_id: access.authUserId,
+      p_operation_key: operationKey,
+    };
+  } else if (action === "archive") {
+    const reason = requiredText(body?.reason, 500);
+    if (!reason || reason.length < 3) {
+      return NextResponse.json(
+        { error: "Archive reason is required." },
+        { status: 400 },
+      );
+    }
+    rpcName = "archive_customer_account_atomic";
+    rpcArgs = {
+      p_shop_id: access.profile.shop_id,
+      p_customer_id: customerId,
+      p_reason: reason,
+      p_actor_user_id: access.authUserId,
+      p_operation_key: operationKey,
+    };
+  } else if (action === "merge") {
+    const targetCustomerId = uuid(body?.targetCustomerId);
+    const reason = requiredText(body?.reason, 500);
+    if (!targetCustomerId || !reason || reason.length < 3) {
+      return NextResponse.json(
+        { error: "Target customer and merge reason are required." },
+        { status: 400 },
+      );
+    }
+    rpcName = "merge_customer_accounts_atomic";
+    rpcArgs = {
+      p_shop_id: access.profile.shop_id,
+      p_source_customer_id: customerId,
+      p_target_customer_id: targetCustomerId,
+      p_reason: reason,
+      p_actor_user_id: access.authUserId,
+      p_operation_key: operationKey,
+    };
+  } else {
+    return NextResponse.json(
+      { error: "Unsupported account action." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await access.supabase.rpc(
+    rpcName as never,
+    rpcArgs as never,
+  );
+  if (error) {
+    const message = errorMessage(error);
+    return NextResponse.json(
+      { error: message },
+      { status: statusFor(message) },
+    );
+  }
+  return NextResponse.json(data ?? { ok: true });
+}

--- a/app/api/customers/accounts/route.ts
+++ b/app/api/customers/accounts/route.ts
@@ -1,0 +1,150 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type DuplicateCandidate = {
+  id: string;
+  display_name: string;
+  account_type: string;
+  email: string | null;
+  phone: string | null;
+  reasons: string[];
+  score: number;
+};
+
+type CreateResult = {
+  ok: boolean;
+  code?: string;
+  matched_existing?: boolean;
+  customer?: { id: string };
+  duplicate_candidates?: DuplicateCandidate[];
+};
+
+const ACCOUNT_TYPES = new Set([
+  "individual",
+  "business",
+  "fleet",
+  "enterprise",
+]);
+
+function text(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized && normalized.length <= maxLength ? normalized : null;
+}
+
+function optionalText(value: unknown, maxLength: number): string | null {
+  if (value == null || value === "") return null;
+  return text(value, maxLength);
+}
+
+function message(error: {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+}): string {
+  return [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+}
+
+export async function GET(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
+  if (!access.ok) return access.response;
+
+  const params = new URL(request.url).searchParams;
+  const { data, error } = await access.supabase.rpc(
+    "find_customer_account_duplicates" as never,
+    {
+      p_shop_id: access.profile.shop_id,
+      p_name: optionalText(params.get("name"), 200),
+      p_business_name: optionalText(params.get("businessName"), 200),
+      p_email: optionalText(params.get("email"), 320),
+      p_phone: optionalText(params.get("phone"), 50),
+      p_vin: optionalText(params.get("vin"), 40),
+      p_exclude_customer_id: optionalText(params.get("excludeCustomerId"), 50),
+      p_actor_user_id: access.authUserId,
+    } as never,
+  );
+
+  if (error) {
+    return NextResponse.json({ error: message(error) }, { status: 400 });
+  }
+  return NextResponse.json({
+    ok: true,
+    duplicateCandidates: Array.isArray(data) ? data : [],
+  });
+}
+
+export async function POST(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
+  if (!access.ok) return access.response;
+
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const accountType = text(body?.accountType, 20)?.toLowerCase() ?? "";
+  const name = optionalText(body?.name, 200);
+  const businessName = optionalText(body?.businessName, 200);
+  const operationKey =
+    text(body?.operationKey, 200) ??
+    text(request.headers.get("idempotency-key"), 200);
+
+  if (
+    !ACCOUNT_TYPES.has(accountType) ||
+    (!name && !businessName) ||
+    !operationKey
+  ) {
+    return NextResponse.json(
+      { error: "Customer type, name, and operation key are required." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await access.supabase.rpc(
+    "create_customer_account_atomic" as never,
+    {
+      p_shop_id: access.profile.shop_id,
+      p_account_type: accountType,
+      p_name: name,
+      p_business_name: businessName,
+      p_email: optionalText(body?.email, 320),
+      p_phone: optionalText(body?.phone, 50),
+      p_address: optionalText(body?.address, 500),
+      p_city: optionalText(body?.city, 120),
+      p_province: optionalText(body?.province, 120),
+      p_postal_code: optionalText(body?.postalCode, 30),
+      p_notes: optionalText(body?.notes, 4000),
+      p_vin: optionalText(body?.vin, 40),
+      p_match_existing: body?.matchExisting === true,
+      p_allow_duplicate: body?.allowDuplicate === true,
+      p_actor_user_id: access.authUserId,
+      p_operation_key: operationKey,
+    } as never,
+  );
+
+  if (error) {
+    const errorMessage = message(error);
+    return NextResponse.json(
+      { error: errorMessage },
+      { status: errorMessage.includes("ROLE_REQUIRED") ? 403 : 400 },
+    );
+  }
+
+  const result = (data ?? { ok: false }) as CreateResult;
+  if (!result.ok && result.code === "CUSTOMER_DUPLICATE_REVIEW_REQUIRED") {
+    return NextResponse.json(result, { status: 409 });
+  }
+  if (!result.ok || !result.customer?.id) {
+    return NextResponse.json(
+      { error: "Customer account could not be resolved." },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json(result, {
+    status: result.matched_existing ? 200 : 201,
+  });
+}

--- a/app/mobile/work-orders/create/page.tsx
+++ b/app/mobile/work-orders/create/page.tsx
@@ -35,9 +35,7 @@ import { MobileJobLineAdd } from "@/features/work-orders/mobile/MobileJobLineAdd
 import NewWorkOrderLineForm from "@/features/work-orders/components/NewWorkOrderLineForm";
 import { useWorkOrderDraft } from "app/work-orders/state/useWorkOrderDraft";
 import VinCaptureModal from "app/vehicle/VinCaptureModal";
-import {
-  setOfflineMutationScope,
-} from "@/features/shared/lib/offline/mutations";
+import { setOfflineMutationScope } from "@/features/shared/lib/offline/mutations";
 import {
   createAdvisorDraftId,
   getCurrentAdvisorWorkOrderDraft,
@@ -57,6 +55,7 @@ import {
   resolveAndSubmitDependentPartsDrafts,
 } from "@/features/parts/offline/partsRequestDrafts";
 import { requestVehicleRecallEnrichment } from "@/features/vehicles/lib/requestRecallEnrichment";
+import { createCustomerAccount } from "@/features/customers/lib/customerAccountCommands";
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -871,43 +870,22 @@ export default function MobileCreateWorkOrderPage() {
 
     const phone = strOrNull(customer.phone);
     const email = strOrNull(customer.email);
-
-    if (phone || email) {
-      let q = supabase
-        .from("customers")
-        .select("*")
-        .eq("shop_id", shopId)
-        .limit(1);
-      if (phone) q = q.ilike("phone", phone);
-      else if (email) q = q.ilike("email", email);
-
-      const { data: found, error: fErr } = await q;
-      if (fErr) throw fErr;
-      if (found?.length) {
-        setCustomer((prev) => ({ ...prev, id: found[0].id }));
-        return found[0] as CustomerRow;
-      }
-    }
-
-    const { data: inserted, error: insErr } = await supabase
-      .from("customers")
-      .insert({
-        shop_id: shopId,
-        first_name: strOrNull(customer.first_name),
-        last_name: strOrNull(customer.last_name),
-        phone: phone,
-        email: email,
-      })
-      .select("*")
-      .single();
-
-    if (insErr || !inserted) {
-      throw new Error(insErr?.message ?? "Failed to create customer.");
-    }
-
-    setCustomer((prev) => ({ ...prev, id: inserted.id }));
-    return inserted as CustomerRow;
-  }, [customer, shopId, supabase]);
+    const name = [customer.first_name, customer.last_name]
+      .map((value) => value?.trim())
+      .filter(Boolean)
+      .join(" ");
+    const result = await createCustomerAccount({
+      accountType: "individual",
+      name: name || phone || email || "Walk-in Customer",
+      phone,
+      email,
+      vin: vehicle.vin,
+      matchExisting: true,
+    });
+    const resolved = result.customer as CustomerRow;
+    setCustomer((prev) => ({ ...prev, id: resolved.id }));
+    return resolved;
+  }, [customer, shopId, supabase, vehicle.vin]);
 
   const ensureVehicle = useCallback(
     async (cust: CustomerRow): Promise<VehicleRow> => {

--- a/app/portal/settings/page.tsx
+++ b/app/portal/settings/page.tsx
@@ -9,8 +9,25 @@ import type { Database } from "@shared/types/types/supabase";
 import LinkButton from "@shared/components/ui/LinkButton";
 
 type Customer = Database["public"]["Tables"]["customers"]["Row"];
-type SettingsRow = Database["public"]["Tables"]["customer_settings"]["Row"];
-type SettingsInsert = Database["public"]["Tables"]["customer_settings"]["Insert"];
+type PortalSettingsKey =
+  | "customer_id"
+  | "comm_email_enabled"
+  | "comm_sms_enabled"
+  | "marketing_opt_in"
+  | "preferred_contact"
+  | "units"
+  | "language"
+  | "timezone"
+  | "updated_at";
+type PortalSettingsInsertKey = Exclude<PortalSettingsKey, "updated_at">;
+type SettingsRow = Pick<
+  Database["public"]["Tables"]["customer_settings"]["Row"],
+  PortalSettingsKey
+>;
+type SettingsInsert = Pick<
+  Database["public"]["Tables"]["customer_settings"]["Insert"],
+  PortalSettingsInsertKey
+>;
 
 const COPPER = "var(--accent-copper)";
 

--- a/features/agent/tools/createCustomer.ts
+++ b/features/agent/tools/createCustomer.ts
@@ -12,26 +12,46 @@ export type CreateCustomerIn = z.infer<typeof In>;
 const Out = z.object({ customerId: z.string().uuid() });
 export type CreateCustomerOut = z.infer<typeof Out>;
 
-export const toolCreateCustomer: ToolDef<CreateCustomerIn, CreateCustomerOut> = {
-  name: "create_customer",
-  description: "Create a customer in the current shop",
-  inputSchema: In,
-  outputSchema: Out,
-  async run(input, ctx) {
-    const supabase = getServerSupabase();
+export const toolCreateCustomer: ToolDef<CreateCustomerIn, CreateCustomerOut> =
+  {
+    name: "create_customer",
+    description: "Create a customer in the current shop",
+    inputSchema: In,
+    outputSchema: Out,
+    async run(input, ctx) {
+      const supabase = getServerSupabase();
 
-    const { data, error } = await supabase
-      .from("customers")
-      .insert({
-        name: input.name,
-        email: input.email ?? undefined,
-        phone: input.phone ?? undefined,
-        shop_id: ctx.shopId,          // ← critical for RLS
-      })
-      .select("id")
-      .single();
+      const operationKey = `agent-create-customer:${ctx.shopId}:${crypto.randomUUID()}`;
+      const { data, error } = await supabase.rpc(
+        "create_customer_account_atomic" as never,
+        {
+          p_shop_id: ctx.shopId,
+          p_account_type: "individual",
+          p_name: input.name,
+          p_business_name: null,
+          p_email: input.email ?? null,
+          p_phone: input.phone ?? null,
+          p_address: null,
+          p_city: null,
+          p_province: null,
+          p_postal_code: null,
+          p_notes: "Created through the ProFixIQ agent.",
+          p_vin: null,
+          p_match_existing: true,
+          p_allow_duplicate: false,
+          p_actor_user_id: ctx.userId,
+          p_operation_key: operationKey,
+        } as never,
+      );
 
-    if (error || !data) throw new Error(error?.message ?? "Failed to create customer");
-    return { customerId: data.id };
-  },
-};
+      if (error) throw new Error(error.message);
+      const result = data as {
+        ok?: boolean;
+        customer?: { id?: string };
+      } | null;
+      if (!result?.ok || !result.customer?.id) {
+        throw new Error("Possible duplicate customer requires review.");
+      }
+      return { customerId: result.customer.id };
+    },
+  };

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -474,8 +474,8 @@ function Modal({ title, open, onClose, children, footer }: ModalProps) {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="w-full max-w-2xl rounded-2xl border border-[color:var(--desktop-border)] bg-[var(--theme-gradient-panel)] shadow-[var(--theme-shadow-medium)]">
-        <div className="flex items-center justify-between gap-3 border-b border-[color:var(--desktop-border)] px-4 py-3">
+      <div className="flex max-h-[calc(100dvh-1.5rem)] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-[color:var(--desktop-border)] bg-[var(--theme-gradient-panel)] shadow-[var(--theme-shadow-medium)]">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-[color:var(--desktop-border)] px-4 py-3">
           <div className="min-w-0">
             <div className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
               {title}
@@ -489,9 +489,9 @@ function Modal({ title, open, onClose, children, footer }: ModalProps) {
             Close
           </button>
         </div>
-        <div className="px-4 py-4">{children}</div>
+        <div className="min-h-0 overflow-y-auto px-4 py-4">{children}</div>
         {footer ? (
-          <div className="flex items-center justify-end gap-2 border-t border-[color:var(--desktop-border)] px-4 py-3">
+          <div className="flex shrink-0 items-center justify-end gap-2 border-t border-[color:var(--desktop-border)] px-4 py-3">
             {footer}
           </div>
         ) : null}
@@ -746,6 +746,7 @@ export default function CustomerProfilePage(): JSX.Element {
     async (customerId: string) => {
       setLoading(true);
       setViewError(null);
+      let customerWasLoaded = false;
 
       try {
         const { data: cust, error: custErr } = await supabase
@@ -779,6 +780,7 @@ export default function CustomerProfilePage(): JSX.Element {
         }
 
         setCustomer(cust as unknown as Customer);
+        customerWasLoaded = true;
 
         const { data: connectedFleets, error: connectedFleetsError } =
           await supabase
@@ -930,8 +932,12 @@ export default function CustomerProfilePage(): JSX.Element {
       } catch (e: unknown) {
         const msg =
           e instanceof Error ? e.message : "Failed to load customer file.";
-        setViewError(msg);
-        setCustomer(null);
+        setViewError(
+          customerWasLoaded
+            ? `Customer account loaded, but related service data could not be loaded. ${msg}`
+            : msg,
+        );
+        if (!customerWasLoaded) setCustomer(null);
         setVehicles([]);
         setSelectedVehicleId(null);
         setWorkOrders([]);

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -16,6 +16,11 @@ import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicate
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { CustomerCsvImportCard } from "@/features/customers/components/CustomerCsvImportCard";
 import { CustomerAccountDetails } from "@/features/customers/components/CustomerAccountDetails";
+import {
+  createCustomerAccount as createCanonicalCustomerAccount,
+  CustomerDuplicateReviewError,
+  type CustomerDuplicateCandidate,
+} from "@/features/customers/lib/customerAccountCommands";
 import { ImportedHistoryRecordCard } from "@/features/work-orders/components/ImportedHistoryRecordCard";
 import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
@@ -431,32 +436,6 @@ function importedHistorySummary(row: ImportedHistory): string | null {
   return strOrNull(row.description) ?? strOrNull(row.notes);
 }
 
-function normalizeEmail(v: string | null | undefined): string | null {
-  const email = strOrNull(v);
-  return email ? email.toLowerCase() : null;
-}
-
-function normalizePhone(v: string | null | undefined): string | null {
-  const raw = strOrNull(v);
-  if (!raw) return null;
-  const digits = raw.replace(/\D/g, "");
-  return digits || raw;
-}
-
-function splitCustomerName(name: string): {
-  firstName: string | null;
-  lastName: string | null;
-} {
-  const clean = strOrNull(name);
-  if (!clean) return { firstName: null, lastName: null };
-  const parts = clean.split(/\s+/).filter(Boolean);
-  if (parts.length === 1) return { firstName: parts[0], lastName: null };
-  return {
-    firstName: parts.slice(0, -1).join(" "),
-    lastName: parts.at(-1) ?? null,
-  };
-}
-
 /** Storage buckets (from your screenshot set). We don't store bucket in DB, so we "probe" candidates. */
 const BUCKET_PHOTOS_PRIMARY = "vehicle-photos";
 const BUCKET_DOCS_PRIMARY = "vehicle-docs";
@@ -657,6 +636,9 @@ export default function CustomerProfilePage(): JSX.Element {
 
   // Edit modals
   const [editCustomerOpen, setEditCustomerOpen] = useState(false);
+  const [editCustomerDuplicates, setEditCustomerDuplicates] = useState<
+    CustomerDuplicateCandidate[]
+  >([]);
   const [editVehicleOpen, setEditVehicleOpen] = useState(false);
   const [addVehicleOpen, setAddVehicleOpen] = useState(false);
 
@@ -676,6 +658,9 @@ export default function CustomerProfilePage(): JSX.Element {
   const [createCustomerError, setCreateCustomerError] = useState<string | null>(
     null,
   );
+  const [duplicateCandidates, setDuplicateCandidates] = useState<
+    CustomerDuplicateCandidate[]
+  >([]);
   const [
     customerImportPlaceholderVisible,
     setCustomerImportPlaceholderVisible,
@@ -766,7 +751,7 @@ export default function CustomerProfilePage(): JSX.Element {
         const { data: cust, error: custErr } = await supabase
           .from("customers")
           .select(
-            "id, shop_id, first_name, last_name, name, business_name, email, phone, phone_number, created_at, customer_since, address, city, province, postal_code, account_type, is_fleet, active",
+            "id, shop_id, first_name, last_name, name, business_name, email, phone, phone_number, created_at, customer_since, address, city, province, postal_code, account_type, is_fleet, active, merged_into_customer_id",
           )
           .eq("id", customerId)
           .maybeSingle();
@@ -787,7 +772,13 @@ export default function CustomerProfilePage(): JSX.Element {
           return;
         }
 
-        setCustomer(cust as Customer);
+        if (cust.merged_into_customer_id) {
+          router.replace(`/customers/${cust.merged_into_customer_id}`);
+          setLoading(false);
+          return;
+        }
+
+        setCustomer(cust as unknown as Customer);
 
         const { data: connectedFleets, error: connectedFleetsError } =
           await supabase
@@ -951,7 +942,7 @@ export default function CustomerProfilePage(): JSX.Element {
         setLoading(false);
       }
     },
-    [supabase],
+    [router, supabase],
   );
 
   useEffect(() => {
@@ -1084,82 +1075,61 @@ export default function CustomerProfilePage(): JSX.Element {
     [supabase],
   );
 
-  const createCustomer = useCallback(async () => {
-    setCreateCustomerError(null);
+  const createCustomer = useCallback(
+    async (allowDuplicate = false) => {
+      setCreateCustomerError(null);
+      setDuplicateCandidates([]);
 
-    const customerName = strOrNull(newCustomer.customerName);
-    const businessName = strOrNull(newCustomer.businessName);
-    const isBusinessLike =
-      newCustomer.customerType === "business" ||
-      newCustomer.customerType === "fleet" ||
-      newCustomer.customerType === "enterprise";
-    const displayName = isBusinessLike ? businessName : customerName;
+      const customerName = strOrNull(newCustomer.customerName);
+      const businessName = strOrNull(newCustomer.businessName);
+      const isBusinessLike =
+        newCustomer.customerType === "business" ||
+        newCustomer.customerType === "fleet" ||
+        newCustomer.customerType === "enterprise";
+      const displayName = isBusinessLike ? businessName : customerName;
 
-    if (!displayName) {
-      setCreateCustomerError(
-        isBusinessLike
-          ? "Business name is required."
-          : "Customer name is required.",
-      );
-      return;
-    }
-
-    setCreatingCustomer(true);
-    try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-
-      if (!user?.id)
-        throw new Error("You must be signed in to create a customer.");
-
-      const shopId = await getOrLinkShopId(user.id);
-      if (!shopId) throw new Error("Your profile isn’t linked to a shop yet.");
-
-      const splitName = splitCustomerName(customerName ?? "");
-      const normalizedPhone = normalizePhone(newCustomer.phone);
-
-      const insertRecord: DB["public"]["Tables"]["customers"]["Insert"] = {
-        shop_id: shopId,
-        user_id: null,
-        created_by: user.id,
-        account_type: newCustomer.customerType,
-        is_fleet: newCustomer.customerType === "fleet",
-        name: displayName,
-        business_name: isBusinessLike ? businessName : null,
-        first_name: isBusinessLike ? splitName.firstName : splitName.firstName,
-        last_name: isBusinessLike ? splitName.lastName : splitName.lastName,
-        phone: normalizedPhone,
-        phone_number: normalizedPhone,
-        email: normalizeEmail(newCustomer.email),
-        address: strOrNull(newCustomer.address),
-        city: strOrNull(newCustomer.city),
-        province: strOrNull(newCustomer.province),
-        postal_code: strOrNull(newCustomer.postalCode),
-        notes: strOrNull(newCustomer.notes),
-      };
-
-      const { data, error } = await supabase
-        .from("customers")
-        .insert(insertRecord)
-        .select("id")
-        .single();
-
-      if (error || !data?.id) {
-        throw new Error(error?.message ?? "Failed to create customer.");
+      if (!displayName) {
+        setCreateCustomerError(
+          isBusinessLike
+            ? "Business name is required."
+            : "Customer name is required.",
+        );
+        return;
       }
 
-      setCreateCustomerOpen(false);
-      setNewCustomer(EMPTY_NEW_CUSTOMER);
-      router.push(`/customers/${data.id}`);
-    } catch (e: unknown) {
-      setCreateCustomerError(
-        e instanceof Error ? e.message : "Failed to create customer.",
-      );
-    } finally {
-      setCreatingCustomer(false);
-    }
-  }, [getOrLinkShopId, newCustomer, router, supabase]);
+      setCreatingCustomer(true);
+      try {
+        const result = await createCanonicalCustomerAccount({
+          accountType: newCustomer.customerType,
+          name: customerName,
+          businessName: isBusinessLike ? businessName : null,
+          phone: newCustomer.phone,
+          email: newCustomer.email,
+          address: newCustomer.address,
+          city: newCustomer.city,
+          province: newCustomer.province,
+          postalCode: newCustomer.postalCode,
+          notes: newCustomer.notes,
+          allowDuplicate,
+        });
+
+        setCreateCustomerOpen(false);
+        setNewCustomer(EMPTY_NEW_CUSTOMER);
+        router.push(`/customers/${result.customer?.id}`);
+      } catch (e: unknown) {
+        if (e instanceof CustomerDuplicateReviewError) {
+          setDuplicateCandidates(e.candidates);
+          return;
+        }
+        setCreateCustomerError(
+          e instanceof Error ? e.message : "Failed to create customer.",
+        );
+      } finally {
+        setCreatingCustomer(false);
+      }
+    },
+    [newCustomer, router],
+  );
 
   // ------------------ Directory search ------------------
   const loadDirectoryRows = useCallback(async () => {
@@ -1350,62 +1320,93 @@ export default function CustomerProfilePage(): JSX.Element {
     });
   }, [customer]);
 
-  const saveCustomer = useCallback(async () => {
-    if (!customer) return;
+  const saveCustomer = useCallback(
+    async (allowOverlap = false) => {
+      if (!customer) return;
 
-    const updateRecord: Record<string, unknown> = {
-      first_name:
-        typeof custDraft["first_name"] === "string"
-          ? custDraft["first_name"]
-          : null,
-      last_name:
-        typeof custDraft["last_name"] === "string"
-          ? custDraft["last_name"]
-          : null,
-      name:
-        typeof custDraft["name"] === "string"
-          ? (custDraft["name"] as string) || null
-          : null,
-      business_name:
-        typeof custDraft["business_name"] === "string"
-          ? (custDraft["business_name"] as string) || null
-          : null,
-      account_type:
-        typeof custDraft["account_type"] === "string"
-          ? custDraft["account_type"]
-          : "individual",
-      is_fleet: custDraft["account_type"] === "fleet",
-      email: typeof custDraft["email"] === "string" ? custDraft["email"] : null,
-      phone: typeof custDraft["phone"] === "string" ? custDraft["phone"] : null,
-      phone_number:
-        typeof custDraft["phone_number"] === "string"
-          ? custDraft["phone_number"]
-          : null,
-    };
+      const updateRecord: Record<string, unknown> = {
+        first_name:
+          typeof custDraft["first_name"] === "string"
+            ? custDraft["first_name"]
+            : null,
+        last_name:
+          typeof custDraft["last_name"] === "string"
+            ? custDraft["last_name"]
+            : null,
+        name:
+          typeof custDraft["name"] === "string"
+            ? (custDraft["name"] as string) || null
+            : null,
+        business_name:
+          typeof custDraft["business_name"] === "string"
+            ? (custDraft["business_name"] as string) || null
+            : null,
+        account_type:
+          typeof custDraft["account_type"] === "string"
+            ? custDraft["account_type"]
+            : "individual",
+        is_fleet: custDraft["account_type"] === "fleet",
+        email:
+          typeof custDraft["email"] === "string" ? custDraft["email"] : null,
+        phone:
+          typeof custDraft["phone"] === "string" ? custDraft["phone"] : null,
+        phone_number:
+          typeof custDraft["phone_number"] === "string"
+            ? custDraft["phone_number"]
+            : null,
+      };
 
-    // Optional fields (if your schema has them, they'll save; if not, Supabase will error and we show it)
-    if (typeof custDraft["address"] === "string")
-      updateRecord["address"] = custDraft["address"] || null;
-    if (typeof custDraft["city"] === "string")
-      updateRecord["city"] = custDraft["city"] || null;
-    if (typeof custDraft["province"] === "string")
-      updateRecord["province"] = custDraft["province"] || null;
-    if (typeof custDraft["postal_code"] === "string")
-      updateRecord["postal_code"] = custDraft["postal_code"] || null;
+      // Optional fields (if your schema has them, they'll save; if not, Supabase will error and we show it)
+      if (typeof custDraft["address"] === "string")
+        updateRecord["address"] = custDraft["address"] || null;
+      if (typeof custDraft["city"] === "string")
+        updateRecord["city"] = custDraft["city"] || null;
+      if (typeof custDraft["province"] === "string")
+        updateRecord["province"] = custDraft["province"] || null;
+      if (typeof custDraft["postal_code"] === "string")
+        updateRecord["postal_code"] = custDraft["postal_code"] || null;
 
-    const { error } = await supabase
-      .from("customers")
-      .update(updateRecord as DB["public"]["Tables"]["customers"]["Update"])
-      .eq("id", customer.id);
+      if (!allowOverlap) {
+        const params = new URLSearchParams({ excludeCustomerId: customer.id });
+        const values: Array<[string, unknown]> = [
+          ["name", updateRecord["name"]],
+          ["businessName", updateRecord["business_name"]],
+          ["email", updateRecord["email"]],
+          ["phone", updateRecord["phone"]],
+        ];
+        for (const [key, value] of values) {
+          if (typeof value === "string" && value.trim()) {
+            params.set(key, value.trim());
+          }
+        }
+        const response = await fetch(`/api/customers/accounts?${params}`, {
+          cache: "no-store",
+        });
+        const payload = (await response.json().catch(() => null)) as {
+          duplicateCandidates?: CustomerDuplicateCandidate[];
+        } | null;
+        if ((payload?.duplicateCandidates?.length ?? 0) > 0) {
+          setEditCustomerDuplicates(payload?.duplicateCandidates ?? []);
+          return;
+        }
+      }
 
-    if (error) {
-      setViewError(error.message);
-      return;
-    }
+      const { error } = await supabase
+        .from("customers")
+        .update(updateRecord as DB["public"]["Tables"]["customers"]["Update"])
+        .eq("id", customer.id);
 
-    setEditCustomerOpen(false);
-    await fetchCustomerFile(customer.id);
-  }, [customer, custDraft, fetchCustomerFile, supabase]);
+      if (error) {
+        setViewError(error.message);
+        return;
+      }
+
+      setEditCustomerOpen(false);
+      setEditCustomerDuplicates([]);
+      await fetchCustomerFile(customer.id);
+    },
+    [customer, custDraft, fetchCustomerFile, supabase],
+  );
 
   // ------------------ Edit Vehicle ------------------
   const [vehDraft, setVehDraft] = useState<Record<string, unknown>>({});
@@ -1923,7 +1924,7 @@ export default function CustomerProfilePage(): JSX.Element {
               </button>
               <button
                 type="button"
-                onClick={() => void createCustomer()}
+                onClick={() => void createCustomer(false)}
                 disabled={creatingCustomer}
                 className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-on-accent)] shadow-[0_0_22px_rgba(212,118,49,0.75)] hover:brightness-110 disabled:opacity-60"
               >
@@ -1941,6 +1942,44 @@ export default function CustomerProfilePage(): JSX.Element {
             {createCustomerError ? (
               <div className="whitespace-pre-wrap rounded-xl border border-red-500/35 bg-red-950/50 p-3 text-sm text-red-200">
                 {createCustomerError}
+              </div>
+            ) : null}
+
+            {duplicateCandidates.length > 0 ? (
+              <div className="rounded-xl border border-amber-400/40 bg-amber-950/30 p-3">
+                <div className="text-sm font-semibold text-amber-100">
+                  Possible duplicate accounts
+                </div>
+                <p className="mt-1 text-xs leading-5 text-amber-100/75">
+                  Open an existing account when it is the same customer. Create
+                  another only when you have confirmed these are separate
+                  records.
+                </p>
+                <div className="mt-3 space-y-2">
+                  {duplicateCandidates.map((candidate) => (
+                    <button
+                      key={candidate.id}
+                      type="button"
+                      onClick={() => router.push(`/customers/${candidate.id}`)}
+                      className="w-full rounded-lg border border-amber-300/25 bg-black/15 p-2 text-left text-xs text-amber-50 hover:border-amber-300/60"
+                    >
+                      <span className="font-semibold">
+                        {candidate.display_name}
+                      </span>
+                      <span className="ml-2 text-amber-100/65">
+                        Matched {candidate.reasons.join(", ")}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void createCustomer(true)}
+                  disabled={creatingCustomer}
+                  className="mt-3 rounded-lg border border-amber-300/40 px-3 py-2 text-xs font-semibold text-amber-50 hover:bg-amber-200/10 disabled:opacity-60"
+                >
+                  Confirm separate customer
+                </button>
               </div>
             ) : null}
 
@@ -2843,7 +2882,7 @@ export default function CustomerProfilePage(): JSX.Element {
             </button>
             <button
               type="button"
-              onClick={() => void saveCustomer()}
+              onClick={() => void saveCustomer(false)}
               className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-[12px] font-semibold text-[color:var(--theme-text-on-accent)] shadow-[0_0_22px_rgba(212,118,49,0.75)] hover:brightness-110"
             >
               Save
@@ -2851,6 +2890,26 @@ export default function CustomerProfilePage(): JSX.Element {
           </>
         }
       >
+        {editCustomerDuplicates.length > 0 ? (
+          <div className="mb-3 rounded-xl border border-amber-400/40 bg-amber-950/30 p-3 text-xs text-amber-100">
+            <div className="font-semibold">Possible duplicate accounts</div>
+            <div className="mt-2 space-y-1">
+              {editCustomerDuplicates.map((candidate) => (
+                <div key={candidate.id}>
+                  {candidate.display_name} · matched{" "}
+                  {candidate.reasons.join(", ")}
+                </div>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => void saveCustomer(true)}
+              className="mt-3 rounded-lg border border-amber-300/40 px-3 py-2 font-semibold"
+            >
+              Confirm these are separate accounts
+            </button>
+          </div>
+        ) : null}
         <div className="mb-3 space-y-1">
           <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
             Account type

--- a/features/customers/components/CustomerAccountDetails.tsx
+++ b/features/customers/components/CustomerAccountDetails.tsx
@@ -1,7 +1,21 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Building2, Loader2, MapPin, Plus, UserRound } from "lucide-react";
+import { useRouter } from "next/navigation";
+import {
+  Archive,
+  Building2,
+  CircleDollarSign,
+  FileClock,
+  Link2,
+  Loader2,
+  MapPin,
+  Plus,
+  ReceiptText,
+  ShieldAlert,
+  UserRound,
+  Wrench,
+} from "lucide-react";
 import { toast } from "sonner";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@/features/shared/types/types/supabase";
@@ -9,6 +23,60 @@ import { CustomerPricingPanel } from "@/features/customers/components/CustomerPr
 
 type Contact = Database["public"]["Tables"]["customer_contacts"]["Row"];
 type Location = Database["public"]["Tables"]["customer_locations"]["Row"];
+type MergeCandidate = Pick<
+  Database["public"]["Tables"]["customers"]["Row"],
+  "id" | "name" | "business_name" | "email" | "phone"
+>;
+
+type CommercialSettings = {
+  primary_billing_contact_id: string | null;
+  primary_approval_contact_id: string | null;
+  po_required: boolean;
+  payment_terms: string;
+  payment_terms_days: number;
+  tax_exempt: boolean;
+  tax_exemption_reference: string | null;
+  account_status: "good_standing" | "credit_hold" | "account_hold";
+  account_hold_reason: string | null;
+  billing_notes: string | null;
+  customer_reference: string | null;
+};
+
+type AccountCenterSummary = {
+  ok: boolean;
+  customer: {
+    id: string;
+    active: boolean;
+    account_type: string;
+    merged_into_customer_id: string | null;
+  };
+  settings: CommercialSettings;
+  fleet: {
+    id: string;
+    name: string;
+    active: boolean;
+    link_status: "connected" | "not_connected" | "inactive";
+  } | null;
+  fleet_invite: {
+    email: string;
+    status: "pending" | "accepted" | "expired" | "revoked";
+  } | null;
+  counts: {
+    contacts: number;
+    locations: number;
+    vehicles: number;
+    work_orders: number;
+    invoices: number;
+    merged_sources: number;
+  };
+  invoice_summary: {
+    total_billed: number;
+    outstanding: number;
+    last_invoice_at: string | null;
+  };
+  can_manage_commercial: boolean;
+  can_merge_or_archive: boolean;
+};
 
 type Props = {
   customerId: string;
@@ -19,13 +87,36 @@ const inputClass =
   "w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]";
 
 export function CustomerAccountDetails({ customerId, shopId }: Props) {
+  const router = useRouter();
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [locations, setLocations] = useState<Location[]>([]);
+  const [account, setAccount] = useState<AccountCenterSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [showContactForm, setShowContactForm] = useState(false);
   const [showLocationForm, setShowLocationForm] = useState(false);
+  const [showCommercialForm, setShowCommercialForm] = useState(false);
+  const [showLifecycleForm, setShowLifecycleForm] = useState<
+    "archive" | "merge" | null
+  >(null);
+  const [lifecycleReason, setLifecycleReason] = useState("");
+  const [mergeTargetId, setMergeTargetId] = useState("");
+  const [mergeSearch, setMergeSearch] = useState("");
+  const [mergeCandidates, setMergeCandidates] = useState<MergeCandidate[]>([]);
+  const [commercial, setCommercial] = useState<CommercialSettings>({
+    primary_billing_contact_id: null,
+    primary_approval_contact_id: null,
+    po_required: false,
+    payment_terms: "due_on_receipt",
+    payment_terms_days: 0,
+    tax_exempt: false,
+    tax_exemption_reference: null,
+    account_status: "good_standing",
+    account_hold_reason: null,
+    billing_notes: null,
+    customer_reference: null,
+  });
   const [contact, setContact] = useState({
     displayName: "",
     email: "",
@@ -43,28 +134,40 @@ export function CustomerAccountDetails({ customerId, shopId }: Props) {
 
   const load = useCallback(async () => {
     setLoading(true);
-    const [contactsResult, locationsResult] = await Promise.all([
-      supabase
-        .from("customer_contacts")
-        .select("*")
-        .eq("customer_id", customerId)
-        .eq("active", true)
-        .order("is_primary", { ascending: false })
-        .order("created_at"),
-      supabase
-        .from("customer_locations")
-        .select("*")
-        .eq("customer_id", customerId)
-        .eq("active", true)
-        .order("is_primary", { ascending: false })
-        .order("created_at"),
-    ]);
+    const [contactsResult, locationsResult, accountResponse] =
+      await Promise.all([
+        supabase
+          .from("customer_contacts")
+          .select("*")
+          .eq("customer_id", customerId)
+          .eq("active", true)
+          .order("is_primary", { ascending: false })
+          .order("created_at"),
+        supabase
+          .from("customer_locations")
+          .select("*")
+          .eq("customer_id", customerId)
+          .eq("active", true)
+          .order("is_primary", { ascending: false })
+          .order("created_at"),
+        fetch(`/api/customers/${customerId}/account`, { cache: "no-store" }),
+      ]);
 
-    if (contactsResult.error || locationsResult.error) {
+    const accountPayload = (await accountResponse.json().catch(() => null)) as
+      | (AccountCenterSummary & { error?: string })
+      | null;
+    if (
+      contactsResult.error ||
+      locationsResult.error ||
+      !accountResponse.ok ||
+      !accountPayload?.ok
+    ) {
       toast.error("Customer contacts and locations could not be loaded.");
     } else {
       setContacts(contactsResult.data ?? []);
       setLocations(locationsResult.data ?? []);
+      setAccount(accountPayload);
+      setCommercial(accountPayload.settings);
     }
     setLoading(false);
   }, [customerId, supabase]);
@@ -72,6 +175,36 @@ export function CustomerAccountDetails({ customerId, shopId }: Props) {
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    if (showLifecycleForm !== "merge" || mergeSearch.trim().length < 2) {
+      setMergeCandidates([]);
+      return;
+    }
+    const token = mergeSearch
+      .trim()
+      .replace(/[%,()]/g, " ")
+      .slice(0, 80);
+    const timeout = window.setTimeout(() => {
+      void supabase
+        .from("customers")
+        .select("id,name,business_name,email,phone")
+        .eq("shop_id", shopId)
+        .eq("active", true)
+        .neq("id", customerId)
+        .or(
+          [
+            `name.ilike.%${token}%`,
+            `business_name.ilike.%${token}%`,
+            `email.ilike.%${token}%`,
+            `phone.ilike.%${token}%`,
+          ].join(","),
+        )
+        .limit(8)
+        .then(({ data }) => setMergeCandidates(data ?? []));
+    }, 250);
+    return () => window.clearTimeout(timeout);
+  }, [customerId, mergeSearch, shopId, showLifecycleForm, supabase]);
 
   async function addContact(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -136,283 +269,843 @@ export function CustomerAccountDetails({ customerId, shopId }: Props) {
     setSaving(false);
   }
 
+  async function saveCommercialControls(
+    event: React.FormEvent<HTMLFormElement>,
+  ) {
+    event.preventDefault();
+    setSaving(true);
+    try {
+      const response = await fetch(`/api/customers/${customerId}/account`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": crypto.randomUUID(),
+        },
+        body: JSON.stringify({
+          action: "update_commercial_controls",
+          operationKey: crypto.randomUUID(),
+          primaryBillingContactId: commercial.primary_billing_contact_id,
+          primaryApprovalContactId: commercial.primary_approval_contact_id,
+          poRequired: commercial.po_required,
+          paymentTerms: commercial.payment_terms,
+          paymentTermsDays: commercial.payment_terms_days,
+          taxExempt: commercial.tax_exempt,
+          taxExemptionReference: commercial.tax_exemption_reference,
+          accountStatus: commercial.account_status,
+          accountHoldReason: commercial.account_hold_reason,
+          billingNotes: commercial.billing_notes,
+          customerReference: commercial.customer_reference,
+        }),
+      });
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      if (!response.ok) {
+        throw new Error(
+          payload?.error ?? "Commercial controls could not be saved.",
+        );
+      }
+      toast.success("Commercial account controls saved.");
+      setShowCommercialForm(false);
+      await load();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Commercial controls could not be saved.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function runLifecycleAction() {
+    if (!showLifecycleForm || lifecycleReason.trim().length < 3) return;
+    if (showLifecycleForm === "merge" && !mergeTargetId.trim()) return;
+    setSaving(true);
+    try {
+      const operationKey = crypto.randomUUID();
+      const response = await fetch(`/api/customers/${customerId}/account`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": operationKey,
+        },
+        body: JSON.stringify({
+          action: showLifecycleForm,
+          targetCustomerId:
+            showLifecycleForm === "merge" ? mergeTargetId.trim() : null,
+          reason: lifecycleReason,
+          operationKey,
+        }),
+      });
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string;
+        redirect_customer_id?: string;
+      } | null;
+      if (!response.ok) {
+        throw new Error(payload?.error ?? "Customer account action failed.");
+      }
+      if (showLifecycleForm === "merge" && payload?.redirect_customer_id) {
+        toast.success("Customer records merged without deleting history.");
+        router.push(`/customers/${payload.redirect_customer_id}`);
+      } else {
+        toast.success("Customer account archived. History remains available.");
+        router.push("/customers/search");
+      }
+      router.refresh();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Customer account action failed.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const money = useMemo(
+    () =>
+      new Intl.NumberFormat("en-CA", {
+        style: "currency",
+        currency: "CAD",
+      }),
+    [],
+  );
+
   return (
     <div className="space-y-4">
+      <section className="overflow-hidden rounded-2xl border border-[var(--accent-copper-soft)]/45 bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.18),transparent_42%),color:var(--desktop-panel-bg-soft)] shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
+        <div className="border-b border-[color:var(--desktop-border)] p-4 sm:p-5">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper)]">
+                Customer Account Center
+              </div>
+              <h2 className="mt-1 text-xl font-semibold text-[color:var(--theme-text-primary)]">
+                One account. Every commercial and service relationship.
+              </h2>
+              <p className="mt-1 max-w-2xl text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                Contacts, locations, assets, work history, invoices, Fleet
+                access, and negotiated pricing stay attached to this canonical
+                record.
+              </p>
+            </div>
+            {account?.can_manage_commercial ? (
+              <button
+                type="button"
+                onClick={() => setShowCommercialForm((current) => !current)}
+                className="rounded-xl bg-[var(--accent-copper)] px-3 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] hover:brightness-110"
+              >
+                {showCommercialForm ? "Close controls" : "Commercial controls"}
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="grid gap-3 p-4 sm:grid-cols-2 sm:p-5 xl:grid-cols-5">
+          {[
+            [Wrench, "Assets", account?.counts.vehicles ?? 0],
+            [FileClock, "Work orders", account?.counts.work_orders ?? 0],
+            [ReceiptText, "Invoices", account?.counts.invoices ?? 0],
+            [
+              CircleDollarSign,
+              "Outstanding",
+              money.format(account?.invoice_summary.outstanding ?? 0),
+            ],
+            [Link2, "Merged history", account?.counts.merged_sources ?? 0],
+          ].map(([Icon, label, value]) => {
+            const StatIcon = Icon as typeof Wrench;
+            return (
+              <div
+                key={String(label)}
+                className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3"
+              >
+                <StatIcon className="h-4 w-4 text-[var(--accent-copper)]" />
+                <div className="mt-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                  {String(label)}
+                </div>
+                <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                  {String(value)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="grid gap-4 border-t border-[color:var(--desktop-border)] p-4 sm:p-5 xl:grid-cols-[1fr_0.9fr]">
+          <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                  Commercial posture
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                  <span className="rounded-full border border-[color:var(--desktop-border)] px-2.5 py-1">
+                    {commercial.po_required ? "PO required" : "PO optional"}
+                  </span>
+                  <span className="rounded-full border border-[color:var(--desktop-border)] px-2.5 py-1">
+                    {commercial.payment_terms.replaceAll("_", " ")}
+                  </span>
+                  <span
+                    className={`rounded-full border px-2.5 py-1 ${
+                      commercial.account_status === "good_standing"
+                        ? "border-emerald-500/35 text-emerald-200"
+                        : "border-amber-500/40 text-amber-200"
+                    }`}
+                  >
+                    {commercial.account_status.replaceAll("_", " ")}
+                  </span>
+                  {commercial.tax_exempt ? (
+                    <span className="rounded-full border border-sky-500/35 px-2.5 py-1 text-sky-200">
+                      Tax exempt
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              {commercial.account_status !== "good_standing" ? (
+                <ShieldAlert className="h-5 w-5 text-amber-300" />
+              ) : null}
+            </div>
+            {commercial.customer_reference || commercial.billing_notes ? (
+              <div className="mt-3 border-t border-[color:var(--desktop-border)] pt-3 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                {commercial.customer_reference ? (
+                  <div>Reference: {commercial.customer_reference}</div>
+                ) : null}
+                {commercial.billing_notes ? (
+                  <div>Billing: {commercial.billing_notes}</div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-4">
+            <div className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+              Fleet workspace
+            </div>
+            {account?.fleet ? (
+              <div className="mt-2">
+                <div className="font-semibold text-[color:var(--theme-text-primary)]">
+                  {account.fleet.name}
+                </div>
+                <div className="mt-1 text-xs capitalize text-emerald-200">
+                  {account.fleet.link_status.replaceAll("_", " ")}
+                  {account.fleet_invite
+                    ? ` · invite ${account.fleet_invite.status}`
+                    : ""}
+                </div>
+              </div>
+            ) : (
+              <p className="mt-2 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                Ordinary customer account. Fleet is optional and is never
+                created or billed unless the shop explicitly connects it.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {showCommercialForm ? (
+          <form
+            onSubmit={saveCommercialControls}
+            className="border-t border-[color:var(--desktop-border)] bg-black/10 p-4 sm:p-5"
+          >
+            <div className="grid gap-3 lg:grid-cols-3">
+              <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                Billing contact
+                <select
+                  value={commercial.primary_billing_contact_id ?? ""}
+                  onChange={(event) =>
+                    setCommercial((draft) => ({
+                      ...draft,
+                      primary_billing_contact_id: event.target.value || null,
+                    }))
+                  }
+                  className={`${inputClass} mt-1`}
+                >
+                  <option value="">Account primary</option>
+                  {contacts.map((item) => (
+                    <option key={item.id} value={item.id}>
+                      {item.display_name || item.email || "Contact"}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                Approval contact
+                <select
+                  value={commercial.primary_approval_contact_id ?? ""}
+                  onChange={(event) =>
+                    setCommercial((draft) => ({
+                      ...draft,
+                      primary_approval_contact_id: event.target.value || null,
+                    }))
+                  }
+                  className={`${inputClass} mt-1`}
+                >
+                  <option value="">Account primary</option>
+                  {contacts.map((item) => (
+                    <option key={item.id} value={item.id}>
+                      {item.display_name || item.email || "Contact"}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                Payment terms
+                <select
+                  value={commercial.payment_terms}
+                  onChange={(event) =>
+                    setCommercial((draft) => ({
+                      ...draft,
+                      payment_terms: event.target.value,
+                      payment_terms_days:
+                        event.target.value === "custom"
+                          ? draft.payment_terms_days
+                          : Number(event.target.value.match(/\d+/)?.[0] ?? 0),
+                    }))
+                  }
+                  className={`${inputClass} mt-1`}
+                >
+                  <option value="due_on_receipt">Due on receipt</option>
+                  <option value="net_7">Net 7</option>
+                  <option value="net_15">Net 15</option>
+                  <option value="net_30">Net 30</option>
+                  <option value="net_45">Net 45</option>
+                  <option value="net_60">Net 60</option>
+                  <option value="custom">Custom</option>
+                </select>
+              </label>
+              {commercial.payment_terms === "custom" ? (
+                <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                  Custom terms (days)
+                  <input
+                    type="number"
+                    min={0}
+                    max={365}
+                    value={commercial.payment_terms_days}
+                    onChange={(event) =>
+                      setCommercial((draft) => ({
+                        ...draft,
+                        payment_terms_days: Number(event.target.value),
+                      }))
+                    }
+                    className={`${inputClass} mt-1`}
+                  />
+                </label>
+              ) : null}
+              <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                Account standing
+                <select
+                  value={commercial.account_status}
+                  onChange={(event) =>
+                    setCommercial((draft) => ({
+                      ...draft,
+                      account_status: event.target
+                        .value as CommercialSettings["account_status"],
+                    }))
+                  }
+                  className={`${inputClass} mt-1`}
+                >
+                  <option value="good_standing">Good standing</option>
+                  <option value="credit_hold">Credit hold</option>
+                  <option value="account_hold">Account hold</option>
+                </select>
+              </label>
+              {commercial.account_status !== "good_standing" ? (
+                <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                  Hold reason
+                  <input
+                    required
+                    value={commercial.account_hold_reason ?? ""}
+                    onChange={(event) =>
+                      setCommercial((draft) => ({
+                        ...draft,
+                        account_hold_reason: event.target.value,
+                      }))
+                    }
+                    className={`${inputClass} mt-1`}
+                  />
+                </label>
+              ) : null}
+              <label className="flex items-center gap-2 rounded-xl border border-[color:var(--desktop-border)] p-3 text-xs font-semibold">
+                <input
+                  type="checkbox"
+                  checked={commercial.po_required}
+                  onChange={(event) =>
+                    setCommercial((draft) => ({
+                      ...draft,
+                      po_required: event.target.checked,
+                    }))
+                  }
+                />
+                Purchase order required
+              </label>
+              <label className="flex items-center gap-2 rounded-xl border border-[color:var(--desktop-border)] p-3 text-xs font-semibold">
+                <input
+                  type="checkbox"
+                  checked={commercial.tax_exempt}
+                  onChange={(event) =>
+                    setCommercial((draft) => ({
+                      ...draft,
+                      tax_exempt: event.target.checked,
+                    }))
+                  }
+                />
+                Tax exempt
+              </label>
+              {commercial.tax_exempt ? (
+                <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                  Exemption reference
+                  <input
+                    required
+                    value={commercial.tax_exemption_reference ?? ""}
+                    onChange={(event) =>
+                      setCommercial((draft) => ({
+                        ...draft,
+                        tax_exemption_reference: event.target.value,
+                      }))
+                    }
+                    className={`${inputClass} mt-1`}
+                  />
+                </label>
+              ) : null}
+              <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)] lg:col-span-2">
+                Billing notes
+                <textarea
+                  value={commercial.billing_notes ?? ""}
+                  onChange={(event) =>
+                    setCommercial((draft) => ({
+                      ...draft,
+                      billing_notes: event.target.value,
+                    }))
+                  }
+                  rows={2}
+                  className={`${inputClass} mt-1`}
+                />
+              </label>
+              <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                Customer-facing reference
+                <input
+                  value={commercial.customer_reference ?? ""}
+                  onChange={(event) =>
+                    setCommercial((draft) => ({
+                      ...draft,
+                      customer_reference: event.target.value,
+                    }))
+                  }
+                  className={`${inputClass} mt-1`}
+                />
+              </label>
+            </div>
+            <button
+              type="submit"
+              disabled={saving}
+              className="mt-4 rounded-xl bg-[var(--accent-copper)] px-4 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-60"
+            >
+              {saving ? "Saving…" : "Save commercial controls"}
+            </button>
+          </form>
+        ) : null}
+      </section>
+
       <CustomerPricingPanel customerId={customerId} />
       <section className="rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper)]">
-            Account details
-          </div>
-          <h2 className="mt-1 text-lg font-semibold">Contacts & locations</h2>
-          <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-            Keep service, approval, billing, and branch details on one customer
-            file.
-          </p>
-        </div>
-        {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-      </div>
-
-      <div className="mt-4 grid gap-4 xl:grid-cols-2">
-        <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3">
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2 text-sm font-semibold">
-              <UserRound className="h-4 w-4 text-[var(--accent-copper)]" />
-              Contacts
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper)]">
+              Account details
             </div>
-            <button
-              type="button"
-              onClick={() => setShowContactForm((current) => !current)}
-              className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--accent-copper)] hover:underline"
-            >
-              <Plus className="h-3.5 w-3.5" /> Add
-            </button>
+            <h2 className="mt-1 text-lg font-semibold">Contacts & locations</h2>
+            <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+              Keep service, approval, billing, and branch details on one
+              customer file.
+            </p>
           </div>
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+        </div>
 
-          {showContactForm ? (
-            <form onSubmit={addContact} className="mt-3 space-y-2">
-              <input
-                required
-                value={contact.displayName}
-                onChange={(event) =>
-                  setContact((draft) => ({
-                    ...draft,
-                    displayName: event.target.value,
-                  }))
-                }
-                placeholder="Contact name"
-                aria-label="Contact name"
-                className={inputClass}
-              />
-              <div className="grid gap-2 sm:grid-cols-2">
-                <input
-                  type="email"
-                  value={contact.email}
-                  onChange={(event) =>
-                    setContact((draft) => ({
-                      ...draft,
-                      email: event.target.value,
-                    }))
-                  }
-                  placeholder="Email"
-                  aria-label="Contact email"
-                  className={inputClass}
-                />
-                <input
-                  value={contact.phone}
-                  onChange={(event) =>
-                    setContact((draft) => ({
-                      ...draft,
-                      phone: event.target.value,
-                    }))
-                  }
-                  placeholder="Phone"
-                  aria-label="Contact phone"
-                  className={inputClass}
-                />
+        <div className="mt-4 grid gap-4 xl:grid-cols-2">
+          <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <UserRound className="h-4 w-4 text-[var(--accent-copper)]" />
+                Contacts
               </div>
-              <select
-                value={contact.role}
-                onChange={(event) =>
-                  setContact((draft) => ({
-                    ...draft,
-                    role: event.target.value,
-                  }))
-                }
-                aria-label="Contact role"
-                className={inputClass}
-              >
-                <option value="primary">Primary</option>
-                <option value="service">Service</option>
-                <option value="billing">Billing</option>
-                <option value="approver">Approver</option>
-                <option value="other">Other</option>
-              </select>
               <button
-                type="submit"
-                disabled={saving}
-                className="w-full rounded-xl bg-[var(--accent-copper)] px-3 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-60"
+                type="button"
+                onClick={() => setShowContactForm((current) => !current)}
+                className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--accent-copper)] hover:underline"
               >
-                Save contact
+                <Plus className="h-3.5 w-3.5" /> Add
               </button>
-            </form>
-          ) : null}
-
-          <div className="mt-3 space-y-2">
-            {contacts.length === 0 ? (
-              <p className="text-xs text-[color:var(--theme-text-muted)]">
-                No additional contacts yet. The existing customer contact stays
-                available above.
-              </p>
-            ) : (
-              contacts.map((item) => (
-                <div
-                  key={item.id}
-                  className="rounded-lg bg-[color:var(--theme-surface-inset)] p-2.5 text-xs"
-                >
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="font-semibold">
-                      {item.display_name ||
-                        [item.first_name, item.last_name]
-                          .filter(Boolean)
-                          .join(" ") ||
-                        "Contact"}
-                    </span>
-                    <span className="capitalize text-[var(--accent-copper)]">
-                      {item.role}
-                    </span>
-                  </div>
-                  <div className="mt-1 text-[color:var(--theme-text-secondary)]">
-                    {[item.email, item.phone].filter(Boolean).join(" · ") ||
-                      "No contact method"}
-                  </div>
-                </div>
-              ))
-            )}
-          </div>
-        </div>
-
-        <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3">
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2 text-sm font-semibold">
-              <Building2 className="h-4 w-4 text-[var(--accent-copper)]" />
-              Locations
             </div>
-            <button
-              type="button"
-              onClick={() => setShowLocationForm((current) => !current)}
-              className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--accent-copper)] hover:underline"
-            >
-              <Plus className="h-3.5 w-3.5" /> Add
-            </button>
-          </div>
 
-          {showLocationForm ? (
-            <form onSubmit={addLocation} className="mt-3 space-y-2">
-              <div className="grid gap-2 sm:grid-cols-2">
+            {showContactForm ? (
+              <form onSubmit={addContact} className="mt-3 space-y-2">
                 <input
                   required
-                  value={location.name}
+                  value={contact.displayName}
                   onChange={(event) =>
-                    setLocation((draft) => ({
+                    setContact((draft) => ({
                       ...draft,
-                      name: event.target.value,
+                      displayName: event.target.value,
                     }))
                   }
-                  placeholder="Location name"
-                  aria-label="Location name"
+                  placeholder="Contact name"
+                  aria-label="Contact name"
                   className={inputClass}
                 />
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <input
+                    type="email"
+                    value={contact.email}
+                    onChange={(event) =>
+                      setContact((draft) => ({
+                        ...draft,
+                        email: event.target.value,
+                      }))
+                    }
+                    placeholder="Email"
+                    aria-label="Contact email"
+                    className={inputClass}
+                  />
+                  <input
+                    value={contact.phone}
+                    onChange={(event) =>
+                      setContact((draft) => ({
+                        ...draft,
+                        phone: event.target.value,
+                      }))
+                    }
+                    placeholder="Phone"
+                    aria-label="Contact phone"
+                    className={inputClass}
+                  />
+                </div>
                 <select
-                  value={location.locationType}
+                  value={contact.role}
                   onChange={(event) =>
-                    setLocation((draft) => ({
+                    setContact((draft) => ({
                       ...draft,
-                      locationType: event.target.value,
+                      role: event.target.value,
                     }))
                   }
-                  aria-label="Location type"
+                  aria-label="Contact role"
                   className={inputClass}
                 >
+                  <option value="primary">Primary</option>
                   <option value="service">Service</option>
                   <option value="billing">Billing</option>
-                  <option value="branch">Branch</option>
+                  <option value="approver">Approver</option>
                   <option value="other">Other</option>
                 </select>
-              </div>
-              <input
-                value={location.address}
-                onChange={(event) =>
-                  setLocation((draft) => ({
-                    ...draft,
-                    address: event.target.value,
-                  }))
-                }
-                placeholder="Street address"
-                aria-label="Location street address"
-                className={inputClass}
-              />
-              <div className="grid gap-2 sm:grid-cols-3">
-                <input
-                  value={location.city}
-                  onChange={(event) =>
-                    setLocation((draft) => ({
-                      ...draft,
-                      city: event.target.value,
-                    }))
-                  }
-                  placeholder="City"
-                  aria-label="Location city"
-                  className={inputClass}
-                />
-                <input
-                  value={location.province}
-                  onChange={(event) =>
-                    setLocation((draft) => ({
-                      ...draft,
-                      province: event.target.value,
-                    }))
-                  }
-                  placeholder="Province"
-                  aria-label="Location province"
-                  className={inputClass}
-                />
-                <input
-                  value={location.postalCode}
-                  onChange={(event) =>
-                    setLocation((draft) => ({
-                      ...draft,
-                      postalCode: event.target.value,
-                    }))
-                  }
-                  placeholder="Postal code"
-                  aria-label="Location postal code"
-                  className={inputClass}
-                />
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="w-full rounded-xl bg-[var(--accent-copper)] px-3 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-60"
+                >
+                  Save contact
+                </button>
+              </form>
+            ) : null}
+
+            <div className="mt-3 space-y-2">
+              {contacts.length === 0 ? (
+                <p className="text-xs text-[color:var(--theme-text-muted)]">
+                  No additional contacts yet. The existing customer contact
+                  stays available above.
+                </p>
+              ) : (
+                contacts.map((item) => (
+                  <div
+                    key={item.id}
+                    className="rounded-lg bg-[color:var(--theme-surface-inset)] p-2.5 text-xs"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-semibold">
+                        {item.display_name ||
+                          [item.first_name, item.last_name]
+                            .filter(Boolean)
+                            .join(" ") ||
+                          "Contact"}
+                      </span>
+                      <span className="capitalize text-[var(--accent-copper)]">
+                        {item.role}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-[color:var(--theme-text-secondary)]">
+                      {[item.email, item.phone].filter(Boolean).join(" · ") ||
+                        "No contact method"}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2 text-sm font-semibold">
+                <Building2 className="h-4 w-4 text-[var(--accent-copper)]" />
+                Locations
               </div>
               <button
-                type="submit"
-                disabled={saving}
-                className="w-full rounded-xl bg-[var(--accent-copper)] px-3 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-60"
+                type="button"
+                onClick={() => setShowLocationForm((current) => !current)}
+                className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--accent-copper)] hover:underline"
               >
-                Save location
+                <Plus className="h-3.5 w-3.5" /> Add
               </button>
-            </form>
-          ) : null}
+            </div>
 
-          <div className="mt-3 space-y-2">
-            {locations.length === 0 ? (
-              <p className="text-xs text-[color:var(--theme-text-muted)]">
-                No additional locations yet. The existing customer address stays
-                available above.
-              </p>
-            ) : (
-              locations.map((item) => (
-                <div
-                  key={item.id}
-                  className="rounded-lg bg-[color:var(--theme-surface-inset)] p-2.5 text-xs"
-                >
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="flex items-center gap-1 font-semibold">
-                      <MapPin className="h-3.5 w-3.5" /> {item.name}
-                    </span>
-                    <span className="capitalize text-[var(--accent-copper)]">
-                      {item.location_type}
-                    </span>
-                  </div>
-                  <div className="mt-1 text-[color:var(--theme-text-secondary)]">
-                    {[item.address, item.city, item.province, item.postal_code]
-                      .filter(Boolean)
-                      .join(", ") || "Address not entered"}
-                  </div>
+            {showLocationForm ? (
+              <form onSubmit={addLocation} className="mt-3 space-y-2">
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <input
+                    required
+                    value={location.name}
+                    onChange={(event) =>
+                      setLocation((draft) => ({
+                        ...draft,
+                        name: event.target.value,
+                      }))
+                    }
+                    placeholder="Location name"
+                    aria-label="Location name"
+                    className={inputClass}
+                  />
+                  <select
+                    value={location.locationType}
+                    onChange={(event) =>
+                      setLocation((draft) => ({
+                        ...draft,
+                        locationType: event.target.value,
+                      }))
+                    }
+                    aria-label="Location type"
+                    className={inputClass}
+                  >
+                    <option value="service">Service</option>
+                    <option value="billing">Billing</option>
+                    <option value="branch">Branch</option>
+                    <option value="other">Other</option>
+                  </select>
                 </div>
-              ))
-            )}
+                <input
+                  value={location.address}
+                  onChange={(event) =>
+                    setLocation((draft) => ({
+                      ...draft,
+                      address: event.target.value,
+                    }))
+                  }
+                  placeholder="Street address"
+                  aria-label="Location street address"
+                  className={inputClass}
+                />
+                <div className="grid gap-2 sm:grid-cols-3">
+                  <input
+                    value={location.city}
+                    onChange={(event) =>
+                      setLocation((draft) => ({
+                        ...draft,
+                        city: event.target.value,
+                      }))
+                    }
+                    placeholder="City"
+                    aria-label="Location city"
+                    className={inputClass}
+                  />
+                  <input
+                    value={location.province}
+                    onChange={(event) =>
+                      setLocation((draft) => ({
+                        ...draft,
+                        province: event.target.value,
+                      }))
+                    }
+                    placeholder="Province"
+                    aria-label="Location province"
+                    className={inputClass}
+                  />
+                  <input
+                    value={location.postalCode}
+                    onChange={(event) =>
+                      setLocation((draft) => ({
+                        ...draft,
+                        postalCode: event.target.value,
+                      }))
+                    }
+                    placeholder="Postal code"
+                    aria-label="Location postal code"
+                    className={inputClass}
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="w-full rounded-xl bg-[var(--accent-copper)] px-3 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-60"
+                >
+                  Save location
+                </button>
+              </form>
+            ) : null}
+
+            <div className="mt-3 space-y-2">
+              {locations.length === 0 ? (
+                <p className="text-xs text-[color:var(--theme-text-muted)]">
+                  No additional locations yet. The existing customer address
+                  stays available above.
+                </p>
+              ) : (
+                locations.map((item) => (
+                  <div
+                    key={item.id}
+                    className="rounded-lg bg-[color:var(--theme-surface-inset)] p-2.5 text-xs"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="flex items-center gap-1 font-semibold">
+                        <MapPin className="h-3.5 w-3.5" /> {item.name}
+                      </span>
+                      <span className="capitalize text-[var(--accent-copper)]">
+                        {item.location_type}
+                      </span>
+                    </div>
+                    <div className="mt-1 text-[color:var(--theme-text-secondary)]">
+                      {[
+                        item.address,
+                        item.city,
+                        item.province,
+                        item.postal_code,
+                      ]
+                        .filter(Boolean)
+                        .join(", ") || "Address not entered"}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
           </div>
         </div>
-      </div>
       </section>
+
+      {account?.can_merge_or_archive && account.customer.active ? (
+        <section className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] p-4 shadow-[var(--theme-shadow-medium)]">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                Record stewardship
+              </div>
+              <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                No destructive deletion. Archive preserves history; merge moves
+                linked records and keeps a permanent redirect and audit event.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShowLifecycleForm("merge")}
+                className="inline-flex items-center gap-1.5 rounded-xl border border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold"
+              >
+                <Link2 className="h-3.5 w-3.5" /> Merge duplicate
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowLifecycleForm("archive")}
+                className="inline-flex items-center gap-1.5 rounded-xl border border-amber-500/35 px-3 py-2 text-xs font-semibold text-amber-200"
+              >
+                <Archive className="h-3.5 w-3.5" /> Archive account
+              </button>
+            </div>
+          </div>
+          {showLifecycleForm ? (
+            <div className="mt-4 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3">
+              {showLifecycleForm === "merge" ? (
+                <label className="block text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                  Find the canonical customer to keep
+                  <input
+                    value={mergeSearch}
+                    onChange={(event) => {
+                      setMergeSearch(event.target.value);
+                      setMergeTargetId("");
+                    }}
+                    placeholder="Search name, business, email, or phone"
+                    className={`${inputClass} mt-1`}
+                  />
+                  {mergeCandidates.length > 0 ? (
+                    <span className="mt-2 block space-y-1.5">
+                      {mergeCandidates.map((candidate) => (
+                        <button
+                          key={candidate.id}
+                          type="button"
+                          onClick={() => {
+                            setMergeTargetId(candidate.id);
+                            setMergeSearch(
+                              candidate.business_name ||
+                                candidate.name ||
+                                candidate.email ||
+                                candidate.phone ||
+                                candidate.id,
+                            );
+                            setMergeCandidates([]);
+                          }}
+                          className={`block w-full rounded-lg border p-2 text-left text-xs ${
+                            mergeTargetId === candidate.id
+                              ? "border-[var(--accent-copper)] bg-[var(--accent-copper)]/10"
+                              : "border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)]"
+                          }`}
+                        >
+                          <span className="font-semibold text-[color:var(--theme-text-primary)]">
+                            {candidate.business_name ||
+                              candidate.name ||
+                              "Customer"}
+                          </span>
+                          <span className="ml-2 font-normal text-[color:var(--theme-text-muted)]">
+                            {[candidate.email, candidate.phone]
+                              .filter(Boolean)
+                              .join(" · ")}
+                          </span>
+                        </button>
+                      ))}
+                    </span>
+                  ) : null}
+                </label>
+              ) : null}
+              <label className="mt-3 block text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                Required reason
+                <textarea
+                  value={lifecycleReason}
+                  onChange={(event) => setLifecycleReason(event.target.value)}
+                  rows={2}
+                  className={`${inputClass} mt-1`}
+                />
+              </label>
+              <div className="mt-3 flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => void runLifecycleAction()}
+                  disabled={
+                    saving ||
+                    lifecycleReason.trim().length < 3 ||
+                    (showLifecycleForm === "merge" && !mergeTargetId.trim())
+                  }
+                  className="rounded-xl bg-[var(--accent-copper)] px-3 py-2 text-xs font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-50"
+                >
+                  Confirm {showLifecycleForm}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowLifecycleForm(null)}
+                  className="rounded-xl border border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/features/customers/lib/customerAccountCommands.ts
+++ b/features/customers/lib/customerAccountCommands.ts
@@ -1,0 +1,81 @@
+export type CustomerAccountType =
+  | "individual"
+  | "business"
+  | "fleet"
+  | "enterprise";
+
+export type CustomerDuplicateCandidate = {
+  id: string;
+  display_name: string;
+  account_type: CustomerAccountType;
+  email: string | null;
+  phone: string | null;
+  reasons: Array<"name" | "phone" | "email" | "vin">;
+  score: number;
+};
+
+export type CustomerAccountCreateInput = {
+  accountType: CustomerAccountType;
+  name: string | null;
+  businessName?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  address?: string | null;
+  city?: string | null;
+  province?: string | null;
+  postalCode?: string | null;
+  notes?: string | null;
+  vin?: string | null;
+  matchExisting?: boolean;
+  allowDuplicate?: boolean;
+  operationKey?: string;
+};
+
+export type CustomerAccountCreateResult = {
+  ok: boolean;
+  matched_existing?: boolean;
+  customer?: { id: string } & Record<string, unknown>;
+  duplicate_candidates?: CustomerDuplicateCandidate[];
+  code?: string;
+  error?: string;
+};
+
+export class CustomerDuplicateReviewError extends Error {
+  readonly candidates: CustomerDuplicateCandidate[];
+
+  constructor(candidates: CustomerDuplicateCandidate[]) {
+    super(
+      "Review possible duplicate customer accounts before creating another.",
+    );
+    this.name = "CustomerDuplicateReviewError";
+    this.candidates = candidates;
+  }
+}
+
+export async function createCustomerAccount(
+  input: CustomerAccountCreateInput,
+): Promise<CustomerAccountCreateResult> {
+  const operationKey = input.operationKey ?? crypto.randomUUID();
+  const response = await fetch("/api/customers/accounts", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": operationKey,
+    },
+    body: JSON.stringify({ ...input, operationKey }),
+  });
+  const result = (await response
+    .json()
+    .catch(() => null)) as CustomerAccountCreateResult | null;
+
+  if (
+    response.status === 409 &&
+    result?.code === "CUSTOMER_DUPLICATE_REVIEW_REQUIRED"
+  ) {
+    throw new CustomerDuplicateReviewError(result.duplicate_candidates ?? []);
+  }
+  if (!response.ok || !result?.ok || !result.customer?.id) {
+    throw new Error(result?.error ?? "Customer account could not be resolved.");
+  }
+  return result;
+}

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -2787,6 +2787,77 @@ export type Database = {
         }
         Relationships: []
       }
+      customer_account_merges: {
+        Row: {
+          created_at: string
+          id: string
+          merged_by: string
+          moved_record_counts: Json
+          operation_key: string
+          reason: string
+          shop_id: string
+          source_customer_id: string
+          source_snapshot: Json
+          target_customer_id: string
+          target_snapshot: Json
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          merged_by: string
+          moved_record_counts?: Json
+          operation_key: string
+          reason: string
+          shop_id: string
+          source_customer_id: string
+          source_snapshot?: Json
+          target_customer_id: string
+          target_snapshot?: Json
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          merged_by?: string
+          moved_record_counts?: Json
+          operation_key?: string
+          reason?: string
+          shop_id?: string
+          source_customer_id?: string
+          source_snapshot?: Json
+          target_customer_id?: string
+          target_snapshot?: Json
+        }
+        Relationships: [
+          {
+            foreignKeyName: "customer_account_merges_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_account_merges_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_account_merges_source_customer_id_fkey"
+            columns: ["source_customer_id"]
+            isOneToOne: true
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_account_merges_target_customer_id_fkey"
+            columns: ["target_customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       customer_contacts: {
         Row: {
           active: boolean
@@ -3214,37 +3285,76 @@ export type Database = {
       }
       customer_settings: {
         Row: {
+          account_hold_reason: string | null
+          account_status: string
+          billing_notes: string | null
           comm_email_enabled: boolean
           comm_sms_enabled: boolean
           customer_id: string
+          customer_reference: string | null
           language: string | null
           marketing_opt_in: boolean
+          payment_terms: string
+          payment_terms_days: number
           preferred_contact: string | null
+          primary_approval_contact_id: string | null
+          primary_billing_contact_id: string | null
+          po_required: boolean
+          shop_id: string | null
+          tax_exempt: boolean
+          tax_exemption_reference: string | null
           timezone: string | null
           units: string | null
           updated_at: string
+          updated_by: string | null
         }
         Insert: {
+          account_hold_reason?: string | null
+          account_status?: string
+          billing_notes?: string | null
           comm_email_enabled?: boolean
           comm_sms_enabled?: boolean
           customer_id: string
+          customer_reference?: string | null
           language?: string | null
           marketing_opt_in?: boolean
+          payment_terms?: string
+          payment_terms_days?: number
           preferred_contact?: string | null
+          primary_approval_contact_id?: string | null
+          primary_billing_contact_id?: string | null
+          po_required?: boolean
+          shop_id?: string | null
+          tax_exempt?: boolean
+          tax_exemption_reference?: string | null
           timezone?: string | null
           units?: string | null
           updated_at?: string
+          updated_by?: string | null
         }
         Update: {
+          account_hold_reason?: string | null
+          account_status?: string
+          billing_notes?: string | null
           comm_email_enabled?: boolean
           comm_sms_enabled?: boolean
           customer_id?: string
+          customer_reference?: string | null
           language?: string | null
           marketing_opt_in?: boolean
+          payment_terms?: string
+          payment_terms_days?: number
           preferred_contact?: string | null
+          primary_approval_contact_id?: string | null
+          primary_billing_contact_id?: string | null
+          po_required?: boolean
+          shop_id?: string | null
+          tax_exempt?: boolean
+          tax_exemption_reference?: string | null
           timezone?: string | null
           units?: string | null
           updated_at?: string
+          updated_by?: string | null
         }
         Relationships: [
           {
@@ -3254,6 +3364,34 @@ export type Database = {
             referencedRelation: "customers"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "customer_settings_primary_approval_contact_id_fkey"
+            columns: ["primary_approval_contact_id"]
+            isOneToOne: false
+            referencedRelation: "customer_contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_settings_primary_billing_contact_id_fkey"
+            columns: ["primary_billing_contact_id"]
+            isOneToOne: false
+            referencedRelation: "customer_contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_settings_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customer_settings_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
         ]
       }
       customers: {
@@ -3261,6 +3399,9 @@ export type Database = {
           account_type: string
           active: boolean
           address: string | null
+          archive_reason: string | null
+          archived_at: string | null
+          archived_by: string | null
           business_name: string | null
           city: string | null
           created_at: string | null
@@ -3271,10 +3412,17 @@ export type Database = {
           external_id: string | null
           first_name: string | null
           id: string
+          identity_email: string | null
+          identity_name: string | null
+          identity_phone: string | null
           import_confidence: number | null
           import_notes: string | null
           is_fleet: boolean
           last_name: string | null
+          merge_reason: string | null
+          merged_at: string | null
+          merged_by: string | null
+          merged_into_customer_id: string | null
           name: string | null
           notes: string | null
           parent_customer_id: string | null
@@ -3294,6 +3442,9 @@ export type Database = {
           account_type?: string
           active?: boolean
           address?: string | null
+          archive_reason?: string | null
+          archived_at?: string | null
+          archived_by?: string | null
           business_name?: string | null
           city?: string | null
           created_at?: string | null
@@ -3304,10 +3455,17 @@ export type Database = {
           external_id?: string | null
           first_name?: string | null
           id?: string
+          identity_email?: string | null
+          identity_name?: string | null
+          identity_phone?: string | null
           import_confidence?: number | null
           import_notes?: string | null
           is_fleet?: boolean
           last_name?: string | null
+          merge_reason?: string | null
+          merged_at?: string | null
+          merged_by?: string | null
+          merged_into_customer_id?: string | null
           name?: string | null
           notes?: string | null
           parent_customer_id?: string | null
@@ -3327,6 +3485,9 @@ export type Database = {
           account_type?: string
           active?: boolean
           address?: string | null
+          archive_reason?: string | null
+          archived_at?: string | null
+          archived_by?: string | null
           business_name?: string | null
           city?: string | null
           created_at?: string | null
@@ -3337,10 +3498,17 @@ export type Database = {
           external_id?: string | null
           first_name?: string | null
           id?: string
+          identity_email?: string | null
+          identity_name?: string | null
+          identity_phone?: string | null
           import_confidence?: number | null
           import_notes?: string | null
           is_fleet?: boolean
           last_name?: string | null
+          merge_reason?: string | null
+          merged_at?: string | null
+          merged_by?: string | null
+          merged_into_customer_id?: string | null
           name?: string | null
           notes?: string | null
           parent_customer_id?: string | null
@@ -3360,6 +3528,13 @@ export type Database = {
           {
             foreignKeyName: "customers_default_bill_to_customer_id_fkey"
             columns: ["default_bill_to_customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "customers_merged_into_customer_id_fkey"
+            columns: ["merged_into_customer_id"]
             isOneToOne: false
             referencedRelation: "customers"
             referencedColumns: ["id"]
@@ -26528,6 +26703,16 @@ export type Database = {
         }
         Returns: Json
       }
+      archive_customer_account_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_customer_id: string
+          p_operation_key: string
+          p_reason: string
+          p_shop_id: string
+        }
+        Returns: Json
+      }
       apply_job_punch_transition_atomic: {
         Args: {
           p_action: string
@@ -27084,6 +27269,27 @@ export type Database = {
         }
         Returns: string
       }
+      create_customer_account_atomic: {
+        Args: {
+          p_account_type: string
+          p_actor_user_id?: string
+          p_address?: string
+          p_allow_duplicate?: boolean
+          p_business_name?: string
+          p_city?: string
+          p_email?: string
+          p_match_existing?: boolean
+          p_name: string
+          p_notes?: string
+          p_operation_key?: string
+          p_phone?: string
+          p_postal_code?: string
+          p_province?: string
+          p_shop_id: string
+          p_vin?: string
+        }
+        Returns: Json
+      }
       create_customer_pricing_agreement_atomic: {
         Args: {
           p_actor_user_id: string
@@ -27531,8 +27737,29 @@ export type Database = {
         }
         Returns: Json
       }
+      find_customer_account_duplicates: {
+        Args: {
+          p_actor_user_id?: string
+          p_business_name?: string
+          p_email?: string
+          p_exclude_customer_id?: string
+          p_name?: string
+          p_phone?: string
+          p_shop_id: string
+          p_vin?: string
+        }
+        Returns: Json
+      }
       first_segment_uuid: { Args: { p: string }; Returns: string }
       fleet_defect_descriptor: { Args: { p_key: string }; Returns: Json }
+      get_customer_account_center: {
+        Args: {
+          p_actor_user_id?: string
+          p_customer_id: string
+          p_shop_id: string
+        }
+        Returns: Json
+      }
       get_customer_pricing_account_summary: {
         Args: { p_at?: string; p_customer_id: string; p_shop_id: string }
         Returns: Json
@@ -27751,6 +27978,17 @@ export type Database = {
           p_payload: Json
           p_shop_id: string
           p_vehicle_id: string
+        }
+        Returns: Json
+      }
+      merge_customer_accounts_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_operation_key: string
+          p_reason: string
+          p_shop_id: string
+          p_source_customer_id: string
+          p_target_customer_id: string
         }
         Returns: Json
       }
@@ -29035,6 +29273,26 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      update_customer_commercial_controls_atomic: {
+        Args: {
+          p_account_hold_reason: string
+          p_account_status: string
+          p_actor_user_id: string
+          p_billing_notes: string
+          p_customer_id: string
+          p_customer_reference: string
+          p_operation_key: string
+          p_payment_terms: string
+          p_payment_terms_days: number
+          p_po_required: boolean
+          p_primary_approval_contact_id: string
+          p_primary_billing_contact_id: string
+          p_shop_id: string
+          p_tax_exempt: boolean
+          p_tax_exemption_reference: string
+        }
+        Returns: Json
+      }
       update_menu_item_with_parts_intake: {
         Args: {
           p_actor_auth_user_id: string
@@ -29730,4 +29988,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -27751,6 +27751,22 @@ export type Database = {
         Returns: Json
       }
       first_segment_uuid: { Args: { p: string }; Returns: string }
+      fleet_actor_can_manage_scope: {
+        Args: { p_fleet_id: string; p_shop_id: string }
+        Returns: boolean
+      }
+      fleet_actor_can_read_fleet: {
+        Args: { p_fleet_id: string; p_shop_id: string }
+        Returns: boolean
+      }
+      fleet_actor_can_read_member: {
+        Args: {
+          p_fleet_id: string
+          p_member_user_id: string
+          p_shop_id: string
+        }
+        Returns: boolean
+      }
       fleet_defect_descriptor: { Args: { p_key: string }; Returns: Json }
       get_customer_account_center: {
         Args: {
@@ -29988,4 +30004,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -30004,3 +30004,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -27751,22 +27751,6 @@ export type Database = {
         Returns: Json
       }
       first_segment_uuid: { Args: { p: string }; Returns: string }
-      fleet_actor_can_manage_scope: {
-        Args: { p_fleet_id: string; p_shop_id: string }
-        Returns: boolean
-      }
-      fleet_actor_can_read_fleet: {
-        Args: { p_fleet_id: string; p_shop_id: string }
-        Returns: boolean
-      }
-      fleet_actor_can_read_member: {
-        Args: {
-          p_fleet_id: string
-          p_member_user_id: string
-          p_shop_id: string
-        }
-        Returns: boolean
-      }
       fleet_defect_descriptor: { Args: { p_key: string }; Returns: Json }
       get_customer_account_center: {
         Args: {

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -2733,60 +2733,6 @@ export type Database = {
           },
         ]
       }
-      customer_bookings: {
-        Row: {
-          created_at: string | null
-          customer_email: string | null
-          customer_name: string | null
-          customer_phone: string | null
-          id: string
-          labor_hours_estimated: number | null
-          preferred_date: string | null
-          preferred_time: string | null
-          selected_services: Json | null
-          shop_id: string | null
-          status: string | null
-          vehicle_make: string | null
-          vehicle_model: string | null
-          vehicle_year: string | null
-          vin: string | null
-        }
-        Insert: {
-          created_at?: string | null
-          customer_email?: string | null
-          customer_name?: string | null
-          customer_phone?: string | null
-          id?: string
-          labor_hours_estimated?: number | null
-          preferred_date?: string | null
-          preferred_time?: string | null
-          selected_services?: Json | null
-          shop_id?: string | null
-          status?: string | null
-          vehicle_make?: string | null
-          vehicle_model?: string | null
-          vehicle_year?: string | null
-          vin?: string | null
-        }
-        Update: {
-          created_at?: string | null
-          customer_email?: string | null
-          customer_name?: string | null
-          customer_phone?: string | null
-          id?: string
-          labor_hours_estimated?: number | null
-          preferred_date?: string | null
-          preferred_time?: string | null
-          selected_services?: Json | null
-          shop_id?: string | null
-          status?: string | null
-          vehicle_make?: string | null
-          vehicle_model?: string | null
-          vehicle_year?: string | null
-          vin?: string | null
-        }
-        Relationships: []
-      }
       customer_account_merges: {
         Row: {
           created_at: string
@@ -2857,6 +2803,60 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      customer_bookings: {
+        Row: {
+          created_at: string | null
+          customer_email: string | null
+          customer_name: string | null
+          customer_phone: string | null
+          id: string
+          labor_hours_estimated: number | null
+          preferred_date: string | null
+          preferred_time: string | null
+          selected_services: Json | null
+          shop_id: string | null
+          status: string | null
+          vehicle_make: string | null
+          vehicle_model: string | null
+          vehicle_year: string | null
+          vin: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          customer_email?: string | null
+          customer_name?: string | null
+          customer_phone?: string | null
+          id?: string
+          labor_hours_estimated?: number | null
+          preferred_date?: string | null
+          preferred_time?: string | null
+          selected_services?: Json | null
+          shop_id?: string | null
+          status?: string | null
+          vehicle_make?: string | null
+          vehicle_model?: string | null
+          vehicle_year?: string | null
+          vin?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          customer_email?: string | null
+          customer_name?: string | null
+          customer_phone?: string | null
+          id?: string
+          labor_hours_estimated?: number | null
+          preferred_date?: string | null
+          preferred_time?: string | null
+          selected_services?: Json | null
+          shop_id?: string | null
+          status?: string | null
+          vehicle_make?: string | null
+          vehicle_model?: string | null
+          vehicle_year?: string | null
+          vin?: string | null
+        }
+        Relationships: []
       }
       customer_contacts: {
         Row: {
@@ -3296,10 +3296,10 @@ export type Database = {
           marketing_opt_in: boolean
           payment_terms: string
           payment_terms_days: number
+          po_required: boolean
           preferred_contact: string | null
           primary_approval_contact_id: string | null
           primary_billing_contact_id: string | null
-          po_required: boolean
           shop_id: string | null
           tax_exempt: boolean
           tax_exemption_reference: string | null
@@ -3320,10 +3320,10 @@ export type Database = {
           marketing_opt_in?: boolean
           payment_terms?: string
           payment_terms_days?: number
+          po_required?: boolean
           preferred_contact?: string | null
           primary_approval_contact_id?: string | null
           primary_billing_contact_id?: string | null
-          po_required?: boolean
           shop_id?: string | null
           tax_exempt?: boolean
           tax_exemption_reference?: string | null
@@ -3344,10 +3344,10 @@ export type Database = {
           marketing_opt_in?: boolean
           payment_terms?: string
           payment_terms_days?: number
+          po_required?: boolean
           preferred_contact?: string | null
           primary_approval_contact_id?: string | null
           primary_billing_contact_id?: string | null
-          po_required?: boolean
           shop_id?: string | null
           tax_exempt?: boolean
           tax_exemption_reference?: string | null
@@ -26703,16 +26703,6 @@ export type Database = {
         }
         Returns: Json
       }
-      archive_customer_account_atomic: {
-        Args: {
-          p_actor_user_id: string
-          p_customer_id: string
-          p_operation_key: string
-          p_reason: string
-          p_shop_id: string
-        }
-        Returns: Json
-      }
       apply_job_punch_transition_atomic: {
         Args: {
           p_action: string
@@ -26908,6 +26898,16 @@ export type Database = {
         Args: {
           p_actor_profile_id: string
           p_period_id: string
+          p_shop_id: string
+        }
+        Returns: Json
+      }
+      archive_customer_account_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_customer_id: string
+          p_operation_key: string
+          p_reason: string
           p_shop_id: string
         }
         Returns: Json
@@ -29988,3 +29988,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -43,6 +43,7 @@ import {
   requireMutableWorkOrder,
   STALE_CREATE_WORK_ORDER_MESSAGE,
 } from "@/features/work-orders/lib/client/validateMutableWorkOrder";
+import { createCustomerAccount } from "@/features/customers/lib/customerAccountCommands";
 
 // 👇 inspection modal, client-only
 const InspectionModal = dynamic(
@@ -620,9 +621,7 @@ export default function CreateWorkOrderPage() {
   const hasValidatedWorkOrder = Boolean(
     wo?.id && validatedWorkOrderId === wo.id,
   );
-  const isPersistedWorkOrderPending = Boolean(
-    wo?.id && !hasValidatedWorkOrder,
-  );
+  const isPersistedWorkOrderPending = Boolean(wo?.id && !hasValidatedWorkOrder);
 
   // ✅ inspection modal state
   const [inspectionOpen, setInspectionOpen] = useState(false);
@@ -939,14 +938,7 @@ export default function CreateWorkOrderPage() {
     return () => {
       cancelled = true;
     };
-  }, [
-    getOrLinkShopId,
-    setError,
-    setLines,
-    setWo,
-    supabase,
-    wo?.id,
-  ]);
+  }, [getOrLinkShopId, setError, setLines, setWo, supabase, wo?.id]);
 
   // ✅ advisor ownership helper
 
@@ -1312,69 +1304,43 @@ export default function CreateWorkOrderPage() {
       }
     }
 
-    if (normalizedEmail) {
-      const { data: foundByEmail, error: emailErr } = await supabase
+    const personalName = [customer.first_name, customer.last_name]
+      .map((value) => value?.trim())
+      .filter(Boolean)
+      .join(" ");
+    const businessName = strOrNull(customer.business_name ?? null);
+    const result = await createCustomerAccount({
+      accountType: businessName ? "business" : "individual",
+      name:
+        personalName ||
+        businessName ||
+        normalizedPhone ||
+        normalizedEmail ||
+        "Walk-in Customer",
+      businessName,
+      email: normalizedEmail,
+      phone: normalizedPhone,
+      address: customer.address,
+      city: customer.city,
+      province: customer.province,
+      postalCode: customer.postal_code,
+      vin: vehicle.vin,
+      matchExisting: true,
+    });
+    let resolved = result.customer as CustomerRowWithBusiness;
+    if (result.matched_existing) {
+      const { data: patched, error: patchError } = await supabase
         .from("customers")
-        .select("*")
+        .update(buildImplicitCustomerPatch(customerPatch))
+        .eq("id", resolved.id)
         .eq("shop_id", shopId)
-        .eq("email", normalizedEmail)
-        .limit(1);
-
-      if (emailErr) throw emailErr;
-      if (foundByEmail?.length) {
-        const row = foundByEmail[0] as CustomerRowWithBusiness;
-        setCustomerId(row.id);
-
-        const { data: patched, error: patchErr } = await supabase
-          .from("customers")
-          .update(buildImplicitCustomerPatch(customerPatch))
-          .eq("id", row.id)
-          .eq("shop_id", shopId)
-          .select("*")
-          .single();
-
-        if (patchErr) throw patchErr;
-        return (patched ?? row) as CustomerRowWithBusiness;
-      }
-    }
-
-    if (normalizedPhone) {
-      const { data: foundByPhone, error: phoneErr } = await supabase
-        .from("customers")
         .select("*")
-        .eq("shop_id", shopId)
-        .eq("phone", normalizedPhone)
-        .limit(1);
-
-      if (phoneErr) throw phoneErr;
-      if (foundByPhone?.length) {
-        const row = foundByPhone[0] as CustomerRowWithBusiness;
-        setCustomerId(row.id);
-
-        const { data: patched, error: patchErr } = await supabase
-          .from("customers")
-          .update(buildImplicitCustomerPatch(customerPatch))
-          .eq("id", row.id)
-          .eq("shop_id", shopId)
-          .select("*")
-          .single();
-
-        if (patchErr) throw patchErr;
-        return (patched ?? row) as CustomerRowWithBusiness;
-      }
+        .single();
+      if (patchError) throw patchError;
+      resolved = (patched ?? resolved) as CustomerRowWithBusiness;
     }
-
-    const { data: inserted, error: insErr } = await supabase
-      .from("customers")
-      .insert(customerWrite)
-      .select("*")
-      .single();
-
-    if (insErr || !inserted)
-      throw new Error(insErr?.message ?? "Failed to create customer");
-
-    setCustomerId(inserted.id);
-    return inserted as CustomerRowWithBusiness;
+    setCustomerId(resolved.id);
+    return resolved;
   }
 
   // ✅ when a vehicle exists, UPDATE it with the form values so edits persist
@@ -2032,7 +1998,9 @@ export default function CreateWorkOrderPage() {
         return;
       }
       if (!liveLine) {
-        toast.error("This work-order line no longer exists. The list was refreshed.");
+        toast.error(
+          "This work-order line no longer exists. The list was refreshed.",
+        );
         await fetchLines();
         return;
       }
@@ -2616,9 +2584,7 @@ export default function CreateWorkOrderPage() {
                     const id = await handleSaveCustomerVehicle();
                     if (id) await maybeOpenIntakeAfterSave(id);
                   }}
-                  disabled={
-                    savingCv || loading || isPersistedWorkOrderPending
-                  }
+                  disabled={savingCv || loading || isPersistedWorkOrderPending}
                   className="inline-flex min-h-10 items-center justify-center gap-2 rounded-xl bg-[color:var(--brand-primary)] px-4 py-2 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(23,71,255,0.2)] transition hover:brightness-110 disabled:opacity-60"
                 >
                   {savingCv
@@ -2741,7 +2707,7 @@ export default function CreateWorkOrderPage() {
 
             {/* Create-flow maintenance suggestions */}
             <CreateFlowMaintenanceSelector
-              workOrderId={hasValidatedWorkOrder ? wo?.id ?? null : null}
+              workOrderId={hasValidatedWorkOrder ? (wo?.id ?? null) : null}
               vehicleId={vehicleIdProp}
               enabled={hasValidatedWorkOrder && !!customerId && !!vehicleIdProp}
               selectedServiceCodes={selectedMaintenanceCodes}

--- a/scripts/regression-inventory/baseline.json
+++ b/scripts/regression-inventory/baseline.json
@@ -1643,16 +1643,6 @@
       "expiresOn": "2026-09-06"
     },
     {
-      "fingerprint": "b6bb8e4ddbc1a8c054a3",
-      "rule": "dynamic-mutation-payload",
-      "severity": "warning",
-      "domain": "core",
-      "file": "features/customers/app/customers/[id]/page.tsx",
-      "subject": "customers",
-      "message": "insert payload for customers cannot be checked statically",
-      "expiresOn": "2026-09-06"
-    },
-    {
       "fingerprint": "dc5c4f0c0cc5368d8301",
       "rule": "dynamic-mutation-payload",
       "severity": "warning",
@@ -1670,16 +1660,6 @@
       "file": "features/customers/app/customers/[id]/page.tsx",
       "subject": "vehicles",
       "message": "update payload for vehicles cannot be checked statically",
-      "expiresOn": "2026-09-06"
-    },
-    {
-      "fingerprint": "330cef63b0d5264c45a9",
-      "rule": "dynamic-mutation-payload",
-      "severity": "warning",
-      "domain": "core",
-      "file": "features/customers/app/customers/[id]/page.tsx",
-      "subject": "vehicles",
-      "message": "insert payload for vehicles cannot be checked statically",
       "expiresOn": "2026-09-06"
     },
     {
@@ -2080,16 +2060,6 @@
       "file": "features/work-orders/app/work-orders/create/page.tsx",
       "subject": "customers",
       "message": "update payload for customers cannot be checked statically",
-      "expiresOn": "2026-09-06"
-    },
-    {
-      "fingerprint": "d1cac181c12226673afb",
-      "rule": "dynamic-mutation-payload",
-      "severity": "warning",
-      "domain": "work-orders",
-      "file": "features/work-orders/app/work-orders/create/page.tsx",
-      "subject": "customers",
-      "message": "insert payload for customers cannot be checked statically",
       "expiresOn": "2026-09-06"
     },
     {

--- a/supabase/migrations/20260812050000_unified_customer_account_center.sql
+++ b/supabase/migrations/20260812050000_unified_customer_account_center.sql
@@ -1,0 +1,1575 @@
+begin;
+
+set local lock_timeout = '10s';
+set local statement_timeout = '120s';
+
+-- Canonical identity and lifecycle metadata. Existing customer rows remain the
+-- source of truth; archived and merged rows are retained permanently.
+alter table public.customers
+  add column if not exists identity_name text,
+  add column if not exists identity_email text,
+  add column if not exists identity_phone text,
+  add column if not exists archived_at timestamptz,
+  add column if not exists archived_by uuid references auth.users(id) on delete set null,
+  add column if not exists archive_reason text,
+  add column if not exists merged_into_customer_id uuid references public.customers(id) on delete restrict,
+  add column if not exists merged_at timestamptz,
+  add column if not exists merged_by uuid references auth.users(id) on delete set null,
+  add column if not exists merge_reason text;
+
+alter table public.customers
+  drop constraint if exists customers_archive_shape_check;
+alter table public.customers
+  add constraint customers_archive_shape_check check (
+    (active and archived_at is null and archived_by is null and archive_reason is null)
+    or (
+      not active
+      and archived_at is not null
+      and length(btrim(coalesce(archive_reason, ''))) >= 3
+    )
+  ) not valid;
+
+update public.customers
+set archived_at = coalesce(updated_at, created_at, now()),
+    archive_reason = coalesce(
+      nullif(btrim(archive_reason), ''),
+      'Legacy inactive customer account.'
+    )
+where not active
+  and merged_into_customer_id is null;
+
+alter table public.customers validate constraint customers_archive_shape_check;
+
+alter table public.customers
+  drop constraint if exists customers_merge_shape_check;
+alter table public.customers
+  add constraint customers_merge_shape_check check (
+    (merged_into_customer_id is null and merged_at is null and merged_by is null and merge_reason is null)
+    or (
+      merged_into_customer_id is not null
+      and merged_into_customer_id <> id
+      and merged_at is not null
+      and length(btrim(coalesce(merge_reason, ''))) >= 3
+      and not active
+    )
+  ) not valid;
+alter table public.customers validate constraint customers_merge_shape_check;
+
+create or replace function private.normalize_customer_identity_text(p_value text)
+returns text
+language sql
+immutable
+strict
+set search_path = ''
+as $$
+  select nullif(lower(regexp_replace(btrim(p_value), '\s+', ' ', 'g')), '');
+$$;
+
+create or replace function private.normalize_customer_identity_phone(p_value text)
+returns text
+language sql
+immutable
+strict
+set search_path = ''
+as $$
+  select nullif(regexp_replace(p_value, '[^0-9]', '', 'g'), '');
+$$;
+
+revoke all on function private.normalize_customer_identity_text(text)
+  from public, anon, authenticated, service_role;
+revoke all on function private.normalize_customer_identity_phone(text)
+  from public, anon, authenticated, service_role;
+
+create or replace function private.set_customer_identity_keys()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  new.identity_name := private.normalize_customer_identity_text(
+    coalesce(
+      nullif(new.business_name, ''),
+      nullif(new.name, ''),
+      nullif(concat_ws(' ', new.first_name, new.last_name), '')
+    )
+  );
+  new.identity_email := private.normalize_customer_identity_text(new.email);
+  new.identity_phone := private.normalize_customer_identity_phone(
+    coalesce(nullif(new.phone, ''), new.phone_number)
+  );
+  return new;
+end;
+$$;
+
+revoke all on function private.set_customer_identity_keys()
+  from public, anon, authenticated, service_role;
+
+update public.customers customer
+set identity_name = private.normalize_customer_identity_text(
+      coalesce(
+        nullif(customer.business_name, ''),
+        nullif(customer.name, ''),
+        nullif(concat_ws(' ', customer.first_name, customer.last_name), '')
+      )
+    ),
+    identity_email = private.normalize_customer_identity_text(customer.email),
+    identity_phone = private.normalize_customer_identity_phone(
+      coalesce(nullif(customer.phone, ''), customer.phone_number)
+    );
+
+drop trigger if exists set_customer_identity_keys_trigger on public.customers;
+create trigger set_customer_identity_keys_trigger
+before insert or update of
+  name, business_name, first_name, last_name, email, phone, phone_number
+on public.customers
+for each row execute function private.set_customer_identity_keys();
+
+create index if not exists customers_identity_name_idx
+  on public.customers (shop_id, identity_name)
+  where active and merged_into_customer_id is null and identity_name is not null;
+create index if not exists customers_identity_email_idx
+  on public.customers (shop_id, identity_email)
+  where active and merged_into_customer_id is null and identity_email is not null;
+create index if not exists customers_identity_phone_idx
+  on public.customers (shop_id, identity_phone)
+  where active and merged_into_customer_id is null and identity_phone is not null;
+create index if not exists customers_merged_target_idx
+  on public.customers (merged_into_customer_id)
+  where merged_into_customer_id is not null;
+create index if not exists vehicles_shop_normalized_vin_idx
+  on public.vehicles (shop_id, upper(regexp_replace(vin, '[^A-Za-z0-9]', '', 'g')))
+  where vin is not null;
+
+create or replace function private.ensure_customer_settings_row()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.shop_id is not null then
+    insert into public.customer_settings(customer_id, shop_id, updated_at)
+    values (new.id, new.shop_id, now())
+    on conflict (customer_id) do update
+    set shop_id = excluded.shop_id,
+        updated_at = case
+          when public.customer_settings.shop_id is distinct from excluded.shop_id
+          then excluded.updated_at
+          else public.customer_settings.updated_at
+        end;
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function private.ensure_customer_settings_row()
+  from public, anon, authenticated, service_role;
+
+drop trigger if exists ensure_customer_settings_row_trigger on public.customers;
+create trigger ensure_customer_settings_row_trigger
+after insert or update of shop_id on public.customers
+for each row execute function private.ensure_customer_settings_row();
+
+-- Commercial controls extend the established one-to-one customer settings row.
+alter table public.customer_settings
+  add column if not exists shop_id uuid references public.shops(id) on delete cascade,
+  add column if not exists primary_billing_contact_id uuid references public.customer_contacts(id) on delete set null,
+  add column if not exists primary_approval_contact_id uuid references public.customer_contacts(id) on delete set null,
+  add column if not exists po_required boolean not null default false,
+  add column if not exists payment_terms text not null default 'due_on_receipt',
+  add column if not exists payment_terms_days integer not null default 0,
+  add column if not exists tax_exempt boolean not null default false,
+  add column if not exists tax_exemption_reference text,
+  add column if not exists account_status text not null default 'good_standing',
+  add column if not exists account_hold_reason text,
+  add column if not exists billing_notes text,
+  add column if not exists customer_reference text,
+  add column if not exists updated_by uuid references auth.users(id) on delete set null;
+
+update public.customer_settings settings
+set shop_id = customer.shop_id
+from public.customers customer
+where customer.id = settings.customer_id
+  and settings.shop_id is distinct from customer.shop_id;
+
+alter table public.customer_settings
+  drop constraint if exists customer_settings_payment_terms_check;
+alter table public.customer_settings
+  add constraint customer_settings_payment_terms_check check (
+    payment_terms in (
+      'due_on_receipt', 'net_7', 'net_15', 'net_30', 'net_45', 'net_60', 'custom'
+    )
+  ) not valid;
+alter table public.customer_settings
+  drop constraint if exists customer_settings_payment_terms_days_check;
+alter table public.customer_settings
+  add constraint customer_settings_payment_terms_days_check check (
+    payment_terms_days between 0 and 365
+  ) not valid;
+alter table public.customer_settings
+  drop constraint if exists customer_settings_account_status_check;
+alter table public.customer_settings
+  add constraint customer_settings_account_status_check check (
+    account_status in ('good_standing', 'credit_hold', 'account_hold')
+  ) not valid;
+alter table public.customer_settings
+  drop constraint if exists customer_settings_hold_reason_check;
+alter table public.customer_settings
+  add constraint customer_settings_hold_reason_check check (
+    account_status = 'good_standing'
+    or length(btrim(coalesce(account_hold_reason, ''))) >= 3
+  ) not valid;
+alter table public.customer_settings
+  drop constraint if exists customer_settings_tax_exemption_check;
+alter table public.customer_settings
+  add constraint customer_settings_tax_exemption_check check (
+    not tax_exempt
+    or length(btrim(coalesce(tax_exemption_reference, ''))) >= 2
+  ) not valid;
+
+alter table public.customer_settings validate constraint customer_settings_payment_terms_check;
+alter table public.customer_settings validate constraint customer_settings_payment_terms_days_check;
+alter table public.customer_settings validate constraint customer_settings_account_status_check;
+alter table public.customer_settings validate constraint customer_settings_hold_reason_check;
+alter table public.customer_settings validate constraint customer_settings_tax_exemption_check;
+
+create index if not exists customer_settings_shop_customer_idx
+  on public.customer_settings (shop_id, customer_id)
+  where shop_id is not null;
+
+create or replace function private.enforce_customer_settings_boundary()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_customer_shop_id uuid;
+begin
+  select customer.shop_id
+    into v_customer_shop_id
+  from public.customers customer
+  where customer.id = new.customer_id;
+
+  if not found then
+    raise exception using errcode = '23503', message = 'Customer account not found.';
+  end if;
+
+  if new.shop_id is null then
+    new.shop_id := v_customer_shop_id;
+  elsif new.shop_id is distinct from v_customer_shop_id then
+    raise exception using errcode = '23514', message = 'Customer settings must belong to the customer Shop.';
+  end if;
+
+  if new.primary_billing_contact_id is not null and not exists (
+    select 1
+    from public.customer_contacts contact
+    where contact.id = new.primary_billing_contact_id
+      and contact.customer_id = new.customer_id
+      and contact.shop_id = new.shop_id
+      and contact.active
+  ) then
+    raise exception using errcode = '23514', message = 'Billing contact must belong to this customer account.';
+  end if;
+
+  if new.primary_approval_contact_id is not null and not exists (
+    select 1
+    from public.customer_contacts contact
+    where contact.id = new.primary_approval_contact_id
+      and contact.customer_id = new.customer_id
+      and contact.shop_id = new.shop_id
+      and contact.active
+  ) then
+    raise exception using errcode = '23514', message = 'Approval contact must belong to this customer account.';
+  end if;
+
+  if new.account_status = 'good_standing' then
+    new.account_hold_reason := null;
+  end if;
+  if not new.tax_exempt then
+    new.tax_exemption_reference := null;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function private.enforce_customer_settings_boundary()
+  from public, anon, authenticated, service_role;
+
+drop trigger if exists enforce_customer_settings_boundary_trigger
+  on public.customer_settings;
+create trigger enforce_customer_settings_boundary_trigger
+before insert or update of
+  customer_id, shop_id, primary_billing_contact_id,
+  primary_approval_contact_id, account_status, tax_exempt
+on public.customer_settings
+for each row execute function private.enforce_customer_settings_boundary();
+
+-- Give every existing Shop customer the same canonical account-settings anchor.
+-- Existing portal preferences are preserved; only the tenant key is reconciled.
+insert into public.customer_settings(customer_id, shop_id, updated_at)
+select customer.id, customer.shop_id, coalesce(customer.updated_at, customer.created_at, now())
+from public.customers customer
+where customer.shop_id is not null
+on conflict (customer_id) do update
+set shop_id = excluded.shop_id
+where public.customer_settings.shop_id is distinct from excluded.shop_id;
+
+create policy customer_settings_staff_select
+on public.customer_settings for select to authenticated
+using (shop_id is not null and public.is_staff_for_shop(shop_id));
+create policy customer_settings_staff_insert
+on public.customer_settings for insert to authenticated
+with check (shop_id is not null and public.is_staff_for_shop(shop_id));
+create policy customer_settings_staff_update
+on public.customer_settings for update to authenticated
+using (shop_id is not null and public.is_staff_for_shop(shop_id))
+with check (shop_id is not null and public.is_staff_for_shop(shop_id));
+
+-- Append-only merge history and private idempotency ledger.
+create table if not exists public.customer_account_merges (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete restrict,
+  source_customer_id uuid not null references public.customers(id) on delete restrict,
+  target_customer_id uuid not null references public.customers(id) on delete restrict,
+  reason text not null check (length(btrim(reason)) between 3 and 500),
+  merged_by uuid not null references auth.users(id) on delete restrict,
+  operation_key text not null check (length(btrim(operation_key)) between 1 and 200),
+  moved_record_counts jsonb not null default '{}'::jsonb check (
+    jsonb_typeof(moved_record_counts) = 'object'
+  ),
+  source_snapshot jsonb not null default '{}'::jsonb check (
+    jsonb_typeof(source_snapshot) = 'object'
+  ),
+  target_snapshot jsonb not null default '{}'::jsonb check (
+    jsonb_typeof(target_snapshot) = 'object'
+  ),
+  created_at timestamptz not null default now(),
+  constraint customer_account_merges_distinct_accounts_check
+    check (source_customer_id <> target_customer_id),
+  unique (shop_id, operation_key),
+  unique (source_customer_id)
+);
+
+create index if not exists customer_account_merges_target_idx
+  on public.customer_account_merges (shop_id, target_customer_id, created_at desc);
+
+alter table public.customer_account_merges enable row level security;
+create policy customer_account_merges_staff_select
+on public.customer_account_merges for select to authenticated
+using (public.is_staff_for_shop(shop_id));
+revoke all on table public.customer_account_merges
+  from public, anon, authenticated;
+grant select on table public.customer_account_merges to authenticated;
+grant all on table public.customer_account_merges to service_role;
+
+drop policy if exists "staff can delete customers in shop" on public.customers;
+revoke delete on table public.customers from authenticated;
+
+create table if not exists private.customer_account_operations (
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  operation_key text not null,
+  operation_type text not null check (
+    operation_type in ('create', 'update_controls', 'archive', 'merge')
+  ),
+  actor_user_id uuid not null references auth.users(id) on delete restrict,
+  customer_id uuid references public.customers(id) on delete restrict,
+  result jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  primary key (shop_id, operation_key)
+);
+
+revoke all on table private.customer_account_operations
+  from public, anon, authenticated, service_role;
+
+create or replace function private.customer_account_actor_role(
+  p_shop_id uuid,
+  p_actor_user_id uuid
+)
+returns text
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select public.canonical_shop_membership_role(profile.role::text)
+  from public.profiles profile
+  where profile.shop_id = p_shop_id
+    and (profile.id = p_actor_user_id or profile.user_id = p_actor_user_id)
+  order by case when profile.user_id = p_actor_user_id then 0 else 1 end
+  limit 1;
+$$;
+
+revoke all on function private.customer_account_actor_role(uuid, uuid)
+  from public, anon, authenticated, service_role;
+
+create or replace function public.find_customer_account_duplicates(
+  p_shop_id uuid,
+  p_name text default null,
+  p_business_name text default null,
+  p_email text default null,
+  p_phone text default null,
+  p_vin text default null,
+  p_exclude_customer_id uuid default null,
+  p_actor_user_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor_user_id uuid := coalesce(p_actor_user_id, (select auth.uid()));
+  v_role text;
+  v_name text := private.normalize_customer_identity_text(
+    coalesce(nullif(p_business_name, ''), p_name)
+  );
+  v_email text := private.normalize_customer_identity_text(p_email);
+  v_phone text := private.normalize_customer_identity_phone(p_phone);
+  v_vin text := nullif(upper(regexp_replace(coalesce(p_vin, ''), '[^A-Za-z0-9]', '', 'g')), '');
+  v_result jsonb;
+begin
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from v_actor_user_id) then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_ACTOR_MISMATCH';
+  end if;
+
+  v_role := private.customer_account_actor_role(p_shop_id, v_actor_user_id);
+  if coalesce(v_role, '') not in (
+    'owner', 'admin', 'manager', 'advisor', 'service', 'foreman',
+    'mechanic', 'lead_hand', 'parts'
+  ) then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_STAFF_ROLE_REQUIRED';
+  end if;
+
+  select coalesce(jsonb_agg(candidate order by score desc, display_name, id), '[]'::jsonb)
+    into v_result
+  from (
+    select
+      customer.id,
+      coalesce(
+        nullif(customer.business_name, ''),
+        nullif(customer.name, ''),
+        nullif(concat_ws(' ', customer.first_name, customer.last_name), ''),
+        customer.email,
+        customer.phone,
+        'Customer'
+      ) as display_name,
+      customer.account_type,
+      customer.email,
+      coalesce(customer.phone, customer.phone_number) as phone,
+      customer.active,
+      array_remove(array[
+        case when v_email is not null and customer.identity_email = v_email then 'email' end,
+        case when v_phone is not null and customer.identity_phone = v_phone then 'phone' end,
+        case when v_name is not null and customer.identity_name = v_name then 'name' end,
+        case when v_vin is not null and exists (
+          select 1
+          from public.vehicles vehicle
+          where vehicle.shop_id = p_shop_id
+            and vehicle.customer_id = customer.id
+            and upper(regexp_replace(coalesce(vehicle.vin, ''), '[^A-Za-z0-9]', '', 'g')) = v_vin
+        ) then 'vin' end
+      ], null) as reasons,
+      (
+        case when v_email is not null and customer.identity_email = v_email then 100 else 0 end
+        + case when v_phone is not null and customer.identity_phone = v_phone then 90 else 0 end
+        + case when v_vin is not null and exists (
+            select 1
+            from public.vehicles vehicle
+            where vehicle.shop_id = p_shop_id
+              and vehicle.customer_id = customer.id
+              and upper(regexp_replace(coalesce(vehicle.vin, ''), '[^A-Za-z0-9]', '', 'g')) = v_vin
+          ) then 120 else 0 end
+        + case when v_name is not null and customer.identity_name = v_name then 40 else 0 end
+      ) as score
+    from public.customers customer
+    where customer.shop_id = p_shop_id
+      and customer.id is distinct from p_exclude_customer_id
+      and customer.active
+      and customer.merged_into_customer_id is null
+      and (
+        (v_email is not null and customer.identity_email = v_email)
+        or (v_phone is not null and customer.identity_phone = v_phone)
+        or (v_name is not null and customer.identity_name = v_name)
+        or (
+          v_vin is not null
+          and exists (
+            select 1
+            from public.vehicles vehicle
+            where vehicle.shop_id = p_shop_id
+              and vehicle.customer_id = customer.id
+              and upper(regexp_replace(coalesce(vehicle.vin, ''), '[^A-Za-z0-9]', '', 'g')) = v_vin
+          )
+        )
+      )
+    limit 25
+  ) candidate;
+
+  return coalesce(v_result, '[]'::jsonb);
+end;
+$$;
+
+revoke all on function public.find_customer_account_duplicates(
+  uuid, text, text, text, text, text, uuid, uuid
+) from public, anon;
+grant execute on function public.find_customer_account_duplicates(
+  uuid, text, text, text, text, text, uuid, uuid
+) to authenticated, service_role;
+
+create or replace function public.create_customer_account_atomic(
+  p_shop_id uuid,
+  p_account_type text,
+  p_name text,
+  p_business_name text default null,
+  p_email text default null,
+  p_phone text default null,
+  p_address text default null,
+  p_city text default null,
+  p_province text default null,
+  p_postal_code text default null,
+  p_notes text default null,
+  p_vin text default null,
+  p_match_existing boolean default false,
+  p_allow_duplicate boolean default false,
+  p_actor_user_id uuid default null,
+  p_operation_key text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor_user_id uuid := coalesce(p_actor_user_id, (select auth.uid()));
+  v_role text;
+  v_account_type text := lower(btrim(coalesce(p_account_type, 'individual')));
+  v_name text := nullif(btrim(coalesce(p_name, '')), '');
+  v_business_name text := nullif(btrim(coalesce(p_business_name, '')), '');
+  v_email text := private.normalize_customer_identity_text(p_email);
+  v_phone text := private.normalize_customer_identity_phone(p_phone);
+  v_operation_key text := nullif(btrim(coalesce(p_operation_key, '')), '');
+  v_existing_operation private.customer_account_operations%rowtype;
+  v_exact_ids uuid[] := '{}'::uuid[];
+  v_exact_customer public.customers%rowtype;
+  v_duplicates jsonb := '[]'::jsonb;
+  v_customer public.customers%rowtype;
+  v_first_name text;
+  v_last_name text;
+  v_result jsonb;
+begin
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from v_actor_user_id) then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_ACTOR_MISMATCH';
+  end if;
+
+  v_role := private.customer_account_actor_role(p_shop_id, v_actor_user_id);
+  if coalesce(v_role, '') not in (
+    'owner', 'admin', 'manager', 'advisor', 'service', 'foreman',
+    'mechanic', 'lead_hand', 'parts'
+  ) then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_STAFF_ROLE_REQUIRED';
+  end if;
+  if v_account_type not in ('individual', 'business', 'fleet', 'enterprise') then
+    raise exception using errcode = '22023', message = 'Unsupported customer account type.';
+  end if;
+  if v_name is null and v_business_name is null then
+    raise exception using errcode = '22023', message = 'Customer or business name is required.';
+  end if;
+  if v_operation_key is null or length(v_operation_key) > 200 then
+    raise exception using errcode = '22023', message = 'A valid customer operation key is required.';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(
+    p_shop_id::text || ':' || coalesce(v_email, '') || ':' || coalesce(v_phone, '') || ':' || coalesce(v_name, v_business_name, ''),
+    0
+  ));
+
+  select operation.*
+    into v_existing_operation
+  from private.customer_account_operations operation
+  where operation.shop_id = p_shop_id
+    and operation.operation_key = v_operation_key;
+  if found then
+    if v_existing_operation.operation_type <> 'create' then
+      raise exception using errcode = '22023', message = 'CUSTOMER_ACCOUNT_OPERATION_KEY_CONFLICT';
+    end if;
+    return v_existing_operation.result || jsonb_build_object('idempotent', true);
+  end if;
+
+  select coalesce(array_agg(distinct customer.id), '{}'::uuid[])
+    into v_exact_ids
+  from public.customers customer
+  where customer.shop_id = p_shop_id
+    and customer.active
+    and customer.merged_into_customer_id is null
+    and (
+      (v_email is not null and customer.identity_email = v_email)
+      or (v_phone is not null and customer.identity_phone = v_phone)
+      or (
+        nullif(upper(regexp_replace(coalesce(p_vin, ''), '[^A-Za-z0-9]', '', 'g')), '') is not null
+        and exists (
+          select 1
+          from public.vehicles vehicle
+          where vehicle.shop_id = p_shop_id
+            and vehicle.customer_id = customer.id
+            and upper(regexp_replace(coalesce(vehicle.vin, ''), '[^A-Za-z0-9]', '', 'g'))
+              = upper(regexp_replace(p_vin, '[^A-Za-z0-9]', '', 'g'))
+        )
+      )
+    );
+
+  if p_match_existing and cardinality(v_exact_ids) = 1 then
+    select * into v_exact_customer
+    from public.customers customer
+    where customer.id = v_exact_ids[1]
+      and customer.shop_id = p_shop_id;
+
+    v_result := jsonb_build_object(
+      'ok', true,
+      'idempotent', false,
+      'matched_existing', true,
+      'customer', to_jsonb(v_exact_customer),
+      'duplicate_candidates', '[]'::jsonb
+    );
+    insert into private.customer_account_operations(
+      shop_id, operation_key, operation_type, actor_user_id, customer_id, result
+    ) values (
+      p_shop_id, v_operation_key, 'create', v_actor_user_id, v_exact_customer.id, v_result
+    );
+    return v_result;
+  end if;
+
+  v_duplicates := public.find_customer_account_duplicates(
+    p_shop_id,
+    v_name,
+    v_business_name,
+    v_email,
+    v_phone,
+    p_vin,
+    null,
+    v_actor_user_id
+  );
+
+  if jsonb_array_length(v_duplicates) > 0 and not p_allow_duplicate then
+    return jsonb_build_object(
+      'ok', false,
+      'code', 'CUSTOMER_DUPLICATE_REVIEW_REQUIRED',
+      'duplicate_candidates', v_duplicates
+    );
+  end if;
+
+  if v_account_type = 'individual' then
+    v_first_name := nullif(split_part(coalesce(v_name, ''), ' ', 1), '');
+    v_last_name := nullif(btrim(substr(coalesce(v_name, ''), length(coalesce(v_first_name, '')) + 1)), '');
+  else
+    v_first_name := nullif(split_part(coalesce(v_name, ''), ' ', 1), '');
+    v_last_name := nullif(btrim(substr(coalesce(v_name, ''), length(coalesce(v_first_name, '')) + 1)), '');
+  end if;
+
+  insert into public.customers (
+    shop_id, user_id, created_by, account_type, is_fleet, name,
+    business_name, first_name, last_name, phone, phone_number, email,
+    address, city, province, postal_code, notes, active, updated_at
+  ) values (
+    p_shop_id, null, v_actor_user_id, v_account_type, v_account_type = 'fleet',
+    coalesce(v_business_name, v_name),
+    case when v_account_type = 'individual' then null else coalesce(v_business_name, v_name) end,
+    v_first_name, v_last_name, v_phone, v_phone, v_email,
+    nullif(btrim(coalesce(p_address, '')), ''),
+    nullif(btrim(coalesce(p_city, '')), ''),
+    nullif(btrim(coalesce(p_province, '')), ''),
+    nullif(btrim(coalesce(p_postal_code, '')), ''),
+    nullif(btrim(coalesce(p_notes, '')), ''), true, now()
+  ) returning * into v_customer;
+
+  if v_name is not null or v_email is not null or v_phone is not null then
+    insert into public.customer_contacts (
+      shop_id, customer_id, display_name, email, phone, role,
+      is_primary, can_approve, can_view_billing, created_by
+    ) values (
+      p_shop_id, v_customer.id, coalesce(v_name, v_business_name), v_email, v_phone,
+      'primary', true, v_account_type <> 'individual', v_account_type <> 'individual',
+      v_actor_user_id
+    );
+  end if;
+
+  if nullif(btrim(coalesce(p_address, '')), '') is not null then
+    insert into public.customer_locations (
+      shop_id, customer_id, name, location_type, address, city,
+      province, postal_code, is_primary, created_by
+    ) values (
+      p_shop_id, v_customer.id, 'Primary location', 'service', btrim(p_address),
+      nullif(btrim(coalesce(p_city, '')), ''),
+      nullif(btrim(coalesce(p_province, '')), ''),
+      nullif(btrim(coalesce(p_postal_code, '')), ''), true, v_actor_user_id
+    );
+  end if;
+
+  insert into public.customer_settings(customer_id, shop_id, updated_by)
+  values (v_customer.id, p_shop_id, v_actor_user_id)
+  on conflict (customer_id) do nothing;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'matched_existing', false,
+    'customer', to_jsonb(v_customer),
+    'duplicate_candidates', v_duplicates
+  );
+
+  insert into private.customer_account_operations(
+    shop_id, operation_key, operation_type, actor_user_id, customer_id, result
+  ) values (
+    p_shop_id, v_operation_key, 'create', v_actor_user_id, v_customer.id, v_result
+  );
+
+  insert into public.operational_events (
+    shop_id, event_type, actor_user_id, actor_role, entity_type,
+    entity_id, source, idempotency_key, metadata
+  ) values (
+    p_shop_id, 'customer_account.created', v_actor_user_id, v_role,
+    'customer', v_customer.id, 'customer_account_center',
+    'customer-account-create:' || v_operation_key,
+    jsonb_build_object(
+      'account_type', v_account_type,
+      'duplicate_override', p_allow_duplicate,
+      'duplicate_candidate_count', jsonb_array_length(v_duplicates)
+    )
+  ) on conflict (shop_id, idempotency_key) where idempotency_key is not null
+  do nothing;
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.create_customer_account_atomic(
+  uuid, text, text, text, text, text, text, text, text, text, text, text,
+  boolean, boolean, uuid, text
+) from public, anon;
+grant execute on function public.create_customer_account_atomic(
+  uuid, text, text, text, text, text, text, text, text, text, text, text,
+  boolean, boolean, uuid, text
+) to authenticated, service_role;
+
+create or replace function public.get_customer_account_center(
+  p_shop_id uuid,
+  p_customer_id uuid,
+  p_actor_user_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor_user_id uuid := coalesce(p_actor_user_id, (select auth.uid()));
+  v_role text;
+  v_customer public.customers%rowtype;
+  v_settings public.customer_settings%rowtype;
+  v_fleet jsonb;
+  v_latest_invite jsonb;
+  v_counts jsonb;
+  v_invoice_summary jsonb;
+begin
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from v_actor_user_id) then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_ACTOR_MISMATCH';
+  end if;
+  v_role := private.customer_account_actor_role(p_shop_id, v_actor_user_id);
+  if coalesce(v_role, '') = '' then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_STAFF_ROLE_REQUIRED';
+  end if;
+
+  select * into v_customer
+  from public.customers customer
+  where customer.id = p_customer_id and customer.shop_id = p_shop_id;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Customer account not found for Shop.';
+  end if;
+
+  select * into v_settings
+  from public.customer_settings settings
+  where settings.customer_id = p_customer_id;
+
+  select to_jsonb(fleet_row) into v_fleet
+  from (
+    select fleet.id, fleet.name, fleet.active, fleet.created_at,
+      case
+        when not fleet.active then 'inactive'
+        when exists (
+          select 1 from public.fleet_members membership
+          where membership.fleet_id = fleet.id
+        ) then 'connected'
+        else 'not_connected'
+      end as link_status
+    from public.fleets fleet
+    where fleet.shop_id = p_shop_id and fleet.customer_id = p_customer_id
+    order by fleet.active desc, fleet.created_at desc
+    limit 1
+  ) fleet_row;
+
+  if v_fleet is not null then
+    select to_jsonb(invite_row) into v_latest_invite
+    from (
+      select invite.id, invite.email, invite.role, invite.created_at,
+        invite.expires_at, invite.accepted_at, invite.revoked_at,
+        case
+          when invite.accepted_at is not null then 'accepted'
+          when invite.revoked_at is not null then 'revoked'
+          when invite.expires_at <= now() then 'expired'
+          else 'pending'
+        end as status
+      from public.fleet_portal_invites invite
+      where invite.shop_id = p_shop_id
+        and invite.fleet_id = (v_fleet ->> 'id')::uuid
+      order by invite.created_at desc
+      limit 1
+    ) invite_row;
+  end if;
+
+  select jsonb_build_object(
+    'contacts', (select count(*) from public.customer_contacts contact where contact.customer_id = p_customer_id and contact.active),
+    'locations', (select count(*) from public.customer_locations location where location.customer_id = p_customer_id and location.active),
+    'vehicles', (select count(*) from public.vehicles vehicle where vehicle.customer_id = p_customer_id),
+    'work_orders', (select count(*) from public.work_orders work_order where work_order.customer_id = p_customer_id),
+    'invoices', (select count(*) from public.invoices invoice where invoice.customer_id = p_customer_id),
+    'merged_sources', (select count(*) from public.customer_account_merges merge_record where merge_record.target_customer_id = p_customer_id)
+  ) into v_counts;
+
+  select jsonb_build_object(
+    'total_billed', coalesce(sum(invoice.total), 0),
+    'outstanding', coalesce(sum(invoice.outstanding_total), 0),
+    'last_invoice_at', max(coalesce(invoice.issued_at, invoice.created_at))
+  ) into v_invoice_summary
+  from public.invoices invoice
+  where invoice.shop_id = p_shop_id and invoice.customer_id = p_customer_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'customer', to_jsonb(v_customer),
+    'settings', coalesce(to_jsonb(v_settings), jsonb_build_object(
+      'customer_id', p_customer_id,
+      'shop_id', p_shop_id,
+      'po_required', false,
+      'payment_terms', 'due_on_receipt',
+      'payment_terms_days', 0,
+      'tax_exempt', false,
+      'account_status', 'good_standing'
+    )),
+    'fleet', v_fleet,
+    'fleet_invite', v_latest_invite,
+    'counts', v_counts,
+    'invoice_summary', v_invoice_summary,
+    'can_manage_commercial', v_role in ('owner', 'admin', 'manager'),
+    'can_merge_or_archive', v_role in ('owner', 'admin', 'manager')
+  );
+end;
+$$;
+
+revoke all on function public.get_customer_account_center(uuid, uuid, uuid)
+  from public, anon;
+grant execute on function public.get_customer_account_center(uuid, uuid, uuid)
+  to authenticated, service_role;
+
+create or replace function public.update_customer_commercial_controls_atomic(
+  p_shop_id uuid,
+  p_customer_id uuid,
+  p_primary_billing_contact_id uuid,
+  p_primary_approval_contact_id uuid,
+  p_po_required boolean,
+  p_payment_terms text,
+  p_payment_terms_days integer,
+  p_tax_exempt boolean,
+  p_tax_exemption_reference text,
+  p_account_status text,
+  p_account_hold_reason text,
+  p_billing_notes text,
+  p_customer_reference text,
+  p_actor_user_id uuid,
+  p_operation_key text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_role text;
+  v_operation private.customer_account_operations%rowtype;
+  v_settings public.customer_settings%rowtype;
+  v_result jsonb;
+begin
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_ACTOR_MISMATCH';
+  end if;
+  v_role := private.customer_account_actor_role(p_shop_id, p_actor_user_id);
+  if coalesce(v_role, '') not in ('owner', 'admin', 'manager') then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_MANAGER_ROLE_REQUIRED';
+  end if;
+  if not exists (
+    select 1 from public.customers customer
+    where customer.id = p_customer_id and customer.shop_id = p_shop_id
+      and customer.active and customer.merged_into_customer_id is null
+  ) then
+    raise exception using errcode = 'P0002', message = 'Active customer account not found for Shop.';
+  end if;
+  if length(btrim(coalesce(p_operation_key, ''))) not between 1 and 200 then
+    raise exception using errcode = '22023', message = 'A valid customer operation key is required.';
+  end if;
+
+  select * into v_operation
+  from private.customer_account_operations operation
+  where operation.shop_id = p_shop_id and operation.operation_key = btrim(p_operation_key);
+  if found then
+    if v_operation.operation_type <> 'update_controls' or v_operation.customer_id <> p_customer_id then
+      raise exception using errcode = '22023', message = 'CUSTOMER_ACCOUNT_OPERATION_KEY_CONFLICT';
+    end if;
+    return v_operation.result || jsonb_build_object('idempotent', true);
+  end if;
+
+  insert into public.customer_settings (
+    customer_id, shop_id, primary_billing_contact_id, primary_approval_contact_id,
+    po_required, payment_terms, payment_terms_days, tax_exempt,
+    tax_exemption_reference, account_status, account_hold_reason,
+    billing_notes, customer_reference, updated_by, updated_at
+  ) values (
+    p_customer_id, p_shop_id, p_primary_billing_contact_id, p_primary_approval_contact_id,
+    coalesce(p_po_required, false), lower(btrim(coalesce(p_payment_terms, 'due_on_receipt'))),
+    coalesce(p_payment_terms_days, 0), coalesce(p_tax_exempt, false),
+    nullif(btrim(coalesce(p_tax_exemption_reference, '')), ''),
+    lower(btrim(coalesce(p_account_status, 'good_standing'))),
+    nullif(btrim(coalesce(p_account_hold_reason, '')), ''),
+    nullif(btrim(coalesce(p_billing_notes, '')), ''),
+    nullif(btrim(coalesce(p_customer_reference, '')), ''),
+    p_actor_user_id, now()
+  )
+  on conflict (customer_id) do update set
+    shop_id = excluded.shop_id,
+    primary_billing_contact_id = excluded.primary_billing_contact_id,
+    primary_approval_contact_id = excluded.primary_approval_contact_id,
+    po_required = excluded.po_required,
+    payment_terms = excluded.payment_terms,
+    payment_terms_days = excluded.payment_terms_days,
+    tax_exempt = excluded.tax_exempt,
+    tax_exemption_reference = excluded.tax_exemption_reference,
+    account_status = excluded.account_status,
+    account_hold_reason = excluded.account_hold_reason,
+    billing_notes = excluded.billing_notes,
+    customer_reference = excluded.customer_reference,
+    updated_by = excluded.updated_by,
+    updated_at = excluded.updated_at
+  returning * into v_settings;
+
+  v_result := jsonb_build_object('ok', true, 'idempotent', false, 'settings', to_jsonb(v_settings));
+  insert into private.customer_account_operations(
+    shop_id, operation_key, operation_type, actor_user_id, customer_id, result
+  ) values (
+    p_shop_id, btrim(p_operation_key), 'update_controls', p_actor_user_id, p_customer_id, v_result
+  );
+
+  insert into public.operational_events (
+    shop_id, event_type, actor_user_id, actor_role, entity_type,
+    entity_id, source, idempotency_key, metadata
+  ) values (
+    p_shop_id, 'customer_account.commercial_controls_updated', p_actor_user_id,
+    v_role, 'customer', p_customer_id, 'customer_account_center',
+    'customer-controls:' || btrim(p_operation_key),
+    jsonb_build_object(
+      'po_required', p_po_required,
+      'payment_terms', p_payment_terms,
+      'tax_exempt', p_tax_exempt,
+      'account_status', p_account_status
+    )
+  ) on conflict (shop_id, idempotency_key) where idempotency_key is not null
+  do nothing;
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.update_customer_commercial_controls_atomic(
+  uuid, uuid, uuid, uuid, boolean, text, integer, boolean, text,
+  text, text, text, text, uuid, text
+) from public, anon;
+grant execute on function public.update_customer_commercial_controls_atomic(
+  uuid, uuid, uuid, uuid, boolean, text, integer, boolean, text,
+  text, text, text, text, uuid, text
+) to authenticated, service_role;
+
+create or replace function public.archive_customer_account_atomic(
+  p_shop_id uuid,
+  p_customer_id uuid,
+  p_reason text,
+  p_actor_user_id uuid,
+  p_operation_key text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_role text;
+  v_operation private.customer_account_operations%rowtype;
+  v_customer public.customers%rowtype;
+  v_result jsonb;
+begin
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_ACTOR_MISMATCH';
+  end if;
+  v_role := private.customer_account_actor_role(p_shop_id, p_actor_user_id);
+  if coalesce(v_role, '') not in ('owner', 'admin', 'manager') then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_MANAGER_ROLE_REQUIRED';
+  end if;
+  if length(btrim(coalesce(p_reason, ''))) not between 3 and 500 then
+    raise exception using errcode = '22023', message = 'Archive reason must be between 3 and 500 characters.';
+  end if;
+  if length(btrim(coalesce(p_operation_key, ''))) not between 1 and 200 then
+    raise exception using errcode = '22023', message = 'A valid customer operation key is required.';
+  end if;
+
+  select * into v_operation
+  from private.customer_account_operations operation
+  where operation.shop_id = p_shop_id
+    and operation.operation_key = btrim(p_operation_key);
+  if found then
+    if v_operation.operation_type <> 'archive'
+       or v_operation.customer_id <> p_customer_id then
+      raise exception using errcode = '22023', message = 'CUSTOMER_ACCOUNT_OPERATION_KEY_CONFLICT';
+    end if;
+    return v_operation.result || jsonb_build_object('idempotent', true);
+  end if;
+
+  if exists (
+    select 1 from public.fleets fleet
+    where fleet.shop_id = p_shop_id and fleet.customer_id = p_customer_id and fleet.active
+  ) then
+    raise exception using errcode = '23514', message = 'Disconnect or deactivate the Fleet workspace before archiving this account.';
+  end if;
+
+  update public.customers customer
+  set active = false,
+      archived_at = coalesce(customer.archived_at, now()),
+      archived_by = coalesce(customer.archived_by, p_actor_user_id),
+      archive_reason = coalesce(customer.archive_reason, btrim(p_reason)),
+      updated_at = now()
+  where customer.id = p_customer_id and customer.shop_id = p_shop_id
+    and customer.merged_into_customer_id is null
+  returning * into v_customer;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Customer account not found for Shop.';
+  end if;
+
+  v_result := jsonb_build_object('ok', true, 'customer', to_jsonb(v_customer));
+  insert into private.customer_account_operations(
+    shop_id, operation_key, operation_type, actor_user_id, customer_id, result
+  ) values (
+    p_shop_id, btrim(p_operation_key), 'archive', p_actor_user_id, p_customer_id, v_result
+  );
+
+  insert into public.operational_events (
+    shop_id, event_type, actor_user_id, actor_role, entity_type,
+    entity_id, source, idempotency_key, metadata
+  ) values (
+    p_shop_id, 'customer_account.archived', p_actor_user_id, v_role,
+    'customer', p_customer_id, 'customer_account_center',
+    'customer-archive:' || btrim(p_operation_key),
+    jsonb_build_object('reason', btrim(p_reason))
+  ) on conflict (shop_id, idempotency_key) where idempotency_key is not null
+  do nothing;
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.archive_customer_account_atomic(uuid, uuid, text, uuid, text)
+  from public, anon;
+grant execute on function public.archive_customer_account_atomic(uuid, uuid, text, uuid, text)
+  to authenticated, service_role;
+
+create or replace function public.merge_customer_accounts_atomic(
+  p_shop_id uuid,
+  p_source_customer_id uuid,
+  p_target_customer_id uuid,
+  p_reason text,
+  p_actor_user_id uuid,
+  p_operation_key text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_role text;
+  v_operation private.customer_account_operations%rowtype;
+  v_source public.customers%rowtype;
+  v_target public.customers%rowtype;
+  v_existing_merge public.customer_account_merges%rowtype;
+  v_counts jsonb := '{}'::jsonb;
+  v_count integer;
+  v_merge_id uuid;
+  v_result jsonb;
+begin
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_ACTOR_MISMATCH';
+  end if;
+  v_role := private.customer_account_actor_role(p_shop_id, p_actor_user_id);
+  if coalesce(v_role, '') not in ('owner', 'admin', 'manager') then
+    raise exception using errcode = '42501', message = 'CUSTOMER_ACCOUNT_MANAGER_ROLE_REQUIRED';
+  end if;
+  if p_source_customer_id = p_target_customer_id then
+    raise exception using errcode = '22023', message = 'Source and target customer accounts must be different.';
+  end if;
+  if length(btrim(coalesce(p_reason, ''))) not between 3 and 500 then
+    raise exception using errcode = '22023', message = 'Merge reason must be between 3 and 500 characters.';
+  end if;
+  if length(btrim(coalesce(p_operation_key, ''))) not between 1 and 200 then
+    raise exception using errcode = '22023', message = 'A valid customer operation key is required.';
+  end if;
+
+  select * into v_operation
+  from private.customer_account_operations operation
+  where operation.shop_id = p_shop_id
+    and operation.operation_key = btrim(p_operation_key);
+  if found then
+    if v_operation.operation_type <> 'merge'
+       or (v_operation.result ->> 'source_customer_id')::uuid <> p_source_customer_id
+       or (v_operation.result ->> 'target_customer_id')::uuid <> p_target_customer_id then
+      raise exception using errcode = '22023', message = 'CUSTOMER_ACCOUNT_OPERATION_KEY_CONFLICT';
+    end if;
+    return v_operation.result || jsonb_build_object('idempotent', true);
+  end if;
+
+  select * into v_existing_merge
+  from public.customer_account_merges merge_record
+  where merge_record.shop_id = p_shop_id and merge_record.operation_key = btrim(p_operation_key);
+  if found then
+    if v_existing_merge.source_customer_id <> p_source_customer_id
+       or v_existing_merge.target_customer_id <> p_target_customer_id then
+      raise exception using errcode = '22023', message = 'CUSTOMER_ACCOUNT_OPERATION_KEY_CONFLICT';
+    end if;
+    return jsonb_build_object(
+      'ok', true, 'idempotent', true, 'merge', to_jsonb(v_existing_merge),
+      'redirect_customer_id', v_existing_merge.target_customer_id
+    );
+  end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(
+    p_shop_id::text || ':' || least(p_source_customer_id, p_target_customer_id)::text
+      || ':' || greatest(p_source_customer_id, p_target_customer_id)::text,
+    0
+  ));
+
+  select * into v_source
+  from public.customers customer
+  where customer.id = p_source_customer_id and customer.shop_id = p_shop_id
+  for update;
+  select * into v_target
+  from public.customers customer
+  where customer.id = p_target_customer_id and customer.shop_id = p_shop_id
+  for update;
+
+  if v_source.id is null or v_target.id is null then
+    raise exception using errcode = 'P0002', message = 'Both customer accounts must belong to the same Shop.';
+  end if;
+  if not v_source.active or v_source.merged_into_customer_id is not null then
+    raise exception using errcode = '23514', message = 'Source customer account is already archived or merged.';
+  end if;
+  if not v_target.active or v_target.merged_into_customer_id is not null then
+    raise exception using errcode = '23514', message = 'Target customer account must be active.';
+  end if;
+  if v_source.user_id is not null and v_target.user_id is not null
+     and v_source.user_id <> v_target.user_id then
+    raise exception using errcode = '23514', message = 'Customer portal identities conflict; resolve portal access before merging.';
+  end if;
+  if exists (
+    select 1 from public.fleets fleet
+    where fleet.shop_id = p_shop_id and fleet.customer_id = p_source_customer_id and fleet.active
+  ) and exists (
+    select 1 from public.fleets fleet
+    where fleet.shop_id = p_shop_id and fleet.customer_id = p_target_customer_id and fleet.active
+  ) then
+    raise exception using errcode = '23514', message = 'Both accounts have active Fleet workspaces; resolve Fleet ownership before merging.';
+  end if;
+  if exists (
+    select 1
+    from public.customer_pricing_agreements agreement
+    where agreement.shop_id = p_shop_id
+      and agreement.customer_id = p_source_customer_id
+      and agreement.status = 'active'
+  ) then
+    raise exception using
+      errcode = '23514',
+      message = 'Retire or recreate the source account pricing agreement on the canonical target before merging.';
+  end if;
+  if exists (
+    select 1 from public.quickbooks_customer_links link
+    where link.shop_id = p_shop_id and link.customer_id = p_source_customer_id
+  ) and exists (
+    select 1 from public.quickbooks_customer_links link
+    where link.shop_id = p_shop_id and link.customer_id = p_target_customer_id
+  ) then
+    raise exception using
+      errcode = '23514',
+      message = 'Both accounts have QuickBooks customer links; resolve the accounting identity before merging.';
+  end if;
+
+  update public.customer_contacts contact
+  set is_primary = false
+  where contact.customer_id = p_source_customer_id
+    and contact.is_primary
+    and exists (
+      select 1 from public.customer_contacts target_contact
+      where target_contact.customer_id = p_target_customer_id
+        and target_contact.is_primary and target_contact.active
+    );
+  update public.customer_contacts
+  set customer_id = p_target_customer_id, updated_at = now()
+  where customer_id = p_source_customer_id;
+  get diagnostics v_count = row_count;
+  v_counts := v_counts || jsonb_build_object('contacts', v_count);
+
+  update public.customer_locations location
+  set is_primary = false
+  where location.customer_id = p_source_customer_id
+    and location.is_primary
+    and exists (
+      select 1 from public.customer_locations target_location
+      where target_location.customer_id = p_target_customer_id
+        and target_location.is_primary and target_location.active
+    );
+  update public.customer_locations
+  set customer_id = p_target_customer_id, updated_at = now()
+  where customer_id = p_source_customer_id;
+  get diagnostics v_count = row_count;
+  v_counts := v_counts || jsonb_build_object('locations', v_count);
+
+  update public.vehicles set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  get diagnostics v_count = row_count;
+  v_counts := v_counts || jsonb_build_object('vehicles', v_count);
+
+  update public.work_orders set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  get diagnostics v_count = row_count;
+  v_counts := v_counts || jsonb_build_object('work_orders', v_count);
+
+  update public.invoices set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  get diagnostics v_count = row_count;
+  v_counts := v_counts || jsonb_build_object('invoices', v_count);
+
+  update public.history set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  get diagnostics v_count = row_count;
+  v_counts := v_counts || jsonb_build_object('history', v_count);
+
+  update public.bookings set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.content_events set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.conversation_participants set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.conversations set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.followups set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.inspection_sessions set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.mobile_service_followups set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.customer_portal_invites set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.portal_lifecycle_operation_keys set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.portal_notifications set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.quickbooks_customer_links set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.service_addresses set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.shop_ratings set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id
+    and not exists (
+      select 1 from public.shop_ratings target_rating
+      where target_rating.shop_id = p_shop_id
+        and target_rating.customer_id = p_target_customer_id
+    );
+  update public.shop_reviews set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.warranties set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+  update public.work_order_intelligence set customer_id = p_target_customer_id
+  where customer_id = p_source_customer_id;
+
+  update public.fleets set customer_id = p_target_customer_id, updated_at = now()
+  where customer_id = p_source_customer_id;
+
+  insert into public.customer_settings (
+    customer_id, shop_id, comm_email_enabled, comm_sms_enabled, marketing_opt_in,
+    preferred_contact, units, language, timezone, primary_billing_contact_id,
+    primary_approval_contact_id, po_required, payment_terms, payment_terms_days,
+    tax_exempt, tax_exemption_reference, account_status, account_hold_reason,
+    billing_notes, customer_reference, updated_by, updated_at
+  )
+  select
+    p_target_customer_id, p_shop_id, settings.comm_email_enabled,
+    settings.comm_sms_enabled, settings.marketing_opt_in, settings.preferred_contact,
+    settings.units, settings.language, settings.timezone,
+    settings.primary_billing_contact_id, settings.primary_approval_contact_id,
+    settings.po_required, settings.payment_terms, settings.payment_terms_days,
+    settings.tax_exempt, settings.tax_exemption_reference, settings.account_status,
+    settings.account_hold_reason, settings.billing_notes, settings.customer_reference,
+    p_actor_user_id, now()
+  from public.customer_settings settings
+  where settings.customer_id = p_source_customer_id
+    and not exists (
+      select 1 from public.customer_settings target_settings
+      where target_settings.customer_id = p_target_customer_id
+    );
+
+  update public.customer_settings
+  set primary_billing_contact_id = null,
+      primary_approval_contact_id = null,
+      updated_by = p_actor_user_id,
+      updated_at = now()
+  where customer_id = p_source_customer_id;
+
+  update public.customers customer
+  set parent_customer_id = p_target_customer_id
+  where customer.parent_customer_id = p_source_customer_id
+    and customer.id <> p_target_customer_id;
+
+  update public.customers customer
+  set merged_into_customer_id = p_target_customer_id,
+      updated_at = now()
+  where customer.shop_id = p_shop_id
+    and customer.merged_into_customer_id = p_source_customer_id;
+  update public.customer_account_merges merge_record
+  set target_customer_id = p_target_customer_id
+  where merge_record.shop_id = p_shop_id
+    and merge_record.target_customer_id = p_source_customer_id;
+  update public.customers customer
+  set default_bill_to_customer_id = p_target_customer_id
+  where customer.default_bill_to_customer_id = p_source_customer_id
+    and customer.id <> p_target_customer_id;
+
+  -- Transfer the portal identity and a missing canonical email without
+  -- violating the same-Shop email uniqueness constraint. The complete
+  -- pre-merge source row is retained in the append-only merge audit below.
+  update public.customers source
+  set user_id = null,
+      email = case
+        when nullif(v_target.email, '') is null then null
+        else source.email
+      end,
+      updated_at = now()
+  where source.id = p_source_customer_id and source.shop_id = p_shop_id;
+
+  update public.customers target
+  set user_id = coalesce(target.user_id, v_source.user_id),
+      name = coalesce(nullif(target.name, ''), v_source.name),
+      business_name = coalesce(nullif(target.business_name, ''), v_source.business_name),
+      first_name = coalesce(nullif(target.first_name, ''), v_source.first_name),
+      last_name = coalesce(nullif(target.last_name, ''), v_source.last_name),
+      email = coalesce(nullif(target.email, ''), v_source.email),
+      phone = coalesce(nullif(target.phone, ''), v_source.phone),
+      phone_number = coalesce(nullif(target.phone_number, ''), v_source.phone_number),
+      address = coalesce(nullif(target.address, ''), v_source.address),
+      city = coalesce(nullif(target.city, ''), v_source.city),
+      province = coalesce(nullif(target.province, ''), v_source.province),
+      postal_code = coalesce(nullif(target.postal_code, ''), v_source.postal_code),
+      updated_at = now()
+  where target.id = p_target_customer_id and target.shop_id = p_shop_id;
+
+  update public.customers source
+  set active = false,
+      archived_at = now(),
+      archived_by = p_actor_user_id,
+      archive_reason = 'Merged into canonical customer account.',
+      merged_into_customer_id = p_target_customer_id,
+      merged_at = now(),
+      merged_by = p_actor_user_id,
+      merge_reason = btrim(p_reason),
+      updated_at = now()
+  where source.id = p_source_customer_id and source.shop_id = p_shop_id;
+
+  insert into public.customer_account_merges (
+    shop_id, source_customer_id, target_customer_id, reason,
+    merged_by, operation_key, moved_record_counts, source_snapshot, target_snapshot
+  ) values (
+    p_shop_id, p_source_customer_id, p_target_customer_id, btrim(p_reason),
+    p_actor_user_id, btrim(p_operation_key), v_counts,
+    to_jsonb(v_source), to_jsonb(v_target)
+  ) returning id into v_merge_id;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'merge_id', v_merge_id,
+    'source_customer_id', p_source_customer_id,
+    'target_customer_id', p_target_customer_id,
+    'redirect_customer_id', p_target_customer_id,
+    'moved_record_counts', v_counts
+  );
+
+  insert into private.customer_account_operations(
+    shop_id, operation_key, operation_type, actor_user_id, customer_id, result
+  ) values (
+    p_shop_id, btrim(p_operation_key), 'merge', p_actor_user_id, p_target_customer_id, v_result
+  );
+
+  insert into public.operational_events (
+    shop_id, event_type, actor_user_id, actor_role, entity_type,
+    entity_id, source, idempotency_key, metadata
+  ) values (
+    p_shop_id, 'customer_account.merged', p_actor_user_id, v_role,
+    'customer', p_target_customer_id, 'customer_account_center',
+    'customer-merge:' || btrim(p_operation_key),
+    jsonb_build_object(
+      'source_customer_id', p_source_customer_id,
+      'target_customer_id', p_target_customer_id,
+      'reason', btrim(p_reason),
+      'moved_record_counts', v_counts
+    )
+  ) on conflict (shop_id, idempotency_key) where idempotency_key is not null
+  do nothing;
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.merge_customer_accounts_atomic(
+  uuid, uuid, uuid, text, uuid, text
+) from public, anon;
+grant execute on function public.merge_customer_accounts_atomic(
+  uuid, uuid, uuid, text, uuid, text
+) to authenticated, service_role;
+
+-- Keep the confirmed Shop Assistant mutation on the same canonical account
+-- command while preserving the assistant action ledger and response contract.
+create or replace function public.shop_assistant_create_customer_atomic(
+  p_action_id uuid,
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_name text,
+  p_email text default null,
+  p_phone text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_action public.shop_assistant_actions%rowtype;
+  v_role text;
+  v_account_result jsonb;
+  v_customer jsonb;
+  v_result jsonb;
+begin
+  v_action := public.shop_assistant_lock_action_for_tool(
+    p_action_id, p_shop_id, p_actor_user_id, 'create_customer'
+  );
+  if v_action.status = 'succeeded' then
+    return coalesce(v_action.result, '{}'::jsonb) || jsonb_build_object('idempotent', true);
+  end if;
+
+  v_role := public.shop_assistant_profile_role(p_shop_id, p_actor_user_id);
+  if v_role not in ('owner','admin','manager','advisor','service','lead_hand','leadhand','foreman') then
+    raise exception using errcode = '42501', message = 'Your role cannot create customers.';
+  end if;
+
+  v_account_result := public.create_customer_account_atomic(
+    p_shop_id,
+    'individual',
+    p_name,
+    null,
+    p_email,
+    p_phone,
+    null,
+    null,
+    null,
+    null,
+    'Created through the confirmed Shop Assistant action.',
+    null,
+    true,
+    false,
+    p_actor_user_id,
+    'shop-assistant:' || p_action_id::text
+  );
+
+  if not coalesce((v_account_result ->> 'ok')::boolean, false) then
+    raise exception using
+      errcode = '23505',
+      message = 'Possible duplicate customer requires review in the Customer Account Center.';
+  end if;
+
+  v_customer := v_account_result -> 'customer';
+  v_result := jsonb_build_object(
+    'ok', true,
+    'customer', jsonb_build_object(
+      'id', v_customer ->> 'id',
+      'name', coalesce(v_customer ->> 'name', btrim(p_name)),
+      'email', v_customer ->> 'email',
+      'phone', v_customer ->> 'phone',
+      'href', '/customers/' || (v_customer ->> 'id')
+    ),
+    'summary', case
+      when coalesce((v_account_result ->> 'matched_existing')::boolean, false)
+      then coalesce(v_customer ->> 'name', btrim(p_name)) || ' matched the existing canonical customer account.'
+      else coalesce(v_customer ->> 'name', btrim(p_name)) || ' was created as a shop customer.'
+    end
+  );
+
+  update public.shop_assistant_actions
+  set status = 'succeeded',
+      result = v_result,
+      error = null,
+      execution_finished_at = now(),
+      updated_at = now()
+  where id = p_action_id
+    and shop_id = p_shop_id
+    and status = 'executing';
+
+  insert into public.activity_logs(action, user_id, timestamp, target_table, target_id, context)
+  values (
+    'shop_assistant_customer_created',
+    p_actor_user_id,
+    now(),
+    'customer',
+    (v_customer ->> 'id')::uuid,
+    jsonb_build_object(
+      'shop_id', p_shop_id,
+      'action_id', p_action_id,
+      'matched_existing', coalesce((v_account_result ->> 'matched_existing')::boolean, false)
+    )
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.shop_assistant_create_customer_atomic(
+  uuid, uuid, uuid, text, text, text
+) from public, anon;
+grant execute on function public.shop_assistant_create_customer_atomic(
+  uuid, uuid, uuid, text, text, text
+) to authenticated, service_role;
+
+comment on function public.create_customer_account_atomic(
+  uuid, text, text, text, text, text, text, text, text, text, text, text,
+  boolean, boolean, uuid, text
+) is 'Canonical same-Shop customer create/resolve command with duplicate review and idempotency.';
+comment on function public.merge_customer_accounts_atomic(
+  uuid, uuid, uuid, text, uuid, text
+) is 'Non-destructively merges operational history into a canonical customer and archives the source.';
+
+commit;

--- a/supabase/migrations/20260812060000_repair_fleet_access_policy_recursion.sql
+++ b/supabase/migrations/20260812060000_repair_fleet_access_policy_recursion.sql
@@ -1,0 +1,151 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+
+-- fleets_actor_select and fleet_members_actor_select previously selected from
+-- one another. PostgreSQL correctly rejected that mutual RLS dependency as an
+-- infinite recursion. These predicates preserve the existing access rules but
+-- evaluate the cross-table checks as the migration owner, outside row policy
+-- recursion. Each predicate remains bound to auth.uid().
+create or replace function public.fleet_actor_can_read_fleet(
+  p_fleet_id uuid,
+  p_shop_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from public.fleets fleet
+    where fleet.id = p_fleet_id
+      and fleet.shop_id = p_shop_id
+      and (
+        exists (
+          select 1
+          from public.profiles profile
+          where profile.shop_id = p_shop_id
+            and (
+              profile.id = (select auth.uid())
+              or profile.user_id = (select auth.uid())
+            )
+        )
+        or exists (
+          select 1
+          from public.fleet_members membership
+          where membership.fleet_id = p_fleet_id
+            and membership.shop_id = p_shop_id
+            and membership.user_id in (
+              select profile.id
+              from public.profiles profile
+              where profile.id = (select auth.uid())
+                 or profile.user_id = (select auth.uid())
+            )
+        )
+      )
+  );
+$$;
+
+create or replace function public.fleet_actor_can_read_member(
+  p_fleet_id uuid,
+  p_shop_id uuid,
+  p_member_user_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from public.fleets fleet
+    where fleet.id = p_fleet_id
+      and fleet.shop_id = p_shop_id
+      and (
+        p_member_user_id in (
+          select profile.id
+          from public.profiles profile
+          where profile.id = (select auth.uid())
+             or profile.user_id = (select auth.uid())
+        )
+        or exists (
+          select 1
+          from public.profiles profile
+          where profile.shop_id = p_shop_id
+            and (
+              profile.id = (select auth.uid())
+              or profile.user_id = (select auth.uid())
+            )
+        )
+      )
+  );
+$$;
+
+create or replace function public.fleet_actor_can_manage_scope(
+  p_fleet_id uuid,
+  p_shop_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from public.fleets fleet
+    where fleet.id = p_fleet_id
+      and fleet.shop_id = p_shop_id
+      and exists (
+        select 1
+        from public.profiles profile
+        where profile.shop_id = p_shop_id
+          and (
+            profile.id = (select auth.uid())
+            or profile.user_id = (select auth.uid())
+          )
+          and public.canonical_shop_membership_role(profile.role::text)
+            in ('owner', 'admin', 'manager')
+      )
+  );
+$$;
+
+revoke all on function public.fleet_actor_can_read_fleet(uuid, uuid)
+  from public, anon;
+revoke all on function public.fleet_actor_can_read_member(uuid, uuid, uuid)
+  from public, anon;
+revoke all on function public.fleet_actor_can_manage_scope(uuid, uuid)
+  from public, anon;
+grant execute on function public.fleet_actor_can_read_fleet(uuid, uuid)
+  to authenticated, service_role;
+grant execute on function public.fleet_actor_can_read_member(uuid, uuid, uuid)
+  to authenticated, service_role;
+grant execute on function public.fleet_actor_can_manage_scope(uuid, uuid)
+  to authenticated, service_role;
+
+drop policy if exists fleets_actor_select on public.fleets;
+create policy fleets_actor_select
+  on public.fleets
+  for select to authenticated
+  using (public.fleet_actor_can_read_fleet(id, shop_id));
+
+drop policy if exists fleet_members_actor_select on public.fleet_members;
+create policy fleet_members_actor_select
+  on public.fleet_members
+  for select to authenticated
+  using (
+    public.fleet_actor_can_read_member(fleet_id, shop_id, user_id)
+  );
+
+drop policy if exists fleet_members_manager_write on public.fleet_members;
+create policy fleet_members_manager_write
+  on public.fleet_members
+  for all to authenticated
+  using (public.fleet_actor_can_manage_scope(fleet_id, shop_id))
+  with check (public.fleet_actor_can_manage_scope(fleet_id, shop_id));
+
+commit;

--- a/supabase/migrations/20260812061000_restore_authenticated_role_normalizer.sql
+++ b/supabase/migrations/20260812061000_restore_authenticated_role_normalizer.sql
@@ -1,0 +1,15 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+
+-- This immutable helper only normalizes a caller-supplied role label; it does
+-- not read tenant data. Authenticated RLS policies and the security-invoker
+-- customer pricing summary both depend on it, so authenticated must be able to
+-- execute it. Anonymous access remains closed.
+revoke all on function public.canonical_shop_membership_role(text)
+  from public, anon;
+grant execute on function public.canonical_shop_membership_role(text)
+  to authenticated, service_role;
+
+commit;

--- a/supabase/migrations/20260812062000_harden_customer_account_advisors.sql
+++ b/supabase/migrations/20260812062000_harden_customer_account_advisors.sql
@@ -1,0 +1,169 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+
+-- Keep privileged RLS predicates outside every Data API exposed schema. The
+-- authenticated role may execute them only because row policies call them;
+-- callers cannot select arbitrary tenant data from these boolean predicates.
+create schema if not exists rls_helpers authorization postgres;
+revoke all on schema rls_helpers from public, anon;
+grant usage on schema rls_helpers to authenticated, service_role;
+alter default privileges for role postgres in schema rls_helpers
+  revoke execute on functions from public;
+
+create or replace function rls_helpers.fleet_actor_can_read_fleet(
+  p_fleet_id uuid,
+  p_shop_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from public.fleets fleet
+    where fleet.id = p_fleet_id
+      and fleet.shop_id = p_shop_id
+      and (
+        exists (
+          select 1
+          from public.profiles profile
+          where profile.shop_id = p_shop_id
+            and (
+              profile.id = (select auth.uid())
+              or profile.user_id = (select auth.uid())
+            )
+        )
+        or exists (
+          select 1
+          from public.fleet_members membership
+          where membership.fleet_id = p_fleet_id
+            and membership.shop_id = p_shop_id
+            and membership.user_id in (
+              select profile.id
+              from public.profiles profile
+              where profile.id = (select auth.uid())
+                 or profile.user_id = (select auth.uid())
+            )
+        )
+      )
+  );
+$$;
+
+create or replace function rls_helpers.fleet_actor_can_read_member(
+  p_fleet_id uuid,
+  p_shop_id uuid,
+  p_member_user_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from public.fleets fleet
+    where fleet.id = p_fleet_id
+      and fleet.shop_id = p_shop_id
+      and (
+        p_member_user_id in (
+          select profile.id
+          from public.profiles profile
+          where profile.id = (select auth.uid())
+             or profile.user_id = (select auth.uid())
+        )
+        or exists (
+          select 1
+          from public.profiles profile
+          where profile.shop_id = p_shop_id
+            and (
+              profile.id = (select auth.uid())
+              or profile.user_id = (select auth.uid())
+            )
+        )
+      )
+  );
+$$;
+
+create or replace function rls_helpers.fleet_actor_can_manage_scope(
+  p_fleet_id uuid,
+  p_shop_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from public.fleets fleet
+    where fleet.id = p_fleet_id
+      and fleet.shop_id = p_shop_id
+      and exists (
+        select 1
+        from public.profiles profile
+        where profile.shop_id = p_shop_id
+          and (
+            profile.id = (select auth.uid())
+            or profile.user_id = (select auth.uid())
+          )
+          and public.canonical_shop_membership_role(profile.role::text)
+            in ('owner', 'admin', 'manager')
+      )
+  );
+$$;
+
+revoke all on function rls_helpers.fleet_actor_can_read_fleet(uuid, uuid)
+  from public, anon, authenticated, service_role;
+revoke all on function rls_helpers.fleet_actor_can_read_member(uuid, uuid, uuid)
+  from public, anon, authenticated, service_role;
+revoke all on function rls_helpers.fleet_actor_can_manage_scope(uuid, uuid)
+  from public, anon, authenticated, service_role;
+grant execute on function rls_helpers.fleet_actor_can_read_fleet(uuid, uuid)
+  to authenticated, service_role;
+grant execute on function rls_helpers.fleet_actor_can_read_member(uuid, uuid, uuid)
+  to authenticated, service_role;
+grant execute on function rls_helpers.fleet_actor_can_manage_scope(uuid, uuid)
+  to authenticated, service_role;
+
+drop policy if exists fleets_actor_select on public.fleets;
+create policy fleets_actor_select
+  on public.fleets
+  for select to authenticated
+  using (rls_helpers.fleet_actor_can_read_fleet(id, shop_id));
+
+drop policy if exists fleet_members_actor_select on public.fleet_members;
+create policy fleet_members_actor_select
+  on public.fleet_members
+  for select to authenticated
+  using (
+    rls_helpers.fleet_actor_can_read_member(fleet_id, shop_id, user_id)
+  );
+
+drop policy if exists fleet_members_manager_write on public.fleet_members;
+create policy fleet_members_manager_write
+  on public.fleet_members
+  for all to authenticated
+  using (rls_helpers.fleet_actor_can_manage_scope(fleet_id, shop_id))
+  with check (rls_helpers.fleet_actor_can_manage_scope(fleet_id, shop_id));
+
+drop function public.fleet_actor_can_read_fleet(uuid, uuid);
+drop function public.fleet_actor_can_read_member(uuid, uuid, uuid);
+drop function public.fleet_actor_can_manage_scope(uuid, uuid);
+
+create index if not exists customer_account_operations_actor_idx
+  on private.customer_account_operations (actor_user_id);
+create index if not exists customer_account_operations_customer_idx
+  on private.customer_account_operations (customer_id)
+  where customer_id is not null;
+create index if not exists customer_account_merges_merged_by_idx
+  on public.customer_account_merges (merged_by);
+create index if not exists customer_account_merges_target_customer_idx
+  on public.customer_account_merges (target_customer_id);
+
+commit;

--- a/tests/create-work-order-customer-vehicle-save.test.ts
+++ b/tests/create-work-order-customer-vehicle-save.test.ts
@@ -7,13 +7,15 @@ describe("create work order customer and vehicle persistence", () => {
     "utf8",
   );
 
-  it("writes the complete customer form for inserts and existing records", () => {
+  it("writes the complete customer form for canonical creates and existing records", () => {
     expect(page).toContain("const customerWrite = buildCustomerInsert(customer, shopId)");
     expect(page).toContain("const { shop_id: _shopId, ...customerPatch } = customerWrite");
     expect(page).not.toContain("const needsPatch =");
     expect(page).toContain(".update(customerPatch)");
     expect(page).toContain(".update(buildImplicitCustomerPatch(customerPatch))");
-    expect(page).toContain(".insert(customerWrite)");
+    expect(page).toContain("createCustomerAccount({");
+    expect(page).toContain("matchExisting: true");
+    expect(page).not.toContain(".insert(customerWrite)");
   });
 
   it("writes every vehicle field, including cleared values", () => {

--- a/tests/customer-account-center.test.ts
+++ b/tests/customer-account-center.test.ts
@@ -8,6 +8,10 @@ const migration = read(
 const fleetPolicyRepair = read(
   "supabase/migrations/20260812060000_repair_fleet_access_policy_recursion.sql",
 );
+const customerAccountHardening = read(
+  "supabase/migrations/20260812062000_harden_customer_account_advisors.sql",
+);
+const generatedTypes = read("features/shared/types/types/supabase.ts");
 const accountCenter = read(
   "features/customers/components/CustomerAccountDetails.tsx",
 );
@@ -93,6 +97,37 @@ describe("unified Customer Account Center", () => {
     expect(fleetPolicyRepair).toContain("profile.user_id = (select auth.uid())");
     expect(fleetPolicyRepair).not.toMatch(
       /create policy fleets_actor_select[\s\S]*?from public\.fleet_members/i,
+    );
+  });
+
+  it("keeps privileged Fleet predicates outside the Data API surface", () => {
+    expect(customerAccountHardening).toContain(
+      "create schema if not exists rls_helpers",
+    );
+    expect(customerAccountHardening).toContain(
+      "alter default privileges for role postgres in schema rls_helpers",
+    );
+    expect(customerAccountHardening).toContain(
+      "using (rls_helpers.fleet_actor_can_read_fleet(id, shop_id))",
+    );
+    expect(customerAccountHardening).toContain(
+      "drop function public.fleet_actor_can_read_fleet(uuid, uuid)",
+    );
+    expect(generatedTypes).not.toContain("fleet_actor_can_read_fleet:");
+  });
+
+  it("indexes Customer Account audit foreign keys used during retention", () => {
+    expect(customerAccountHardening).toContain(
+      "customer_account_operations_actor_idx",
+    );
+    expect(customerAccountHardening).toContain(
+      "customer_account_operations_customer_idx",
+    );
+    expect(customerAccountHardening).toContain(
+      "customer_account_merges_merged_by_idx",
+    );
+    expect(customerAccountHardening).toContain(
+      "customer_account_merges_target_customer_idx",
     );
   });
 });

--- a/tests/customer-account-center.test.ts
+++ b/tests/customer-account-center.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const migration = read(
+  "supabase/migrations/20260812050000_unified_customer_account_center.sql",
+);
+const accountCenter = read(
+  "features/customers/components/CustomerAccountDetails.tsx",
+);
+const directory = read("features/customers/app/customers/[id]/page.tsx");
+const desktopWorkOrder = read(
+  "features/work-orders/app/work-orders/create/page.tsx",
+);
+const mobileWorkOrder = read("app/mobile/work-orders/create/page.tsx");
+
+describe("unified Customer Account Center", () => {
+  it("normalizes duplicate identity inside each Shop", () => {
+    expect(migration).toContain("identity_name text");
+    expect(migration).toContain("identity_email text");
+    expect(migration).toContain("identity_phone text");
+    expect(migration).toContain("find_customer_account_duplicates");
+    expect(migration).toContain("CUSTOMER_DUPLICATE_REVIEW_REQUIRED");
+    expect(migration).toContain("vehicles_shop_normalized_vin_idx");
+  });
+
+  it("keeps all primary creation surfaces on the canonical command", () => {
+    for (const source of [directory, desktopWorkOrder, mobileWorkOrder]) {
+      expect(source).toContain("createCustomerAccount");
+    }
+    expect(desktopWorkOrder).toContain("matchExisting: true");
+    expect(mobileWorkOrder).toContain("matchExisting: true");
+    expect(directory).toContain("CustomerDuplicateReviewError");
+  });
+
+  it("adds commercial controls without a second competing settings table", () => {
+    expect(migration).toContain("alter table public.customer_settings");
+    expect(migration).toContain("primary_billing_contact_id");
+    expect(migration).toContain("primary_approval_contact_id");
+    expect(migration).toContain("po_required boolean");
+    expect(migration).toContain("payment_terms text");
+    expect(migration).toContain("tax_exempt boolean");
+    expect(migration).toContain("account_status text");
+    expect(migration).not.toContain(
+      "create table public.customer_account_settings",
+    );
+  });
+
+  it("preserves history through archive and merge instead of deletion", () => {
+    expect(migration).toContain("customer_account_merges");
+    expect(migration).toContain("merge_customer_accounts_atomic");
+    expect(migration).toContain("archive_customer_account_atomic");
+    expect(migration).toContain(
+      'drop policy if exists "staff can delete customers in shop"',
+    );
+    expect(migration).toContain(
+      "revoke delete on table public.customers from authenticated",
+    );
+    expect(migration).not.toMatch(/delete from public\.customers/i);
+  });
+
+  it("presents account, Fleet, invoice, lifecycle, and pricing controls together", () => {
+    expect(accountCenter).toContain("Customer Account Center");
+    expect(accountCenter).toContain("Commercial controls");
+    expect(accountCenter).toContain("Fleet workspace");
+    expect(accountCenter).toContain("Outstanding");
+    expect(accountCenter).toContain("Merge duplicate");
+    expect(accountCenter).toContain("<CustomerPricingPanel");
+  });
+});

--- a/tests/customer-account-center.test.ts
+++ b/tests/customer-account-center.test.ts
@@ -5,6 +5,9 @@ const read = (path: string) => readFileSync(path, "utf8");
 const migration = read(
   "supabase/migrations/20260812050000_unified_customer_account_center.sql",
 );
+const fleetPolicyRepair = read(
+  "supabase/migrations/20260812060000_repair_fleet_access_policy_recursion.sql",
+);
 const accountCenter = read(
   "features/customers/components/CustomerAccountDetails.tsx",
 );
@@ -66,5 +69,30 @@ describe("unified Customer Account Center", () => {
     expect(accountCenter).toContain("Outstanding");
     expect(accountCenter).toContain("Merge duplicate");
     expect(accountCenter).toContain("<CustomerPricingPanel");
+  });
+
+  it("keeps long customer forms usable within a desktop viewport", () => {
+    expect(directory).toContain("max-h-[calc(100dvh-1.5rem)]");
+    expect(directory).toContain("min-h-0 overflow-y-auto");
+    expect(directory).toContain("shrink-0 items-center");
+  });
+
+  it("keeps a canonical customer visible when optional service data fails", () => {
+    expect(directory).toContain("let customerWasLoaded = false");
+    expect(directory).toContain("if (!customerWasLoaded) setCustomer(null)");
+    expect(directory).toContain(
+      "Customer account loaded, but related service data could not be loaded.",
+    );
+  });
+
+  it("breaks Fleet policy recursion without broadening Fleet access", () => {
+    expect(fleetPolicyRepair).toContain("fleet_actor_can_read_fleet");
+    expect(fleetPolicyRepair).toContain("fleet_actor_can_read_member");
+    expect(fleetPolicyRepair).toContain("fleet_actor_can_manage_scope");
+    expect(fleetPolicyRepair).toContain("security definer");
+    expect(fleetPolicyRepair).toContain("profile.user_id = (select auth.uid())");
+    expect(fleetPolicyRepair).not.toMatch(
+      /create policy fleets_actor_select[\s\S]*?from public\.fleet_members/i,
+    );
   });
 });

--- a/tests/customer-account-foundation.test.ts
+++ b/tests/customer-account-foundation.test.ts
@@ -39,9 +39,9 @@ describe("customer account foundation", () => {
   });
 
   it("separates a staff creator from the customer portal identity", () => {
-    expect(customerPage).toContain("user_id: null");
-    expect(customerPage).toContain("created_by: user.id");
-    expect(customerPage).toContain("account_type: newCustomer.customerType");
+    expect(customerPage).toContain("createCanonicalCustomerAccount");
+    expect(customerPage).toContain("accountType: newCustomer.customerType");
+    expect(customerPage).not.toContain('.from("customers")\n        .insert');
   });
 
   it("links Fleet to an explicitly verified existing customer", () => {

--- a/tests/customer-specific-pricing-engine.test.ts
+++ b/tests/customer-specific-pricing-engine.test.ts
@@ -5,6 +5,10 @@ const migration = readFileSync(
   "supabase/migrations/20260812022359_customer_specific_pricing_engine.sql",
   "utf8",
 );
+const roleNormalizerGrant = readFileSync(
+  "supabase/migrations/20260812061000_restore_authenticated_role_normalizer.sql",
+  "utf8",
+);
 const quoteReview = readFileSync(
   "features/work-orders/quote-review/QuoteReviewView.tsx",
   "utf8",
@@ -40,5 +44,13 @@ describe("customer-specific pricing engine contracts", () => {
     expect(
       quoteSend.indexOf("apply_customer_pricing_to_quote_atomic"),
     ).toBeLessThan(quoteSend.indexOf('from("work_order_quote_lines")'));
+  });
+
+  it("allows authenticated security-invoker pricing reads to normalize roles", () => {
+    expect(roleNormalizerGrant).toContain(
+      "grant execute on function public.canonical_shop_membership_role(text)",
+    );
+    expect(roleNormalizerGrant).toContain("to authenticated, service_role");
+    expect(roleNormalizerGrant).toContain("from public, anon");
   });
 });

--- a/tests/customers/unified-customer-account-center.runtime.sql
+++ b/tests/customers/unified-customer-account-center.runtime.sql
@@ -296,6 +296,80 @@ begin
 end;
 $$;
 
+insert into public.fleets (
+  id, shop_id, customer_id, name, created_by
+)
+select
+  '61300000-0000-4000-8000-000000000001',
+  '61200000-0000-4000-8000-000000000001',
+  customer.id,
+  'Account Center Runtime Fleet',
+  '61100000-0000-4000-8000-000000000001'
+from public.customers customer
+where customer.shop_id = '61200000-0000-4000-8000-000000000001'
+  and customer.email = 'billing@morgan.example';
+
+-- A different-Shop actor is denied before any explicit Fleet membership.
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"61100000-0000-4000-8000-000000000002","role":"authenticated"}',
+  true
+);
+
+do $$
+begin
+  if exists (
+    select 1 from public.fleets
+    where id = '61300000-0000-4000-8000-000000000001'
+  ) then
+    raise exception 'Cross-Shop non-member read a Fleet workspace.';
+  end if;
+end;
+$$;
+
+reset role;
+select set_config('request.jwt.claims', '', true);
+select set_config('request.jwt.claim.role', '', true);
+
+insert into public.fleet_members (
+  fleet_id, shop_id, user_id, role, created_by
+) values (
+  '61300000-0000-4000-8000-000000000001',
+  '61200000-0000-4000-8000-000000000001',
+  '61100000-0000-4000-8000-000000000002',
+  'viewer',
+  '61100000-0000-4000-8000-000000000001'
+);
+
+-- Shop staff can read the Fleet and its membership rows without RLS recursion.
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"61100000-0000-4000-8000-000000000001","role":"authenticated"}',
+  true
+);
+
+do $$
+begin
+  if not exists (
+    select 1 from public.fleets
+    where id = '61300000-0000-4000-8000-000000000001'
+  ) or not exists (
+    select 1 from public.fleet_members
+    where fleet_id = '61300000-0000-4000-8000-000000000001'
+      and user_id = '61100000-0000-4000-8000-000000000002'
+  ) then
+    raise exception 'Shop staff could not read the linked Fleet relationship.';
+  end if;
+end;
+$$;
+
+reset role;
+select set_config('request.jwt.claims', '', true);
+select set_config('request.jwt.claim.role', '', true);
+
+-- An explicit Fleet member can read that Fleet and their own membership row.
 set local role authenticated;
 select set_config(
   'request.jwt.claims',
@@ -307,6 +381,17 @@ do $$
 declare
   v_denied boolean := false;
 begin
+  if not exists (
+    select 1 from public.fleets
+    where id = '61300000-0000-4000-8000-000000000001'
+  ) or not exists (
+    select 1 from public.fleet_members
+    where fleet_id = '61300000-0000-4000-8000-000000000001'
+      and user_id = '61100000-0000-4000-8000-000000000002'
+  ) then
+    raise exception 'Explicit Fleet member could not read their Fleet scope.';
+  end if;
+
   begin
     perform public.find_customer_account_duplicates(
       '61200000-0000-4000-8000-000000000001',

--- a/tests/customers/unified-customer-account-center.runtime.sql
+++ b/tests/customers/unified-customer-account-center.runtime.sql
@@ -1,0 +1,329 @@
+\set ON_ERROR_STOP on
+
+-- @regression-flow customers.account-center
+begin;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values
+  (
+    '61100000-0000-4000-8000-000000000001',
+    'account-center-owner-a@example.com',
+    '{"full_name":"Account Center Owner A"}'::jsonb
+  ),
+  (
+    '61100000-0000-4000-8000-000000000002',
+    'account-center-owner-b@example.com',
+    '{"full_name":"Account Center Owner B"}'::jsonb
+  )
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name)
+values
+  (
+    '61100000-0000-4000-8000-000000000001',
+    '61100000-0000-4000-8000-000000000001',
+    'owner',
+    'Account Center Owner A'
+  ),
+  (
+    '61100000-0000-4000-8000-000000000002',
+    '61100000-0000-4000-8000-000000000002',
+    'owner',
+    'Account Center Owner B'
+  )
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name;
+
+insert into public.shops (id, owner_id, business_name, name, labor_rate, country)
+values
+  (
+    '61200000-0000-4000-8000-000000000001',
+    '61100000-0000-4000-8000-000000000001',
+    'Account Center Shop A',
+    'Account Center Shop A',
+    150,
+    'CA'
+  ),
+  (
+    '61200000-0000-4000-8000-000000000002',
+    '61100000-0000-4000-8000-000000000002',
+    'Account Center Shop B',
+    'Account Center Shop B',
+    160,
+    'CA'
+  );
+
+update public.profiles
+set shop_id = case id
+  when '61100000-0000-4000-8000-000000000001'::uuid
+    then '61200000-0000-4000-8000-000000000001'::uuid
+  else '61200000-0000-4000-8000-000000000002'::uuid
+end
+where id in (
+  '61100000-0000-4000-8000-000000000001',
+  '61100000-0000-4000-8000-000000000002'
+);
+
+do $$
+declare
+  v_target jsonb;
+  v_same jsonb;
+  v_name_duplicate jsonb;
+  v_source jsonb;
+  v_archive jsonb;
+  v_target_id uuid;
+  v_source_id uuid;
+  v_archive_id uuid;
+  v_billing_contact_id uuid;
+  v_merge jsonb;
+  v_summary jsonb;
+begin
+  v_target := public.create_customer_account_atomic(
+    '61200000-0000-4000-8000-000000000001',
+    'business',
+    'Alex Morgan',
+    'Morgan Earthworks',
+    'BILLING@MORGAN.EXAMPLE',
+    '+1 (403) 555-0101',
+    '10 Service Road',
+    'Calgary',
+    'AB',
+    'T1X 0A1',
+    'Runtime canonical target',
+    null,
+    false,
+    false,
+    '61100000-0000-4000-8000-000000000001',
+    'account-center-target'
+  );
+  if not (v_target ->> 'ok')::boolean then
+    raise exception 'Canonical target was not created: %', v_target;
+  end if;
+  v_target_id := (v_target #>> '{customer,id}')::uuid;
+
+  v_same := public.create_customer_account_atomic(
+    '61200000-0000-4000-8000-000000000001',
+    'business',
+    'Alex Morgan',
+    'Morgan Earthworks',
+    'billing@morgan.example',
+    '4035550101',
+    null, null, null, null, null, null,
+    true,
+    false,
+    '61100000-0000-4000-8000-000000000001',
+    'account-center-exact-reuse'
+  );
+  if not (v_same ->> 'matched_existing')::boolean
+     or (v_same #>> '{customer,id}')::uuid <> v_target_id then
+    raise exception 'Exact email/phone did not reuse canonical account: %', v_same;
+  end if;
+
+  v_name_duplicate := public.create_customer_account_atomic(
+    '61200000-0000-4000-8000-000000000001',
+    'business',
+    'Different Contact',
+    'Morgan Earthworks',
+    null,
+    null,
+    null, null, null, null, null, null,
+    false,
+    false,
+    '61100000-0000-4000-8000-000000000001',
+    'account-center-name-review'
+  );
+  if (v_name_duplicate ->> 'code') is distinct from 'CUSTOMER_DUPLICATE_REVIEW_REQUIRED'
+     or jsonb_array_length(v_name_duplicate -> 'duplicate_candidates') = 0 then
+    raise exception 'Name overlap did not require duplicate review: %', v_name_duplicate;
+  end if;
+
+  select id into strict v_billing_contact_id
+  from public.customer_contacts
+  where customer_id = v_target_id and is_primary;
+
+  perform public.update_customer_commercial_controls_atomic(
+    '61200000-0000-4000-8000-000000000001',
+    v_target_id,
+    v_billing_contact_id,
+    v_billing_contact_id,
+    true,
+    'net_30',
+    30,
+    true,
+    'AB-EXEMPT-42',
+    'credit_hold',
+    'Awaiting current account authorization',
+    'Send consolidated statements monthly.',
+    'Morgan PO account',
+    '61100000-0000-4000-8000-000000000001',
+    'account-center-controls'
+  );
+
+  if not exists (
+    select 1 from public.customer_settings settings
+    where settings.customer_id = v_target_id
+      and settings.shop_id = '61200000-0000-4000-8000-000000000001'
+      and settings.po_required
+      and settings.payment_terms = 'net_30'
+      and settings.tax_exempt
+      and settings.account_status = 'credit_hold'
+      and settings.primary_billing_contact_id = v_billing_contact_id
+  ) then
+    raise exception 'Commercial controls were not stored on the canonical settings row.';
+  end if;
+
+  v_source := public.create_customer_account_atomic(
+    '61200000-0000-4000-8000-000000000001',
+    'individual',
+    'Alex Morgan Duplicate',
+    null,
+    'alex.duplicate@example.com',
+    '4035550199',
+    null, null, null, null,
+    'Runtime duplicate source',
+    null,
+    false,
+    true,
+    '61100000-0000-4000-8000-000000000001',
+    'account-center-source'
+  );
+  v_source_id := (v_source #>> '{customer,id}')::uuid;
+  update public.customers
+  set user_id = '61100000-0000-4000-8000-000000000001'
+  where id = v_source_id;
+
+  v_merge := public.merge_customer_accounts_atomic(
+    '61200000-0000-4000-8000-000000000001',
+    v_source_id,
+    v_target_id,
+    'Confirmed duplicate created during runtime verification.',
+    '61100000-0000-4000-8000-000000000001',
+    'account-center-merge'
+  );
+  if not (v_merge ->> 'ok')::boolean
+     or (v_merge ->> 'redirect_customer_id')::uuid <> v_target_id then
+    raise exception 'Customer merge did not return canonical redirect: %', v_merge;
+  end if;
+  if not exists (
+    select 1 from public.customers customer
+    where customer.id = v_source_id
+      and not customer.active
+      and customer.merged_into_customer_id = v_target_id
+      and customer.merged_at is not null
+      and customer.user_id is null
+  ) then
+    raise exception 'Merged source customer was not retained as an archived redirect.';
+  end if;
+  if not exists (
+    select 1 from public.customers customer
+    where customer.id = v_target_id
+      and customer.user_id = '61100000-0000-4000-8000-000000000001'
+  ) then
+    raise exception 'Customer portal identity was not transferred to the canonical target.';
+  end if;
+  if exists (
+    select 1 from public.customer_contacts contact
+    where contact.customer_id = v_source_id
+  ) or not exists (
+    select 1 from public.customer_contacts contact
+    where contact.customer_id = v_target_id
+      and contact.email = 'alex.duplicate@example.com'
+  ) then
+    raise exception 'Merge did not consolidate customer contacts.';
+  end if;
+  if not exists (
+    select 1 from public.customer_account_merges merge
+    where merge.source_customer_id = v_source_id
+      and merge.target_customer_id = v_target_id
+      and merge.source_snapshot ->> 'id' = v_source_id::text
+      and merge.target_snapshot ->> 'id' = v_target_id::text
+  ) then
+    raise exception 'Merge audit history was not recorded.';
+  end if;
+
+  v_archive := public.create_customer_account_atomic(
+    '61200000-0000-4000-8000-000000000001',
+    'individual',
+    'Archive Runtime Customer',
+    null,
+    'archive.runtime@example.com',
+    null,
+    null, null, null, null, null, null,
+    false,
+    false,
+    '61100000-0000-4000-8000-000000000001',
+    'account-center-archive-source'
+  );
+  v_archive_id := (v_archive #>> '{customer,id}')::uuid;
+  perform public.archive_customer_account_atomic(
+    '61200000-0000-4000-8000-000000000001',
+    v_archive_id,
+    'Customer requested account closure.',
+    '61100000-0000-4000-8000-000000000001',
+    'account-center-archive'
+  );
+  if not coalesce((public.archive_customer_account_atomic(
+    '61200000-0000-4000-8000-000000000001',
+    v_archive_id,
+    'Customer requested account closure.',
+    '61100000-0000-4000-8000-000000000001',
+    'account-center-archive'
+  ) ->> 'idempotent')::boolean, false) then
+    raise exception 'Archive command did not replay idempotently.';
+  end if;
+  if not exists (
+    select 1 from public.customers customer
+    where customer.id = v_archive_id
+      and not customer.active
+      and customer.archived_at is not null
+      and customer.merged_into_customer_id is null
+  ) then
+    raise exception 'Archive removed or failed to retain the customer account.';
+  end if;
+
+  v_summary := public.get_customer_account_center(
+    '61200000-0000-4000-8000-000000000001',
+    v_target_id,
+    '61100000-0000-4000-8000-000000000001'
+  );
+  if (v_summary #>> '{counts,merged_sources}')::integer <> 1
+     or (v_summary #>> '{settings,po_required}')::boolean is not true
+     or (v_summary ->> 'can_manage_commercial')::boolean is not true then
+    raise exception 'Account Center summary did not consolidate expected state: %', v_summary;
+  end if;
+end;
+$$;
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"61100000-0000-4000-8000-000000000002","role":"authenticated"}',
+  true
+);
+
+do $$
+declare
+  v_denied boolean := false;
+begin
+  begin
+    perform public.find_customer_account_duplicates(
+      '61200000-0000-4000-8000-000000000001',
+      'Morgan Earthworks', null, null, null, null, null,
+      '61100000-0000-4000-8000-000000000002'
+    );
+  exception when insufficient_privilege then
+    v_denied := true;
+  end;
+  if not v_denied then
+    raise exception 'Cross-Shop actor inspected customer duplicate candidates.';
+  end if;
+end;
+$$;
+
+reset role;
+select set_config('request.jwt.claims', '', true);
+select set_config('request.jwt.claim.role', '', true);
+
+rollback;

--- a/tests/pricing/customer-specific-pricing.runtime.sql
+++ b/tests/pricing/customer-specific-pricing.runtime.sql
@@ -318,6 +318,34 @@ begin
 end;
 $$;
 
+-- The Account Center reads Pricing through this security-invoker summary.
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"51100000-0000-4000-8000-000000000001","role":"authenticated"}',
+  true
+);
+
+do $$
+declare
+  v_summary jsonb;
+begin
+  v_summary := public.get_customer_pricing_account_summary(
+    '51200000-0000-4000-8000-000000000001',
+    '51300000-0000-4000-8000-000000000001',
+    now()
+  );
+  if not coalesce((v_summary ->> 'ok')::boolean, false)
+     or jsonb_array_length(v_summary -> 'agreements') <> 2 then
+    raise exception 'Authenticated Account Center pricing summary failed: %', v_summary;
+  end if;
+end;
+$$;
+
+reset role;
+select set_config('request.jwt.claims', '', true);
+select set_config('request.jwt.claim.role', '', true);
+
 select public.retire_customer_pricing_agreement_atomic(
   '51200000-0000-4000-8000-000000000001',
   (


### PR DESCRIPTION
## What changed

- Builds a unified Customer Account Center on the existing canonical `customers` record.
- Keeps **Create Work Order** as the primary fast path while routing desktop, mobile, directory, Agent, and Shop Assistant creation through one duplicate-aware account command.
- Separates Individual, Business, Fleet, and Enterprise account types without forcing ordinary businesses into Fleet.
- Detects same-Shop overlaps by normalized name, email, phone, and VIN; exact email/phone/VIN matches can reuse one existing account while ambiguous matches require explicit review.
- Consolidates contacts, locations, assets, work orders, invoices, Fleet link/invite status, commercial posture, and customer pricing in one Account Center.
- Adds manager-only commercial controls for billing and approval contacts, PO requirements, payment terms, tax exemption, account/credit hold, billing notes, and customer references.
- Replaces destructive customer deletion with archive and audited merge operations. Merge reparents operational history, transfers portal identity safely, preserves source/target snapshots, and blocks ambiguous active pricing, Fleet, portal, or QuickBooks conflicts.
- Backfills a canonical `customer_settings` anchor for every existing Shop customer without changing existing portal preferences.
- Repairs recursive Fleet RLS through non-Data-API policy helpers and restores authenticated pricing role normalization.
- Adds the missing audit foreign-key indexes and removes resolved regression-inventory baseline entries.
- Extends durable Supabase Clean Replay with rollback-based Customer Account Center runtime coverage.

## Automated smoke test

Authenticated browser smoke against the Supabase preview branch passed at the final application tree:

- Customer directory loaded and created one canonical Business account.
- Create Work Order remained the primary action.
- Fleet stayed optional and unlinked.
- Primary contact and location appeared in the Account Center.
- PO-required, net-30 terms, billing note, and customer reference saved.
- An email + phone collision produced duplicate review and resolved to the existing canonical record.
- Dedicated pricing loaded with Shop-default fallback and no non-success pricing response.
- Archive preserved the record and its relationships; no destructive delete occurred.
- Browser page errors: 0.
- Database proof: canonical count 1, active contacts 1, active locations 1, Fleet links 0, archived=true, active smoke records remaining 0.

## Validation

Final GitHub head: `ee5ce1348404863848e7d10ed70c8d2520604c68`

- Agent PR Checks: passed
- Supabase Clean Replay Validation: passed
- Customer-specific Pricing Validation: passed
- P0-006 Stripe Identity Validation: passed
- TypeScript typecheck: passed
- Changed-file ESLint: passed
- Full Vitest suite: passed
- Next.js production build: passed
- Regression inventory: 0 new errors, 0 stale baseline entries
- Preview Supabase migrations, APIs, and services: healthy
- Preview task-created advisor findings: cleared

## Migrations

Reviewed task-owned migrations, in order:

1. `20260812050000_unified_customer_account_center.sql`
2. `20260812060000_repair_fleet_access_policy_recursion.sql`
3. `20260812061000_restore_authenticated_role_normalizer.sql`
4. `20260812062000_harden_customer_account_advisors.sql`

All four are applied and smoke-tested on preview project `mxlsxuteeuixcvqennhe`.

Canonical production `scjjkmuwadwkaaqjoigx` is healthy and remains unchanged at `20260812022359_customer_specific_pricing_engine`. The connected branch merge accepted the deprecated UUID but produced no production action/history/schema change; the connector rejects the current branch-ref identifier locally. Do **not** use individual management-API migrations because they would generate non-repository versions. The exact-version safe path is the existing Supabase Git deployment after this PR is merged to `main`.

## Delivery state

- Intentionally remains a **draft**.
- GitHub PR is open, mergeable, and unmerged.
- No production migration was applied.
- No production data was changed.
