### PR TITLE
Customer Pricing V2

### DIFF
--- a/.github/workflows/customer-specific-pricing-validation.yml
+++ b/.github/workflows/customer-specific-pricing-validation.yml
@@ -13,7 +13,9 @@ on:
       - "features/pricing/**"
       - "features/work-orders/quote-review/QuoteReviewView.tsx"
       - "supabase/migrations/20260812022359_customer_specific_pricing_engine.sql"
+      - "supabase/migrations/20260812140518_customer_pricing_v2.sql"
       - "tests/customer-specific-pricing-engine.test.ts"
+      - "tests/customer-pricing-v2.test.ts"
       - "tests/pricing/customer-specific-pricing.runtime.sql"
       - ".github/workflows/customer-specific-pricing-validation.yml"
 
@@ -44,10 +46,12 @@ jobs:
           pnpm exec vitest run
           features/pricing/lib/customerPricing.test.ts
           tests/customer-specific-pricing-engine.test.ts
+          tests/customer-pricing-v2.test.ts
       - name: Pricing lint
         run: >-
           pnpm exec eslint
           app/api/customers/[id]/pricing/route.ts
+          app/api/quotes/send/route.ts
           app/api/work-orders/[id]/customer-pricing/route.ts
           features/customers/components/CustomerPricingPanel.tsx
           features/customers/components/CustomerAccountDetails.tsx

--- a/app/api/customers/[id]/pricing/route.ts
+++ b/app/api/customers/[id]/pricing/route.ts
@@ -204,6 +204,7 @@ export async function POST(request: Request, context: RouteContext) {
     (body?.customerFeeCap != null &&
       body.customerFeeCap !== "" &&
       customerFeeCap == null) ||
+    (customerFeeType !== "percentage" && customerFeeCap != null) ||
     !Number.isInteger(expiryWarningDays) ||
     expiryWarningDays < 0 ||
     expiryWarningDays > 365 ||

--- a/app/api/customers/[id]/pricing/route.ts
+++ b/app/api/customers/[id]/pricing/route.ts
@@ -43,6 +43,46 @@ function percent(value: unknown): number | null {
   return numberValue != null && numberValue <= 100 ? numberValue : null;
 }
 
+type MatrixTier = {
+  cost_from: number;
+  cost_to: number | null;
+  markup_percent: number;
+};
+
+function partsMarkupMatrix(value: unknown): MatrixTier[] | null {
+  if (value == null) return [];
+  if (!Array.isArray(value) || value.length > 50) return null;
+  let previousUpper: number | null = null;
+  const tiers: MatrixTier[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const raw = value[index];
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+    const row = raw as Record<string, unknown>;
+    const costFrom = moneyOrNull(row.costFrom);
+    const costTo = moneyOrNull(row.costTo);
+    const markupPercent = moneyOrNull(row.markupPercent);
+    if (
+      costFrom == null ||
+      markupPercent == null ||
+      markupPercent > 1000 ||
+      (index === 0 && costFrom !== 0) ||
+      (index > 0 && (previousUpper == null || costFrom <= previousUpper)) ||
+      (row.costTo != null && row.costTo !== "" && costTo == null) ||
+      (costTo != null && costTo < costFrom) ||
+      (index < value.length - 1 && costTo == null)
+    ) {
+      return null;
+    }
+    tiers.push({
+      cost_from: costFrom,
+      cost_to: costTo,
+      markup_percent: markupPercent,
+    });
+    previousUpper = costTo;
+  }
+  return tiers;
+}
+
 function errorMessage(error: {
   message: string;
   details?: string | null;
@@ -128,6 +168,14 @@ export async function POST(request: Request, context: RouteContext) {
   const laborRate = moneyOrNull(body?.laborRate);
   const laborDiscountPercent = percent(body?.laborDiscountPercent);
   const partsDiscountPercent = percent(body?.partsDiscountPercent);
+  const matrix = partsMarkupMatrix(body?.partsMarkupMatrix);
+  const minimumPartsMarginPercent = percent(
+    body?.minimumPartsMarginPercent,
+  );
+  const customerFeeType = boundedText(body?.customerFeeType, 20) ?? "none";
+  const customerFeeValue = moneyOrNull(body?.customerFeeValue ?? 0);
+  const customerFeeCap = moneyOrNull(body?.customerFeeCap);
+  const expiryWarningDays = Number(body?.expiryWarningDays ?? 30);
   const effectiveFrom = optionalDate(body?.effectiveFrom);
   const effectiveUntil = optionalDate(body?.effectiveUntil);
   const approvalReason = boundedText(body?.approvalReason, 500);
@@ -146,6 +194,19 @@ export async function POST(request: Request, context: RouteContext) {
     !["CAD", "USD"].includes(currency) ||
     laborDiscountPercent == null ||
     partsDiscountPercent == null ||
+    matrix == null ||
+    minimumPartsMarginPercent == null ||
+    minimumPartsMarginPercent >= 100 ||
+    !["none", "flat", "percentage"].includes(customerFeeType) ||
+    customerFeeValue == null ||
+    (customerFeeType === "percentage" && customerFeeValue > 100) ||
+    (customerFeeType === "none" && customerFeeValue !== 0) ||
+    (body?.customerFeeCap != null &&
+      body.customerFeeCap !== "" &&
+      customerFeeCap == null) ||
+    !Number.isInteger(expiryWarningDays) ||
+    expiryWarningDays < 0 ||
+    expiryWarningDays > 365 ||
     !effectiveFrom ||
     (body?.effectiveUntil && !effectiveUntil) ||
     !approvalReason ||
@@ -173,7 +234,10 @@ export async function POST(request: Request, context: RouteContext) {
   if (
     laborRate == null &&
     laborDiscountPercent === 0 &&
-    partsDiscountPercent === 0
+    partsDiscountPercent === 0 &&
+    matrix.length === 0 &&
+    minimumPartsMarginPercent === 0 &&
+    customerFeeType === "none"
   ) {
     return NextResponse.json(
       { error: "At least one customer pricing adjustment is required." },
@@ -182,7 +246,7 @@ export async function POST(request: Request, context: RouteContext) {
   }
 
   const { data, error } = await access.supabase.rpc(
-    "create_customer_pricing_agreement_atomic" as never,
+    "create_customer_pricing_agreement_v2_atomic" as never,
     {
       p_shop_id: access.profile.shop_id,
       p_customer_id: id,
@@ -192,6 +256,12 @@ export async function POST(request: Request, context: RouteContext) {
       p_labor_rate: laborRate,
       p_labor_discount_percent: laborDiscountPercent,
       p_parts_discount_percent: partsDiscountPercent,
+      p_parts_markup_matrix: matrix,
+      p_minimum_parts_margin_percent: minimumPartsMarginPercent,
+      p_customer_fee_type: customerFeeType,
+      p_customer_fee_value: customerFeeValue,
+      p_customer_fee_cap: customerFeeCap,
+      p_expiry_warning_days: expiryWarningDays,
       p_effective_from: effectiveFrom,
       p_effective_until: effectiveUntil,
       p_approval_reason: approvalReason,

--- a/app/api/quotes/send/route.ts
+++ b/app/api/quotes/send/route.ts
@@ -806,12 +806,52 @@ export async function POST(req: Request) {
       : body?.quoteTotal;
     let sendableQuoteLineIds: string[] = [];
 
+    const requestAllowsResend = req.headers.get("x-profix-resend") === "1";
+    const { data: pricingCandidateRowsRaw, error: pricingCandidateError } =
+      await supabaseAdmin
+        .from("work_order_quote_lines")
+        .select(
+          "id, status, stage, sent_to_customer_at, approved_at, declined_at, work_order_line_id",
+        )
+        .eq("shop_id", wo.shop_id)
+        .eq("work_order_id", workOrderId);
+    if (pricingCandidateError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          trace,
+          error: "Failed to identify quote lines ready for pricing",
+          detail: pricingCandidateError.message,
+        },
+        { status: 500 },
+      );
+    }
+
+    const pricingQuoteLineIds = (pricingCandidateRowsRaw ?? [])
+      .filter(
+        (line) =>
+          isSendableQuoteLine(line) ||
+          (requestAllowsResend && isResendableQuoteLine(line)),
+      )
+      .map((line) => line.id);
+    if (pricingQuoteLineIds.length === 0) {
+      return NextResponse.json(
+        {
+          ok: false,
+          trace,
+          error:
+            "No canonical quote lines are ready to send. Mark advisor-reviewed lines ready_to_send/quoted after parts pricing is complete.",
+        },
+        { status: 409 },
+      );
+    }
+
     const { error: customerPricingError } = await supabaseAdmin.rpc(
       "apply_customer_pricing_v2_to_quote_atomic" as never,
       {
         p_shop_id: wo.shop_id,
         p_work_order_id: workOrderId,
-        p_quote_line_ids: [],
+        p_quote_line_ids: pricingQuoteLineIds,
         p_actor_user_id: access.authUserId,
         p_at: new Date().toISOString(),
       } as never,
@@ -833,6 +873,35 @@ export async function POST(req: Request) {
           detail,
         },
         { status: 409 },
+      );
+    }
+
+    const {
+      data: resolvedSuppliesOverrides,
+      error: resolvedSuppliesOverrideError,
+    } = await supabaseAdmin
+      .from("work_orders")
+      .select(
+        "shop_supplies_enabled_override, shop_supplies_amount_override",
+      )
+      .eq("id", workOrderId)
+      .eq("shop_id", wo.shop_id)
+      .maybeSingle<
+        Pick<
+          WorkOrderRow,
+          | "shop_supplies_enabled_override"
+          | "shop_supplies_amount_override"
+        >
+      >();
+    if (resolvedSuppliesOverrideError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          trace,
+          error: "Failed to load resolved customer fee",
+          detail: resolvedSuppliesOverrideError.message,
+        },
+        { status: 500 },
       );
     }
 
@@ -881,7 +950,6 @@ export async function POST(req: Request) {
       >
     >;
 
-    const requestAllowsResend = req.headers.get("x-profix-resend") === "1";
     const estimateHasApprovedLines = Boolean(
       wo.estimate_number && quoteLineRows.some(isApprovedQuoteLine),
     );
@@ -946,7 +1014,9 @@ export async function POST(req: Request) {
         shopForSupplies as Parameters<typeof resolveShopSuppliesSettings>[0],
       ),
       override: resolveShopSuppliesOverride(
-        wo as Parameters<typeof resolveShopSuppliesOverride>[0],
+        (resolvedSuppliesOverrides ?? wo) as Parameters<
+          typeof resolveShopSuppliesOverride
+        >[0],
       ),
     });
     const hasPersistedLineTax = sendableQuoteLines.some(

--- a/app/api/quotes/send/route.ts
+++ b/app/api/quotes/send/route.ts
@@ -807,7 +807,7 @@ export async function POST(req: Request) {
     let sendableQuoteLineIds: string[] = [];
 
     const { error: customerPricingError } = await supabaseAdmin.rpc(
-      "apply_customer_pricing_to_quote_atomic" as never,
+      "apply_customer_pricing_v2_to_quote_atomic" as never,
       {
         p_shop_id: wo.shop_id,
         p_work_order_id: workOrderId,

--- a/app/api/work-orders/[id]/customer-pricing/route.ts
+++ b/app/api/work-orders/[id]/customer-pricing/route.ts
@@ -41,7 +41,7 @@ export async function POST(request: Request, context: RouteContext) {
   }
 
   const { data, error } = await access.supabase.rpc(
-    "apply_customer_pricing_to_quote_atomic" as never,
+    "apply_customer_pricing_v2_to_quote_atomic" as never,
     {
       p_shop_id: access.profile.shop_id,
       p_work_order_id: workOrderId,

--- a/features/customers/components/CustomerPricingPanel.tsx
+++ b/features/customers/components/CustomerPricingPanel.tsx
@@ -9,6 +9,8 @@ import {
   Loader2,
   Plus,
   ShieldCheck,
+  TriangleAlert,
+  X,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -26,12 +28,30 @@ type PricingAgreement = {
   labor_rate: number | null;
   labor_discount_percent: number;
   parts_discount_percent: number;
+  parts_markup_matrix: MatrixTier[];
+  minimum_parts_margin_percent: number;
+  customer_fee_type: "none" | "flat" | "percentage";
+  customer_fee_value: number;
+  customer_fee_cap: number | null;
+  expiry_warning_days: number;
   effective_from: string;
   effective_until: string | null;
   approval_reason: string;
   notes: string | null;
   retired_reason: string | null;
   created_at: string;
+};
+
+type MatrixTier = {
+  cost_from: number;
+  cost_to: number | null;
+  markup_percent: number;
+};
+
+type MatrixTierDraft = {
+  costFrom: string;
+  costTo: string;
+  markupPercent: string;
 };
 
 type PricingSummary = {
@@ -56,6 +76,12 @@ type Draft = {
   laborRate: string;
   laborDiscountPercent: string;
   partsDiscountPercent: string;
+  partsMarkupMatrix: MatrixTierDraft[];
+  minimumPartsMarginPercent: string;
+  customerFeeType: "none" | "flat" | "percentage";
+  customerFeeValue: string;
+  customerFeeCap: string;
+  expiryWarningDays: string;
   effectiveFrom: string;
   effectiveUntil: string;
   approvalReason: string;
@@ -78,6 +104,12 @@ function emptyDraft(sourceType: AgreementSource): Draft {
     laborRate: "",
     laborDiscountPercent: "",
     partsDiscountPercent: "",
+    partsMarkupMatrix: [],
+    minimumPartsMarginPercent: "",
+    customerFeeType: "none",
+    customerFeeValue: "",
+    customerFeeCap: "",
+    expiryWarningDays: "30",
     effectiveFrom: today(),
     effectiveUntil: "",
     approvalReason: "",
@@ -103,7 +135,26 @@ function agreementTerms(agreement: PricingAgreement): string[] {
   if (agreement.parts_discount_percent > 0) {
     terms.push(`${agreement.parts_discount_percent}% off parts sell price`);
   }
+  if (agreement.parts_markup_matrix?.length > 0) {
+    terms.push(`${agreement.parts_markup_matrix.length}-tier parts matrix`);
+  }
+  if (agreement.minimum_parts_margin_percent > 0) {
+    terms.push(`${agreement.minimum_parts_margin_percent}% minimum parts margin`);
+  }
+  if (agreement.customer_fee_type !== "none") {
+    terms.push(
+      agreement.customer_fee_type === "flat"
+        ? `${agreement.currency} $${agreement.customer_fee_value.toFixed(2)} customer fee`
+        : `${agreement.customer_fee_value}% customer fee${agreement.customer_fee_cap != null ? ` (max $${agreement.customer_fee_cap.toFixed(2)})` : ""}`,
+    );
+  }
   return terms;
+}
+
+function daysUntil(date: string): number {
+  const end = Date.parse(`${date.slice(0, 10)}T00:00:00Z`);
+  const now = Date.parse(`${today()}T00:00:00Z`);
+  return Math.ceil((end - now) / 86_400_000);
 }
 
 function effectiveWindow(agreement: PricingAgreement): string {
@@ -195,6 +246,24 @@ export function CustomerPricingPanel({ customerId }: Props) {
               ? Number(draft.laborDiscountPercent || 0)
               : 0,
           partsDiscountPercent: Number(draft.partsDiscountPercent || 0),
+          partsMarkupMatrix: draft.partsMarkupMatrix.map((tier) => ({
+            costFrom: Number(tier.costFrom),
+            costTo: tier.costTo === "" ? null : Number(tier.costTo),
+            markupPercent: Number(tier.markupPercent),
+          })),
+          minimumPartsMarginPercent: Number(
+            draft.minimumPartsMarginPercent || 0,
+          ),
+          customerFeeType: draft.customerFeeType,
+          customerFeeValue:
+            draft.customerFeeType === "none"
+              ? 0
+              : Number(draft.customerFeeValue || 0),
+          customerFeeCap:
+            draft.customerFeeCap === ""
+              ? null
+              : Number(draft.customerFeeCap),
+          expiryWarningDays: Number(draft.expiryWarningDays || 30),
           effectiveFrom: draft.effectiveFrom,
           effectiveUntil: draft.effectiveUntil || null,
           approvalReason: draft.approvalReason,
@@ -265,6 +334,13 @@ export function CustomerPricingPanel({ customerId }: Props) {
 
   const effective = summary?.effective_agreement ?? null;
   const agreements = summary?.agreements ?? [];
+  const expiringAgreements = agreements.filter((agreement) => {
+    if (agreement.status !== "active" || !agreement.effective_until) {
+      return false;
+    }
+    const remaining = daysUntil(agreement.effective_until);
+    return remaining >= 0 && remaining <= agreement.expiry_warning_days;
+  });
 
   return (
     <section className="overflow-hidden rounded-2xl border border-[color:var(--accent-copper-soft)]/45 bg-[radial-gradient(circle_at_top_right,rgba(197,122,74,0.16),transparent_38%),color:var(--desktop-panel-bg-soft)] shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
@@ -301,6 +377,23 @@ export function CustomerPricingPanel({ customerId }: Props) {
           ) : null}
         </div>
       </div>
+
+      {expiringAgreements.length > 0 ? (
+        <div className="border-b border-amber-300/25 bg-amber-400/10 px-4 py-3 sm:px-5">
+          <div className="flex items-start gap-2 text-xs text-amber-100">
+            <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>
+              <span className="font-bold">Contract expiry:</span>{" "}
+              {expiringAgreements
+                .map(
+                  (agreement) =>
+                    `${agreement.name} ends in ${daysUntil(agreement.effective_until!)} day(s)`,
+                )
+                .join(" · ")}
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       <div className="grid gap-4 p-4 sm:p-5 xl:grid-cols-[1.15fr_0.85fr]">
         <div className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-4">
@@ -497,6 +590,196 @@ export function CustomerPricingPanel({ customerId }: Props) {
             </label>
           </div>
 
+          <div className="mt-4 rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <div className="text-xs font-semibold text-[color:var(--theme-text-primary)]">
+                  Parts matrix
+                </div>
+                <p className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">
+                  Cost bands set sell markup before any customer discount. Leave
+                  empty to preserve the quoted base sell price.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() =>
+                  setDraft((current) => ({
+                    ...current,
+                    partsMarkupMatrix: [
+                      ...current.partsMarkupMatrix,
+                      {
+                        costFrom:
+                          current.partsMarkupMatrix.length === 0 ? "0" : "",
+                        costTo: "",
+                        markupPercent: "",
+                      },
+                    ],
+                  }))
+                }
+                className="rounded-lg border border-[var(--accent-copper-soft)]/45 px-2.5 py-1.5 text-[11px] font-semibold text-[var(--accent-copper)]"
+              >
+                Add cost band
+              </button>
+            </div>
+            {draft.partsMarkupMatrix.length > 0 ? (
+              <div className="mt-3 space-y-2">
+                {draft.partsMarkupMatrix.map((tier, index) => (
+                  <div
+                    key={`${index}-${tier.costFrom}`}
+                    className="grid grid-cols-[1fr_1fr_1fr_auto] gap-2"
+                  >
+                    <input
+                      required
+                      inputMode="decimal"
+                      aria-label={`Tier ${index + 1} cost from`}
+                      placeholder="Cost from"
+                      value={tier.costFrom}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          partsMarkupMatrix: current.partsMarkupMatrix.map(
+                            (item, itemIndex) =>
+                              itemIndex === index
+                                ? { ...item, costFrom: event.target.value }
+                                : item,
+                          ),
+                        }))
+                      }
+                      className={inputClass}
+                    />
+                    <input
+                      required={index < draft.partsMarkupMatrix.length - 1}
+                      inputMode="decimal"
+                      aria-label={`Tier ${index + 1} cost to`}
+                      placeholder={
+                        index === draft.partsMarkupMatrix.length - 1
+                          ? "No maximum"
+                          : "Cost to"
+                      }
+                      value={tier.costTo}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          partsMarkupMatrix: current.partsMarkupMatrix.map(
+                            (item, itemIndex) =>
+                              itemIndex === index
+                                ? { ...item, costTo: event.target.value }
+                                : item,
+                          ),
+                        }))
+                      }
+                      className={inputClass}
+                    />
+                    <input
+                      required
+                      inputMode="decimal"
+                      aria-label={`Tier ${index + 1} markup percent`}
+                      placeholder="Markup %"
+                      value={tier.markupPercent}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          partsMarkupMatrix: current.partsMarkupMatrix.map(
+                            (item, itemIndex) =>
+                              itemIndex === index
+                                ? {
+                                    ...item,
+                                    markupPercent: event.target.value,
+                                  }
+                                : item,
+                          ),
+                        }))
+                      }
+                      className={inputClass}
+                    />
+                    <button
+                      type="button"
+                      aria-label={`Remove tier ${index + 1}`}
+                      onClick={() =>
+                        setDraft((current) => ({
+                          ...current,
+                          partsMarkupMatrix: current.partsMarkupMatrix.filter(
+                            (_, itemIndex) => itemIndex !== index,
+                          ),
+                        }))
+                      }
+                      className="rounded-xl border border-[color:var(--desktop-border)] px-2 text-[color:var(--theme-text-secondary)]"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Minimum parts margin %
+              <input
+                inputMode="decimal"
+                value={draft.minimumPartsMarginPercent}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    minimumPartsMarginPercent: event.target.value,
+                  }))
+                }
+                placeholder="Example: 25"
+                className={`mt-1 ${inputClass}`}
+              />
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Customer fee
+              <select
+                value={draft.customerFeeType}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    customerFeeType: event.target.value as Draft["customerFeeType"],
+                  }))
+                }
+                className={`mt-1 ${inputClass}`}
+              >
+                <option value="none">No customer fee</option>
+                <option value="flat">Flat amount</option>
+                <option value="percentage">Percent of labor + parts</option>
+              </select>
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Fee {draft.customerFeeType === "percentage" ? "%" : "amount"}
+              <input
+                disabled={draft.customerFeeType === "none"}
+                required={draft.customerFeeType !== "none"}
+                inputMode="decimal"
+                value={draft.customerFeeValue}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    customerFeeValue: event.target.value,
+                  }))
+                }
+                className={`mt-1 ${inputClass} disabled:opacity-45`}
+              />
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Fee cap (optional)
+              <input
+                disabled={draft.customerFeeType !== "percentage"}
+                inputMode="decimal"
+                value={draft.customerFeeCap}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    customerFeeCap: event.target.value,
+                  }))
+                }
+                className={`mt-1 ${inputClass} disabled:opacity-45`}
+              />
+            </label>
+          </div>
+
           <div className="mt-3 grid gap-3 md:grid-cols-2">
             <label className="text-xs text-[color:var(--theme-text-secondary)]">
               Effective from
@@ -523,6 +806,23 @@ export function CustomerPricingPanel({ customerId }: Props) {
                   setDraft((current) => ({
                     ...current,
                     effectiveUntil: event.target.value,
+                  }))
+                }
+                className={`mt-1 ${inputClass}`}
+              />
+            </label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Expiry warning days
+              <input
+                required
+                type="number"
+                min={0}
+                max={365}
+                value={draft.expiryWarningDays}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    expiryWarningDays: event.target.value,
                   }))
                 }
                 className={`mt-1 ${inputClass}`}

--- a/features/customers/components/CustomerPricingPanel.tsx
+++ b/features/customers/components/CustomerPricingPanel.tsx
@@ -49,6 +49,7 @@ type MatrixTier = {
 };
 
 type MatrixTierDraft = {
+  id: string;
   costFrom: string;
   costTo: string;
   markupPercent: string;
@@ -260,6 +261,7 @@ export function CustomerPricingPanel({ customerId }: Props) {
               ? 0
               : Number(draft.customerFeeValue || 0),
           customerFeeCap:
+            draft.customerFeeType !== "percentage" ||
             draft.customerFeeCap === ""
               ? null
               : Number(draft.customerFeeCap),
@@ -609,6 +611,7 @@ export function CustomerPricingPanel({ customerId }: Props) {
                     partsMarkupMatrix: [
                       ...current.partsMarkupMatrix,
                       {
+                        id: crypto.randomUUID(),
                         costFrom:
                           current.partsMarkupMatrix.length === 0 ? "0" : "",
                         costTo: "",
@@ -626,7 +629,7 @@ export function CustomerPricingPanel({ customerId }: Props) {
               <div className="mt-3 space-y-2">
                 {draft.partsMarkupMatrix.map((tier, index) => (
                   <div
-                    key={`${index}-${tier.costFrom}`}
+                    key={tier.id}
                     className="grid grid-cols-[1fr_1fr_1fr_auto] gap-2"
                   >
                     <input
@@ -738,6 +741,10 @@ export function CustomerPricingPanel({ customerId }: Props) {
                   setDraft((current) => ({
                     ...current,
                     customerFeeType: event.target.value as Draft["customerFeeType"],
+                    customerFeeCap:
+                      event.target.value === "percentage"
+                        ? current.customerFeeCap
+                        : "",
                   }))
                 }
                 className={`mt-1 ${inputClass}`}

--- a/features/pricing/lib/customerPricing.test.ts
+++ b/features/pricing/lib/customerPricing.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   CUSTOMER_PRICING_PRECEDENCE,
+  contractExpiryStatus,
+  resolveCustomerFee,
   resolveCustomerPricing,
+  resolveV2PartPricing,
   selectEffectiveCustomerPricingAgreement,
+  validatePartsMarkupMatrix,
   type CustomerPricingAgreement,
 } from "./customerPricing";
 
@@ -117,5 +121,104 @@ describe("customer pricing precedence", () => {
       resolvedLaborTotal: 160,
       resolvedPartsTotal: 70,
     });
+  });
+});
+
+describe("Pricing V2 rules", () => {
+  const matrix = [
+    { costFrom: 0, costTo: 49.99, markupPercent: 100 },
+    { costFrom: 50, costTo: 199.99, markupPercent: 60 },
+    { costFrom: 200, costTo: null, markupPercent: 35 },
+  ];
+
+  it("selects the cost band before applying a customer discount", () => {
+    expect(validatePartsMarkupMatrix(matrix)).toBe(true);
+    expect(
+      resolveV2PartPricing({
+        unitCost: 100,
+        baseUnitPrice: 140,
+        matrix,
+        partsDiscountPercent: 10,
+        minimumPartsMarginPercent: 20,
+      }),
+    ).toMatchObject({
+      matrixMarkupPercent: 60,
+      matrixUnitPrice: 160,
+      discountedUnitPrice: 144,
+      resolvedUnitPrice: 144,
+      floorApplied: false,
+      provenance: "matrix",
+    });
+  });
+
+  it("protects the minimum parts margin after discounts", () => {
+    expect(
+      resolveV2PartPricing({
+        unitCost: 100,
+        baseUnitPrice: 110,
+        matrix: [],
+        partsDiscountPercent: 20,
+        minimumPartsMarginPercent: 25,
+      }),
+    ).toMatchObject({
+      discountedUnitPrice: 88,
+      marginFloorUnitPrice: 133.33,
+      resolvedUnitPrice: 133.33,
+      floorApplied: true,
+    });
+  });
+
+  it("does not invent margin evidence when cost is unknown", () => {
+    expect(
+      resolveV2PartPricing({
+        unitCost: null,
+        baseUnitPrice: 200,
+        matrix,
+        partsDiscountPercent: 5,
+        minimumPartsMarginPercent: 30,
+      }),
+    ).toMatchObject({
+      cost: null,
+      matrixMarkupPercent: null,
+      marginFloorUnitPrice: null,
+      resolvedUnitPrice: 190,
+      floorApplied: false,
+      provenance: "base_sell",
+    });
+  });
+
+  it("calculates capped flat and percentage customer fees", () => {
+    expect(
+      resolveCustomerFee({
+        type: "percentage",
+        value: 6,
+        cap: 50,
+        laborAndPartsSubtotal: 1000,
+      }),
+    ).toBe(50);
+    expect(
+      resolveCustomerFee({
+        type: "flat",
+        value: 32.5,
+        laborAndPartsSubtotal: 1000,
+      }),
+    ).toBe(32.5);
+  });
+
+  it("classifies contract expiry using the agreement warning window", () => {
+    expect(
+      contractExpiryStatus({
+        effectiveUntil: "2026-09-01",
+        at: "2026-08-12T18:00:00Z",
+        warningDays: 30,
+      }),
+    ).toBe("expiring_soon");
+    expect(
+      contractExpiryStatus({
+        effectiveUntil: "2026-08-01",
+        at: "2026-08-12T18:00:00Z",
+        warningDays: 30,
+      }),
+    ).toBe("expired");
   });
 });

--- a/features/pricing/lib/customerPricing.ts
+++ b/features/pricing/lib/customerPricing.ts
@@ -19,10 +19,44 @@ export type CustomerPricingAgreement = {
   laborRate: number | null;
   laborDiscountPercent: number;
   partsDiscountPercent: number;
+  partsMarkupMatrix?: PartsMarkupTier[];
+  minimumPartsMarginPercent?: number;
+  customerFeeType?: CustomerFeeType;
+  customerFeeValue?: number;
+  customerFeeCap?: number | null;
+  expiryWarningDays?: number;
   effectiveFrom: string;
   effectiveUntil: string | null;
   createdAt: string;
 };
+
+export type PartsMarkupTier = {
+  costFrom: number;
+  costTo: number | null;
+  markupPercent: number;
+};
+
+export type CustomerFeeType = "none" | "flat" | "percentage";
+
+export type V2PartPricingResolution = {
+  cost: number | null;
+  baseUnitPrice: number;
+  matrixMarkupPercent: number | null;
+  matrixUnitPrice: number;
+  discountPercent: number;
+  discountedUnitPrice: number;
+  minimumMarginPercent: number;
+  marginFloorUnitPrice: number | null;
+  resolvedUnitPrice: number;
+  floorApplied: boolean;
+  provenance: "matrix" | "base_sell";
+};
+
+export type ContractExpiryStatus =
+  | "no_expiry"
+  | "active"
+  | "expiring_soon"
+  | "expired";
 
 export type ApprovedManualPricingOverride = {
   approved: boolean;
@@ -50,6 +84,131 @@ export type CustomerPricingResolution = {
 
 function money(value: number): number {
   return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function boundedPercent(value: number): number {
+  return Math.min(100, nonNegative(value));
+}
+
+export function validatePartsMarkupMatrix(
+  tiers: PartsMarkupTier[],
+): boolean {
+  if (tiers.length > 50) return false;
+  let previousUpper: number | null = null;
+  return tiers.every((tier, index) => {
+    const from = nonNegative(tier.costFrom);
+    const to = tier.costTo == null ? null : nonNegative(tier.costTo);
+    const valid =
+      Number.isFinite(tier.costFrom) &&
+      Number.isFinite(tier.markupPercent) &&
+      tier.costFrom === from &&
+      tier.markupPercent >= 0 &&
+      tier.markupPercent <= 1000 &&
+      (to == null || (Number.isFinite(tier.costTo) && to >= from)) &&
+      (index === 0 ? from === 0 : previousUpper != null && from > previousUpper);
+    previousUpper = to;
+    return valid && (index === tiers.length - 1 || to != null);
+  });
+}
+
+function matrixTierForCost(
+  tiers: PartsMarkupTier[],
+  cost: number,
+): PartsMarkupTier | null {
+  if (!validatePartsMarkupMatrix(tiers)) return null;
+  return (
+    tiers.find(
+      (tier) =>
+        cost >= tier.costFrom && (tier.costTo == null || cost <= tier.costTo),
+    ) ?? null
+  );
+}
+
+export function resolveV2PartPricing(input: {
+  unitCost: number | null;
+  baseUnitPrice: number;
+  matrix: PartsMarkupTier[];
+  partsDiscountPercent: number;
+  minimumPartsMarginPercent: number;
+}): V2PartPricingResolution {
+  const cost =
+    input.unitCost == null || !Number.isFinite(input.unitCost)
+      ? null
+      : money(nonNegative(input.unitCost));
+  const baseUnitPrice = money(nonNegative(input.baseUnitPrice));
+  const tier = cost == null ? null : matrixTierForCost(input.matrix, cost);
+  const matrixUnitPrice = money(
+    tier && cost != null
+      ? cost * (1 + boundedPercent(tier.markupPercent) / 100)
+      : baseUnitPrice,
+  );
+  const discountPercent = boundedPercent(input.partsDiscountPercent);
+  const discountedUnitPrice = money(
+    matrixUnitPrice * (1 - discountPercent / 100),
+  );
+  const minimumMarginPercent = Math.min(
+    99.99,
+    boundedPercent(input.minimumPartsMarginPercent),
+  );
+  const marginFloorUnitPrice =
+    cost == null || minimumMarginPercent <= 0
+      ? null
+      : money(cost / (1 - minimumMarginPercent / 100));
+  const resolvedUnitPrice = money(
+    Math.max(discountedUnitPrice, marginFloorUnitPrice ?? 0),
+  );
+
+  return {
+    cost,
+    baseUnitPrice,
+    matrixMarkupPercent: tier?.markupPercent ?? null,
+    matrixUnitPrice,
+    discountPercent,
+    discountedUnitPrice,
+    minimumMarginPercent,
+    marginFloorUnitPrice,
+    resolvedUnitPrice,
+    floorApplied:
+      marginFloorUnitPrice != null && marginFloorUnitPrice > discountedUnitPrice,
+    provenance: tier ? "matrix" : "base_sell",
+  };
+}
+
+export function resolveCustomerFee(input: {
+  type: CustomerFeeType;
+  value: number;
+  cap?: number | null;
+  laborAndPartsSubtotal: number;
+}): number {
+  const value = nonNegative(input.value);
+  const subtotal = money(nonNegative(input.laborAndPartsSubtotal));
+  const calculated =
+    input.type === "flat"
+      ? value
+      : input.type === "percentage"
+        ? subtotal * (boundedPercent(value) / 100)
+        : 0;
+  const cap =
+    input.cap == null || !Number.isFinite(input.cap)
+      ? null
+      : nonNegative(input.cap);
+  return money(cap == null ? calculated : Math.min(calculated, cap));
+}
+
+export function contractExpiryStatus(input: {
+  effectiveUntil: string | null;
+  at: string;
+  warningDays: number;
+}): ContractExpiryStatus {
+  if (!input.effectiveUntil) return "no_expiry";
+  const end = Date.parse(`${input.effectiveUntil.slice(0, 10)}T00:00:00Z`);
+  const at = Date.parse(`${dateOnly(input.at)}T00:00:00Z`);
+  if (!Number.isFinite(end) || !Number.isFinite(at)) return "active";
+  if (end < at) return "expired";
+  const daysRemaining = Math.ceil((end - at) / 86_400_000);
+  return daysRemaining <= Math.max(0, Math.floor(input.warningDays))
+    ? "expiring_soon"
+    : "active";
 }
 
 function nonNegative(value: number): number {

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -3151,6 +3151,12 @@ export type Database = {
           notes: string | null
           operation_key: string
           parts_discount_percent: number
+          parts_markup_matrix: Json
+          minimum_parts_margin_percent: number
+          customer_fee_type: string
+          customer_fee_value: number
+          customer_fee_cap: number | null
+          expiry_warning_days: number
           retired_at: string | null
           retired_by: string | null
           retired_reason: string | null
@@ -3176,6 +3182,12 @@ export type Database = {
           notes?: string | null
           operation_key: string
           parts_discount_percent?: number
+          parts_markup_matrix?: Json
+          minimum_parts_margin_percent?: number
+          customer_fee_type?: string
+          customer_fee_value?: number
+          customer_fee_cap?: number | null
+          expiry_warning_days?: number
           retired_at?: string | null
           retired_by?: string | null
           retired_reason?: string | null
@@ -3201,6 +3213,12 @@ export type Database = {
           notes?: string | null
           operation_key?: string
           parts_discount_percent?: number
+          parts_markup_matrix?: Json
+          minimum_parts_margin_percent?: number
+          customer_fee_type?: string
+          customer_fee_value?: number
+          customer_fee_cap?: number | null
+          expiry_warning_days?: number
           retired_at?: string | null
           retired_by?: string | null
           retired_reason?: string | null
@@ -24981,6 +24999,9 @@ export type Database = {
           customer_approval_signature_url: string | null
           customer_approved_by: string | null
           customer_id: string | null
+          customer_pricing_fee_agreement_id: string | null
+          customer_pricing_fee_resolved_at: string | null
+          customer_pricing_fee_total: number | null
           customer_name: string | null
           customer_signature_url: string | null
           estimate_authorized_at: string | null
@@ -25067,6 +25088,9 @@ export type Database = {
           customer_approval_signature_url?: string | null
           customer_approved_by?: string | null
           customer_id?: string | null
+          customer_pricing_fee_agreement_id?: string | null
+          customer_pricing_fee_resolved_at?: string | null
+          customer_pricing_fee_total?: number | null
           customer_name?: string | null
           customer_signature_url?: string | null
           estimate_authorized_at?: string | null
@@ -25153,6 +25177,9 @@ export type Database = {
           customer_approval_signature_url?: string | null
           customer_approved_by?: string | null
           customer_id?: string | null
+          customer_pricing_fee_agreement_id?: string | null
+          customer_pricing_fee_resolved_at?: string | null
+          customer_pricing_fee_total?: number | null
           customer_name?: string | null
           customer_signature_url?: string | null
           estimate_authorized_at?: string | null
@@ -25227,6 +25254,13 @@ export type Database = {
           vehicle_year?: number | null
         }
         Relationships: [
+          {
+            foreignKeyName: "work_orders_customer_pricing_fee_agreement_id_fkey"
+            columns: ["customer_pricing_fee_agreement_id"]
+            isOneToOne: false
+            referencedRelation: "customer_pricing_agreements"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "work_orders_customer_id_fkey"
             columns: ["customer_id"]
@@ -26675,6 +26709,16 @@ export type Database = {
         }
         Returns: Json
       }
+      apply_customer_pricing_v2_to_quote_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_at?: string
+          p_quote_line_ids: string[]
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
       apply_customer_quote_decision_atomic: {
         Args: {
           p_actor_user_id: string
@@ -27305,6 +27349,32 @@ export type Database = {
           p_notes: string
           p_operation_key: string
           p_parts_discount_percent: number
+          p_shop_id: string
+          p_source_type: string
+        }
+        Returns: Json
+      }
+      create_customer_pricing_agreement_v2_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_approval_reason: string
+          p_at?: string
+          p_currency: string
+          p_customer_fee_cap: number
+          p_customer_fee_type: string
+          p_customer_fee_value: number
+          p_customer_id: string
+          p_effective_from: string
+          p_effective_until: string
+          p_expiry_warning_days: number
+          p_labor_discount_percent: number
+          p_labor_rate: number
+          p_minimum_parts_margin_percent: number
+          p_name: string
+          p_notes: string
+          p_operation_key: string
+          p_parts_discount_percent: number
+          p_parts_markup_matrix: Json
           p_shop_id: string
           p_source_type: string
         }
@@ -29988,4 +30058,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -3141,22 +3141,22 @@ export type Database = {
           created_at: string
           created_by: string
           currency: string
+          customer_fee_cap: number | null
+          customer_fee_type: string
+          customer_fee_value: number
           customer_id: string
           effective_from: string
           effective_until: string | null
+          expiry_warning_days: number
           id: string
           labor_discount_percent: number
           labor_rate: number | null
+          minimum_parts_margin_percent: number
           name: string
           notes: string | null
           operation_key: string
           parts_discount_percent: number
           parts_markup_matrix: Json
-          minimum_parts_margin_percent: number
-          customer_fee_type: string
-          customer_fee_value: number
-          customer_fee_cap: number | null
-          expiry_warning_days: number
           retired_at: string | null
           retired_by: string | null
           retired_reason: string | null
@@ -3172,22 +3172,22 @@ export type Database = {
           created_at?: string
           created_by: string
           currency?: string
+          customer_fee_cap?: number | null
+          customer_fee_type?: string
+          customer_fee_value?: number
           customer_id: string
           effective_from?: string
           effective_until?: string | null
+          expiry_warning_days?: number
           id?: string
           labor_discount_percent?: number
           labor_rate?: number | null
+          minimum_parts_margin_percent?: number
           name: string
           notes?: string | null
           operation_key: string
           parts_discount_percent?: number
           parts_markup_matrix?: Json
-          minimum_parts_margin_percent?: number
-          customer_fee_type?: string
-          customer_fee_value?: number
-          customer_fee_cap?: number | null
-          expiry_warning_days?: number
           retired_at?: string | null
           retired_by?: string | null
           retired_reason?: string | null
@@ -3203,22 +3203,22 @@ export type Database = {
           created_at?: string
           created_by?: string
           currency?: string
+          customer_fee_cap?: number | null
+          customer_fee_type?: string
+          customer_fee_value?: number
           customer_id?: string
           effective_from?: string
           effective_until?: string | null
+          expiry_warning_days?: number
           id?: string
           labor_discount_percent?: number
           labor_rate?: number | null
+          minimum_parts_margin_percent?: number
           name?: string
           notes?: string | null
           operation_key?: string
           parts_discount_percent?: number
           parts_markup_matrix?: Json
-          minimum_parts_margin_percent?: number
-          customer_fee_type?: string
-          customer_fee_value?: number
-          customer_fee_cap?: number | null
-          expiry_warning_days?: number
           retired_at?: string | null
           retired_by?: string | null
           retired_reason?: string | null
@@ -24999,10 +24999,10 @@ export type Database = {
           customer_approval_signature_url: string | null
           customer_approved_by: string | null
           customer_id: string | null
+          customer_name: string | null
           customer_pricing_fee_agreement_id: string | null
           customer_pricing_fee_resolved_at: string | null
           customer_pricing_fee_total: number | null
-          customer_name: string | null
           customer_signature_url: string | null
           estimate_authorized_at: string | null
           estimate_converted_at: string | null
@@ -25088,10 +25088,10 @@ export type Database = {
           customer_approval_signature_url?: string | null
           customer_approved_by?: string | null
           customer_id?: string | null
+          customer_name?: string | null
           customer_pricing_fee_agreement_id?: string | null
           customer_pricing_fee_resolved_at?: string | null
           customer_pricing_fee_total?: number | null
-          customer_name?: string | null
           customer_signature_url?: string | null
           estimate_authorized_at?: string | null
           estimate_converted_at?: string | null
@@ -25177,10 +25177,10 @@ export type Database = {
           customer_approval_signature_url?: string | null
           customer_approved_by?: string | null
           customer_id?: string | null
+          customer_name?: string | null
           customer_pricing_fee_agreement_id?: string | null
           customer_pricing_fee_resolved_at?: string | null
           customer_pricing_fee_total?: number | null
-          customer_name?: string | null
           customer_signature_url?: string | null
           estimate_authorized_at?: string | null
           estimate_converted_at?: string | null
@@ -25255,17 +25255,17 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "work_orders_customer_pricing_fee_agreement_id_fkey"
-            columns: ["customer_pricing_fee_agreement_id"]
-            isOneToOne: false
-            referencedRelation: "customer_pricing_agreements"
-            referencedColumns: ["id"]
-          },
-          {
             foreignKeyName: "work_orders_customer_id_fkey"
             columns: ["customer_id"]
             isOneToOne: false
             referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_orders_customer_pricing_fee_agreement_id_fkey"
+            columns: ["customer_pricing_fee_agreement_id"]
+            isOneToOne: false
+            referencedRelation: "customer_pricing_agreements"
             referencedColumns: ["id"]
           },
           {
@@ -27483,6 +27483,9 @@ export type Database = {
           customer_approved_by: string | null
           customer_id: string | null
           customer_name: string | null
+          customer_pricing_fee_agreement_id: string | null
+          customer_pricing_fee_resolved_at: string | null
+          customer_pricing_fee_total: number | null
           customer_signature_url: string | null
           estimate_authorized_at: string | null
           estimate_converted_at: string | null
@@ -30058,3 +30061,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -74,6 +74,7 @@ type QuoteMetadata = {
   parts_quote?: Json;
   labor_rate?: Json;
   customer_pricing?: Json;
+  customer_pricing_v2?: Json;
   technician_notes?: Json;
   tech_notes?: Json;
 };
@@ -266,12 +267,21 @@ function customerPricingSummary(line: Pick<QuoteLine, "metadata">): {
   resolvedLaborRate: number | null;
   laborDiscountPercent: number;
   partsDiscountPercent: number;
+  matrixTierCount: number;
+  minimumPartsMarginPercent: number;
+  marginFloorAdjustmentTotal: number;
 } | null {
   const value = quoteMetadata(line).customer_pricing;
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const record = value as Record<string, Json>;
   const sourceType = jsonString(record.source_type);
   if (!sourceType || sourceType === "shop_default") return null;
+  const v2Value = quoteMetadata(line).customer_pricing_v2;
+  const v2 =
+    v2Value && typeof v2Value === "object" && !Array.isArray(v2Value)
+      ? (v2Value as Record<string, Json>)
+      : null;
+  const matrix = v2?.parts_matrix;
   return {
     sourceType,
     agreementName: jsonString(record.agreement_name) || null,
@@ -279,6 +289,11 @@ function customerPricingSummary(line: Pick<QuoteLine, "metadata">): {
     resolvedLaborRate: jsonNumber(record.resolved_labor_rate),
     laborDiscountPercent: jsonNumber(record.labor_discount_percent) ?? 0,
     partsDiscountPercent: jsonNumber(record.parts_discount_percent) ?? 0,
+    matrixTierCount: Array.isArray(matrix) ? matrix.length : 0,
+    minimumPartsMarginPercent:
+      jsonNumber(v2?.minimum_parts_margin_percent) ?? 0,
+    marginFloorAdjustmentTotal:
+      jsonNumber(v2?.margin_floor_adjustment_total) ?? 0,
   };
 }
 
@@ -294,6 +309,12 @@ function customerPricingLabel(summary: NonNullable<ReturnType<typeof customerPri
         : null,
     summary.partsDiscountPercent > 0
       ? `${summary.partsDiscountPercent}% parts`
+      : null,
+    summary.matrixTierCount > 0
+      ? `${summary.matrixTierCount}-tier matrix`
+      : null,
+    summary.minimumPartsMarginPercent > 0
+      ? `${summary.minimumPartsMarginPercent}% margin floor${summary.marginFloorAdjustmentTotal > 0 ? ` (+${fmt(summary.marginFloorAdjustmentTotal)} protected)` : ""}`
       : null,
   ].filter(Boolean);
   return `${summary.agreementName || source}${terms.length > 0 ? ` · ${terms.join(" · ")}` : ""}`;

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -787,698 +787,116 @@ export default function QuoteReviewView(props: {
     setSaving(true);
     try {
       for (const line of dirty) {
-        const laborHours = quoteLineLaborHours(line);
-        const laborTotal = quoteLineLaborTotal(line, laborRate);
-        const partsTotal = quoteLinePartsTotal(line);
-        if (partsTotal == null) {
-          toast.error(
-            "This protected quote needs manual pricing review and cannot be recalculated as $0.",
-          );
-          return false;
-        }
-        const subtotal = laborTotal + partsTotal;
-        const metadata = {
-          ...quoteMetadata(line),
-          labor_rate: quoteLineLaborRate(line, laborRate),
-        } as Json;
+        const laborHoÛ≠ª∂âûÀk∫wµÁ[èè‹‹[èààù[Bà‹\ùú›\Y\àœ»\ùùô[ô‹à»‹[èî›\Y\éà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹\ùú›\Y\àœ»\ùùô[ô‹üO‹‹[èè‹‹[èààù[Bà‹öX⁄[ô‘]X\ò[ù[ôY»
+à‹[à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^X[Xô\ãLLèê›\úô[ù‹\ò][€ò[öX⁄[ô»Y[à8†%]\»õ›Hö[ò[^ôY›\›€Y\àX⁄\⁄[€ãè‹‹[èÇà
+Hà
+àÇà‹[èû‹\ù€‹›Xô[
+\ù
+_O‹‹[èÇà‹[èû‹\ùŸ[Xô[
+\ù
+_O‹‹[èÇà‹\ùò€‹›[ôU›[OHù[»‹[èê€‹›[ôNà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèûŸõ]
+\ùò€‹›[ôU›[
+_O‹‹[èè‹‹[èààù[Bà‹\ùúŸ[[ôU›[OHù[»‹[èîŸ[[ôNà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèûŸõ]
+\ùúŸ[[ôU›[
+_O‹‹[èè‹‹[èààù[BàœÇà
+_Bà‹\ùú›]\»»‹[èî›]\Œà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹›]\”Xô[
+\ùú›]\ _O‹‹[èè‹‹[èààù[BàŸ]èÇà‹ô\]Y\›»
+àHôYè^ÿ‹\ùÀ‹ô\]Y\›À…‹ô\]Y\›öYXH€\‹”ò[YOHõ]Là[õ[ôKYõ^õ›[ôY[»õ‹ô\àõ‹ô\ã\⁄ﬁKLÃÃÕHôÀ\⁄ﬁKMÃLLãçHKLKçH^^»õ€ù\Ÿ[ZXõ€^\⁄ﬁKLL›ô\éòôÀ\⁄ﬁKMÃMHèÇàöY]»\ù»ô\]Y\›8†%‹\ù‘ô\]Y\›Xô[
+[ôK[ô^
+_BàÿOÇà
+Hàù[BàŸ]èÇà
+N¬àJ_BàŸ]èÇà
+Hà
+à]à€\‹”ò[YOHõ]Làõ›[ôY[»õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äK][YK\›\ôòXŸKZ[úŸ]
+WHLà^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà]èî\ùŒà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèìõ€ôO‹‹[èèŸ]èÇà]èî\ù»ô\]Y\›à‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèìõ›ô\]Z\ôY‹‹[èèŸ]èÇàŸ]èÇà
+_BàŸ]èÇÇà‹€›\òŸ\Àõ[ô›à»
+à]à€\‹”ò[YOHõ]L»õ›[ôY^õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äK][YK\›\ôòXŸKZ[úŸ]
+WHL»^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà€›\òŸH[ú‹X›[€àY]Y]Nà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹€›\òŸ\Àöõ⁄[äà8†(àä_O‹‹[èÇàŸ]èÇà
+Hàù[BÇà‹›‹Àõ[ô›à»
+à]à€\‹”ò[YOHõ]L»õ^õ^]‹ò\ÿ\LàèÇà‹›‹ÀõX\
 
-        const patch: QuoteLineUpdate = {
-          description: line.description,
-          ai_complaint: line.ai_complaint,
-          ai_cause: line.ai_cause,
-          ai_correction: line.ai_correction,
-          notes: line.notes,
-          est_labor_hours: line.est_labor_hours,
-          labor_hours: laborHours,
-          labor_rate: quoteLineLaborRate(line, laborRate),
-          labor_total: laborTotal,
-          parts_total: partsTotal,
-          subtotal,
-          grand_total: subtotal,
-          status: line.status,
-          stage: line.stage,
-          metadata,
-          updated_at: new Date().toISOString(),
-        };
+\õ
+HOà
+àHŸ^O^›\õHôYè^›\õH\ôŸ]Hóÿõ[ö»àô[Hõõ‹ôYô\úô\àà€\‹”ò[YOHúõ›[ôY[»õ‹ô\àõ‹ô\ã\⁄ﬁKLÃÃÕHôÀ\⁄ﬁKMÃLLãçHKLKçH^^»õ€ù\Ÿ[ZXõ€^\⁄ﬁKLL›ô\éòôÀ\⁄ﬁKMÃMHèÇà]öY[òŸH›¬àÿOÇà
+J_BàŸ]èÇà
+Hàù[BÇà]à€\‹”ò[YOHõ]L»õ^õ^]‹ò\ÿ\LàèÇàù]€à\OHòù]€àà\ÿXõY^ÿ€€[Y\ò⁄X[Y][ô—\ÿXõYH€ê€X⁄œ^ 
+HOàŸ]‹[ë]Z[ 
+ô]äHOà
+»ããúô]ã€[ôKöYNà\ô]ñ€[ôKöYHJJ_H€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûHõ›[ôY^L»KLà^^»õ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH\ÿXõYõ‹X⁄]KMHèÇà€‹[ë]Z[÷€[ôKöYH»íYHY]‹àààëY]][›H[ôHüBàÿù]€èÇàù]€à\OHòù]€àà\ÿXõY^ÿ€€[Y\ò⁄X[Y][ô—\ÿXõYH€ê€X⁄œ^ 
+HOàX\ö‘ôX€€[Y[ôYôXYJ[ôJ_H€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûHõ›[ôY^L»KLà^^»õ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH\ÿXõYõ‹X⁄]KMHèÇàôX€€\]HôXYH›]Bàÿù]€èÇà»[[ôKúŸ[ù›◊ÿ›\›€Y\óÿ]	âàÿ[îŸ[ô[ôJ[ôJH»‹[à€\‹”ò[YOHúõ›[ôY^õ‹ô\àõ‹ô\ãY[Y\ò[LÃÃÕHôÀY[Y\ò[MÃLL»KLà^^»õ€ù\Ÿ[ZXõ€^Y[Y\ò[LLèï⁄[Ÿ[ô‹‹[èààù[Bà»X€€[Y\ò⁄X[Y][ô—\ÿXõY»Çàù]€à\OHòù]€àà\ÿXõY^»Xÿ[îŸ[ô[ôJ[ôJH	âàZ\‘Ÿ[ùõ‹ëX⁄\⁄[€ä[ôJ_H€ê€X⁄œ^ 
+HOà‹[ëX⁄\⁄[€ëX[Ÿ [ôKò\õ›ôHä_H€\‹”ò[YOHúõ›[ôY^õ‹ô\àõ‹ô\ãY[Y\ò[LÃÕôÀY[Y\ò[MLÃMHL»KLà^^»õ€ù\Ÿ[ZXõ€^Y[Y\ò[LL\ÿXõYõ‹X⁄]KMHèê\õ›ôOÿù]€èÇàù]€à\OHòù]€àà€ê€X⁄œ^ 
+HOà‹[ëX⁄\⁄[€ëX[Ÿ [ôKôYô\àä_H€\‹”ò[YOHúõ›[ôY^õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äK][YKXõ‹ô\ã\€Ÿù
+WHôÀVÿ€€‹éùò\äK][YK\›\ôòXŸK\›XùJWHL»KLà^^»õ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèëYô\èÿù]€èÇàù]€à\OHòù]€àà€ê€X⁄œ^ 
+HOà‹[ëX⁄\⁄[€ëX[Ÿ [ôKôX€[ôHä_H€\‹”ò[YOHúõ›[ôY^õ‹ô\àõ‹ô\ã\ôYMÕHôÀ\ôYMLÃLL»KLà^^»õ€ù\Ÿ[ZXõ€^\ôYLLèëX€[ôOÿù]€èÇàœààù[BàŸ]èÇÇà€‹[ë]Z[÷€[ôKöYH	âàX€€[Y\ò⁄X[Y][ô—\ÿXõY»
+à]à€\‹”ò[YOHô\⁄›‹\[ô[\€Ÿù]L»MèÇà]à€\‹”ò[YO^Ÿ[XôYY»ô‹öYÿ\L»ààô‹öYÿ\L»Yô‹öYX€€ÀLàüOÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà]H»\ÿ‹ö\[€Çà[ú]ò[YO^€[ôKô\ÿ‹ö\[€àœ»àüH€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»\ÿ‹ö\[€éàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà€€\Z[ùà[ú]ò[YO^€[ôKòZWÿ€€\Z[ùœ»àüH€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»ZWÿ€€\Z[ùàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàX⁄öX⁄X[àõ›\¬à[ú]ò[YO^›X⁄õ›\ﬂH€ê⁄[ôŸO^ JHOà]⁄][›S[ôSY]Y]J[ôK»X⁄öX⁄X[ó€õ›\ŒàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàYö\€‹àõ›\¬à[ú]ò[YO^€[ôKõõ›\»œ»àüH€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»õ›\ŒàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàXõ‹à›\ú¬à[ú][ú][ŸOHôX⁄[X[àò[YO^‘›ö[ô Xõ‹í›\ú _H€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»Xõ‹ó⁄›\úŒà\”ù[Xô\äKù\ôŸ]ùò[YJHœ»\›€Xõ‹ó⁄›\úŒà\”ù[Xô\äKù\ôŸ]ùò[YJHœ»J_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàXõ‹àò]Bà[ú][ú][ŸOHôX⁄[X[àò[YO^‘›ö[ô [ôSXõ‹îò]J_H€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»€Xõ‹îò]QòYùà\”ù[Xô\äKù\ôŸ]ùò[YJHœ»J_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàXõ‹à[[›[ùà[ú][ú][ŸOHôX⁄[X[àò[YO^‘›ö[ô Xõ‹ï›[
+_H€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»Xõ‹ó››[à\”ù[Xô\äKù\ôŸ]ùò[YJHœ»J_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà\ù»Ÿ[›[
+ÿ[›[]Y
+Bà[ú]àò[YO^‹\ù’›[OHù[»ààà›ö[ô \ù’›[
+_BàXŸZ€\èHìX[ùX[ô]öY]»ô\]Z\ôYÇàôXY€õBà\öXKY\ÿ‹öXôYûO^ÿ\ùÀ\Ÿ[Z[I€[ôKöYXBà€\‹”ò[YO^ÿ	⁄[ú]€ﬂH›\ú€‹ã[õ›X[›ŸY‹X⁄]KNBàœÇà‹[àY^ÿ\ùÀ\Ÿ[Z[I€[ôKöYXH€\‹”ò[YOHõ]LHõÿ⁄»^VÃL\H^Vÿ€€‹éùò\äK][YK]^[]]Y
+WHèÇàY]XX⁄][Iò\‹Œ‹»Ÿ[öXŸH[àH[öŸY\ù»ô\]Y\›»][›Hô]öY]»ôXÿ[›[]\»\»›[Çà‹‹[èÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà›]\¬àŸ[X›ò[YO^€[ôKú›]\»œ»àüH€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»›]\ŒàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂOÇà‹[€àò[YOHú[ô[ô◊‹\ù»èú[ô[ô»\ùœ€‹[€èÇà‹[€àò[YOHú][›YèúôXYH»][›Y€‹[€èÇà‹[€àò[YOHúŸ[ùèúŸ[ù€‹[€èÇà‹Ÿ[X›Çà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà›YŸBàŸ[X›ò[YO^€[ôKú›YŸHœ»àüH€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»›YŸNàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂOÇà‹[€àò[YOHòYö\€‹ó‹[ô[ô»èòYö\€‹à[ô[ôœ€‹[€èÇà‹[€àò[YOHúôXYW›◊‹Ÿ[ôèúôXYH»Ÿ[ô€‹[€èÇà‹[€àò[YOHúŸ[ùèúŸ[ù€‹[€èÇà‹Ÿ[X›Çà€Xô[ÇàŸ]èÇàŸ]èÇà
+Hàù[BàŸ]èÇàŸ]èÇà
+N¬àJ_BàŸ]èÇà
+_BàŸ]èÇÇà›€‹ö”[ô\Àõ[ô›à»
+à]à€\‹”ò[YO^ÿ	ÿÿ\ôH]MOÇà]à€\‹”ò[YO^ÿõ‹ô\ãXà	Ÿ]öY\üH	‹YHKL»^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWXOÇàX›]ôH\õ›ôY»[ò⁄XõH€‹ö¬àŸ]èÇà]à€\‹”ò[YOHô]öYK^H]öYKVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHèÇà›€‹ö”[ô\ÀõX\
 
-        const { error } = await supabase
-          .from("work_order_quote_lines")
-          .update(patch)
-          .eq("id", line.id)
-          .eq("shop_id", wo.shop_id)
-          .eq("work_order_id", woId);
-        if (error) throw error;
-      }
+[ôJHOà
+à]àŸ^O^€[ôKöYH€\‹”ò[YO^ÿ	‹YHKL»^\€XOÇà]à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹ÿYôUö[J[ôKô\ÿ‹ö\[€äH[ôH	€[ôKõ[ôW€õ»œ»àüXOŸ]èÇà]à€\‹”ò[YOHõ]LH^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèî›]\Œà‹›]\”Xô[
+[ôKú›]\ _H8†(à\õ›ò[à‹›]\”Xô[
+[ôKò\õ›ò[‹›]J_H8†(à[ò⁄XõNà€[ôKú[ò⁄XõH»ûY\»ààõõ»üOŸ]èÇàŸ]èÇà
+J_BàŸ]èÇàŸ]èÇà
+Hàù[BàŸ]èÇÇà]à€\‹”ò[YO^Ÿ[XôYY»àààú‹XŸK^KMüOÇà]à€\‹”ò[YO^ÿÿ\ôOÇà]à€\‹”ò[YO^ÿõ‹ô\ãXà	Ÿ]öY\üH	‹YHKL»^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWXOî][›HôXY[ô\‹œŸ]èÇà]à€\‹”ò[YO^ÿ	‹YHKM^\€H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWXOÇà]à€\‹”ò[YOHôõ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àèè‹[èîôXYH»Ÿ[ô‹‹[èè‹[à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹][›U›[ÀúŸ[ôXõ_O‹‹[èèŸ]èÇà]à€\‹”ò[YOHõ]Làõ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àèè‹[èî[ô[ô»\ùœ‹‹[èè‹[à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹][›U›[Àú[ô[ô‘\ùﬂO‹‹[èèŸ]èÇà]à€\‹”ò[YOHõ]Làõ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àèè‹[èîŸ[ù‹‹[èè‹[à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹][›U›[ÀúŸ[ùO‹‹[èèŸ]èÇà]à€\‹”ò[YO^ÿ]L»õ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àõ‹ô\ã]	Ÿ]öY\üHLÿOè‹[èìXõ‹è‹‹[èè‹[à€\‹”ò[YOHôõ€ù[YY][H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèûŸõ]
+][›U›[ÀõXõ‹ä_O‹‹[èèŸ]èÇà]à€\‹”ò[YOHõ]Làõ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àèè‹[èû‹][›U›[Àú\ù‘öX⁄[ô‘]X\ò[ù[ôY»î\ù»
+õ›X›Y
+Hààî\ù»üO‹‹[èè‹[à€\‹”ò[YOHôõ€ù[YY][H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹][›U›[Àú\ù’›[[ò]òZ[XõH»ìX[ùX[ô]öY]»ààõ]
+][›U›[Àú\ù _O‹‹[èèŸ]èÇà‹][›U›[Àú\ù‘öX⁄[ô‘]X\ò[ù[ôY»]à€\‹”ò[YOHõ]LH^^»^X[Xô\ãLLèîõ›X›Yö[ò[^ôY›[»\ôHô]Z[ôY»]X\ò[ù[ôY][HöX⁄[ô»\»^€YYèŸ]èààù[Bà]à€\‹”ò[YOHõ]Làõ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àèè‹[èî⁄‹›\Y\œ‹‹[èè‹[à€\‹”ò[YOHôõ€ù[YY][H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèûŸõ]
+][›U›[Àú⁄‹›\Y\Àò[[›[ù
+_O‹‹[èèŸ]èÇà]à€\‹”ò[YOHõ]LH^^»^Vÿ€€‹éùò\äK][YK]^[]]Y
+WHèû‹⁄‹›\Y\‘›[[X\ûU^
+][›U›[Àú⁄‹›\Y\ _OŸ]èÇà]à€\‹”ò[YO^ÿ]L»õ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àõ‹ô\ã]	Ÿ]öY\üHLÿOè‹[à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèë‹ò[ô›[‹‹[èè‹[à€\‹”ò[YOHù^[»õ€ùXõ€à›[O^ﬁ»€€‹éà”‘Tà_Oû‹][›U›[Àô‹ò[ô›[[ò]òZ[XõH»ìX[ùX[ô]öY]»ààõ]
+][›U›[Àù›[
+_O‹‹[èèŸ]èÇà]à€\‹”ò[YO^ÿ]Mõ‹ô\ã]	Ÿ]öY\üHLÿOÇà]à€\‹”ò[YOHù^^»õ€ù\Ÿ[ZXõ€\\òÿ\ŸHòX⁄⁄[ôÀVÃåM[WH^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèî⁄‹›\Y\»›ô\úöYOŸ]èÇàŸ[X›àò[YO^‹›\Y\—[òXõYòYùOHù[»ôYò][àà›\Y\—[òXõYòYù»õ€àààõŸôàüBà€ê⁄[ôŸO^ JHOàŸ]›\Y\—[òXõYòYù
+Kù\ôŸ]ùò[YHOOHôYò][à»ù[àKù\ôŸ]ùò[YHOOHõ€àä_Bà€\‹”ò[YOHõ]LàÀYù[õ›[ôY[»õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äKY\⁄›‹Z][KXô WHL»KLà^\€H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH›][ôK[õ€ôHÇàÇà‹[€àò[YOHôYò][èï\ŸH⁄‹Yò][€‹[€èÇà‹[€àò[YOHõ€àèí[ò€YH⁄‹›\Y\œ€‹[€èÇà‹[€àò[YOHõŸôàèîô[[›ôH⁄‹›\Y\œ€‹[€èÇà‹Ÿ[X›Çà[ú]àò[YO^‹›\Y\–[[›[ùòYùBà€ê⁄[ôŸO^ JHOàŸ]›\Y\–[[›[ùòYù
+Kù\ôŸ]ùò[YJ_BàXŸZ€\èHì‹[€ò[ö^Y›ô\úöYH[[›[ùÇà€\‹”ò[YOHõ]LàÀYù[õ›[ôY[»õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äKY\⁄›‹Z][KXô WHL»KLà^\€H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH›][ôK[õ€ôHXŸZ€\éù^Vÿ€€‹éùò\äK][YK]^[]]Y
+WHÇàœÇà]à€\‹”ò[YOHõ]Là‹öY‹öYX€€ÀLàÿ\LàèÇàù]€à\OHòù]€àà€ê€X⁄œ^ 
+HOàõ⁄Yÿ]ôT›\Y\”›ô\úöYJ
+_H\ÿXõY^‹ÿ]ö[ô‘›\Y\”›ô\úöY_H€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûHõ›[ôY[»L»KLà^^»õ€ù\Ÿ[ZXõ€\ÿXõYõ‹X⁄]KMåèÇà‹ÿ]ö[ô‘›\Y\”›ô\úöYH»îÿ]ö[ô¯†)àààîÿ]ôH›ô\úöYHüBàÿù]€èÇàù]€à\OHòù]€àà€ê€X⁄œ^‹ô\Ÿ]›\Y\”›ô\úöY_H€\‹”ò[YOHúõ›[ôY[»õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äK][YKXõ‹ô\ã\€Ÿù
+WHôÀVÿ€€‹éùò\äK][YK\›\ôòXŸK\›XùJWHL»KLà^^»õ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH›ô\éòôÀVÿ€€‹éùò\äK][YK\›\ôòXŸK\›XùJWHèîô\Ÿ]òYùÿù]€èÇàŸ]èÇàŸ]èÇàù]€à€ê€X⁄œ^ 
+HOàõ⁄Yÿ]ôP[\ùJ
+_H\ÿXõY^‹ÿ]ö[ôﬂH€\‹”ò[YOHô\⁄›‹Xùã\ö[X\ûH]MÀYù[õ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€\ÿXõYõ‹X⁄]KMåèÇà‹ÿ]ö[ô»»îÿ]ö[ô¯†)àààîÿ]ôH⁄[ôŸ\»üBàÿù]€èÇàŸ]èÇàŸ]èÇÇà]à€\‹”ò[YO^ÿÿ\ôOÇà]à€\‹”ò[YO^ÿõ‹ô\ãXà	Ÿ]öY\üH	‹YHKL»^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWXOîŸ[ô»›\›€Y\èŸ]èÇà]à€\‹”ò[YO^ÿ	‹YHKM^\€H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWXOÇàŸ[ô»€õHÿ[õ€öXÿ[€‹ö◊€‹ô\ó‹][›W€[ô\»]\ôHôXYH»Ÿ[ôà[ô[ô»\ùÀX€[ôYYô\úôY\õ›ôY[ô€€ùô\ùY[ô\»\ôHõ›Ÿ[ùÇà‹][›U›[ÀúŸ[ôXõHOOH»
+à]à€\‹”ò[YOHõ]L»õ›[ôY^õ‹ô\àõ‹ô\ãX[Xô\ãLÃÃÕHôÀX[Xô\ãMÃLL»^X[Xô\ãLLèìõ»ôXYHÿ[õ€öXÿ[][›H[ô\»\ôH]òZ[XõH»Ÿ[ôèŸ]èÇà
+Hàù[Bà€Z\‹⁄[ô–›\›€Y\ë[XZ[Ÿ[ôõÿ⁄Ÿ\à»
+à]à€\‹”ò[YOHõ]L»õ›[ôY^õ‹ô\àõ‹ô\ã\⁄ﬁKMÃÕHôÀ\⁄ﬁKMLÃLL»èÇà]à€\‹”ò[YOHù^^»õ€ù\Ÿ[ZXõ€\\òÿ\ŸHòX⁄⁄[ôÀVÃåM[WH^\⁄ﬁKLLèêõÿ⁄ŸYŸ]èÇà]à€\‹”ò[YOHõ]LH^\€Hõ€ù\Ÿ[ZXõ€^\⁄ﬁKLLèû‹Ÿ[ôõÿ⁄Ÿ\àœ»ê›\›€Y\à[XZ[ô\]Z\ôY»Ÿ[ô][›HüOŸ]èÇà]à€\‹”ò[YOHõ]Làõ^õ^X€€ÿ\Là€Nôõ^\õ›»èÇà[ú]\OHô[XZ[àò[YO^‹[ô[ô–›\›€Y\ë[XZ[H€ê⁄[ôŸO^ JHOàŸ][ô[ô–›\›€Y\ë[XZ[
+Kù\ôŸ]ùò[YJ_HXŸZ€\èHò›\›€Y\ê[XZ[ò€€Hà€\‹”ò[YOHùÀYù[õ›[ôY[»õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äKY\⁄›‹Z][KXô WHL»KLà^\€H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH›][ôK[õ€ôHXŸZ€\éù^Vÿ€€‹éùò\äK][YK]^[]]Y
+WHõÿ›\Œòõ‹ô\ã\⁄ﬁKLÃÕÃàœÇàù]€à\OHòù]€àà€ê€X⁄œ^ 
+HOàõ⁄Yÿ]ôP›\›€Y\ë[XZ[[õ[ôJ
+_H\ÿXõY^‹ÿ]ö[ô–›\›€Y\ë[XZ[H€\‹”ò[YOHúõ›[ôY[»õ‹ô\àõ‹ô\ãX[Xô\ãLÃÕHôÀX[Xô\ãMÃMHL»KLà^\€Hõ€ù\Ÿ[ZXõ€^\⁄ﬁKLL›ô\éòôÀX[Xô\ãMÃå\ÿXõYõ‹X⁄]KMåèÇà‹ÿ]ö[ô–›\›€Y\ë[XZ[»îÿ]ö[ô¯†)àààîÿ]ôH[XZ[üBàÿù]€èÇàŸ]èÇàŸ]èÇà
+Hàù[Bàù]€à€ê€X⁄œ^ 
+HOàõ⁄YŸ[ô][›U–›\›€Y\äò[ŸJ_H\ÿXõY^‹Ÿ[ô[ô»ÿ]ö[ô–›\›€Y\ë[XZ[][›U›[ÀúŸ[ôXõHOOHH€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûH]L»ÀYù[õ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH\ÿXõYõ‹X⁄]KMåèÇà‹Ÿ[ô[ô»»îŸ[ô[ô¯†)àààîŸ[ôôXYH][›H[ô\»üBàÿù]€èÇà‹][›U›[ÀúŸ[ùà»
+àù]€à€ê€X⁄œ^ 
+HOàõ⁄YŸ[ô][›U–›\›€Y\äùYJ_H\ÿXõY^‹Ÿ[ô[ô»ÿ]ö[ô–›\›€Y\ë[XZ[Z\‹⁄[ô–›\›€Y\ë[XZ[H€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûH]LàÀYù[õ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH\ÿXõYõ‹X⁄]KMåèÇà‹Ÿ[ô[ô»»îŸ[ô[ô¯†)àààîô\Ÿ[ô][›HüBàÿù]€èÇà
+Hàù[Bà]à€\‹”ò[YOHõ]L»^^»^Vÿ€€‹éùò\äK][YK]^[]]Y
+WHèî‹ù[[ö»⁄[ôNà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèã‹‹ù[‹][›\Àﬁ›€“YO‹‹[èèŸ]èÇà]à€\‹”ò[YOHõ]Là^^»^Vÿ€€‹éùò\äK][YK]^[]]Y
+WHèê›\›€Y\à‹ù[X⁄\⁄[€ú»[ô⁄‹\ôX€‹ôY€ôHX⁄\⁄[€ú»\ŸHHÿ[YHÿ[õ€öXÿ[\õ›ò[YôXﬁX€KèŸ]èÇàŸ]èÇàŸ]èÇÇà]à€\‹”ò[YO^ÿÿ\ôOÇà]à€\‹”ò[YO^ÿõ‹ô\ãXà	Ÿ]öY\üH	‹YHKL»^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWXOî]ZX⁄»YõÿèŸ]èÇà]à€\‹”ò[YO^ÿ	‹YHKM^\€H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWXOÇàYX›]ôH€‹ö»€õH⁄[à[ù[ù[€ò[HôYYYà[ú‹X›[€àôX€€[Y[ô][€ú»⁄›[›^H[àÿ[õ€öXÿ[][›H[ô\»[ù[›\›€Y\à\õ›ò[€X]\öX[^ò][€ãÇàù]€à\OHòù]€àà€ê€X⁄œ^€‹[êYõÿï⁄]ôYö[H€\‹”ò[YOHô\⁄›‹Xùã\ö[X\ûH]L»ÀYù[õ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€èä»Yõÿà[ôOÿù]€èÇàŸ]èÇàŸ]èÇàŸ]èÇàŸ]èÇÇà»Y[XôYY	âà]à€\‹”ò[YOHõ]Mà^^»^Vÿ€€‹éùò\äK][YK]^[]]Y
+WHèï€‹ö»‹ô\àQà›€ÀöYH8†(à›]\Œà‹›]\”Xô[
+€Àú›]\ _OŸ]èüBÇàŸX⁄\⁄[€ëX[Ÿ»»
+à]à€\‹”ò[YOHôö^Y[úŸ]LãVÃLHõ^][\ÀXŸ[ù\àù\›YûKXŸ[ù\àôÀXõX⁄ÀÕçHMàõ€OHôX[Ÿ»à\öXK[[Ÿ[HùùYHà\öXK[Xô[YûOHú⁄‹YX⁄\⁄[€ã]]HèÇà]à€\‹”ò[YOHùÀYù[X^]À[»õ›[ôYLûõ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äK][YK\›\ôòXŸK[›ô\õ^JWHMH⁄Y›ÀLûèÇà]à€\‹”ò[YOHù^^»õ€ù\Ÿ[ZXõ€\\òÿ\ŸHòX⁄⁄[ôÀVÃåN[WH^Vÿ€€‹éùò\äK][YK]^[]]Y
+WHèê€\‹⁄X»⁄‹\õ›ò[Ÿ]èÇààYHú⁄‹YX⁄\⁄[€ã]]Hà€\‹”ò[YOHõ]Là^[»õ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèîôX€‹ô‹›]\”Xô[
+X⁄\⁄[€ëX[ŸÀôX⁄\⁄[€ä_H8†%‹ÿYôUö[JX⁄\⁄[€ëX[ŸÀõ[ôKô\ÿ‹ö\[€äHú][›H[ôHüO⁄èÇà€\‹”ò[YOHõ]Là^\€H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèï\ŸH\»Yù\à€€ôö\õZ[ô»H›\›€Y\âò\‹Œ‹»X⁄\⁄[€à›]⁄YHH‹ù[àHYö\€‹ã€€ùX›Y]Ÿ[YK[ôõ›H\ôHô]Z[ôY⁄]H][›Kè‹ÇàXô[€\‹”ò[YOHõ]Mõÿ⁄»^^»õ€ù[YY][H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà›\›€Y\à€€ùX›Y]ŸàŸ[X›ò[YO^ŸX⁄\⁄[€ê€€ùX›H€ê⁄[ôŸO^ ]ô[ù
+HOàŸ]X⁄\⁄[€ê€€ùX›
+]ô[ùù\ôŸ]ùò[YH\»€€ùX›Y]Ÿ
+_H€\‹”ò[YO^⁄[ú]€ﬂOÇà‹[€àò[YOHú€ôHèî€ôHÿ[€‹[€èè‹[€àò[YOHö[ó‹\ú€€àèí[à\ú€€è€‹[€èè‹[€àò[YOHô[XZ[èë[XZ[€‹[€èè‹[€àò[YOHõ›\àèì›\è€‹[€èÇà‹Ÿ[X›Çà€Xô[ÇàXô[€\‹”ò[YOHõ]L»õÿ⁄»^^»õ€ù[YY][H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàYö\€‹àõ›H
+‹[€ò[
+Bà^\ôXHò[YO^ŸX⁄\⁄[€ìõ›_H€ê⁄[ôŸO^ ]ô[ù
+HOàŸ]X⁄\⁄[€ìõ›J]ô[ùù\ôŸ]ùò[YKú€XŸJL
+J_Hõ›‹œ^ÃﬂHXŸZ€\èHë^[\Nà\õ›ôYûH€ôH⁄]ò[ZYH]éåMHKàà€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[Çà]à€\‹”ò[YOHõ]MHõ^õ^]‹ò\ù\›YûKY[ôÿ\LàèÇàù]€à\OHòù]€àà\ÿXõY^ŸX⁄\⁄[€îÿ]ö[ôﬂH€ê€X⁄œ^ 
+HOàŸ]X⁄\⁄[€ëX[Ÿ ù[
+_H€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûHõ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€\ÿXõYõ‹X⁄]KMLèêÿ[òŸ[ÿù]€èÇàù]€à\OHòù]€àà\ÿXõY^ŸX⁄\⁄[€îÿ]ö[ôﬂH€ê€X⁄œ^ 
+HOàõ⁄Y€€ôö\õT⁄‹X⁄\⁄[€ä
+_H€\‹”ò[YO^ŸX⁄\⁄[€ëX[ŸÀôX⁄\⁄[€àOOHôX€[ôHà»úõ›[ôY^õ‹ô\àõ‹ô\ã\ôYMÕHôÀ\ôYMLÃMHMKLà^\€Hõ€ù\Ÿ[ZXõ€^\ôYLL\ÿXõYõ‹X⁄]KMLààô\⁄›‹Xùã\ö[X\ûHõ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€\ÿXõYõ‹X⁄]KMLüOûŸX⁄\⁄[€îÿ]ö[ô»»îôX€‹ô[ô¯†)ààà€€ôö\õH	‹›]\”Xô[
+X⁄\⁄[€ëX[ŸÀôX⁄\⁄[€ä_XOÿù]€èÇàŸ]èÇàŸ]èÇàŸ]èÇà
+Hàù[BÇàYõÿì[Ÿ[à\”‹[è^ÿYõÿì‹[üBà€ê€‹ŸO^ 
+HOàŸ]Yõÿì‹[äò[ŸJ_Bà€‹ö”‹ô\íY^›€ÀöYBàôZX€RY^›€ÀùôZX€W⁄YBà⁄‹Y^›€Àú⁄‹⁄YBàX⁄Y^ÿ›\úô[ù\Ÿ\íYBà€íõÿêYY^ 
+HOà¬àŸ]Yõÿì‹[äò[ŸJN¬àõ⁄Yô[ÿY
 
-      const pricingResponse = await fetch(
-        `/api/work-orders/${woId}/customer-pricing`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ quoteLineIds: dirty.map((line) => line.id) }),
-        },
-      );
-      const pricingPayload = (await pricingResponse.json().catch(() => null)) as {
-        error?: string;
-      } | null;
-      if (!pricingResponse.ok) {
-        throw new Error(
-          pricingPayload?.error ?? "Customer pricing could not be resolved.",
-        );
-      }
-
-      toast.success("Quote lines saved.");
-      await reload();
-      return true;
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to save quote lines.");
-      return false;
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  function openDecisionDialog(line: EditableQuoteLine, decision: QuoteDecision) {
-    setDecisionContact("phone");
-    setDecisionNote("");
-    setDecisionDialog({ line, decision });
-  }
-
-  async function confirmShopDecision() {
-    if (!decisionDialog || decisionSaving) return;
-    setDecisionSaving(true);
-    try {
-      if (quoteLines.some((line) => line._dirty)) {
-        const saved = await saveAllDirty();
-        if (!saved) return;
-      }
-      const response = await fetch(`/api/work-orders/quotes/${decisionDialog.line.id}/authorize`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ decision: decisionDialog.decision, contactMethod: decisionContact, note: decisionNote, operationKey: crypto.randomUUID() }),
-      });
-      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
-      if (!response.ok) throw new Error(payload?.error ?? "Could not record the shop decision.");
-      const pastTense = decisionDialog.decision === "approve" ? "approved" : decisionDialog.decision === "decline" ? "declined" : "deferred";
-      toast.success(`Quote line ${pastTense} by the shop.`);
-      setDecisionDialog(null);
-      await reload();
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Could not record the shop decision.");
-    } finally {
-      setDecisionSaving(false);
-    }
-  }
-
-  async function saveSuppliesOverride() {
-    if (!wo?.shop_id || savingSuppliesOverride) return;
-    const amountOverride = suppliesAmountDraft.trim() ? asNumber(suppliesAmountDraft) : null;
-    if (suppliesAmountDraft.trim() && amountOverride == null) {
-      toast.error("Enter a valid shop supplies override amount.");
-      return;
-    }
-
-    setSavingSuppliesOverride(true);
-    try {
-      const { error } = await supabase
-        .from("work_orders")
-        .update({
-          shop_supplies_enabled_override: suppliesEnabledDraft,
-          shop_supplies_amount_override: amountOverride,
-          updated_at: new Date().toISOString(),
-        } as DB["public"]["Tables"]["work_orders"]["Update"])
-        .eq("id", wo.id)
-        .eq("shop_id", wo.shop_id);
-      if (error) throw error;
-      toast.success("Shop supplies override saved.");
-      await reload();
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to save shop supplies override.");
-    } finally {
-      setSavingSuppliesOverride(false);
-    }
-  }
-
-  function resetSuppliesOverride() {
-    setSuppliesEnabledDraft(null);
-    setSuppliesAmountDraft("");
-  }
-
-  async function saveCustomerEmailInline() {
-    if (!wo?.customer_id) {
-      toast.error("No customer linked to this work order.");
-      return;
-    }
-    const nextEmail = safeTrim(pendingCustomerEmail);
-    if (!nextEmail || !isValidEmail(nextEmail)) {
-      toast.error("Enter a valid customer email.");
-      return;
-    }
-
-    setSavingCustomerEmail(true);
-    try {
-      const { error } = await supabase.from("customers").update({ email: nextEmail }).eq("id", wo.customer_id);
-      if (error) throw error;
-      setSendBlocker(null);
-      toast.success("Customer email saved.");
-      await reload();
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to save customer email.");
-    } finally {
-      setSavingCustomerEmail(false);
-    }
-  }
-
-  async function sendQuoteToCustomer(resend = false) {
-    if (!woId || sending) return;
-    setSending(true);
-    try {
-      const saved = await saveAllDirty();
-      if (!saved) return;
-
-      const res = await fetch(`/api/work-orders/${woId}/send-quote`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(resend ? { "x-profix-resend": "1" } : {}),
-        },
-        body: JSON.stringify({}),
-      });
-      const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string; detail?: string } | null;
-
-      if (!res.ok || !json?.ok) {
-        const message = safeTrim(json?.error ?? json?.detail ?? "Failed to send quote.");
-        if (message.toLowerCase().includes("email")) setSendBlocker("Customer email required to send quote");
-        toast.error(message);
-        return;
-      }
-
-      setSendBlocker(null);
-      toast.success(resend ? "Quote resent to customer." : "Quote sent to customer using canonical quote lines.");
-      await reload();
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to send quote.");
-    } finally {
-      setSending(false);
-    }
-  }
-
-  function openAddJobWithPrefill() {
-    if (typeof window !== "undefined") {
-      sessionStorage.setItem(
-        "addJobModal:prefill",
-        JSON.stringify({ jobName: "", notes: "", laborHours: null, partsPaste: "", parts: null }),
-      );
-    }
-    setAddJobOpen(true);
-  }
-
-  if (!woId) return <div className="p-6 text-red-300">Missing work order id.</div>;
-  if (loading && !loadedOnce) return <div className="p-6 text-[color:var(--theme-text-secondary)]">Loading‚Ä¶</div>;
-  if (!wo) return <div className="p-6 text-red-300">Work order not found.</div>;
-
-  const outerCls = embedded ? "min-h-full w-full px-0 py-0 text-foreground" : "min-h-screen px-4 py-6 text-foreground";
-  const containerCls = embedded ? "mx-auto w-full max-w-none" : "mx-auto max-w-7xl";
-  const padX = embedded ? "px-3" : "px-5";
-  const padY = embedded ? "py-3" : "py-4";
-  const mainGridCls = embedded ? "mt-3 grid gap-3" : "mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.6fr)_380px]";
-  const actionBtnCls = embedded ? `${ui.buttonSecondary} px-3 py-1.5 text-xs disabled:opacity-60` : `${ui.buttonSecondary} px-4 py-2 text-sm disabled:opacity-60`;
-  const saveBtnCls = embedded ? `${ui.buttonPrimary} px-3 py-1.5 text-xs disabled:opacity-60` : `${ui.buttonPrimary} px-4 py-2 text-sm disabled:opacity-60`;
-
-  return (
-    <div className={outerCls} style={{ ["--copper" as never]: COPPER }}>
-      <div className={containerCls}>
-        {loading ? (
-          <div className="mb-2 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">
-            Refreshing canonical quote lines‚Ä¶
-          </div>
-        ) : null}
-
-        <div className={embedded ? "mb-2 flex flex-wrap items-center justify-between gap-2" : "mb-4 flex flex-wrap items-center justify-between gap-3"}>
-          {!embedded && (
-            <button onClick={() => router.back()} className="text-sm text-[color:var(--copper)] hover:underline">
-              ‚Üê Back
-            </button>
-          )}
-          <div className="flex flex-wrap items-center gap-2">
-            <button onClick={() => void sendQuoteToCustomer(false)} disabled={sending || quoteTotals.sendable === 0} className={actionBtnCls} title="Email the ready canonical quote lines to the customer">
-              {sending ? "Sending‚Ä¶" : "Send Quote"}
-            </button>
-            {quoteTotals.sent > 0 ? (
-              <button onClick={() => void sendQuoteToCustomer(true)} disabled={sending || missingCustomerEmail} className={actionBtnCls} title="Resend the current customer portal quote email">
-                {sending ? "Sending‚Ä¶" : "Resend Quote"}
-              </button>
-            ) : null}
-            <button onClick={() => void saveAllDirty()} disabled={saving} className={saveBtnCls} title="Save canonical quote line changes">
-              {saving ? "Saving‚Ä¶" : "Save"}
-            </button>
-            {!embedded && (
-              <a href={`/work-orders/${woId}`} className="desktop-btn-secondary rounded-full px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)]" title="Open the work order">
-                Open WO
-              </a>
-            )}
-          </div>
-        </div>
-
-        <div className={`${card} ${padX} ${padY}`}>
-          <div className={embedded ? "grid gap-3" : "grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,1.15fr)_auto]"}>
-            <div className="min-w-0">
-              <div className="text-xs uppercase tracking-[0.25em] text-[color:var(--theme-text-secondary)]">Advisor quote review</div>
-              <div className={embedded ? "mt-1 text-xl font-semibold text-[color:var(--theme-text-primary)]" : "mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]"}>
-                <span className="text-[color:var(--theme-text-primary)]">#</span>
-                <span style={{ color: COPPER }}>{wo.custom_id ? wo.custom_id : wo.id.slice(0, 8)}</span>
-              </div>
-              <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Canonical quote lines: {quoteLines.length} ‚Ä¢ Active work lines: {workLines.length}</div>
-            </div>
-
-            <div className="desktop-panel-soft w-full px-4 py-3">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--theme-text-muted)]">Customer contact</div>
-              <div className={embedded ? "mt-2 grid gap-2" : "mt-2 grid gap-2 sm:grid-cols-3"}>
-                <div className="min-w-0">
-                  <div className="text-[11px] text-[color:var(--theme-text-muted)]">Name</div>
-                  <div className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">{customerDisplayName(customer)}</div>
-                </div>
-                <div className="min-w-0">
-                  <div className="text-[11px] text-[color:var(--theme-text-muted)]">Phone</div>
-                  {tel ? <a href={`tel:${tel}`} className="truncate text-sm font-semibold text-[color:var(--copper)] hover:underline">{customerPhone}</a> : <div className="truncate text-sm font-semibold text-[color:var(--theme-text-secondary)]">‚Äî</div>}
-                </div>
-                <div className="min-w-0">
-                  <div className="text-[11px] text-[color:var(--theme-text-muted)]">Email</div>
-                  {customerEmail ? <a href={`mailto:${customerEmail}`} className="block break-all text-sm font-semibold leading-tight text-[color:var(--copper)] hover:underline">{customerEmail}</a> : <div className="truncate text-sm font-semibold text-[color:var(--theme-text-secondary)]">‚Äî</div>}
-                </div>
-              </div>
-            </div>
-
-            <div className={embedded ? "text-left" : "text-right self-start"}>
-              <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">Shop labor rate</div>
-              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">{fmt(laborRate)}/hr</div>
-            </div>
-          </div>
-        </div>
-
-        <div className={mainGridCls}>
-          <div>
-            <div className={card}>
-              <div className={`border-b ${divider} ${padX} py-3 text-sm font-semibold text-[color:var(--theme-text-primary)]`}>
-                Canonical quote lines
-              </div>
-              {quoteLines.length === 0 ? (
-                <div className={`${padX} py-4 text-sm text-[color:var(--theme-text-secondary)]`}>
-                  No canonical quote lines exist for this work order yet. Phase 5B does not create temporary work_order_lines for portal visibility; customer portal rendering remains Phase 5C.
-                </div>
-              ) : (
-                <div className="divide-y divide-[color:var(--desktop-border)]">
-                  {quoteLines.map((line, index) => {
-                    const workflow = workflowDisplay(line);
-                    const partsWorkflow = partsWorkflowLabel(line);
-                    const partsSummary = partsQuoteSummary(line);
-                    const meta = quoteMetadata(line);
-                    const photos = [...jsonStringArray(meta.photo_urls), ...jsonStringArray(meta.evidence_urls)];
-                    const techNotes = jsonString(meta.technician_notes) || jsonString(meta.tech_notes) || safeTrim(line.ai_cause);
-                    const laborHours = quoteLineLaborHours(line);
-                    const lineLaborRate = quoteLineLaborRate(line, laborRate);
-                    const laborTotal = quoteLineLaborTotal(line, laborRate);
-                    const partsTotal = quoteLinePartsTotal(line);
-                    const total = quoteLineTotal(line, laborRate);
-                    const sources = sourceSummary(line);
-                    const historyInsight = historyInsights[line.id];
-                    const finalDecision = isFinalDecision(line);
-                    const pricingQuarantined =
-                      partsSummary?.customerPricingQuarantined === true;
-                    const dedicatedPricing = customerPricingSummary(line);
-                    const commercialEditingDisabled =
-                      finalDecision || pricingQuarantined;
-                    const finalizedLineTotalUnavailable =
-                      pricingQuarantined &&
-                      partsTotal == null &&
-                      asNumber(line.grand_total) == null &&
-                      asNumber(line.subtotal) == null;
-
-                    return (
-                      <div key={line.id} className={`${padX} py-4`}>
-                        <div className="desktop-panel-soft p-4">
-                          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                            <div className="min-w-0 flex-1">
-                              <div className="flex flex-wrap items-center gap-2">
-                                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">Quote line {index + 1}</div>
-                                <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${badgeClass(workflow.tone)}`}>{workflow.label}</span>
-                                {partsWorkflow ? <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${badgeClass(partsWorkflow.tone)}`}>{partsWorkflow.label}</span> : null}
-                                {dedicatedPricing ? <span className="rounded-full border border-emerald-300/35 bg-emerald-400/10 px-2.5 py-1 text-[11px] font-semibold capitalize text-emerald-100">{customerPricingLabel(dedicatedPricing)}</span> : null}
-                                {line._dirty ? <span className="rounded-full border border-amber-300/40 bg-amber-400/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100">Unsaved</span> : null}
-                              </div>
-                              <h3 className="mt-2 text-base font-semibold text-[color:var(--theme-text-primary)]">{safeTrim(line.description) || "Untitled quote line"}</h3>
-                              {safeTrim(line.ai_complaint) ? <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Complaint: {line.ai_complaint}</p> : null}
-                              {safeTrim(line.notes) ? <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Notes: {line.notes}</p> : null}
-                              {techNotes ? <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Technician notes: {techNotes}</p> : null}
-                              <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">{workflow.detail}</p>
-                            </div>
-                            <div className="min-w-[180px] rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-3 text-sm">
-                              <div className="flex justify-between gap-4"><span className="text-[color:var(--theme-text-secondary)]">Labor</span><span className="font-semibold text-[color:var(--theme-text-primary)]">{fmt(laborTotal)}</span></div>
-                              <div className="mt-1 flex justify-between gap-4"><span className="text-[color:var(--theme-text-secondary)]">{pricingQuarantined ? "Parts (finalized)" : "Parts"}</span><span className="font-semibold text-[color:var(--theme-text-primary)]">{partsTotal == null ? "Manual review" : fmt(partsTotal)}</span></div>
-                              <div className={`mt-2 flex justify-between gap-4 border-t ${divider} pt-2`}><span className="text-[color:var(--theme-text-secondary)]">Total</span><span className="font-bold" style={{ color: COPPER }}>{finalizedLineTotalUnavailable ? "Manual review" : fmt(total)}</span></div>
-                            </div>
-                          </div>
-
-                          <div className="mt-3 grid gap-2 text-xs text-[color:var(--theme-text-secondary)] sm:grid-cols-2 lg:grid-cols-4">
-                            <div>Stage: <span className="text-[color:var(--theme-text-primary)]">{statusLabel(line.stage)}</span></div>
-                            <div>Status: <span className="text-[color:var(--theme-text-primary)]">{statusLabel(line.status)}</span></div>
-                            <div>Labor hours: <span className="text-[color:var(--theme-text-primary)]">{laborHours}</span></div>
-                            <div>Labor rate: <span className="text-[color:var(--theme-text-primary)]">{fmt(lineLaborRate)}/hr</span></div>
-                          </div>
-
-                          {pricingQuarantined ? (
-                            <div role="alert" className="mt-3 rounded-xl border border-amber-300/40 bg-amber-400/10 p-3 text-xs text-amber-50">
-                              <div className="font-semibold uppercase tracking-[0.16em]">Manual pricing review required</div>
-                              <div className="mt-1">
-                                This protected quote keeps its finalized decision total. Current Parts Request pricing is hidden because it is not the finalized customer decision.
-                              </div>
-                              <div className="mt-1 font-semibold">
-                                {partsTotal == null
-                                  ? "Finalized parts total is unavailable; do not treat it as $0."
-                                  : `Finalized parts total: ${fmt(partsTotal)}`}
-                              </div>
-                              <PricingQuarantineRemediation
-                                quoteLineId={line.id}
-                                quoteLineUpdatedAt={line.updated_at}
-                                finalizedPartsTotal={partsTotal}
-                                parts={partsByQuoteLine[line.id] ?? []}
-                                onRemediated={reload}
-                              />
-                            </div>
-                          ) : null}
-
-                          {historyInsight ? (
-                            <div className="mt-3 rounded-xl border border-sky-300/30 bg-sky-400/10 p-3 text-xs">
-                              <div className="flex flex-wrap items-start justify-between gap-2">
-                                <div>
-                                  <div className="font-semibold uppercase tracking-[0.16em] text-sky-100">Relevant vehicle history</div>
-                                  <div className="mt-1 text-[color:var(--theme-text-primary)]">Completed {historyDistanceLabel(historyInsight)}{historyInsight.workOrderNumber ? ` on WO ${historyInsight.workOrderNumber}` : " on a prior work order"}.</div>
-                                  <div className="mt-1 text-[color:var(--theme-text-secondary)]">{historyInsight.description}</div>
-                                </div>
-                                <a href={`/work-orders/${historyInsight.workOrderId}`} className="rounded-lg border border-sky-300/35 px-2.5 py-1.5 font-semibold text-sky-100 hover:bg-sky-400/10">View prior WO</a>
-                              </div>
-                            </div>
-                          ) : historyLoading ? <div className="mt-3 text-xs text-[color:var(--theme-text-muted)]">Checking relevant vehicle history‚Ä¶</div> : null}
-
-                          <div className="mt-3 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-secondary)]">
-                            <div className="flex flex-wrap items-center justify-between gap-2">
-                              <div className="font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">Required parts</div>
-                              <div className="flex flex-wrap items-center gap-2">
-                                {partsSummary ? <div className="text-[color:var(--theme-text-secondary)]">Sync: <span className="text-[color:var(--theme-text-primary)]">{partsSummary.customerPricingQuarantined ? "manual review ‚Ä¢ customer item pricing quarantined" : <>{partsSummary.pendingCount > 0 ? "pending" : "quoted"} ‚Ä¢ {partsSummary.quotedCount}/{partsSummary.requiredCount} quoted ‚Ä¢ {partsSummary.partsTotal == null ? "total pending" : fmt(partsSummary.partsTotal)}</>}</span></div> : null}
-                                {(partsByQuoteLine[line.id] ?? []).length > 0 ? <button type="button" onClick={() => setOpenParts((prev) => ({ ...prev, [line.id]: !prev[line.id] }))} className="rounded-lg border border-[color:var(--desktop-border)] px-2.5 py-1.5 font-semibold text-[color:var(--theme-text-primary)]">{openParts[line.id] ? "Hide parts" : `View ${(partsByQuoteLine[line.id] ?? []).length} parts`}</button> : null}
-                              </div>
-                            </div>
-                            {(partsByQuoteLine[line.id] ?? []).length > 0 && openParts[line.id] ? (
-                              <div className="mt-2 space-y-2">
-                                {(partsByQuoteLine[line.id] ?? []).map((part) => {
-                                  const request = part.requestId ? (requestsByQuoteLine[line.id] ?? []).find((candidate) => candidate.id === part.requestId) ?? null : null;
-                                  const selected = selectedPartLabel(part);
-                                  return (
-                                    <div key={`${part.source}:${part.requestItemId ?? part.requestId ?? part.description}`} className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-2">
-                                      {selected ? (
-                                        <>
-                                          <div className="text-[color:var(--theme-text-primary)]">Requested: <span className="font-semibold text-[color:var(--theme-text-primary)]">{part.description} √ó {part.quantity}</span></div>
-                                          <div className="mt-1 text-[color:var(--theme-text-secondary)]">Selected: <span className="text-[color:var(--theme-text-primary)]">{selected}</span></div>
-                                        </>
-                                      ) : (
-                                        <div className="font-semibold text-[color:var(--theme-text-primary)]">{part.description} √ó {part.quantity}</div>
-                                      )}
-                                      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[color:var(--theme-text-secondary)]">
-                                        {part.requestedPartNumber ? <span>Requested part #: <span className="text-[color:var(--theme-text-primary)]">{part.requestedPartNumber}</span></span> : null}
-                                        {part.manufacturer ? <span>Manufacturer: <span className="text-[color:var(--theme-text-primary)]">{part.manufacturer}</span></span> : null}
-                                        {part.supplier ?? part.vendor ? <span>Supplier: <span className="text-[color:var(--theme-text-primary)]">{part.supplier ?? part.vendor}</span></span> : null}
-                                        {pricingQuarantined ? (
-                                          <span className="font-semibold text-amber-100">Current operational pricing hidden ‚Äî it is not the finalized customer decision.</span>
-                                        ) : (
-                                          <>
-                                            <span>{partCostLabel(part)}</span>
-                                            <span>{partSellLabel(part)}</span>
-                                            {part.costLineTotal != null ? <span>Cost line: <span className="text-[color:var(--theme-text-primary)]">{fmt(part.costLineTotal)}</span></span> : null}
-                                            {part.sellLineTotal != null ? <span>Sell line: <span className="text-[color:var(--theme-text-primary)]">{fmt(part.sellLineTotal)}</span></span> : null}
-                                          </>
-                                        )}
-                                        {part.status ? <span>Status: <span className="text-[color:var(--theme-text-primary)]">{statusLabel(part.status)}</span></span> : null}
-                                      </div>
-                                      {request ? (
-                                        <a href={`/parts/requests/${request.id}`} className="mt-2 inline-flex rounded-lg border border-sky-300/35 bg-sky-400/10 px-2.5 py-1.5 text-xs font-semibold text-sky-100 hover:bg-sky-400/15">
-                                          View Parts Request ‚Äî {partsRequestLabel(line, index)}
-                                        </a>
-                                      ) : null}
-                                    </div>
-                                  );
-                                })}
-                              </div>
-                            ) : (
-                              <div className="mt-2 rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-2 text-[color:var(--theme-text-secondary)]">
-                                <div>Parts: <span className="text-[color:var(--theme-text-primary)]">None</span></div>
-                                <div>Parts Request: <span className="text-[color:var(--theme-text-primary)]">Not required</span></div>
-                              </div>
-                            )}
-                          </div>
-
-                          {sources.length > 0 ? (
-                            <div className="mt-3 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-secondary)]">
-                              Source inspection metadata: <span className="text-[color:var(--theme-text-primary)]">{sources.join(" ‚Ä¢ ")}</span>
-                            </div>
-                          ) : null}
-
-                          {photos.length > 0 ? (
-                            <div className="mt-3 flex flex-wrap gap-2">
-                              {photos.map((url) => (
-                                <a key={url} href={url} target="_blank" rel="noreferrer" className="rounded-lg border border-sky-300/35 bg-sky-400/10 px-2.5 py-1.5 text-xs font-semibold text-sky-100 hover:bg-sky-400/15">
-                                  Evidence photo
-                                </a>
-                              ))}
-                            </div>
-                          ) : null}
-
-                          <div className="mt-3 flex flex-wrap gap-2">
-                            <button type="button" disabled={commercialEditingDisabled} onClick={() => setOpenDetails((prev) => ({ ...prev, [line.id]: !prev[line.id] }))} className="desktop-btn-secondary rounded-xl px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-45">
-                              {openDetails[line.id] ? "Hide editor" : "Edit quote line"}
-                            </button>
-                            <button type="button" disabled={commercialEditingDisabled} onClick={() => markRecommendedReady(line)} className="desktop-btn-secondary rounded-xl px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-45">
-                              Recompute ready state
-                            </button>
-                            {!line.sent_to_customer_at && canSendLine(line) ? <span className="rounded-xl border border-emerald-300/35 bg-emerald-400/10 px-3 py-2 text-xs font-semibold text-emerald-100">Will send</span> : null}
-                            {!commercialEditingDisabled ? <>
-                              <button type="button" disabled={!canSendLine(line) && !isSentForDecision(line)} onClick={() => openDecisionDialog(line, "approve")} className="rounded-xl border border-emerald-300/40 bg-emerald-500/15 px-3 py-2 text-xs font-semibold text-emerald-100 disabled:opacity-45">Approve</button>
-                              <button type="button" onClick={() => openDecisionDialog(line, "defer")} className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)]">Defer</button>
-                              <button type="button" onClick={() => openDecisionDialog(line, "decline")} className="rounded-xl border border-red-400/45 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-100">Decline</button>
-                            </> : null}
-                          </div>
-
-                          {openDetails[line.id] && !commercialEditingDisabled ? (
-                            <div className="desktop-panel-soft mt-3 p-4">
-                              <div className={embedded ? "grid gap-3" : "grid gap-3 md:grid-cols-2"}>
-                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
-                                  Title / description
-                                  <input value={line.description ?? ""} onChange={(e) => patchQuoteLine(line.id, { description: e.target.value })} className={inputCls} />
-                                </label>
-                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
-                                  Complaint
-                                  <input value={line.ai_complaint ?? ""} onChange={(e) => patchQuoteLine(line.id, { ai_complaint: e.target.value })} className={inputCls} />
-                                </label>
-                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
-                                  Technician notes
-                                  <input value={techNotes} onChange={(e) => patchQuoteLineMetadata(line, { technician_notes: e.target.value })} className={inputCls} />
-                                </label>
-                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
-                                  Advisor notes
-                                  <input value={line.notes ?? ""} onChange={(e) => patchQuoteLine(line.id, { notes: e.target.value })} className={inputCls} />
-                                </label>
-                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
-                                  Labor hours
-                                  <input inputMode="decimal" value={String(laborHours)} onChange={(e) => patchQuoteLine(line.id, { labor_hours: asNumber(e.target.value) ?? 0, est_labor_hours: asNumber(e.target.value) ?? 0 })} className={inputCls} />
-                                </label>
-                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
-                                  Labor rate
-                                  <input inputMode="decimal" value={String(lineLaborRate)} onChange={(e) => patchQuoteLine(line.id, { _laborRateDraft: asNumber(e.target.value) ?? 0 })} className={inputCls} />
-                                </label>
-                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
-                                  Labor amount
-                                  <input inputMode="decimal" value={String(laborTotal)} onChange={(e) => patchQuoteLine(line.id, { labor_total: asNumber(e.target.value) ?? 0 })} className={inputCls} />
-                                </label>
-                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
-                                  Parts sell total (calculated)
-                                  <input
-                                    value={partsTotal == null ? "" : String(partsTotal)}
-                                    placeholder="Manual review required"
-                                    readOnly
-                                    aria-describedby={`parts-sell-help-${line.id}`}
-                                    className={`${inputCls} cursor-not-allowed opacity-80`}
-                                  />
-                                  <span id={`parts-sell-help-${line.id}`} className="mt-1 block text-[11px] text-[color:var(--theme-text-muted)]">
-                                    Edit each item&apos;s sell price in the linked Parts Request; Quote Review recalculates this total.
-                                  </span>
-                                </label>
-                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
-                                  Status
-                                  <select value={line.status ?? ""} onChange={(e) => patchQuoteLine(line.id, { status: e.target.value })} className={inputCls}>
-                                    <option value="pending_parts">pending parts</option>
-                                    <option value="quoted">ready / quoted</option>
-                                    <option value="sent">sent</option>
-                                  </select>
-                                </label>
-                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
-                                  Stage
-                                  <select value={line.stage ?? ""} onChange={(e) => patchQuoteLine(line.id, { stage: e.target.value })} className={inputCls}>
-                                    <option value="advisor_pending">advisor pending</option>
-                                    <option value="ready_to_send">ready to send</option>
-                                    <option value="sent">sent</option>
-                                  </select>
-                                </label>
-                              </div>
-                            </div>
-                          ) : null}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-
-            {workLines.length > 0 ? (
-              <div className={`${card} mt-4`}>
-                <div className={`border-b ${divider} ${padX} py-3 text-sm font-semibold text-[color:var(--theme-text-primary)]`}>
-                  Active approved / punchable work
-                </div>
-                <div className="divide-y divide-[color:var(--desktop-border)]">
-                  {workLines.map((line) => (
-                    <div key={line.id} className={`${padX} py-3 text-sm`}>
-                      <div className="font-semibold text-[color:var(--theme-text-primary)]">{safeTrim(line.description) || `Line ${line.line_no ?? ""}`}</div>
-                      <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">Status: {statusLabel(line.status)} ‚Ä¢ Approval: {statusLabel(line.approval_state)} ‚Ä¢ Punchable: {line.punchable ? "yes" : "no"}</div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ) : null}
-          </div>
-
-          <div className={embedded ? "" : "space-y-4"}>
-            <div className={card}>
-              <div className={`border-b ${divider} ${padX} py-3 text-sm font-semibold text-[color:var(--theme-text-primary)]`}>Quote readiness</div>
-              <div className={`${padX} py-4 text-sm text-[color:var(--theme-text-secondary)]`}>
-                <div className="flex items-center justify-between"><span>Ready to send</span><span className="font-semibold text-[color:var(--theme-text-primary)]">{quoteTotals.sendable}</span></div>
-                <div className="mt-2 flex items-center justify-between"><span>Pending parts</span><span className="font-semibold text-[color:var(--theme-text-primary)]">{quoteTotals.pendingParts}</span></div>
-                <div className="mt-2 flex items-center justify-between"><span>Sent</span><span className="font-semibold text-[color:var(--theme-text-primary)]">{quoteTotals.sent}</span></div>
-                <div className={`mt-3 flex items-center justify-between border-t ${divider} pt-3`}><span>Labor</span><span className="font-medium text-[color:var(--theme-text-primary)]">{fmt(quoteTotals.labor)}</span></div>
-                <div className="mt-2 flex items-center justify-between"><span>{quoteTotals.partsPricingQuarantined ? "Parts (protected)" : "Parts"}</span><span className="font-medium text-[color:var(--theme-text-primary)]">{quoteTotals.partsTotalUnavailable ? "Manual review" : fmt(quoteTotals.parts)}</span></div>
-                {quoteTotals.partsPricingQuarantined ? <div className="mt-1 text-xs text-amber-100">Protected finalized totals are retained; quarantined item pricing is excluded.</div> : null}
-                <div className="mt-2 flex items-center justify-between"><span>Shop supplies</span><span className="font-medium text-[color:var(--theme-text-primary)]">{fmt(quoteTotals.shopSupplies.amount)}</span></div>
-                <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">{shopSuppliesSummaryText(quoteTotals.shopSupplies)}</div>
-                <div className={`mt-3 flex items-center justify-between border-t ${divider} pt-3`}><span className="font-semibold text-[color:var(--theme-text-primary)]">Grand total</span><span className="text-lg font-bold" style={{ color: COPPER }}>{quoteTotals.grandTotalUnavailable ? "Manual review" : fmt(quoteTotals.total)}</span></div>
-                <div className={`mt-4 border-t ${divider} pt-3`}>
-                  <div className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">Shop supplies override</div>
-                  <select
-                    value={suppliesEnabledDraft == null ? "default" : suppliesEnabledDraft ? "on" : "off"}
-                    onChange={(e) => setSuppliesEnabledDraft(e.target.value === "default" ? null : e.target.value === "on")}
-                    className="mt-2 w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none"
-                  >
-                    <option value="default">Use shop default</option>
-                    <option value="on">Include shop supplies</option>
-                    <option value="off">Remove shop supplies</option>
-                  </select>
-                  <input
-                    value={suppliesAmountDraft}
-                    onChange={(e) => setSuppliesAmountDraft(e.target.value)}
-                    placeholder="Optional fixed override amount"
-                    className="mt-2 w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)]"
-                  />
-                  <div className="mt-2 grid grid-cols-2 gap-2">
-                    <button type="button" onClick={() => void saveSuppliesOverride()} disabled={savingSuppliesOverride} className="desktop-btn-secondary rounded-lg px-3 py-2 text-xs font-semibold disabled:opacity-60">
-                      {savingSuppliesOverride ? "Saving‚Ä¶" : "Save override"}
-                    </button>
-                    <button type="button" onClick={resetSuppliesOverride} className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-subtle)]">Reset draft</button>
-                  </div>
-                </div>
-                <button onClick={() => void saveAllDirty()} disabled={saving} className="desktop-btn-primary mt-4 w-full rounded-xl px-4 py-2 text-sm font-semibold disabled:opacity-60">
-                  {saving ? "Saving‚Ä¶" : "Save changes"}
-                </button>
-              </div>
-            </div>
-
-            <div className={card}>
-              <div className={`border-b ${divider} ${padX} py-3 text-sm font-semibold text-[color:var(--theme-text-primary)]`}>Send to customer</div>
-              <div className={`${padX} py-4 text-sm text-[color:var(--theme-text-secondary)]`}>
-                Sends only canonical work_order_quote_lines that are ready to send. Pending parts, declined, deferred, approved, and converted lines are not sent.
-                {quoteTotals.sendable === 0 ? (
-                  <div className="mt-3 rounded-xl border border-amber-300/35 bg-amber-400/10 p-3 text-amber-100">No ready canonical quote lines are available to send.</div>
-                ) : null}
-                {missingCustomerEmail || sendBlocker ? (
-                  <div className="mt-3 rounded-xl border border-sky-400/35 bg-sky-500/10 p-3">
-                    <div className="text-xs font-semibold uppercase tracking-[0.14em] text-sky-100">Blocked</div>
-                    <div className="mt-1 text-sm font-semibold text-sky-100">{sendBlocker ?? "Customer email required to send quote"}</div>
-                    <div className="mt-2 flex flex-col gap-2 sm:flex-row">
-                      <input type="email" value={pendingCustomerEmail} onChange={(e) => setPendingCustomerEmail(e.target.value)} placeholder="customer@email.com" className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)] focus:border-sky-300/70" />
-                      <button type="button" onClick={() => void saveCustomerEmailInline()} disabled={savingCustomerEmail} className="rounded-lg border border-amber-300/45 bg-amber-400/15 px-3 py-2 text-sm font-semibold text-sky-100 hover:bg-amber-400/20 disabled:opacity-60">
-                        {savingCustomerEmail ? "Saving‚Ä¶" : "Save email"}
-                      </button>
-                    </div>
-                  </div>
-                ) : null}
-                <button onClick={() => void sendQuoteToCustomer(false)} disabled={sending || savingCustomerEmail || quoteTotals.sendable === 0} className="desktop-btn-secondary mt-3 w-full rounded-xl px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-60">
-                  {sending ? "Sending‚Ä¶" : "Send ready quote lines"}
-                </button>
-                {quoteTotals.sent > 0 ? (
-                  <button onClick={() => void sendQuoteToCustomer(true)} disabled={sending || savingCustomerEmail || missingCustomerEmail} className="desktop-btn-secondary mt-2 w-full rounded-xl px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-60">
-                    {sending ? "Sending‚Ä¶" : "Resend quote"}
-                  </button>
-                ) : null}
-                <div className="mt-3 text-xs text-[color:var(--theme-text-muted)]">Portal link will be: <span className="text-[color:var(--theme-text-secondary)]">/portal/quotes/{woId}</span></div>
-                <div className="mt-2 text-xs text-[color:var(--theme-text-muted)]">Customer portal decisions and shop-recorded phone decisions use the same canonical approval lifecycle.</div>
-              </div>
-            </div>
-
-            <div className={card}>
-              <div className={`border-b ${divider} ${padX} py-3 text-sm font-semibold text-[color:var(--theme-text-primary)]`}>Quick add job</div>
-              <div className={`${padX} py-4 text-sm text-[color:var(--theme-text-secondary)]`}>
-                Add active work only when intentionally needed. Inspection recommendations should stay in canonical quote lines until customer approval/materialization.
-                <button type="button" onClick={openAddJobWithPrefill} className="desktop-btn-primary mt-3 w-full rounded-xl px-4 py-2 text-sm font-semibold">+ Add job line</button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {!embedded && <div className="mt-6 text-xs text-[color:var(--theme-text-muted)]">Work Order ID: {wo.id} ‚Ä¢ Status: {statusLabel(wo.status)}</div>}
-
-        {decisionDialog ? (
-          <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/65 p-4" role="dialog" aria-modal="true" aria-labelledby="shop-decision-title">
-            <div className="w-full max-w-lg rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-overlay)] p-5 shadow-2xl">
-              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">Classic shop approval</div>
-              <h2 id="shop-decision-title" className="mt-2 text-lg font-semibold text-[color:var(--theme-text-primary)]">Record {statusLabel(decisionDialog.decision)} ‚Äî {safeTrim(decisionDialog.line.description) || "quote line"}</h2>
-              <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">Use this after confirming the customer&apos;s decision outside the portal. The advisor, contact method, time, and note are retained with the quote.</p>
-              <label className="mt-4 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
-                Customer contact method
-                <select value={decisionContact} onChange={(event) => setDecisionContact(event.target.value as ContactMethod)} className={inputCls}>
-                  <option value="phone">Phone call</option><option value="in_person">In person</option><option value="email">Email</option><option value="other">Other</option>
-                </select>
-              </label>
-              <label className="mt-3 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
-                Advisor note (optional)
-                <textarea value={decisionNote} onChange={(event) => setDecisionNote(event.target.value.slice(0, 1000))} rows={3} placeholder="Example: Approved by phone with Jamie at 2:15 PM." className={inputCls} />
-              </label>
-              <div className="mt-5 flex flex-wrap justify-end gap-2">
-                <button type="button" disabled={decisionSaving} onClick={() => setDecisionDialog(null)} className="desktop-btn-secondary rounded-xl px-4 py-2 text-sm font-semibold disabled:opacity-50">Cancel</button>
-                <button type="button" disabled={decisionSaving} onClick={() => void confirmShopDecision()} className={decisionDialog.decision === "decline" ? "rounded-xl border border-red-400/45 bg-red-500/15 px-4 py-2 text-sm font-semibold text-red-100 disabled:opacity-50" : "desktop-btn-primary rounded-xl px-4 py-2 text-sm font-semibold disabled:opacity-50"}>{decisionSaving ? "Recording‚Ä¶" : `Confirm ${statusLabel(decisionDialog.decision)}`}</button>
-              </div>
-            </div>
-          </div>
-        ) : null}
-
-        <AddJobModal
-          isOpen={addJobOpen}
-          onClose={() => setAddJobOpen(false)}
-          workOrderId={wo.id}
-          vehicleId={wo.vehicle_id}
-          shopId={wo.shop_id}
-          techId={currentUserId}
-          onJobAdded={() => {
-            setAddJobOpen(false);
-            void reload();
-          }}
-        />
-      </div>
-    </div>
-  );
-}
+N¬à_BàœÇàŸ]èÇàŸ]èÇà
+N¬üB

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -787,116 +787,698 @@ export default function QuoteReviewView(props: {
     setSaving(true);
     try {
       for (const line of dirty) {
-        const laborHoÛ≠ª∂âûÀk∫wµÁ[èè‹‹[èààù[Bà‹\ùú›\Y\àœ»\ùùô[ô‹à»‹[èî›\Y\éà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹\ùú›\Y\àœ»\ùùô[ô‹üO‹‹[èè‹‹[èààù[Bà‹öX⁄[ô‘]X\ò[ù[ôY»
-à‹[à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^X[Xô\ãLLèê›\úô[ù‹\ò][€ò[öX⁄[ô»Y[à8†%]\»õ›Hö[ò[^ôY›\›€Y\àX⁄\⁄[€ãè‹‹[èÇà
-Hà
-àÇà‹[èû‹\ù€‹›Xô[
-\ù
-_O‹‹[èÇà‹[èû‹\ùŸ[Xô[
-\ù
-_O‹‹[èÇà‹\ùò€‹›[ôU›[OHù[»‹[èê€‹›[ôNà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèûŸõ]
-\ùò€‹›[ôU›[
-_O‹‹[èè‹‹[èààù[Bà‹\ùúŸ[[ôU›[OHù[»‹[èîŸ[[ôNà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèûŸõ]
-\ùúŸ[[ôU›[
-_O‹‹[èè‹‹[èààù[BàœÇà
-_Bà‹\ùú›]\»»‹[èî›]\Œà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹›]\”Xô[
-\ùú›]\ _O‹‹[èè‹‹[èààù[BàŸ]èÇà‹ô\]Y\›»
-àHôYè^ÿ‹\ùÀ‹ô\]Y\›À…‹ô\]Y\›öYXH€\‹”ò[YOHõ]Là[õ[ôKYõ^õ›[ôY[»õ‹ô\àõ‹ô\ã\⁄ﬁKLÃÃÕHôÀ\⁄ﬁKMÃLLãçHKLKçH^^»õ€ù\Ÿ[ZXõ€^\⁄ﬁKLL›ô\éòôÀ\⁄ﬁKMÃMHèÇàöY]»\ù»ô\]Y\›8†%‹\ù‘ô\]Y\›Xô[
-[ôK[ô^
-_BàÿOÇà
-Hàù[BàŸ]èÇà
-N¬àJ_BàŸ]èÇà
-Hà
-à]à€\‹”ò[YOHõ]Làõ›[ôY[»õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äK][YK\›\ôòXŸKZ[úŸ]
-WHLà^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà]èî\ùŒà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèìõ€ôO‹‹[èèŸ]èÇà]èî\ù»ô\]Y\›à‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèìõ›ô\]Z\ôY‹‹[èèŸ]èÇàŸ]èÇà
-_BàŸ]èÇÇà‹€›\òŸ\Àõ[ô›à»
-à]à€\‹”ò[YOHõ]L»õ›[ôY^õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äK][YK\›\ôòXŸKZ[úŸ]
-WHL»^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà€›\òŸH[ú‹X›[€àY]Y]Nà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹€›\òŸ\Àöõ⁄[äà8†(àä_O‹‹[èÇàŸ]èÇà
-Hàù[BÇà‹›‹Àõ[ô›à»
-à]à€\‹”ò[YOHõ]L»õ^õ^]‹ò\ÿ\LàèÇà‹›‹ÀõX\
+        const laborHours = quoteLineLaborHours(line);
+        const laborTotal = quoteLineLaborTotal(line, laborRate);
+        const partsTotal = quoteLinePartsTotal(line);
+        if (partsTotal == null) {
+          toast.error(
+            "This protected quote needs manual pricing review and cannot be recalculated as $0.",
+          );
+          return false;
+        }
+        const subtotal = laborTotal + partsTotal;
+        const metadata = {
+          ...quoteMetadata(line),
+          labor_rate: quoteLineLaborRate(line, laborRate),
+        } as Json;
 
-\õ
-HOà
-àHŸ^O^›\õHôYè^›\õH\ôŸ]Hóÿõ[ö»àô[Hõõ‹ôYô\úô\àà€\‹”ò[YOHúõ›[ôY[»õ‹ô\àõ‹ô\ã\⁄ﬁKLÃÃÕHôÀ\⁄ﬁKMÃLLãçHKLKçH^^»õ€ù\Ÿ[ZXõ€^\⁄ﬁKLL›ô\éòôÀ\⁄ﬁKMÃMHèÇà]öY[òŸH›¬àÿOÇà
-J_BàŸ]èÇà
-Hàù[BÇà]à€\‹”ò[YOHõ]L»õ^õ^]‹ò\ÿ\LàèÇàù]€à\OHòù]€àà\ÿXõY^ÿ€€[Y\ò⁄X[Y][ô—\ÿXõYH€ê€X⁄œ^ 
-HOàŸ]‹[ë]Z[ 
-ô]äHOà
-»ããúô]ã€[ôKöYNà\ô]ñ€[ôKöYHJJ_H€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûHõ›[ôY^L»KLà^^»õ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH\ÿXõYõ‹X⁄]KMHèÇà€‹[ë]Z[÷€[ôKöYH»íYHY]‹àààëY]][›H[ôHüBàÿù]€èÇàù]€à\OHòù]€àà\ÿXõY^ÿ€€[Y\ò⁄X[Y][ô—\ÿXõYH€ê€X⁄œ^ 
-HOàX\ö‘ôX€€[Y[ôYôXYJ[ôJ_H€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûHõ›[ôY^L»KLà^^»õ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH\ÿXõYõ‹X⁄]KMHèÇàôX€€\]HôXYH›]Bàÿù]€èÇà»[[ôKúŸ[ù›◊ÿ›\›€Y\óÿ]	âàÿ[îŸ[ô[ôJ[ôJH»‹[à€\‹”ò[YOHúõ›[ôY^õ‹ô\àõ‹ô\ãY[Y\ò[LÃÃÕHôÀY[Y\ò[MÃLL»KLà^^»õ€ù\Ÿ[ZXõ€^Y[Y\ò[LLèï⁄[Ÿ[ô‹‹[èààù[Bà»X€€[Y\ò⁄X[Y][ô—\ÿXõY»Çàù]€à\OHòù]€àà\ÿXõY^»Xÿ[îŸ[ô[ôJ[ôJH	âàZ\‘Ÿ[ùõ‹ëX⁄\⁄[€ä[ôJ_H€ê€X⁄œ^ 
-HOà‹[ëX⁄\⁄[€ëX[Ÿ [ôKò\õ›ôHä_H€\‹”ò[YOHúõ›[ôY^õ‹ô\àõ‹ô\ãY[Y\ò[LÃÕôÀY[Y\ò[MLÃMHL»KLà^^»õ€ù\Ÿ[ZXõ€^Y[Y\ò[LL\ÿXõYõ‹X⁄]KMHèê\õ›ôOÿù]€èÇàù]€à\OHòù]€àà€ê€X⁄œ^ 
-HOà‹[ëX⁄\⁄[€ëX[Ÿ [ôKôYô\àä_H€\‹”ò[YOHúõ›[ôY^õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äK][YKXõ‹ô\ã\€Ÿù
-WHôÀVÿ€€‹éùò\äK][YK\›\ôòXŸK\›XùJWHL»KLà^^»õ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèëYô\èÿù]€èÇàù]€à\OHòù]€àà€ê€X⁄œ^ 
-HOà‹[ëX⁄\⁄[€ëX[Ÿ [ôKôX€[ôHä_H€\‹”ò[YOHúõ›[ôY^õ‹ô\àõ‹ô\ã\ôYMÕHôÀ\ôYMLÃLL»KLà^^»õ€ù\Ÿ[ZXõ€^\ôYLLèëX€[ôOÿù]€èÇàœààù[BàŸ]èÇÇà€‹[ë]Z[÷€[ôKöYH	âàX€€[Y\ò⁄X[Y][ô—\ÿXõY»
-à]à€\‹”ò[YOHô\⁄›‹\[ô[\€Ÿù]L»MèÇà]à€\‹”ò[YO^Ÿ[XôYY»ô‹öYÿ\L»ààô‹öYÿ\L»Yô‹öYX€€ÀLàüOÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà]H»\ÿ‹ö\[€Çà[ú]ò[YO^€[ôKô\ÿ‹ö\[€àœ»àüH€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»\ÿ‹ö\[€éàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà€€\Z[ùà[ú]ò[YO^€[ôKòZWÿ€€\Z[ùœ»àüH€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»ZWÿ€€\Z[ùàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàX⁄öX⁄X[àõ›\¬à[ú]ò[YO^›X⁄õ›\ﬂH€ê⁄[ôŸO^ JHOà]⁄][›S[ôSY]Y]J[ôK»X⁄öX⁄X[ó€õ›\ŒàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàYö\€‹àõ›\¬à[ú]ò[YO^€[ôKõõ›\»œ»àüH€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»õ›\ŒàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàXõ‹à›\ú¬à[ú][ú][ŸOHôX⁄[X[àò[YO^‘›ö[ô Xõ‹í›\ú _H€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»Xõ‹ó⁄›\úŒà\”ù[Xô\äKù\ôŸ]ùò[YJHœ»\›€Xõ‹ó⁄›\úŒà\”ù[Xô\äKù\ôŸ]ùò[YJHœ»J_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàXõ‹àò]Bà[ú][ú][ŸOHôX⁄[X[àò[YO^‘›ö[ô [ôSXõ‹îò]J_H€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»€Xõ‹îò]QòYùà\”ù[Xô\äKù\ôŸ]ùò[YJHœ»J_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàXõ‹à[[›[ùà[ú][ú][ŸOHôX⁄[X[àò[YO^‘›ö[ô Xõ‹ï›[
-_H€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»Xõ‹ó››[à\”ù[Xô\äKù\ôŸ]ùò[YJHœ»J_H€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà\ù»Ÿ[›[
-ÿ[›[]Y
-Bà[ú]àò[YO^‹\ù’›[OHù[»ààà›ö[ô \ù’›[
-_BàXŸZ€\èHìX[ùX[ô]öY]»ô\]Z\ôYÇàôXY€õBà\öXKY\ÿ‹öXôYûO^ÿ\ùÀ\Ÿ[Z[I€[ôKöYXBà€\‹”ò[YO^ÿ	⁄[ú]€ﬂH›\ú€‹ã[õ›X[›ŸY‹X⁄]KNBàœÇà‹[àY^ÿ\ùÀ\Ÿ[Z[I€[ôKöYXH€\‹”ò[YOHõ]LHõÿ⁄»^VÃL\H^Vÿ€€‹éùò\äK][YK]^[]]Y
-WHèÇàY]XX⁄][Iò\‹Œ‹»Ÿ[öXŸH[àH[öŸY\ù»ô\]Y\›»][›Hô]öY]»ôXÿ[›[]\»\»›[Çà‹‹[èÇà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà›]\¬àŸ[X›ò[YO^€[ôKú›]\»œ»àüH€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»›]\ŒàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂOÇà‹[€àò[YOHú[ô[ô◊‹\ù»èú[ô[ô»\ùœ€‹[€èÇà‹[€àò[YOHú][›YèúôXYH»][›Y€‹[€èÇà‹[€àò[YOHúŸ[ùèúŸ[ù€‹[€èÇà‹Ÿ[X›Çà€Xô[ÇàXô[€\‹”ò[YOHù^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà›YŸBàŸ[X›ò[YO^€[ôKú›YŸHœ»àüH€ê⁄[ôŸO^ JHOà]⁄][›S[ôJ[ôKöY»›YŸNàKù\ôŸ]ùò[YHJ_H€\‹”ò[YO^⁄[ú]€ﬂOÇà‹[€àò[YOHòYö\€‹ó‹[ô[ô»èòYö\€‹à[ô[ôœ€‹[€èÇà‹[€àò[YOHúôXYW›◊‹Ÿ[ôèúôXYH»Ÿ[ô€‹[€èÇà‹[€àò[YOHúŸ[ùèúŸ[ù€‹[€èÇà‹Ÿ[X›Çà€Xô[ÇàŸ]èÇàŸ]èÇà
-Hàù[BàŸ]èÇàŸ]èÇà
-N¬àJ_BàŸ]èÇà
-_BàŸ]èÇÇà›€‹ö”[ô\Àõ[ô›à»
-à]à€\‹”ò[YO^ÿ	ÿÿ\ôH]MOÇà]à€\‹”ò[YO^ÿõ‹ô\ãXà	Ÿ]öY\üH	‹YHKL»^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWXOÇàX›]ôH\õ›ôY»[ò⁄XõH€‹ö¬àŸ]èÇà]à€\‹”ò[YOHô]öYK^H]öYKVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHèÇà›€‹ö”[ô\ÀõX\
+        const patch: QuoteLineUpdate = {
+          description: line.description,
+          ai_complaint: line.ai_complaint,
+          ai_cause: line.ai_cause,
+          ai_correction: line.ai_correction,
+          notes: line.notes,
+          est_labor_hours: line.est_labor_hours,
+          labor_hours: laborHours,
+          labor_rate: quoteLineLaborRate(line, laborRate),
+          labor_total: laborTotal,
+          parts_total: partsTotal,
+          subtotal,
+          grand_total: subtotal,
+          status: line.status,
+          stage: line.stage,
+          metadata,
+          updated_at: new Date().toISOString(),
+        };
 
-[ôJHOà
-à]àŸ^O^€[ôKöYH€\‹”ò[YO^ÿ	‹YHKL»^\€XOÇà]à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹ÿYôUö[J[ôKô\ÿ‹ö\[€äH[ôH	€[ôKõ[ôW€õ»œ»àüXOŸ]èÇà]à€\‹”ò[YOHõ]LH^^»^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèî›]\Œà‹›]\”Xô[
-[ôKú›]\ _H8†(à\õ›ò[à‹›]\”Xô[
-[ôKò\õ›ò[‹›]J_H8†(à[ò⁄XõNà€[ôKú[ò⁄XõH»ûY\»ààõõ»üOŸ]èÇàŸ]èÇà
-J_BàŸ]èÇàŸ]èÇà
-Hàù[BàŸ]èÇÇà]à€\‹”ò[YO^Ÿ[XôYY»àààú‹XŸK^KMüOÇà]à€\‹”ò[YO^ÿÿ\ôOÇà]à€\‹”ò[YO^ÿõ‹ô\ãXà	Ÿ]öY\üH	‹YHKL»^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWXOî][›HôXY[ô\‹œŸ]èÇà]à€\‹”ò[YO^ÿ	‹YHKM^\€H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWXOÇà]à€\‹”ò[YOHôõ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àèè‹[èîôXYH»Ÿ[ô‹‹[èè‹[à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹][›U›[ÀúŸ[ôXõ_O‹‹[èèŸ]èÇà]à€\‹”ò[YOHõ]Làõ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àèè‹[èî[ô[ô»\ùœ‹‹[èè‹[à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹][›U›[Àú[ô[ô‘\ùﬂO‹‹[èèŸ]èÇà]à€\‹”ò[YOHõ]Làõ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àèè‹[èîŸ[ù‹‹[èè‹[à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹][›U›[ÀúŸ[ùO‹‹[èèŸ]èÇà]à€\‹”ò[YO^ÿ]L»õ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àõ‹ô\ã]	Ÿ]öY\üHLÿOè‹[èìXõ‹è‹‹[èè‹[à€\‹”ò[YOHôõ€ù[YY][H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèûŸõ]
-][›U›[ÀõXõ‹ä_O‹‹[èèŸ]èÇà]à€\‹”ò[YOHõ]Làõ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àèè‹[èû‹][›U›[Àú\ù‘öX⁄[ô‘]X\ò[ù[ôY»î\ù»
-õ›X›Y
-Hààî\ù»üO‹‹[èè‹[à€\‹”ò[YOHôõ€ù[YY][H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèû‹][›U›[Àú\ù’›[[ò]òZ[XõH»ìX[ùX[ô]öY]»ààõ]
-][›U›[Àú\ù _O‹‹[èèŸ]èÇà‹][›U›[Àú\ù‘öX⁄[ô‘]X\ò[ù[ôY»]à€\‹”ò[YOHõ]LH^^»^X[Xô\ãLLèîõ›X›Yö[ò[^ôY›[»\ôHô]Z[ôY»]X\ò[ù[ôY][HöX⁄[ô»\»^€YYèŸ]èààù[Bà]à€\‹”ò[YOHõ]Làõ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àèè‹[èî⁄‹›\Y\œ‹‹[èè‹[à€\‹”ò[YOHôõ€ù[YY][H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèûŸõ]
-][›U›[Àú⁄‹›\Y\Àò[[›[ù
-_O‹‹[èèŸ]èÇà]à€\‹”ò[YOHõ]LH^^»^Vÿ€€‹éùò\äK][YK]^[]]Y
-WHèû‹⁄‹›\Y\‘›[[X\ûU^
-][›U›[Àú⁄‹›\Y\ _OŸ]èÇà]à€\‹”ò[YO^ÿ]L»õ^][\ÀXŸ[ù\àù\›YûKXô]ŸY[àõ‹ô\ã]	Ÿ]öY\üHLÿOè‹[à€\‹”ò[YOHôõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèë‹ò[ô›[‹‹[èè‹[à€\‹”ò[YOHù^[»õ€ùXõ€à›[O^ﬁ»€€‹éà”‘Tà_Oû‹][›U›[Àô‹ò[ô›[[ò]òZ[XõH»ìX[ùX[ô]öY]»ààõ]
-][›U›[Àù›[
-_O‹‹[èèŸ]èÇà]à€\‹”ò[YO^ÿ]Mõ‹ô\ã]	Ÿ]öY\üHLÿOÇà]à€\‹”ò[YOHù^^»õ€ù\Ÿ[ZXõ€\\òÿ\ŸHòX⁄⁄[ôÀVÃåM[WH^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèî⁄‹›\Y\»›ô\úöYOŸ]èÇàŸ[X›àò[YO^‹›\Y\—[òXõYòYùOHù[»ôYò][àà›\Y\—[òXõYòYù»õ€àààõŸôàüBà€ê⁄[ôŸO^ JHOàŸ]›\Y\—[òXõYòYù
-Kù\ôŸ]ùò[YHOOHôYò][à»ù[àKù\ôŸ]ùò[YHOOHõ€àä_Bà€\‹”ò[YOHõ]LàÀYù[õ›[ôY[»õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äKY\⁄›‹Z][KXô WHL»KLà^\€H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH›][ôK[õ€ôHÇàÇà‹[€àò[YOHôYò][èï\ŸH⁄‹Yò][€‹[€èÇà‹[€àò[YOHõ€àèí[ò€YH⁄‹›\Y\œ€‹[€èÇà‹[€àò[YOHõŸôàèîô[[›ôH⁄‹›\Y\œ€‹[€èÇà‹Ÿ[X›Çà[ú]àò[YO^‹›\Y\–[[›[ùòYùBà€ê⁄[ôŸO^ JHOàŸ]›\Y\–[[›[ùòYù
-Kù\ôŸ]ùò[YJ_BàXŸZ€\èHì‹[€ò[ö^Y›ô\úöYH[[›[ùÇà€\‹”ò[YOHõ]LàÀYù[õ›[ôY[»õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äKY\⁄›‹Z][KXô WHL»KLà^\€H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH›][ôK[õ€ôHXŸZ€\éù^Vÿ€€‹éùò\äK][YK]^[]]Y
-WHÇàœÇà]à€\‹”ò[YOHõ]Là‹öY‹öYX€€ÀLàÿ\LàèÇàù]€à\OHòù]€àà€ê€X⁄œ^ 
-HOàõ⁄Yÿ]ôT›\Y\”›ô\úöYJ
-_H\ÿXõY^‹ÿ]ö[ô‘›\Y\”›ô\úöY_H€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûHõ›[ôY[»L»KLà^^»õ€ù\Ÿ[ZXõ€\ÿXõYõ‹X⁄]KMåèÇà‹ÿ]ö[ô‘›\Y\”›ô\úöYH»îÿ]ö[ô¯†)àààîÿ]ôH›ô\úöYHüBàÿù]€èÇàù]€à\OHòù]€àà€ê€X⁄œ^‹ô\Ÿ]›\Y\”›ô\úöY_H€\‹”ò[YOHúõ›[ôY[»õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äK][YKXõ‹ô\ã\€Ÿù
-WHôÀVÿ€€‹éùò\äK][YK\›\ôòXŸK\›XùJWHL»KLà^^»õ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH›ô\éòôÀVÿ€€‹éùò\äK][YK\›\ôòXŸK\›XùJWHèîô\Ÿ]òYùÿù]€èÇàŸ]èÇàŸ]èÇàù]€à€ê€X⁄œ^ 
-HOàõ⁄Yÿ]ôP[\ùJ
-_H\ÿXõY^‹ÿ]ö[ôﬂH€\‹”ò[YOHô\⁄›‹Xùã\ö[X\ûH]MÀYù[õ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€\ÿXõYõ‹X⁄]KMåèÇà‹ÿ]ö[ô»»îÿ]ö[ô¯†)àààîÿ]ôH⁄[ôŸ\»üBàÿù]€èÇàŸ]èÇàŸ]èÇÇà]à€\‹”ò[YO^ÿÿ\ôOÇà]à€\‹”ò[YO^ÿõ‹ô\ãXà	Ÿ]öY\üH	‹YHKL»^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWXOîŸ[ô»›\›€Y\èŸ]èÇà]à€\‹”ò[YO^ÿ	‹YHKM^\€H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWXOÇàŸ[ô»€õHÿ[õ€öXÿ[€‹ö◊€‹ô\ó‹][›W€[ô\»]\ôHôXYH»Ÿ[ôà[ô[ô»\ùÀX€[ôYYô\úôY\õ›ôY[ô€€ùô\ùY[ô\»\ôHõ›Ÿ[ùÇà‹][›U›[ÀúŸ[ôXõHOOH»
-à]à€\‹”ò[YOHõ]L»õ›[ôY^õ‹ô\àõ‹ô\ãX[Xô\ãLÃÃÕHôÀX[Xô\ãMÃLL»^X[Xô\ãLLèìõ»ôXYHÿ[õ€öXÿ[][›H[ô\»\ôH]òZ[XõH»Ÿ[ôèŸ]èÇà
-Hàù[Bà€Z\‹⁄[ô–›\›€Y\ë[XZ[Ÿ[ôõÿ⁄Ÿ\à»
-à]à€\‹”ò[YOHõ]L»õ›[ôY^õ‹ô\àõ‹ô\ã\⁄ﬁKMÃÕHôÀ\⁄ﬁKMLÃLL»èÇà]à€\‹”ò[YOHù^^»õ€ù\Ÿ[ZXõ€\\òÿ\ŸHòX⁄⁄[ôÀVÃåM[WH^\⁄ﬁKLLèêõÿ⁄ŸYŸ]èÇà]à€\‹”ò[YOHõ]LH^\€Hõ€ù\Ÿ[ZXõ€^\⁄ﬁKLLèû‹Ÿ[ôõÿ⁄Ÿ\àœ»ê›\›€Y\à[XZ[ô\]Z\ôY»Ÿ[ô][›HüOŸ]èÇà]à€\‹”ò[YOHõ]Làõ^õ^X€€ÿ\Là€Nôõ^\õ›»èÇà[ú]\OHô[XZ[àò[YO^‹[ô[ô–›\›€Y\ë[XZ[H€ê⁄[ôŸO^ JHOàŸ][ô[ô–›\›€Y\ë[XZ[
-Kù\ôŸ]ùò[YJ_HXŸZ€\èHò›\›€Y\ê[XZ[ò€€Hà€\‹”ò[YOHùÀYù[õ›[ôY[»õ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äKY\⁄›‹Z][KXô WHL»KLà^\€H^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH›][ôK[õ€ôHXŸZ€\éù^Vÿ€€‹éùò\äK][YK]^[]]Y
-WHõÿ›\Œòõ‹ô\ã\⁄ﬁKLÃÕÃàœÇàù]€à\OHòù]€àà€ê€X⁄œ^ 
-HOàõ⁄Yÿ]ôP›\›€Y\ë[XZ[[õ[ôJ
-_H\ÿXõY^‹ÿ]ö[ô–›\›€Y\ë[XZ[H€\‹”ò[YOHúõ›[ôY[»õ‹ô\àõ‹ô\ãX[Xô\ãLÃÕHôÀX[Xô\ãMÃMHL»KLà^\€Hõ€ù\Ÿ[ZXõ€^\⁄ﬁKLL›ô\éòôÀX[Xô\ãMÃå\ÿXõYõ‹X⁄]KMåèÇà‹ÿ]ö[ô–›\›€Y\ë[XZ[»îÿ]ö[ô¯†)àààîÿ]ôH[XZ[üBàÿù]€èÇàŸ]èÇàŸ]èÇà
-Hàù[Bàù]€à€ê€X⁄œ^ 
-HOàõ⁄YŸ[ô][›U–›\›€Y\äò[ŸJ_H\ÿXõY^‹Ÿ[ô[ô»ÿ]ö[ô–›\›€Y\ë[XZ[][›U›[ÀúŸ[ôXõHOOHH€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûH]L»ÀYù[õ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH\ÿXõYõ‹X⁄]KMåèÇà‹Ÿ[ô[ô»»îŸ[ô[ô¯†)àààîŸ[ôôXYH][›H[ô\»üBàÿù]€èÇà‹][›U›[ÀúŸ[ùà»
-àù]€à€ê€X⁄œ^ 
-HOàõ⁄YŸ[ô][›U–›\›€Y\äùYJ_H\ÿXõY^‹Ÿ[ô[ô»ÿ]ö[ô–›\›€Y\ë[XZ[Z\‹⁄[ô–›\›€Y\ë[XZ[H€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûH]LàÀYù[õ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWH\ÿXõYõ‹X⁄]KMåèÇà‹Ÿ[ô[ô»»îŸ[ô[ô¯†)àààîô\Ÿ[ô][›HüBàÿù]€èÇà
-Hàù[Bà]à€\‹”ò[YOHõ]L»^^»^Vÿ€€‹éùò\äK][YK]^[]]Y
-WHèî‹ù[[ö»⁄[ôNà‹[à€\‹”ò[YOHù^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèã‹‹ù[‹][›\Àﬁ›€“YO‹‹[èèŸ]èÇà]à€\‹”ò[YOHõ]Là^^»^Vÿ€€‹éùò\äK][YK]^[]]Y
-WHèê›\›€Y\à‹ù[X⁄\⁄[€ú»[ô⁄‹\ôX€‹ôY€ôHX⁄\⁄[€ú»\ŸHHÿ[YHÿ[õ€öXÿ[\õ›ò[YôXﬁX€KèŸ]èÇàŸ]èÇàŸ]èÇÇà]à€\‹”ò[YO^ÿÿ\ôOÇà]à€\‹”ò[YO^ÿõ‹ô\ãXà	Ÿ]öY\üH	‹YHKL»^\€Hõ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWXOî]ZX⁄»YõÿèŸ]èÇà]à€\‹”ò[YO^ÿ	‹YHKM^\€H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWXOÇàYX›]ôH€‹ö»€õH⁄[à[ù[ù[€ò[HôYYYà[ú‹X›[€àôX€€[Y[ô][€ú»⁄›[›^H[àÿ[õ€öXÿ[][›H[ô\»[ù[›\›€Y\à\õ›ò[€X]\öX[^ò][€ãÇàù]€à\OHòù]€àà€ê€X⁄œ^€‹[êYõÿï⁄]ôYö[H€\‹”ò[YOHô\⁄›‹Xùã\ö[X\ûH]L»ÀYù[õ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€èä»Yõÿà[ôOÿù]€èÇàŸ]èÇàŸ]èÇàŸ]èÇàŸ]èÇÇà»Y[XôYY	âà]à€\‹”ò[YOHõ]Mà^^»^Vÿ€€‹éùò\äK][YK]^[]]Y
-WHèï€‹ö»‹ô\àQà›€ÀöYH8†(à›]\Œà‹›]\”Xô[
-€Àú›]\ _OŸ]èüBÇàŸX⁄\⁄[€ëX[Ÿ»»
-à]à€\‹”ò[YOHôö^Y[úŸ]LãVÃLHõ^][\ÀXŸ[ù\àù\›YûKXŸ[ù\àôÀXõX⁄ÀÕçHMàõ€OHôX[Ÿ»à\öXK[[Ÿ[HùùYHà\öXK[Xô[YûOHú⁄‹YX⁄\⁄[€ã]]HèÇà]à€\‹”ò[YOHùÀYù[X^]À[»õ›[ôYLûõ‹ô\àõ‹ô\ãVÿ€€‹éùò\äKY\⁄›‹Xõ‹ô\äWHôÀVÿ€€‹éùò\äK][YK\›\ôòXŸK[›ô\õ^JWHMH⁄Y›ÀLûèÇà]à€\‹”ò[YOHù^^»õ€ù\Ÿ[ZXõ€\\òÿ\ŸHòX⁄⁄[ôÀVÃåN[WH^Vÿ€€‹éùò\äK][YK]^[]]Y
-WHèê€\‹⁄X»⁄‹\õ›ò[Ÿ]èÇààYHú⁄‹YX⁄\⁄[€ã]]Hà€\‹”ò[YOHõ]Là^[»õ€ù\Ÿ[ZXõ€^Vÿ€€‹éùò\äK][YK]^\ö[X\ûJWHèîôX€‹ô‹›]\”Xô[
-X⁄\⁄[€ëX[ŸÀôX⁄\⁄[€ä_H8†%‹ÿYôUö[JX⁄\⁄[€ëX[ŸÀõ[ôKô\ÿ‹ö\[€äHú][›H[ôHüO⁄èÇà€\‹”ò[YOHõ]Là^\€H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèï\ŸH\»Yù\à€€ôö\õZ[ô»H›\›€Y\âò\‹Œ‹»X⁄\⁄[€à›]⁄YHH‹ù[àHYö\€‹ã€€ùX›Y]Ÿ[YK[ôõ›H\ôHô]Z[ôY⁄]H][›Kè‹ÇàXô[€\‹”ò[YOHõ]Mõÿ⁄»^^»õ€ù[YY][H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇà›\›€Y\à€€ùX›Y]ŸàŸ[X›ò[YO^ŸX⁄\⁄[€ê€€ùX›H€ê⁄[ôŸO^ ]ô[ù
-HOàŸ]X⁄\⁄[€ê€€ùX›
-]ô[ùù\ôŸ]ùò[YH\»€€ùX›Y]Ÿ
-_H€\‹”ò[YO^⁄[ú]€ﬂOÇà‹[€àò[YOHú€ôHèî€ôHÿ[€‹[€èè‹[€àò[YOHö[ó‹\ú€€àèí[à\ú€€è€‹[€èè‹[€àò[YOHô[XZ[èë[XZ[€‹[€èè‹[€àò[YOHõ›\àèì›\è€‹[€èÇà‹Ÿ[X›Çà€Xô[ÇàXô[€\‹”ò[YOHõ]L»õÿ⁄»^^»õ€ù[YY][H^Vÿ€€‹éùò\äK][YK]^\ŸX€€ô\ûJWHèÇàYö\€‹àõ›H
-‹[€ò[
-Bà^\ôXHò[YO^ŸX⁄\⁄[€ìõ›_H€ê⁄[ôŸO^ ]ô[ù
-HOàŸ]X⁄\⁄[€ìõ›J]ô[ùù\ôŸ]ùò[YKú€XŸJL
-J_Hõ›‹œ^ÃﬂHXŸZ€\èHë^[\Nà\õ›ôYûH€ôH⁄]ò[ZYH]éåMHKàà€\‹”ò[YO^⁄[ú]€ﬂHœÇà€Xô[Çà]à€\‹”ò[YOHõ]MHõ^õ^]‹ò\ù\›YûKY[ôÿ\LàèÇàù]€à\OHòù]€àà\ÿXõY^ŸX⁄\⁄[€îÿ]ö[ôﬂH€ê€X⁄œ^ 
-HOàŸ]X⁄\⁄[€ëX[Ÿ ù[
-_H€\‹”ò[YOHô\⁄›‹Xùã\ŸX€€ô\ûHõ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€\ÿXõYõ‹X⁄]KMLèêÿ[òŸ[ÿù]€èÇàù]€à\OHòù]€àà\ÿXõY^ŸX⁄\⁄[€îÿ]ö[ôﬂH€ê€X⁄œ^ 
-HOàõ⁄Y€€ôö\õT⁄‹X⁄\⁄[€ä
-_H€\‹”ò[YO^ŸX⁄\⁄[€ëX[ŸÀôX⁄\⁄[€àOOHôX€[ôHà»úõ›[ôY^õ‹ô\àõ‹ô\ã\ôYMÕHôÀ\ôYMLÃMHMKLà^\€Hõ€ù\Ÿ[ZXõ€^\ôYLL\ÿXõYõ‹X⁄]KMLààô\⁄›‹Xùã\ö[X\ûHõ›[ôY^MKLà^\€Hõ€ù\Ÿ[ZXõ€\ÿXõYõ‹X⁄]KMLüOûŸX⁄\⁄[€îÿ]ö[ô»»îôX€‹ô[ô¯†)ààà€€ôö\õH	‹›]\”Xô[
-X⁄\⁄[€ëX[ŸÀôX⁄\⁄[€ä_XOÿù]€èÇàŸ]èÇàŸ]èÇàŸ]èÇà
-Hàù[BÇàYõÿì[Ÿ[à\”‹[è^ÿYõÿì‹[üBà€ê€‹ŸO^ 
-HOàŸ]Yõÿì‹[äò[ŸJ_Bà€‹ö”‹ô\íY^›€ÀöYBàôZX€RY^›€ÀùôZX€W⁄YBà⁄‹Y^›€Àú⁄‹⁄YBàX⁄Y^ÿ›\úô[ù\Ÿ\íYBà€íõÿêYY^ 
-HOà¬àŸ]Yõÿì‹[äò[ŸJN¬àõ⁄Yô[ÿY
+        const { error } = await supabase
+          .from("work_order_quote_lines")
+          .update(patch)
+          .eq("id", line.id)
+          .eq("shop_id", wo.shop_id)
+          .eq("work_order_id", woId);
+        if (error) throw error;
+      }
 
-N¬à_BàœÇàŸ]èÇàŸ]èÇà
-N¬üB
+      const pricingResponse = await fetch(
+        `/api/work-orders/${woId}/customer-pricing`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ quoteLineIds: dirty.map((line) => line.id) }),
+        },
+      );
+      const pricingPayload = (await pricingResponse.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      if (!pricingResponse.ok) {
+        throw new Error(
+          pricingPayload?.error ?? "Customer pricing could not be resolved.",
+        );
+      }
+
+      toast.success("Quote lines saved.");
+      await reload();
+      return true;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save quote lines.");
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function openDecisionDialog(line: EditableQuoteLine, decision: QuoteDecision) {
+    setDecisionContact("phone");
+    setDecisionNote("");
+    setDecisionDialog({ line, decision });
+  }
+
+  async function confirmShopDecision() {
+    if (!decisionDialog || decisionSaving) return;
+    setDecisionSaving(true);
+    try {
+      if (quoteLines.some((line) => line._dirty)) {
+        const saved = await saveAllDirty();
+        if (!saved) return;
+      }
+      const response = await fetch(`/api/work-orders/quotes/${decisionDialog.line.id}/authorize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: decisionDialog.decision, contactMethod: decisionContact, note: decisionNote, operationKey: crypto.randomUUID() }),
+      });
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+      if (!response.ok) throw new Error(payload?.error ?? "Could not record the shop decision.");
+      const pastTense = decisionDialog.decision === "approve" ? "approved" : decisionDialog.decision === "decline" ? "declined" : "deferred";
+      toast.success(`Quote line ${pastTense} by the shop.`);
+      setDecisionDialog(null);
+      await reload();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not record the shop decision.");
+    } finally {
+      setDecisionSaving(false);
+    }
+  }
+
+  async function saveSuppliesOverride() {
+    if (!wo?.shop_id || savingSuppliesOverride) return;
+    const amountOverride = suppliesAmountDraft.trim() ? asNumber(suppliesAmountDraft) : null;
+    if (suppliesAmountDraft.trim() && amountOverride == null) {
+      toast.error("Enter a valid shop supplies override amount.");
+      return;
+    }
+
+    setSavingSuppliesOverride(true);
+    try {
+      const { error } = await supabase
+        .from("work_orders")
+        .update({
+          shop_supplies_enabled_override: suppliesEnabledDraft,
+          shop_supplies_amount_override: amountOverride,
+          updated_at: new Date().toISOString(),
+        } as DB["public"]["Tables"]["work_orders"]["Update"])
+        .eq("id", wo.id)
+        .eq("shop_id", wo.shop_id);
+      if (error) throw error;
+      toast.success("Shop supplies override saved.");
+      await reload();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save shop supplies override.");
+    } finally {
+      setSavingSuppliesOverride(false);
+    }
+  }
+
+  function resetSuppliesOverride() {
+    setSuppliesEnabledDraft(null);
+    setSuppliesAmountDraft("");
+  }
+
+  async function saveCustomerEmailInline() {
+    if (!wo?.customer_id) {
+      toast.error("No customer linked to this work order.");
+      return;
+    }
+    const nextEmail = safeTrim(pendingCustomerEmail);
+    if (!nextEmail || !isValidEmail(nextEmail)) {
+      toast.error("Enter a valid customer email.");
+      return;
+    }
+
+    setSavingCustomerEmail(true);
+    try {
+      const { error } = await supabase.from("customers").update({ email: nextEmail }).eq("id", wo.customer_id);
+      if (error) throw error;
+      setSendBlocker(null);
+      toast.success("Customer email saved.");
+      await reload();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save customer email.");
+    } finally {
+      setSavingCustomerEmail(false);
+    }
+  }
+
+  async function sendQuoteToCustomer(resend = false) {
+    if (!woId || sending) return;
+    setSending(true);
+    try {
+      const saved = await saveAllDirty();
+      if (!saved) return;
+
+      const res = await fetch(`/api/work-orders/${woId}/send-quote`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(resend ? { "x-profix-resend": "1" } : {}),
+        },
+        body: JSON.stringify({}),
+      });
+      const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string; detail?: string } | null;
+
+      if (!res.ok || !json?.ok) {
+        const message = safeTrim(json?.error ?? json?.detail ?? "Failed to send quote.");
+        if (message.toLowerCase().includes("email")) setSendBlocker("Customer email required to send quote");
+        toast.error(message);
+        return;
+      }
+
+      setSendBlocker(null);
+      toast.success(resend ? "Quote resent to customer." : "Quote sent to customer using canonical quote lines.");
+      await reload();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to send quote.");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  function openAddJobWithPrefill() {
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem(
+        "addJobModal:prefill",
+        JSON.stringify({ jobName: "", notes: "", laborHours: null, partsPaste: "", parts: null }),
+      );
+    }
+    setAddJobOpen(true);
+  }
+
+  if (!woId) return <div className="p-6 text-red-300">Missing work order id.</div>;
+  if (loading && !loadedOnce) return <div className="p-6 text-[color:var(--theme-text-secondary)]">Loading‚Ä¶</div>;
+  if (!wo) return <div className="p-6 text-red-300">Work order not found.</div>;
+
+  const outerCls = embedded ? "min-h-full w-full px-0 py-0 text-foreground" : "min-h-screen px-4 py-6 text-foreground";
+  const containerCls = embedded ? "mx-auto w-full max-w-none" : "mx-auto max-w-7xl";
+  const padX = embedded ? "px-3" : "px-5";
+  const padY = embedded ? "py-3" : "py-4";
+  const mainGridCls = embedded ? "mt-3 grid gap-3" : "mt-4 grid gap-4 xl:grid-cols-[minmax(0,1.6fr)_380px]";
+  const actionBtnCls = embedded ? `${ui.buttonSecondary} px-3 py-1.5 text-xs disabled:opacity-60` : `${ui.buttonSecondary} px-4 py-2 text-sm disabled:opacity-60`;
+  const saveBtnCls = embedded ? `${ui.buttonPrimary} px-3 py-1.5 text-xs disabled:opacity-60` : `${ui.buttonPrimary} px-4 py-2 text-sm disabled:opacity-60`;
+
+  return (
+    <div className={outerCls} style={{ ["--copper" as never]: COPPER }}>
+      <div className={containerCls}>
+        {loading ? (
+          <div className="mb-2 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">
+            Refreshing canonical quote lines‚Ä¶
+          </div>
+        ) : null}
+
+        <div className={embedded ? "mb-2 flex flex-wrap items-center justify-between gap-2" : "mb-4 flex flex-wrap items-center justify-between gap-3"}>
+          {!embedded && (
+            <button onClick={() => router.back()} className="text-sm text-[color:var(--copper)] hover:underline">
+              ‚Üê Back
+            </button>
+          )}
+          <div className="flex flex-wrap items-center gap-2">
+            <button onClick={() => void sendQuoteToCustomer(false)} disabled={sending || quoteTotals.sendable === 0} className={actionBtnCls} title="Email the ready canonical quote lines to the customer">
+              {sending ? "Sending‚Ä¶" : "Send Quote"}
+            </button>
+            {quoteTotals.sent > 0 ? (
+              <button onClick={() => void sendQuoteToCustomer(true)} disabled={sending || missingCustomerEmail} className={actionBtnCls} title="Resend the current customer portal quote email">
+                {sending ? "Sending‚Ä¶" : "Resend Quote"}
+              </button>
+            ) : null}
+            <button onClick={() => void saveAllDirty()} disabled={saving} className={saveBtnCls} title="Save canonical quote line changes">
+              {saving ? "Saving‚Ä¶" : "Save"}
+            </button>
+            {!embedded && (
+              <a href={`/work-orders/${woId}`} className="desktop-btn-secondary rounded-full px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)]" title="Open the work order">
+                Open WO
+              </a>
+            )}
+          </div>
+        </div>
+
+        <div className={`${card} ${padX} ${padY}`}>
+          <div className={embedded ? "grid gap-3" : "grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,1.15fr)_auto]"}>
+            <div className="min-w-0">
+              <div className="text-xs uppercase tracking-[0.25em] text-[color:var(--theme-text-secondary)]">Advisor quote review</div>
+              <div className={embedded ? "mt-1 text-xl font-semibold text-[color:var(--theme-text-primary)]" : "mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]"}>
+                <span className="text-[color:var(--theme-text-primary)]">#</span>
+                <span style={{ color: COPPER }}>{wo.custom_id ? wo.custom_id : wo.id.slice(0, 8)}</span>
+              </div>
+              <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Canonical quote lines: {quoteLines.length} ‚Ä¢ Active work lines: {workLines.length}</div>
+            </div>
+
+            <div className="desktop-panel-soft w-full px-4 py-3">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--theme-text-muted)]">Customer contact</div>
+              <div className={embedded ? "mt-2 grid gap-2" : "mt-2 grid gap-2 sm:grid-cols-3"}>
+                <div className="min-w-0">
+                  <div className="text-[11px] text-[color:var(--theme-text-muted)]">Name</div>
+                  <div className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">{customerDisplayName(customer)}</div>
+                </div>
+                <div className="min-w-0">
+                  <div className="text-[11px] text-[color:var(--theme-text-muted)]">Phone</div>
+                  {tel ? <a href={`tel:${tel}`} className="truncate text-sm font-semibold text-[color:var(--copper)] hover:underline">{customerPhone}</a> : <div className="truncate text-sm font-semibold text-[color:var(--theme-text-secondary)]">‚Äî</div>}
+                </div>
+                <div className="min-w-0">
+                  <div className="text-[11px] text-[color:var(--theme-text-muted)]">Email</div>
+                  {customerEmail ? <a href={`mailto:${customerEmail}`} className="block break-all text-sm font-semibold leading-tight text-[color:var(--copper)] hover:underline">{customerEmail}</a> : <div className="truncate text-sm font-semibold text-[color:var(--theme-text-secondary)]">‚Äî</div>}
+                </div>
+              </div>
+            </div>
+
+            <div className={embedded ? "text-left" : "text-right self-start"}>
+              <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">Shop labor rate</div>
+              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">{fmt(laborRate)}/hr</div>
+            </div>
+          </div>
+        </div>
+
+        <div className={mainGridCls}>
+          <div>
+            <div className={card}>
+              <div className={`border-b ${divider} ${padX} py-3 text-sm font-semibold text-[color:var(--theme-text-primary)]`}>
+                Canonical quote lines
+              </div>
+              {quoteLines.length === 0 ? (
+                <div className={`${padX} py-4 text-sm text-[color:var(--theme-text-secondary)]`}>
+                  No canonical quote lines exist for this work order yet. Phase 5B does not create temporary work_order_lines for portal visibility; customer portal rendering remains Phase 5C.
+                </div>
+              ) : (
+                <div className="divide-y divide-[color:var(--desktop-border)]">
+                  {quoteLines.map((line, index) => {
+                    const workflow = workflowDisplay(line);
+                    const partsWorkflow = partsWorkflowLabel(line);
+                    const partsSummary = partsQuoteSummary(line);
+                    const meta = quoteMetadata(line);
+                    const photos = [...jsonStringArray(meta.photo_urls), ...jsonStringArray(meta.evidence_urls)];
+                    const techNotes = jsonString(meta.technician_notes) || jsonString(meta.tech_notes) || safeTrim(line.ai_cause);
+                    const laborHours = quoteLineLaborHours(line);
+                    const lineLaborRate = quoteLineLaborRate(line, laborRate);
+                    const laborTotal = quoteLineLaborTotal(line, laborRate);
+                    const partsTotal = quoteLinePartsTotal(line);
+                    const total = quoteLineTotal(line, laborRate);
+                    const sources = sourceSummary(line);
+                    const historyInsight = historyInsights[line.id];
+                    const finalDecision = isFinalDecision(line);
+                    const pricingQuarantined =
+                      partsSummary?.customerPricingQuarantined === true;
+                    const dedicatedPricing = customerPricingSummary(line);
+                    const commercialEditingDisabled =
+                      finalDecision || pricingQuarantined;
+                    const finalizedLineTotalUnavailable =
+                      pricingQuarantined &&
+                      partsTotal == null &&
+                      asNumber(line.grand_total) == null &&
+                      asNumber(line.subtotal) == null;
+
+                    return (
+                      <div key={line.id} className={`${padX} py-4`}>
+                        <div className="desktop-panel-soft p-4">
+                          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                            <div className="min-w-0 flex-1">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">Quote line {index + 1}</div>
+                                <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${badgeClass(workflow.tone)}`}>{workflow.label}</span>
+                                {partsWorkflow ? <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${badgeClass(partsWorkflow.tone)}`}>{partsWorkflow.label}</span> : null}
+                                {dedicatedPricing ? <span className="rounded-full border border-emerald-300/35 bg-emerald-400/10 px-2.5 py-1 text-[11px] font-semibold capitalize text-emerald-100">{customerPricingLabel(dedicatedPricing)}</span> : null}
+                                {line._dirty ? <span className="rounded-full border border-amber-300/40 bg-amber-400/10 px-2.5 py-1 text-[11px] font-semibold text-amber-100">Unsaved</span> : null}
+                              </div>
+                              <h3 className="mt-2 text-base font-semibold text-[color:var(--theme-text-primary)]">{safeTrim(line.description) || "Untitled quote line"}</h3>
+                              {safeTrim(line.ai_complaint) ? <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Complaint: {line.ai_complaint}</p> : null}
+                              {safeTrim(line.notes) ? <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Notes: {line.notes}</p> : null}
+                              {techNotes ? <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Technician notes: {techNotes}</p> : null}
+                              <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">{workflow.detail}</p>
+                            </div>
+                            <div className="min-w-[180px] rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-3 text-sm">
+                              <div className="flex justify-between gap-4"><span className="text-[color:var(--theme-text-secondary)]">Labor</span><span className="font-semibold text-[color:var(--theme-text-primary)]">{fmt(laborTotal)}</span></div>
+                              <div className="mt-1 flex justify-between gap-4"><span className="text-[color:var(--theme-text-secondary)]">{pricingQuarantined ? "Parts (finalized)" : "Parts"}</span><span className="font-semibold text-[color:var(--theme-text-primary)]">{partsTotal == null ? "Manual review" : fmt(partsTotal)}</span></div>
+                              <div className={`mt-2 flex justify-between gap-4 border-t ${divider} pt-2`}><span className="text-[color:var(--theme-text-secondary)]">Total</span><span className="font-bold" style={{ color: COPPER }}>{finalizedLineTotalUnavailable ? "Manual review" : fmt(total)}</span></div>
+                            </div>
+                          </div>
+
+                          <div className="mt-3 grid gap-2 text-xs text-[color:var(--theme-text-secondary)] sm:grid-cols-2 lg:grid-cols-4">
+                            <div>Stage: <span className="text-[color:var(--theme-text-primary)]">{statusLabel(line.stage)}</span></div>
+                            <div>Status: <span className="text-[color:var(--theme-text-primary)]">{statusLabel(line.status)}</span></div>
+                            <div>Labor hours: <span className="text-[color:var(--theme-text-primary)]">{laborHours}</span></div>
+                            <div>Labor rate: <span className="text-[color:var(--theme-text-primary)]">{fmt(lineLaborRate)}/hr</span></div>
+                          </div>
+
+                          {pricingQuarantined ? (
+                            <div role="alert" className="mt-3 rounded-xl border border-amber-300/40 bg-amber-400/10 p-3 text-xs text-amber-50">
+                              <div className="font-semibold uppercase tracking-[0.16em]">Manual pricing review required</div>
+                              <div className="mt-1">
+                                This protected quote keeps its finalized decision total. Current Parts Request pricing is hidden because it is not the finalized customer decision.
+                              </div>
+                              <div className="mt-1 font-semibold">
+                                {partsTotal == null
+                                  ? "Finalized parts total is unavailable; do not treat it as $0."
+                                  : `Finalized parts total: ${fmt(partsTotal)}`}
+                              </div>
+                              <PricingQuarantineRemediation
+                                quoteLineId={line.id}
+                                quoteLineUpdatedAt={line.updated_at}
+                                finalizedPartsTotal={partsTotal}
+                                parts={partsByQuoteLine[line.id] ?? []}
+                                onRemediated={reload}
+                              />
+                            </div>
+                          ) : null}
+
+                          {historyInsight ? (
+                            <div className="mt-3 rounded-xl border border-sky-300/30 bg-sky-400/10 p-3 text-xs">
+                              <div className="flex flex-wrap items-start justify-between gap-2">
+                                <div>
+                                  <div className="font-semibold uppercase tracking-[0.16em] text-sky-100">Relevant vehicle history</div>
+                                  <div className="mt-1 text-[color:var(--theme-text-primary)]">Completed {historyDistanceLabel(historyInsight)}{historyInsight.workOrderNumber ? ` on WO ${historyInsight.workOrderNumber}` : " on a prior work order"}.</div>
+                                  <div className="mt-1 text-[color:var(--theme-text-secondary)]">{historyInsight.description}</div>
+                                </div>
+                                <a href={`/work-orders/${historyInsight.workOrderId}`} className="rounded-lg border border-sky-300/35 px-2.5 py-1.5 font-semibold text-sky-100 hover:bg-sky-400/10">View prior WO</a>
+                              </div>
+                            </div>
+                          ) : historyLoading ? <div className="mt-3 text-xs text-[color:var(--theme-text-muted)]">Checking relevant vehicle history‚Ä¶</div> : null}
+
+                          <div className="mt-3 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-secondary)]">
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div className="font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">Required parts</div>
+                              <div className="flex flex-wrap items-center gap-2">
+                                {partsSummary ? <div className="text-[color:var(--theme-text-secondary)]">Sync: <span className="text-[color:var(--theme-text-primary)]">{partsSummary.customerPricingQuarantined ? "manual review ‚Ä¢ customer item pricing quarantined" : <>{partsSummary.pendingCount > 0 ? "pending" : "quoted"} ‚Ä¢ {partsSummary.quotedCount}/{partsSummary.requiredCount} quoted ‚Ä¢ {partsSummary.partsTotal == null ? "total pending" : fmt(partsSummary.partsTotal)}</>}</span></div> : null}
+                                {(partsByQuoteLine[line.id] ?? []).length > 0 ? <button type="button" onClick={() => setOpenParts((prev) => ({ ...prev, [line.id]: !prev[line.id] }))} className="rounded-lg border border-[color:var(--desktop-border)] px-2.5 py-1.5 font-semibold text-[color:var(--theme-text-primary)]">{openParts[line.id] ? "Hide parts" : `View ${(partsByQuoteLine[line.id] ?? []).length} parts`}</button> : null}
+                              </div>
+                            </div>
+                            {(partsByQuoteLine[line.id] ?? []).length > 0 && openParts[line.id] ? (
+                              <div className="mt-2 space-y-2">
+                                {(partsByQuoteLine[line.id] ?? []).map((part) => {
+                                  const request = part.requestId ? (requestsByQuoteLine[line.id] ?? []).find((candidate) => candidate.id === part.requestId) ?? null : null;
+                                  const selected = selectedPartLabel(part);
+                                  return (
+                                    <div key={`${part.source}:${part.requestItemId ?? part.requestId ?? part.description}`} className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-2">
+                                      {selected ? (
+                                        <>
+                                          <div className="text-[color:var(--theme-text-primary)]">Requested: <span className="font-semibold text-[color:var(--theme-text-primary)]">{part.description} √ó {part.quantity}</span></div>
+                                          <div className="mt-1 text-[color:var(--theme-text-secondary)]">Selected: <span className="text-[color:var(--theme-text-primary)]">{selected}</span></div>
+                                        </>
+                                      ) : (
+                                        <div className="font-semibold text-[color:var(--theme-text-primary)]">{part.description} √ó {part.quantity}</div>
+                                      )}
+                                      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[color:var(--theme-text-secondary)]">
+                                        {part.requestedPartNumber ? <span>Requested part #: <span className="text-[color:var(--theme-text-primary)]">{part.requestedPartNumber}</span></span> : null}
+                                        {part.manufacturer ? <span>Manufacturer: <span className="text-[color:var(--theme-text-primary)]">{part.manufacturer}</span></span> : null}
+                                        {part.supplier ?? part.vendor ? <span>Supplier: <span className="text-[color:var(--theme-text-primary)]">{part.supplier ?? part.vendor}</span></span> : null}
+                                        {pricingQuarantined ? (
+                                          <span className="font-semibold text-amber-100">Current operational pricing hidden ‚Äî it is not the finalized customer decision.</span>
+                                        ) : (
+                                          <>
+                                            <span>{partCostLabel(part)}</span>
+                                            <span>{partSellLabel(part)}</span>
+                                            {part.costLineTotal != null ? <span>Cost line: <span className="text-[color:var(--theme-text-primary)]">{fmt(part.costLineTotal)}</span></span> : null}
+                                            {part.sellLineTotal != null ? <span>Sell line: <span className="text-[color:var(--theme-text-primary)]">{fmt(part.sellLineTotal)}</span></span> : null}
+                                          </>
+                                        )}
+                                        {part.status ? <span>Status: <span className="text-[color:var(--theme-text-primary)]">{statusLabel(part.status)}</span></span> : null}
+                                      </div>
+                                      {request ? (
+                                        <a href={`/parts/requests/${request.id}`} className="mt-2 inline-flex rounded-lg border border-sky-300/35 bg-sky-400/10 px-2.5 py-1.5 text-xs font-semibold text-sky-100 hover:bg-sky-400/15">
+                                          View Parts Request ‚Äî {partsRequestLabel(line, index)}
+                                        </a>
+                                      ) : null}
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            ) : (
+                              <div className="mt-2 rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-2 text-[color:var(--theme-text-secondary)]">
+                                <div>Parts: <span className="text-[color:var(--theme-text-primary)]">None</span></div>
+                                <div>Parts Request: <span className="text-[color:var(--theme-text-primary)]">Not required</span></div>
+                              </div>
+                            )}
+                          </div>
+
+                          {sources.length > 0 ? (
+                            <div className="mt-3 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-secondary)]">
+                              Source inspection metadata: <span className="text-[color:var(--theme-text-primary)]">{sources.join(" ‚Ä¢ ")}</span>
+                            </div>
+                          ) : null}
+
+                          {photos.length > 0 ? (
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              {photos.map((url) => (
+                                <a key={url} href={url} target="_blank" rel="noreferrer" className="rounded-lg border border-sky-300/35 bg-sky-400/10 px-2.5 py-1.5 text-xs font-semibold text-sky-100 hover:bg-sky-400/15">
+                                  Evidence photo
+                                </a>
+                              ))}
+                            </div>
+                          ) : null}
+
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            <button type="button" disabled={commercialEditingDisabled} onClick={() => setOpenDetails((prev) => ({ ...prev, [line.id]: !prev[line.id] }))} className="desktop-btn-secondary rounded-xl px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-45">
+                              {openDetails[line.id] ? "Hide editor" : "Edit quote line"}
+                            </button>
+                            <button type="button" disabled={commercialEditingDisabled} onClick={() => markRecommendedReady(line)} className="desktop-btn-secondary rounded-xl px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-45">
+                              Recompute ready state
+                            </button>
+                            {!line.sent_to_customer_at && canSendLine(line) ? <span className="rounded-xl border border-emerald-300/35 bg-emerald-400/10 px-3 py-2 text-xs font-semibold text-emerald-100">Will send</span> : null}
+                            {!commercialEditingDisabled ? <>
+                              <button type="button" disabled={!canSendLine(line) && !isSentForDecision(line)} onClick={() => openDecisionDialog(line, "approve")} className="rounded-xl border border-emerald-300/40 bg-emerald-500/15 px-3 py-2 text-xs font-semibold text-emerald-100 disabled:opacity-45">Approve</button>
+                              <button type="button" onClick={() => openDecisionDialog(line, "defer")} className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)]">Defer</button>
+                              <button type="button" onClick={() => openDecisionDialog(line, "decline")} className="rounded-xl border border-red-400/45 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-100">Decline</button>
+                            </> : null}
+                          </div>
+
+                          {openDetails[line.id] && !commercialEditingDisabled ? (
+                            <div className="desktop-panel-soft mt-3 p-4">
+                              <div className={embedded ? "grid gap-3" : "grid gap-3 md:grid-cols-2"}>
+                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
+                                  Title / description
+                                  <input value={line.description ?? ""} onChange={(e) => patchQuoteLine(line.id, { description: e.target.value })} className={inputCls} />
+                                </label>
+                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
+                                  Complaint
+                                  <input value={line.ai_complaint ?? ""} onChange={(e) => patchQuoteLine(line.id, { ai_complaint: e.target.value })} className={inputCls} />
+                                </label>
+                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
+                                  Technician notes
+                                  <input value={techNotes} onChange={(e) => patchQuoteLineMetadata(line, { technician_notes: e.target.value })} className={inputCls} />
+                                </label>
+                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
+                                  Advisor notes
+                                  <input value={line.notes ?? ""} onChange={(e) => patchQuoteLine(line.id, { notes: e.target.value })} className={inputCls} />
+                                </label>
+                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
+                                  Labor hours
+                                  <input inputMode="decimal" value={String(laborHours)} onChange={(e) => patchQuoteLine(line.id, { labor_hours: asNumber(e.target.value) ?? 0, est_labor_hours: asNumber(e.target.value) ?? 0 })} className={inputCls} />
+                                </label>
+                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
+                                  Labor rate
+                                  <input inputMode="decimal" value={String(lineLaborRate)} onChange={(e) => patchQuoteLine(line.id, { _laborRateDraft: asNumber(e.target.value) ?? 0 })} className={inputCls} />
+                                </label>
+                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
+                                  Labor amount
+                                  <input inputMode="decimal" value={String(laborTotal)} onChange={(e) => patchQuoteLine(line.id, { labor_total: asNumber(e.target.value) ?? 0 })} className={inputCls} />
+                                </label>
+                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
+                                  Parts sell total (calculated)
+                                  <input
+                                    value={partsTotal == null ? "" : String(partsTotal)}
+                                    placeholder="Manual review required"
+                                    readOnly
+                                    aria-describedby={`parts-sell-help-${line.id}`}
+                                    className={`${inputCls} cursor-not-allowed opacity-80`}
+                                  />
+                                  <span id={`parts-sell-help-${line.id}`} className="mt-1 block text-[11px] text-[color:var(--theme-text-muted)]">
+                                    Edit each item&apos;s sell price in the linked Parts Request; Quote Review recalculates this total.
+                                  </span>
+                                </label>
+                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
+                                  Status
+                                  <select value={line.status ?? ""} onChange={(e) => patchQuoteLine(line.id, { status: e.target.value })} className={inputCls}>
+                                    <option value="pending_parts">pending parts</option>
+                                    <option value="quoted">ready / quoted</option>
+                                    <option value="sent">sent</option>
+                                  </select>
+                                </label>
+                                <label className="text-xs text-[color:var(--theme-text-secondary)]">
+                                  Stage
+                                  <select value={line.stage ?? ""} onChange={(e) => patchQuoteLine(line.id, { stage: e.target.value })} className={inputCls}>
+                                    <option value="advisor_pending">advisor pending</option>
+                                    <option value="ready_to_send">ready to send</option>
+                                    <option value="sent">sent</option>
+                                  </select>
+                                </label>
+                              </div>
+                            </div>
+                          ) : null}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {workLines.length > 0 ? (
+              <div className={`${card} mt-4`}>
+                <div className={`border-b ${divider} ${padX} py-3 text-sm font-semibold text-[color:var(--theme-text-primary)]`}>
+                  Active approved / punchable work
+                </div>
+                <div className="divide-y divide-[color:var(--desktop-border)]">
+                  {workLines.map((line) => (
+                    <div key={line.id} className={`${padX} py-3 text-sm`}>
+                      <div className="font-semibold text-[color:var(--theme-text-primary)]">{safeTrim(line.description) || `Line ${line.line_no ?? ""}`}</div>
+                      <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">Status: {statusLabel(line.status)} ‚Ä¢ Approval: {statusLabel(line.approval_state)} ‚Ä¢ Punchable: {line.punchable ? "yes" : "no"}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          <div className={embedded ? "" : "space-y-4"}>
+            <div className={card}>
+              <div className={`border-b ${divider} ${padX} py-3 text-sm font-semibold text-[color:var(--theme-text-primary)]`}>Quote readiness</div>
+              <div className={`${padX} py-4 text-sm text-[color:var(--theme-text-secondary)]`}>
+                <div className="flex items-center justify-between"><span>Ready to send</span><span className="font-semibold text-[color:var(--theme-text-primary)]">{quoteTotals.sendable}</span></div>
+                <div className="mt-2 flex items-center justify-between"><span>Pending parts</span><span className="font-semibold text-[color:var(--theme-text-primary)]">{quoteTotals.pendingParts}</span></div>
+                <div className="mt-2 flex items-center justify-between"><span>Sent</span><span className="font-semibold text-[color:var(--theme-text-primary)]">{quoteTotals.sent}</span></div>
+                <div className={`mt-3 flex items-center justify-between border-t ${divider} pt-3`}><span>Labor</span><span className="font-medium text-[color:var(--theme-text-primary)]">{fmt(quoteTotals.labor)}</span></div>
+                <div className="mt-2 flex items-center justify-between"><span>{quoteTotals.partsPricingQuarantined ? "Parts (protected)" : "Parts"}</span><span className="font-medium text-[color:var(--theme-text-primary)]">{quoteTotals.partsTotalUnavailable ? "Manual review" : fmt(quoteTotals.parts)}</span></div>
+                {quoteTotals.partsPricingQuarantined ? <div className="mt-1 text-xs text-amber-100">Protected finalized totals are retained; quarantined item pricing is excluded.</div> : null}
+                <div className="mt-2 flex items-center justify-between"><span>Shop supplies</span><span className="font-medium text-[color:var(--theme-text-primary)]">{fmt(quoteTotals.shopSupplies.amount)}</span></div>
+                <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">{shopSuppliesSummaryText(quoteTotals.shopSupplies)}</div>
+                <div className={`mt-3 flex items-center justify-between border-t ${divider} pt-3`}><span className="font-semibold text-[color:var(--theme-text-primary)]">Grand total</span><span className="text-lg font-bold" style={{ color: COPPER }}>{quoteTotals.grandTotalUnavailable ? "Manual review" : fmt(quoteTotals.total)}</span></div>
+                <div className={`mt-4 border-t ${divider} pt-3`}>
+                  <div className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">Shop supplies override</div>
+                  <select
+                    value={suppliesEnabledDraft == null ? "default" : suppliesEnabledDraft ? "on" : "off"}
+                    onChange={(e) => setSuppliesEnabledDraft(e.target.value === "default" ? null : e.target.value === "on")}
+                    className="mt-2 w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none"
+                  >
+                    <option value="default">Use shop default</option>
+                    <option value="on">Include shop supplies</option>
+                    <option value="off">Remove shop supplies</option>
+                  </select>
+                  <input
+                    value={suppliesAmountDraft}
+                    onChange={(e) => setSuppliesAmountDraft(e.target.value)}
+                    placeholder="Optional fixed override amount"
+                    className="mt-2 w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)]"
+                  />
+                  <div className="mt-2 grid grid-cols-2 gap-2">
+                    <button type="button" onClick={() => void saveSuppliesOverride()} disabled={savingSuppliesOverride} className="desktop-btn-secondary rounded-lg px-3 py-2 text-xs font-semibold disabled:opacity-60">
+                      {savingSuppliesOverride ? "Saving‚Ä¶" : "Save override"}
+                    </button>
+                    <button type="button" onClick={resetSuppliesOverride} className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-subtle)]">Reset draft</button>
+                  </div>
+                </div>
+                <button onClick={() => void saveAllDirty()} disabled={saving} className="desktop-btn-primary mt-4 w-full rounded-xl px-4 py-2 text-sm font-semibold disabled:opacity-60">
+                  {saving ? "Saving‚Ä¶" : "Save changes"}
+                </button>
+              </div>
+            </div>
+
+            <div className={card}>
+              <div className={`border-b ${divider} ${padX} py-3 text-sm font-semibold text-[color:var(--theme-text-primary)]`}>Send to customer</div>
+              <div className={`${padX} py-4 text-sm text-[color:var(--theme-text-secondary)]`}>
+                Sends only canonical work_order_quote_lines that are ready to send. Pending parts, declined, deferred, approved, and converted lines are not sent.
+                {quoteTotals.sendable === 0 ? (
+                  <div className="mt-3 rounded-xl border border-amber-300/35 bg-amber-400/10 p-3 text-amber-100">No ready canonical quote lines are available to send.</div>
+                ) : null}
+                {missingCustomerEmail || sendBlocker ? (
+                  <div className="mt-3 rounded-xl border border-sky-400/35 bg-sky-500/10 p-3">
+                    <div className="text-xs font-semibold uppercase tracking-[0.14em] text-sky-100">Blocked</div>
+                    <div className="mt-1 text-sm font-semibold text-sky-100">{sendBlocker ?? "Customer email required to send quote"}</div>
+                    <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+                      <input type="email" value={pendingCustomerEmail} onChange={(e) => setPendingCustomerEmail(e.target.value)} placeholder="customer@email.com" className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)] focus:border-sky-300/70" />
+                      <button type="button" onClick={() => void saveCustomerEmailInline()} disabled={savingCustomerEmail} className="rounded-lg border border-amber-300/45 bg-amber-400/15 px-3 py-2 text-sm font-semibold text-sky-100 hover:bg-amber-400/20 disabled:opacity-60">
+                        {savingCustomerEmail ? "Saving‚Ä¶" : "Save email"}
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+                <button onClick={() => void sendQuoteToCustomer(false)} disabled={sending || savingCustomerEmail || quoteTotals.sendable === 0} className="desktop-btn-secondary mt-3 w-full rounded-xl px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-60">
+                  {sending ? "Sending‚Ä¶" : "Send ready quote lines"}
+                </button>
+                {quoteTotals.sent > 0 ? (
+                  <button onClick={() => void sendQuoteToCustomer(true)} disabled={sending || savingCustomerEmail || missingCustomerEmail} className="desktop-btn-secondary mt-2 w-full rounded-xl px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-60">
+                    {sending ? "Sending‚Ä¶" : "Resend quote"}
+                  </button>
+                ) : null}
+                <div className="mt-3 text-xs text-[color:var(--theme-text-muted)]">Portal link will be: <span className="text-[color:var(--theme-text-secondary)]">/portal/quotes/{woId}</span></div>
+                <div className="mt-2 text-xs text-[color:var(--theme-text-muted)]">Customer portal decisions and shop-recorded phone decisions use the same canonical approval lifecycle.</div>
+              </div>
+            </div>
+
+            <div className={card}>
+              <div className={`border-b ${divider} ${padX} py-3 text-sm font-semibold text-[color:var(--theme-text-primary)]`}>Quick add job</div>
+              <div className={`${padX} py-4 text-sm text-[color:var(--theme-text-secondary)]`}>
+                Add active work only when intentionally needed. Inspection recommendations should stay in canonical quote lines until customer approval/materialization.
+                <button type="button" onClick={openAddJobWithPrefill} className="desktop-btn-primary mt-3 w-full rounded-xl px-4 py-2 text-sm font-semibold">+ Add job line</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {!embedded && <div className="mt-6 text-xs text-[color:var(--theme-text-muted)]">Work Order ID: {wo.id} ‚Ä¢ Status: {statusLabel(wo.status)}</div>}
+
+        {decisionDialog ? (
+          <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/65 p-4" role="dialog" aria-modal="true" aria-labelledby="shop-decision-title">
+            <div className="w-full max-w-lg rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-overlay)] p-5 shadow-2xl">
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">Classic shop approval</div>
+              <h2 id="shop-decision-title" className="mt-2 text-lg font-semibold text-[color:var(--theme-text-primary)]">Record {statusLabel(decisionDialog.decision)} ‚Äî {safeTrim(decisionDialog.line.description) || "quote line"}</h2>
+              <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">Use this after confirming the customer&apos;s decision outside the portal. The advisor, contact method, time, and note are retained with the quote.</p>
+              <label className="mt-4 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                Customer contact method
+                <select value={decisionContact} onChange={(event) => setDecisionContact(event.target.value as ContactMethod)} className={inputCls}>
+                  <option value="phone">Phone call</option><option value="in_person">In person</option><option value="email">Email</option><option value="other">Other</option>
+                </select>
+              </label>
+              <label className="mt-3 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                Advisor note (optional)
+                <textarea value={decisionNote} onChange={(event) => setDecisionNote(event.target.value.slice(0, 1000))} rows={3} placeholder="Example: Approved by phone with Jamie at 2:15 PM." className={inputCls} />
+              </label>
+              <div className="mt-5 flex flex-wrap justify-end gap-2">
+                <button type="button" disabled={decisionSaving} onClick={() => setDecisionDialog(null)} className="desktop-btn-secondary rounded-xl px-4 py-2 text-sm font-semibold disabled:opacity-50">Cancel</button>
+                <button type="button" disabled={decisionSaving} onClick={() => void confirmShopDecision()} className={decisionDialog.decision === "decline" ? "rounded-xl border border-red-400/45 bg-red-500/15 px-4 py-2 text-sm font-semibold text-red-100 disabled:opacity-50" : "desktop-btn-primary rounded-xl px-4 py-2 text-sm font-semibold disabled:opacity-50"}>{decisionSaving ? "Recording‚Ä¶" : `Confirm ${statusLabel(decisionDialog.decision)}`}</button>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        <AddJobModal
+          isOpen={addJobOpen}
+          onClose={() => setAddJobOpen(false)}
+          workOrderId={wo.id}
+          vehicleId={wo.vehicle_id}
+          shopId={wo.shop_id}
+          techId={currentUserId}
+          onJobAdded={() => {
+            setAddJobOpen(false);
+            void reload();
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/supabase/migrations/20260812140518_customer_pricing_v2.sql
+++ b/supabase/migrations/20260812140518_customer_pricing_v2.sql
@@ -1,0 +1,807 @@
+begin;
+
+set local lock_timeout = '10s';
+set local statement_timeout = '120s';
+
+alter table public.customer_pricing_agreements
+  add column parts_markup_matrix jsonb not null default '[]'::jsonb,
+  add column minimum_parts_margin_percent numeric(5,2) not null default 0,
+  add column customer_fee_type text not null default 'none',
+  add column customer_fee_value numeric(12,2) not null default 0,
+  add column customer_fee_cap numeric(12,2),
+  add column expiry_warning_days integer not null default 30;
+
+alter table public.customer_pricing_agreements
+  add constraint customer_pricing_agreements_parts_markup_matrix_array
+    check (jsonb_typeof(parts_markup_matrix) = 'array'),
+  add constraint customer_pricing_agreements_minimum_parts_margin_range
+    check (minimum_parts_margin_percent between 0 and 99.99),
+  add constraint customer_pricing_agreements_customer_fee_type_check
+    check (customer_fee_type in ('none', 'flat', 'percentage')),
+  add constraint customer_pricing_agreements_customer_fee_value_check
+    check (
+      customer_fee_value >= 0
+      and (customer_fee_type <> 'percentage' or customer_fee_value <= 100)
+      and (customer_fee_type <> 'none' or customer_fee_value = 0)
+    ),
+  add constraint customer_pricing_agreements_customer_fee_cap_check
+    check (customer_fee_cap is null or customer_fee_cap >= 0),
+  add constraint customer_pricing_agreements_expiry_warning_days_check
+    check (expiry_warning_days between 0 and 365);
+
+alter table public.customer_pricing_agreements
+  drop constraint customer_pricing_agreements_has_adjustment,
+  add constraint customer_pricing_agreements_has_adjustment
+    check (
+      labor_rate is not null
+      or labor_discount_percent > 0
+      or parts_discount_percent > 0
+      or jsonb_array_length(parts_markup_matrix) > 0
+      or minimum_parts_margin_percent > 0
+      or customer_fee_type <> 'none'
+    );
+
+alter table public.work_orders
+  add column customer_pricing_fee_agreement_id uuid
+    references public.customer_pricing_agreements(id) on delete restrict,
+  add column customer_pricing_fee_total numeric(12,2),
+  add column customer_pricing_fee_resolved_at timestamptz;
+
+alter table public.work_orders
+  add constraint work_orders_customer_pricing_fee_total_nonnegative
+    check (customer_pricing_fee_total is null or customer_pricing_fee_total >= 0);
+
+create index work_orders_customer_pricing_fee_agreement_idx
+  on public.work_orders (customer_pricing_fee_agreement_id)
+  where customer_pricing_fee_agreement_id is not null;
+
+create or replace function private.valid_parts_markup_matrix(p_matrix jsonb)
+returns boolean
+language sql
+immutable
+security invoker
+set search_path = ''
+as $$
+  with tiers as (
+    select
+      entry.ordinality,
+      case when entry.value ->> 'cost_from' ~ '^[0-9]+([.][0-9]+)?$'
+        then (entry.value ->> 'cost_from')::numeric end as cost_from,
+      case when entry.value ->> 'cost_to' ~ '^[0-9]+([.][0-9]+)?$'
+        then (entry.value ->> 'cost_to')::numeric end as cost_to,
+      case when entry.value ->> 'markup_percent' ~ '^[0-9]+([.][0-9]+)?$'
+        then (entry.value ->> 'markup_percent')::numeric end as markup_percent,
+      entry.value ? 'cost_to' and entry.value -> 'cost_to' <> 'null'::jsonb as has_cost_to,
+      lag(case when entry.value ->> 'cost_to' ~ '^[0-9]+([.][0-9]+)?$'
+        then (entry.value ->> 'cost_to')::numeric end)
+        over (order by entry.ordinality) as previous_cost_to,
+      count(*) over () as tier_count
+    from jsonb_array_elements(
+      case
+        when jsonb_typeof(coalesce(p_matrix, '[]'::jsonb)) = 'array'
+          then coalesce(p_matrix, '[]'::jsonb)
+        else '[]'::jsonb
+      end
+    )
+      with ordinality entry(value, ordinality)
+  )
+  select
+    jsonb_typeof(coalesce(p_matrix, '[]'::jsonb)) = 'array'
+    and jsonb_array_length(
+      case
+        when jsonb_typeof(coalesce(p_matrix, '[]'::jsonb)) = 'array'
+          then coalesce(p_matrix, '[]'::jsonb)
+        else '[]'::jsonb
+      end
+    ) <= 50
+    and not exists (
+      select 1
+      from tiers tier
+      where tier.cost_from is null
+        or tier.cost_from < 0
+        or tier.markup_percent is null
+        or tier.markup_percent < 0
+        or tier.markup_percent > 1000
+        or (tier.has_cost_to and (tier.cost_to is null or tier.cost_to < tier.cost_from))
+        or (tier.ordinality = 1 and tier.cost_from <> 0)
+        or (tier.ordinality > 1 and (
+          tier.previous_cost_to is null or tier.cost_from <= tier.previous_cost_to
+        ))
+        or (tier.ordinality < tier.tier_count and not tier.has_cost_to)
+    );
+$$;
+
+create or replace function private.parts_matrix_markup_for_cost(
+  p_matrix jsonb,
+  p_unit_cost numeric
+)
+returns numeric
+language sql
+immutable
+security invoker
+set search_path = ''
+as $$
+  select (tier.value ->> 'markup_percent')::numeric
+  from jsonb_array_elements(coalesce(p_matrix, '[]'::jsonb))
+    with ordinality tier(value, ordinality)
+  where p_unit_cost >= (tier.value ->> 'cost_from')::numeric
+    and (
+      not (tier.value ? 'cost_to')
+      or tier.value -> 'cost_to' = 'null'::jsonb
+      or p_unit_cost <= (tier.value ->> 'cost_to')::numeric
+    )
+  order by tier.ordinality
+  limit 1;
+$$;
+
+revoke all on function private.valid_parts_markup_matrix(jsonb)
+  from public, anon, authenticated, service_role;
+revoke all on function private.parts_matrix_markup_for_cost(jsonb, numeric)
+  from public, anon, authenticated, service_role;
+
+create or replace function private.guard_customer_pricing_agreement_history()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if tg_op = 'DELETE' then
+    raise exception using errcode = '55000',
+      message = 'CUSTOMER_PRICING_AGREEMENT_HISTORY_IS_APPEND_ONLY';
+  end if;
+
+  if old.status <> 'active' then
+    raise exception using errcode = '55000',
+      message = 'CUSTOMER_PRICING_AGREEMENT_TERMINAL_STATE_IS_IMMUTABLE';
+  end if;
+
+  if new.status not in ('superseded', 'retired')
+     or new.shop_id is distinct from old.shop_id
+     or new.customer_id is distinct from old.customer_id
+     or new.source_type is distinct from old.source_type
+     or new.name is distinct from old.name
+     or new.currency is distinct from old.currency
+     or new.labor_rate is distinct from old.labor_rate
+     or new.labor_discount_percent is distinct from old.labor_discount_percent
+     or new.parts_discount_percent is distinct from old.parts_discount_percent
+     or new.parts_markup_matrix is distinct from old.parts_markup_matrix
+     or new.minimum_parts_margin_percent is distinct from old.minimum_parts_margin_percent
+     or new.customer_fee_type is distinct from old.customer_fee_type
+     or new.customer_fee_value is distinct from old.customer_fee_value
+     or new.customer_fee_cap is distinct from old.customer_fee_cap
+     or new.expiry_warning_days is distinct from old.expiry_warning_days
+     or new.effective_from is distinct from old.effective_from
+     or new.effective_until is distinct from old.effective_until
+     or new.approval_reason is distinct from old.approval_reason
+     or new.notes is distinct from old.notes
+     or new.operation_key is distinct from old.operation_key
+     or new.supersedes_agreement_id is distinct from old.supersedes_agreement_id
+     or new.approved_by is distinct from old.approved_by
+     or new.created_by is distinct from old.created_by
+     or new.created_at is distinct from old.created_at then
+    raise exception using errcode = '55000',
+      message = 'CUSTOMER_PRICING_AGREEMENT_TERMS_REQUIRE_A_NEW_VERSION';
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.create_customer_pricing_agreement_v2_atomic(
+  p_shop_id uuid,
+  p_customer_id uuid,
+  p_source_type text,
+  p_name text,
+  p_currency text,
+  p_labor_rate numeric,
+  p_labor_discount_percent numeric,
+  p_parts_discount_percent numeric,
+  p_parts_markup_matrix jsonb,
+  p_minimum_parts_margin_percent numeric,
+  p_customer_fee_type text,
+  p_customer_fee_value numeric,
+  p_customer_fee_cap numeric,
+  p_expiry_warning_days integer,
+  p_effective_from date,
+  p_effective_until date,
+  p_approval_reason text,
+  p_notes text,
+  p_operation_key text,
+  p_actor_user_id uuid,
+  p_at timestamptz default now()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_actor_role text;
+  v_existing public.customer_pricing_agreements%rowtype;
+  v_superseded_id uuid;
+  v_created public.customer_pricing_agreements%rowtype;
+  v_now timestamptz := coalesce(p_at, now());
+  v_source_type text := lower(btrim(coalesce(p_source_type, '')));
+  v_currency text := upper(btrim(coalesce(p_currency, 'CAD')));
+  v_labor_rate numeric := case when p_labor_rate is null then null else round(p_labor_rate, 2) end;
+  v_labor_discount numeric := round(coalesce(p_labor_discount_percent, 0), 2);
+  v_parts_discount numeric := round(coalesce(p_parts_discount_percent, 0), 2);
+  v_matrix jsonb := coalesce(p_parts_markup_matrix, '[]'::jsonb);
+  v_minimum_margin numeric := round(coalesce(p_minimum_parts_margin_percent, 0), 2);
+  v_fee_type text := lower(btrim(coalesce(p_customer_fee_type, 'none')));
+  v_fee_value numeric := round(coalesce(p_customer_fee_value, 0), 2);
+  v_fee_cap numeric := case when p_customer_fee_cap is null then null else round(p_customer_fee_cap, 2) end;
+  v_warning_days integer := coalesce(p_expiry_warning_days, 30);
+begin
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'PRICING_ACTOR_MISMATCH';
+  end if;
+
+  select public.canonical_shop_membership_role(profile.role::text)
+    into v_actor_role
+  from public.profiles profile
+  where profile.shop_id = p_shop_id
+    and (profile.id = p_actor_user_id or profile.user_id = p_actor_user_id)
+  order by case when profile.user_id = p_actor_user_id then 0 else 1 end
+  limit 1;
+
+  if coalesce(v_actor_role, '') not in ('owner', 'admin', 'manager') then
+    raise exception using errcode = '42501', message = 'PRICING_MANAGER_ROLE_REQUIRED';
+  end if;
+
+  select agreement.* into v_existing
+  from public.customer_pricing_agreements agreement
+  where agreement.shop_id = p_shop_id
+    and agreement.operation_key = btrim(coalesce(p_operation_key, ''));
+
+  if found then
+    if v_existing.customer_id is distinct from p_customer_id
+       or v_existing.source_type is distinct from v_source_type
+       or v_existing.name is distinct from btrim(coalesce(p_name, ''))
+       or v_existing.currency is distinct from v_currency
+       or v_existing.labor_rate is distinct from v_labor_rate
+       or v_existing.labor_discount_percent is distinct from v_labor_discount
+       or v_existing.parts_discount_percent is distinct from v_parts_discount
+       or v_existing.parts_markup_matrix is distinct from v_matrix
+       or v_existing.minimum_parts_margin_percent is distinct from v_minimum_margin
+       or v_existing.customer_fee_type is distinct from v_fee_type
+       or v_existing.customer_fee_value is distinct from v_fee_value
+       or v_existing.customer_fee_cap is distinct from v_fee_cap
+       or v_existing.expiry_warning_days is distinct from v_warning_days
+       or v_existing.effective_from is distinct from coalesce(p_effective_from, v_now::date)
+       or v_existing.effective_until is distinct from p_effective_until
+       or v_existing.approval_reason is distinct from btrim(coalesce(p_approval_reason, '')) then
+      raise exception using errcode = '22023', message = 'PRICING_OPERATION_KEY_CONFLICT';
+    end if;
+    return jsonb_build_object('ok', true, 'idempotent', true, 'agreement', to_jsonb(v_existing));
+  end if;
+
+  if nullif(btrim(coalesce(p_operation_key, '')), '') is null or length(btrim(p_operation_key)) > 200 then
+    raise exception using errcode = '22023', message = 'A valid pricing operation key is required.';
+  end if;
+  if v_source_type not in ('customer_specific', 'customer_contract', 'fleet_contract') then
+    raise exception using errcode = '22023', message = 'Unsupported customer pricing source.';
+  end if;
+  if v_currency not in ('CAD', 'USD') then
+    raise exception using errcode = '22023', message = 'Pricing currency must be CAD or USD.';
+  end if;
+  if length(btrim(coalesce(p_name, ''))) not between 1 and 120 then
+    raise exception using errcode = '22023', message = 'Agreement name is required and must be 120 characters or fewer.';
+  end if;
+  if length(btrim(coalesce(p_approval_reason, ''))) not between 3 and 500 then
+    raise exception using errcode = '22023', message = 'Approval reason must be between 3 and 500 characters.';
+  end if;
+  if v_labor_rate < 0 or v_labor_discount not between 0 and 100
+     or v_parts_discount not between 0 and 100
+     or v_minimum_margin not between 0 and 99.99 then
+    raise exception using errcode = '22023', message = 'Pricing values are outside the supported range.';
+  end if;
+  if v_labor_rate is not null and v_labor_discount > 0 then
+    raise exception using errcode = '22023', message = 'Choose a fixed labor rate or a labor discount, not both.';
+  end if;
+  if not private.valid_parts_markup_matrix(v_matrix) then
+    raise exception using errcode = '22023', message = 'Parts matrix tiers are invalid, overlapping, or out of order.';
+  end if;
+  if v_fee_type not in ('none', 'flat', 'percentage')
+     or v_fee_value < 0
+     or (v_fee_type = 'percentage' and v_fee_value > 100)
+     or (v_fee_type = 'none' and v_fee_value <> 0)
+     or v_fee_cap < 0 then
+    raise exception using errcode = '22023', message = 'Customer fee settings are invalid.';
+  end if;
+  if v_warning_days not between 0 and 365 then
+    raise exception using errcode = '22023', message = 'Expiry warning days must be between 0 and 365.';
+  end if;
+  if v_labor_rate is null and v_labor_discount = 0 and v_parts_discount = 0
+     and jsonb_array_length(v_matrix) = 0 and v_minimum_margin = 0 and v_fee_type = 'none' then
+    raise exception using errcode = '22023', message = 'At least one customer pricing adjustment is required.';
+  end if;
+  if p_effective_until is not null and p_effective_until < coalesce(p_effective_from, v_now::date) then
+    raise exception using errcode = '22023', message = 'Agreement end date cannot be before its start date.';
+  end if;
+  if not exists (
+    select 1 from public.customers customer
+    where customer.id = p_customer_id and customer.shop_id = p_shop_id
+      and coalesce(customer.active, true)
+  ) then
+    raise exception using errcode = 'P0002', message = 'Customer account not found for shop.';
+  end if;
+  if v_source_type = 'fleet_contract' and not exists (
+    select 1 from public.fleets fleet
+    where fleet.shop_id = p_shop_id and fleet.customer_id = p_customer_id
+      and coalesce(fleet.active, true)
+  ) then
+    raise exception using errcode = '23514', message = 'Fleet contract pricing requires a linked active Fleet account.';
+  end if;
+
+  select agreement.id into v_superseded_id
+  from public.customer_pricing_agreements agreement
+  where agreement.shop_id = p_shop_id and agreement.customer_id = p_customer_id
+    and agreement.status = 'active'
+    and (agreement.source_type = v_source_type or (
+      agreement.source_type in ('customer_contract', 'fleet_contract')
+      and v_source_type in ('customer_contract', 'fleet_contract')
+    ))
+  order by agreement.effective_from desc, agreement.created_at desc, agreement.id desc
+  limit 1 for update;
+
+  update public.customer_pricing_agreements agreement
+  set status = 'superseded', retired_by = p_actor_user_id, retired_at = v_now,
+      retired_reason = 'Superseded by a newer pricing agreement.', updated_at = v_now
+  where agreement.shop_id = p_shop_id and agreement.customer_id = p_customer_id
+    and agreement.status = 'active'
+    and (agreement.source_type = v_source_type or (
+      agreement.source_type in ('customer_contract', 'fleet_contract')
+      and v_source_type in ('customer_contract', 'fleet_contract')
+    ));
+
+  insert into public.customer_pricing_agreements (
+    shop_id, customer_id, source_type, name, status, currency, labor_rate,
+    labor_discount_percent, parts_discount_percent, parts_markup_matrix,
+    minimum_parts_margin_percent, customer_fee_type, customer_fee_value,
+    customer_fee_cap, expiry_warning_days, effective_from, effective_until,
+    approval_reason, notes, operation_key, supersedes_agreement_id, approved_by,
+    created_by, created_at, updated_at
+  ) values (
+    p_shop_id, p_customer_id, v_source_type, btrim(p_name), 'active', v_currency,
+    v_labor_rate, v_labor_discount, v_parts_discount, v_matrix, v_minimum_margin,
+    v_fee_type, v_fee_value, v_fee_cap, v_warning_days,
+    coalesce(p_effective_from, v_now::date), p_effective_until,
+    btrim(p_approval_reason), nullif(btrim(coalesce(p_notes, '')), ''),
+    btrim(p_operation_key), v_superseded_id, p_actor_user_id, p_actor_user_id,
+    v_now, v_now
+  ) returning * into v_created;
+
+  insert into public.operational_events (
+    shop_id, event_type, actor_user_id, actor_role, entity_type, entity_id,
+    source, idempotency_key, metadata
+  ) values (
+    p_shop_id, 'customer_pricing.v2_agreement_created', p_actor_user_id,
+    v_actor_role, 'customer_pricing_agreement', v_created.id,
+    'customer_pricing_engine', 'customer-pricing-agreement:' || btrim(p_operation_key),
+    jsonb_build_object(
+      'customer_id', p_customer_id, 'source_type', v_source_type,
+      'supersedes_agreement_id', v_superseded_id,
+      'matrix_tier_count', jsonb_array_length(v_matrix),
+      'minimum_parts_margin_percent', v_minimum_margin,
+      'customer_fee_type', v_fee_type,
+      'effective_from', v_created.effective_from,
+      'effective_until', v_created.effective_until
+    )
+  ) on conflict (shop_id, idempotency_key) where idempotency_key is not null do nothing;
+
+  return jsonb_build_object('ok', true, 'idempotent', false, 'agreement', to_jsonb(v_created));
+end;
+$$;
+
+revoke all on function public.create_customer_pricing_agreement_v2_atomic(
+  uuid, uuid, text, text, text, numeric, numeric, numeric, jsonb, numeric,
+  text, numeric, numeric, integer, date, date, text, text, text, uuid, timestamptz
+) from public, anon;
+grant execute on function public.create_customer_pricing_agreement_v2_atomic(
+  uuid, uuid, text, text, text, numeric, numeric, numeric, jsonb, numeric,
+  text, numeric, numeric, integer, date, date, text, text, text, uuid, timestamptz
+) to authenticated, service_role;
+
+-- Keep the V1 command authenticated during the expand/deploy window so the
+-- currently deployed application remains compatible. Application routes move
+-- to V2 in this change; a later contract migration can retire V1 safely.
+
+create or replace function public.apply_customer_pricing_v2_to_quote_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_quote_line_ids uuid[],
+  p_actor_user_id uuid,
+  p_at timestamptz default now()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_base_result jsonb;
+  v_work_order public.work_orders%rowtype;
+  v_agreement public.customer_pricing_agreements%rowtype;
+  v_line public.work_order_quote_lines%rowtype;
+  v_previous public.pricing_resolution_snapshots%rowtype;
+  v_snapshot public.pricing_resolution_snapshots%rowtype;
+  v_item public.part_request_items%rowtype;
+  v_previous_part jsonb;
+  v_part_prices jsonb;
+  v_provenance jsonb;
+  v_now timestamptz := coalesce(p_at, now());
+  v_quantity numeric;
+  v_unit_cost numeric;
+  v_base_unit_price numeric;
+  v_markup_percent numeric;
+  v_matrix_unit_price numeric;
+  v_discounted_unit_price numeric;
+  v_margin_floor_unit_price numeric;
+  v_resolved_unit_price numeric;
+  v_resolved_parts_total numeric;
+  v_floor_adjustment_total numeric;
+  v_subtotal numeric;
+  v_fee_total numeric := 0;
+  v_fee_base numeric := 0;
+  v_resolution_hash text;
+  v_v2_applied jsonb := '[]'::jsonb;
+begin
+  v_base_result := public.apply_customer_pricing_to_quote_atomic(
+    p_shop_id,
+    p_work_order_id,
+    p_quote_line_ids,
+    p_actor_user_id,
+    v_now
+  );
+
+  select work_order.* into v_work_order
+  from public.work_orders work_order
+  where work_order.id = p_work_order_id and work_order.shop_id = p_shop_id
+  for update;
+
+  if not found or v_work_order.customer_id is null then
+    return v_base_result || jsonb_build_object('pricing_v2', false);
+  end if;
+
+  select agreement.* into v_agreement
+  from public.customer_pricing_agreements agreement
+  where agreement.shop_id = p_shop_id
+    and agreement.customer_id = v_work_order.customer_id
+    and agreement.status = 'active'
+    and agreement.effective_from <= v_now::date
+    and (agreement.effective_until is null or agreement.effective_until >= v_now::date)
+  order by
+    case agreement.source_type
+      when 'fleet_contract' then 800
+      when 'customer_contract' then 800
+      when 'customer_specific' then 700
+      else 100
+    end desc,
+    agreement.effective_from desc,
+    agreement.created_at desc,
+    agreement.id desc
+  limit 1;
+
+  if not found then
+    if v_work_order.customer_pricing_fee_agreement_id is not null then
+      update public.work_orders
+      set shop_supplies_enabled_override = null,
+          shop_supplies_amount_override = null,
+          customer_pricing_fee_agreement_id = null,
+          customer_pricing_fee_total = null,
+          customer_pricing_fee_resolved_at = null,
+          updated_at = v_now
+      where id = p_work_order_id and shop_id = p_shop_id;
+    end if;
+    return v_base_result || jsonb_build_object('pricing_v2', false, 'customer_fee_total', 0);
+  end if;
+
+  if jsonb_array_length(v_agreement.parts_markup_matrix) > 0
+     or v_agreement.minimum_parts_margin_percent > 0 then
+    for v_line in
+      select quote_line.*
+      from public.work_order_quote_lines quote_line
+      where quote_line.shop_id = p_shop_id
+        and quote_line.work_order_id = p_work_order_id
+        and (
+          coalesce(cardinality(p_quote_line_ids), 0) = 0
+          or quote_line.id = any(p_quote_line_ids)
+        )
+      order by quote_line.created_at, quote_line.id
+      for update
+    loop
+      select snapshot.* into v_previous
+      from public.pricing_resolution_snapshots snapshot
+      where snapshot.id = v_line.customer_pricing_snapshot_id
+        and snapshot.shop_id = p_shop_id;
+
+      if not found or v_previous.agreement_id is distinct from v_agreement.id then
+        continue;
+      end if;
+
+      v_part_prices := '[]'::jsonb;
+      v_resolved_parts_total := 0;
+      v_floor_adjustment_total := 0;
+
+      for v_item in
+        select item.*
+        from public.part_request_items item
+        join public.part_requests request on request.id = item.request_id
+        where item.shop_id = p_shop_id
+          and item.work_order_id = p_work_order_id
+          and item.quote_line_id = v_line.id
+          and request.shop_id = item.shop_id
+          and lower(coalesce(request.status::text, 'requested')) not in (
+            'cancelled', 'canceled', 'rejected', 'declined', 'voided'
+          )
+          and lower(coalesce(item.status::text, 'requested')) not in (
+            'cancelled', 'canceled', 'rejected', 'declined', 'voided'
+          )
+        order by request.created_at, request.id, item.id
+        for update of item
+      loop
+        v_quantity := greatest(
+          coalesce(v_item.qty, 0), coalesce(v_item.qty_requested, 0),
+          coalesce(v_item.qty_approved, 0), 0
+        );
+        if v_quantity <= 0 then continue; end if;
+
+        select part.value into v_previous_part
+        from jsonb_array_elements(v_previous.part_prices) part(value)
+        where part.value ->> 'request_item_id' = v_item.id::text
+        limit 1;
+
+        if v_previous_part is null
+           or coalesce(v_previous_part ->> 'base_unit_price', '') !~ '^[0-9]+([.][0-9]+)?$' then
+          raise exception using errcode = '55000',
+            message = 'PRICING_V2_PROVENANCE_MISSING',
+            detail = format('Part request item %s has no immutable base sell price.', v_item.id);
+        end if;
+
+        v_base_unit_price := (v_previous_part ->> 'base_unit_price')::numeric;
+        v_unit_cost := case
+          when v_item.unit_cost is not null and v_item.unit_cost >= 0
+            then round(v_item.unit_cost, 2)
+          else null
+        end;
+        v_markup_percent := case when v_unit_cost is null then null else
+          private.parts_matrix_markup_for_cost(v_agreement.parts_markup_matrix, v_unit_cost)
+        end;
+        v_matrix_unit_price := round(case
+          when v_unit_cost is not null and v_markup_percent is not null
+            then v_unit_cost * (1 + v_markup_percent / 100)
+          else v_base_unit_price
+        end, 2);
+        v_discounted_unit_price := round(
+          v_matrix_unit_price * (1 - v_agreement.parts_discount_percent / 100), 2
+        );
+        v_margin_floor_unit_price := case
+          when v_unit_cost is not null and v_agreement.minimum_parts_margin_percent > 0
+            then round(v_unit_cost / (1 - v_agreement.minimum_parts_margin_percent / 100), 2)
+          else null
+        end;
+        v_resolved_unit_price := greatest(
+          v_discounted_unit_price, coalesce(v_margin_floor_unit_price, 0)
+        );
+
+        if round(coalesce(v_item.quoted_price, v_item.unit_price, 0), 2)
+             is distinct from v_resolved_unit_price then
+          if v_item.work_order_line_id is not null
+             or coalesce(v_item.qty_ordered, 0) > 0
+             or coalesce(v_item.qty_received, 0) > 0
+             or coalesce(v_item.qty_reserved, 0) > 0
+             or coalesce(v_item.qty_consumed, 0) > 0
+             or coalesce(v_item.qty_returned, 0) > 0
+             or v_item.po_id is not null then
+            raise exception using errcode = '55000',
+              message = 'CUSTOMER_PRICING_PART_LIFECYCLE_LOCKED',
+              detail = format('Part request item %s has operational activity.', v_item.id);
+          end if;
+          update public.part_request_items
+          set quoted_price = v_resolved_unit_price,
+              unit_price = v_resolved_unit_price,
+              markup_pct = case when v_unit_cost > 0
+                then round(((v_resolved_unit_price / v_unit_cost) - 1) * 100, 4)
+                else markup_pct end,
+              updated_at = v_now
+          where id = v_item.id and shop_id = p_shop_id;
+        end if;
+
+        v_resolved_parts_total := round(
+          v_resolved_parts_total + v_quantity * v_resolved_unit_price, 2
+        );
+        v_floor_adjustment_total := round(
+          v_floor_adjustment_total
+          + v_quantity * greatest(v_resolved_unit_price - v_discounted_unit_price, 0), 2
+        );
+        v_part_prices := v_part_prices || jsonb_build_array(jsonb_build_object(
+          'request_item_id', v_item.id,
+          'request_id', v_item.request_id,
+          'description', v_item.description,
+          'quantity', v_quantity,
+          'unit_cost', v_unit_cost,
+          'cost_known', v_unit_cost is not null,
+          'base_unit_price', v_base_unit_price,
+          'matrix_markup_percent', v_markup_percent,
+          'matrix_unit_price', v_matrix_unit_price,
+          'discount_percent', v_agreement.parts_discount_percent,
+          'discounted_unit_price', v_discounted_unit_price,
+          'minimum_margin_percent', v_agreement.minimum_parts_margin_percent,
+          'margin_floor_unit_price', v_margin_floor_unit_price,
+          'margin_floor_applied', v_margin_floor_unit_price is not null
+            and v_margin_floor_unit_price > v_discounted_unit_price,
+          'resolved_unit_price', v_resolved_unit_price,
+          'resolved_line_total', round(v_quantity * v_resolved_unit_price, 2),
+          'provenance', case when v_markup_percent is null then 'base_sell' else 'matrix' end
+        ));
+      end loop;
+
+      if jsonb_array_length(v_part_prices) = 0 then
+        if coalesce(v_previous.base_parts_total, 0) > 0 then
+          raise exception using errcode = '55000',
+            message = 'PRICING_V2_REQUIRES_CANONICAL_PART_ITEMS',
+            detail = format('Quote line %s has parts totals without canonical request items.', v_line.id);
+        end if;
+        continue;
+      end if;
+
+      update public.work_order_quote_lines
+      set parts_total = v_resolved_parts_total,
+          subtotal = round(coalesce(labor_total, 0) + v_resolved_parts_total, 2),
+          grand_total = round(coalesce(labor_total, 0) + v_resolved_parts_total + coalesce(tax_total, 0), 2),
+          updated_at = v_now
+      where id = v_line.id and shop_id = p_shop_id;
+
+      v_provenance := jsonb_build_object(
+        'version', 2,
+        'agreement_id', v_agreement.id,
+        'agreement_name', v_agreement.name,
+        'parts_matrix', v_agreement.parts_markup_matrix,
+        'minimum_parts_margin_percent', v_agreement.minimum_parts_margin_percent,
+        'parts_discount_percent', v_agreement.parts_discount_percent,
+        'margin_floor_adjustment_total', v_floor_adjustment_total,
+        'resolved_at', v_now,
+        'resolved_by', p_actor_user_id
+      );
+
+      update public.work_order_quote_lines
+      set metadata = jsonb_set(
+            coalesce(metadata, '{}'::jsonb), '{customer_pricing_v2}', v_provenance, true
+          ),
+          updated_at = v_now
+      where id = v_line.id and shop_id = p_shop_id
+      returning * into v_line;
+
+      v_resolution_hash := encode(
+        extensions.digest(
+          convert_to(jsonb_build_object(
+            'prior_snapshot_id', v_previous.id,
+            'parts', v_part_prices,
+            'provenance', v_provenance,
+            'resolved_parts_total', v_resolved_parts_total
+          )::text, 'UTF8'),
+          'sha256'
+        ),
+        'hex'
+      );
+
+      insert into public.pricing_resolution_snapshots (
+        shop_id, customer_id, work_order_id, quote_line_id, agreement_id,
+        supersedes_snapshot_id, source_type, precedence_rank, currency,
+        base_labor_rate, resolved_labor_rate, labor_discount_percent,
+        base_labor_total, resolved_labor_total, base_parts_total,
+        resolved_parts_total, parts_discount_percent, part_prices,
+        input_snapshot, result_snapshot, resolution_hash, resolved_by,
+        resolved_at, created_at
+      ) values (
+        p_shop_id, v_previous.customer_id, p_work_order_id, v_line.id,
+        v_agreement.id, v_previous.id, v_previous.source_type,
+        v_previous.precedence_rank, v_previous.currency,
+        v_previous.base_labor_rate, v_previous.resolved_labor_rate,
+        v_previous.labor_discount_percent, v_previous.base_labor_total,
+        v_previous.resolved_labor_total, v_previous.base_parts_total,
+        v_resolved_parts_total, v_agreement.parts_discount_percent,
+        v_part_prices,
+        v_previous.input_snapshot || jsonb_build_object('pricing_v2', v_provenance),
+        v_previous.result_snapshot || jsonb_build_object(
+          'pricing_v2', v_provenance,
+          'resolved_parts_total', v_resolved_parts_total
+        ),
+        v_resolution_hash, p_actor_user_id, v_now, v_now
+      ) returning * into v_snapshot;
+
+      update public.work_order_quote_lines
+      set customer_pricing_snapshot_id = v_snapshot.id,
+          metadata = jsonb_set(metadata, '{customer_pricing_v2,snapshot_id}', to_jsonb(v_snapshot.id), true),
+          updated_at = v_now
+      where id = v_line.id and shop_id = p_shop_id;
+
+      v_v2_applied := v_v2_applied || jsonb_build_array(jsonb_build_object(
+        'quote_line_id', v_line.id,
+        'snapshot_id', v_snapshot.id,
+        'supersedes_snapshot_id', v_previous.id,
+        'resolved_parts_total', v_resolved_parts_total,
+        'margin_floor_adjustment_total', v_floor_adjustment_total
+      ));
+    end loop;
+  end if;
+
+  select round(coalesce(sum(
+    coalesce(quote_line.labor_total, 0) + coalesce(quote_line.parts_total, 0)
+  ), 0), 2) into v_fee_base
+  from public.work_order_quote_lines quote_line
+  where quote_line.shop_id = p_shop_id
+    and quote_line.work_order_id = p_work_order_id
+    and lower(coalesce(quote_line.status::text, '')) not in (
+      'cancelled', 'canceled', 'rejected', 'declined', 'voided'
+    );
+
+  v_fee_total := round(case v_agreement.customer_fee_type
+    when 'flat' then v_agreement.customer_fee_value
+    when 'percentage' then v_fee_base * v_agreement.customer_fee_value / 100
+    else 0
+  end, 2);
+  if v_agreement.customer_fee_cap is not null then
+    v_fee_total := least(v_fee_total, v_agreement.customer_fee_cap);
+  end if;
+
+  if v_agreement.customer_fee_type = 'none' then
+    if v_work_order.customer_pricing_fee_agreement_id is not null then
+      update public.work_orders
+      set shop_supplies_enabled_override = null,
+          shop_supplies_amount_override = null,
+          customer_pricing_fee_agreement_id = null,
+          customer_pricing_fee_total = null,
+          customer_pricing_fee_resolved_at = null,
+          updated_at = v_now
+      where id = p_work_order_id and shop_id = p_shop_id;
+    end if;
+  else
+    update public.work_orders
+    set shop_supplies_enabled_override = true,
+        shop_supplies_amount_override = v_fee_total,
+        customer_pricing_fee_agreement_id = v_agreement.id,
+        customer_pricing_fee_total = v_fee_total,
+        customer_pricing_fee_resolved_at = v_now,
+        updated_at = v_now
+    where id = p_work_order_id and shop_id = p_shop_id;
+  end if;
+
+  insert into public.operational_events (
+    shop_id, event_type, actor_user_id, entity_type, entity_id, source, metadata
+  ) values (
+    p_shop_id, 'customer_pricing.v2_resolved', p_actor_user_id,
+    'work_order', p_work_order_id, 'customer_pricing_engine',
+    jsonb_build_object(
+      'agreement_id', v_agreement.id,
+      'quote_lines', v_v2_applied,
+      'customer_fee_type', v_agreement.customer_fee_type,
+      'customer_fee_base', v_fee_base,
+      'customer_fee_total', v_fee_total
+    )
+  );
+
+  return v_base_result || jsonb_build_object(
+    'pricing_v2', true,
+    'v2_applied', v_v2_applied,
+    'customer_fee_type', v_agreement.customer_fee_type,
+    'customer_fee_total', v_fee_total
+  );
+end;
+$$;
+
+revoke all on function public.apply_customer_pricing_v2_to_quote_atomic(
+  uuid, uuid, uuid[], uuid, timestamptz
+) from public, anon;
+grant execute on function public.apply_customer_pricing_v2_to_quote_atomic(
+  uuid, uuid, uuid[], uuid, timestamptz
+) to authenticated, service_role;
+
+comment on function public.apply_customer_pricing_v2_to_quote_atomic(
+  uuid, uuid, uuid[], uuid, timestamptz
+) is 'Canonical Pricing V2 quote resolver. Extends immutable V1 snapshots with cost-band parts matrices, margin floors, customer fees, and explicit provenance.';
+
+commit;

--- a/supabase/migrations/20260812140518_customer_pricing_v2.sql
+++ b/supabase/migrations/20260812140518_customer_pricing_v2.sql
@@ -58,6 +58,41 @@ create index work_orders_customer_pricing_fee_agreement_idx
   on public.work_orders (customer_pricing_fee_agreement_id)
   where customer_pricing_fee_agreement_id is not null;
 
+-- The canonical supplies override remains advisor-editable. If any direct
+-- writer changes it without advancing the resolver timestamp, that edit takes
+-- ownership and the agreement attribution must be cleared atomically.
+create or replace function private.clear_customer_pricing_fee_attribution_on_manual_supplies_override()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if (
+       new.shop_supplies_enabled_override
+         is distinct from old.shop_supplies_enabled_override
+       or new.shop_supplies_amount_override
+         is distinct from old.shop_supplies_amount_override
+     )
+     and new.customer_pricing_fee_agreement_id is not null
+     and new.customer_pricing_fee_resolved_at
+       is not distinct from old.customer_pricing_fee_resolved_at then
+    new.customer_pricing_fee_agreement_id := null;
+    new.customer_pricing_fee_total := null;
+    new.customer_pricing_fee_resolved_at := null;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists work_orders_clear_customer_pricing_fee_on_manual_supplies_override
+  on public.work_orders;
+create trigger work_orders_clear_customer_pricing_fee_on_manual_supplies_override
+before update of shop_supplies_enabled_override, shop_supplies_amount_override
+on public.work_orders
+for each row
+execute function private.clear_customer_pricing_fee_attribution_on_manual_supplies_override();
+
 create or replace function private.valid_parts_markup_matrix(p_matrix jsonb)
 returns boolean
 language sql

--- a/supabase/migrations/20260812140518_customer_pricing_v2.sql
+++ b/supabase/migrations/20260812140518_customer_pricing_v2.sql
@@ -25,7 +25,10 @@ alter table public.customer_pricing_agreements
       and (customer_fee_type <> 'none' or customer_fee_value = 0)
     ),
   add constraint customer_pricing_agreements_customer_fee_cap_check
-    check (customer_fee_cap is null or customer_fee_cap >= 0),
+    check (
+      customer_fee_cap is null
+      or (customer_fee_type = 'percentage' and customer_fee_cap >= 0)
+    ),
   add constraint customer_pricing_agreements_expiry_warning_days_check
     check (expiry_warning_days between 0 and 365);
 
@@ -306,9 +309,10 @@ begin
   end if;
   if v_fee_type not in ('none', 'flat', 'percentage')
      or v_fee_value < 0
-     or (v_fee_type = 'percentage' and v_fee_value > 100)
-     or (v_fee_type = 'none' and v_fee_value <> 0)
-     or v_fee_cap < 0 then
+      or (v_fee_type = 'percentage' and v_fee_value > 100)
+      or (v_fee_type = 'none' and v_fee_value <> 0)
+      or v_fee_cap < 0
+      or (v_fee_type <> 'percentage' and v_fee_cap is not null) then
     raise exception using errcode = '22023', message = 'Customer fee settings are invalid.';
   end if;
   if v_warning_days not between 0 and 365 then
@@ -423,10 +427,12 @@ set search_path = ''
 as $$
 declare
   v_base_result jsonb;
+  v_actor_role text;
   v_work_order public.work_orders%rowtype;
   v_agreement public.customer_pricing_agreements%rowtype;
   v_line public.work_order_quote_lines%rowtype;
   v_previous public.pricing_resolution_snapshots%rowtype;
+  v_current_snapshot public.pricing_resolution_snapshots%rowtype;
   v_snapshot public.pricing_resolution_snapshots%rowtype;
   v_item public.part_request_items%rowtype;
   v_previous_part jsonb;
@@ -447,23 +453,61 @@ declare
   v_fee_total numeric := 0;
   v_fee_base numeric := 0;
   v_resolution_hash text;
+  v_skip_v1 boolean := false;
+  v_fee_changed boolean := false;
   v_v2_applied jsonb := '[]'::jsonb;
+  v_v2_unchanged jsonb := '[]'::jsonb;
 begin
-  v_base_result := public.apply_customer_pricing_to_quote_atomic(
-    p_shop_id,
-    p_work_order_id,
-    p_quote_line_ids,
-    p_actor_user_id,
-    v_now
-  );
+  if auth.role() <> 'service_role'
+     and ((select auth.uid()) is null or (select auth.uid()) is distinct from p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'PRICING_ACTOR_MISMATCH';
+  end if;
+
+  select public.canonical_shop_membership_role(profile.role::text)
+    into v_actor_role
+  from public.profiles profile
+  where profile.shop_id = p_shop_id
+    and (profile.id = p_actor_user_id or profile.user_id = p_actor_user_id)
+  order by case when profile.user_id = p_actor_user_id then 0 else 1 end
+  limit 1;
+
+  if coalesce(v_actor_role, '') not in (
+    'owner', 'admin', 'manager', 'advisor', 'service', 'foreman'
+  ) then
+    raise exception using errcode = '42501', message = 'QUOTE_PRICING_ROLE_REQUIRED';
+  end if;
 
   select work_order.* into v_work_order
   from public.work_orders work_order
   where work_order.id = p_work_order_id and work_order.shop_id = p_shop_id
   for update;
 
-  if not found or v_work_order.customer_id is null then
-    return v_base_result || jsonb_build_object('pricing_v2', false);
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Work order not found for shop.';
+  end if;
+  if v_work_order.customer_id is null then
+    return jsonb_build_object(
+      'ok', true, 'agreement', null, 'pricing_v2', false,
+      'applied', '[]'::jsonb, 'unchanged', '[]'::jsonb,
+      'skipped', jsonb_build_array(jsonb_build_object('reason', 'no_customer'))
+    );
+  end if;
+  if public.work_order_is_financially_locked(p_shop_id, p_work_order_id) then
+    raise exception using errcode = '55000', message = 'FINANCIALLY_LOCKED: customer pricing cannot change after invoice finalization.';
+  end if;
+  if coalesce(cardinality(p_quote_line_ids), 0) > 0
+     and (
+       select count(distinct quote_line.id)
+       from public.work_order_quote_lines quote_line
+       where quote_line.shop_id = p_shop_id
+         and quote_line.work_order_id = p_work_order_id
+         and quote_line.id = any(p_quote_line_ids)
+     ) <> (
+       select count(distinct requested.id)
+       from unnest(p_quote_line_ids) requested(id)
+       where requested.id is not null
+     ) then
+    raise exception using errcode = 'P0002', message = 'One or more quote lines were not found for this work order.';
   end if;
 
   select agreement.* into v_agreement
@@ -486,6 +530,9 @@ begin
   limit 1;
 
   if not found then
+    v_base_result := public.apply_customer_pricing_to_quote_atomic(
+      p_shop_id, p_work_order_id, p_quote_line_ids, p_actor_user_id, v_now
+    );
     if v_work_order.customer_pricing_fee_agreement_id is not null then
       update public.work_orders
       set shop_supplies_enabled_override = null,
@@ -497,6 +544,50 @@ begin
       where id = p_work_order_id and shop_id = p_shop_id;
     end if;
     return v_base_result || jsonb_build_object('pricing_v2', false, 'customer_fee_total', 0);
+  end if;
+
+  -- Repeated Quote Review loads must not let V1 temporarily undo an existing
+  -- V2 matrix/floor result. If every target line already has a V2 snapshot for
+  -- this immutable agreement and labor inputs are unchanged, V2 can resolve
+  -- directly from its stored base sell provenance.
+  select coalesce(bool_and(
+    snapshot.id is not null
+    and snapshot.agreement_id is not distinct from v_agreement.id
+    and coalesce(snapshot.input_snapshot -> 'pricing_v2' ->> 'version', '') = '2'
+    and round(coalesce(quote_line.labor_rate, 0), 2)
+      is not distinct from snapshot.resolved_labor_rate
+    and round(coalesce(quote_line.labor_total, 0), 2)
+      is not distinct from snapshot.resolved_labor_total
+    and greatest(
+      coalesce(quote_line.labor_hours, 0),
+      coalesce(quote_line.est_labor_hours, 0), 0
+    ) is not distinct from case
+      when coalesce(snapshot.input_snapshot ->> 'labor_hours', '') ~ '^[0-9]+([.][0-9]+)?$'
+        then (snapshot.input_snapshot ->> 'labor_hours')::numeric
+      else null
+    end
+  ), false) into v_skip_v1
+  from public.work_order_quote_lines quote_line
+  left join public.pricing_resolution_snapshots snapshot
+    on snapshot.id = quote_line.customer_pricing_snapshot_id
+   and snapshot.shop_id = quote_line.shop_id
+   and snapshot.quote_line_id = quote_line.id
+  where quote_line.shop_id = p_shop_id
+    and quote_line.work_order_id = p_work_order_id
+    and (
+      coalesce(cardinality(p_quote_line_ids), 0) = 0
+      or quote_line.id = any(p_quote_line_ids)
+    );
+
+  if v_skip_v1 then
+    v_base_result := jsonb_build_object(
+      'ok', true, 'agreement', to_jsonb(v_agreement),
+      'applied', '[]'::jsonb, 'unchanged', '[]'::jsonb, 'skipped', '[]'::jsonb
+    );
+  else
+    v_base_result := public.apply_customer_pricing_to_quote_atomic(
+      p_shop_id, p_work_order_id, p_quote_line_ids, p_actor_user_id, v_now
+    );
   end if;
 
   if jsonb_array_length(v_agreement.parts_markup_matrix) > 0
@@ -520,6 +611,21 @@ begin
 
       if not found or v_previous.agreement_id is distinct from v_agreement.id then
         continue;
+      end if;
+      v_current_snapshot := v_previous;
+
+      if coalesce(v_previous.input_snapshot -> 'pricing_v2' ->> 'version', '') = '2'
+         and v_previous.supersedes_snapshot_id is not null then
+        select snapshot.* into v_previous
+        from public.pricing_resolution_snapshots snapshot
+        where snapshot.id = v_previous.supersedes_snapshot_id
+          and snapshot.shop_id = p_shop_id
+          and snapshot.quote_line_id = v_line.id;
+        if not found then
+          raise exception using errcode = '55000',
+            message = 'PRICING_V2_BASE_SNAPSHOT_MISSING',
+            detail = format('Quote line %s has no immutable V1 base snapshot.', v_line.id);
+        end if;
       end if;
 
       v_part_prices := '[]'::jsonb;
@@ -554,8 +660,8 @@ begin
         where part.value ->> 'request_item_id' = v_item.id::text
         limit 1;
 
-        if v_previous_part is null
-           or coalesce(v_previous_part ->> 'base_unit_price', '') !~ '^[0-9]+([.][0-9]+)?$' then
+        if v_previous_part is null then continue; end if;
+        if coalesce(v_previous_part ->> 'base_unit_price', '') !~ '^[0-9]+([.][0-9]+)?$' then
           raise exception using errcode = '55000',
             message = 'PRICING_V2_PROVENANCE_MISSING',
             detail = format('Part request item %s has no immutable base sell price.', v_item.id);
@@ -640,20 +746,8 @@ begin
       end loop;
 
       if jsonb_array_length(v_part_prices) = 0 then
-        if coalesce(v_previous.base_parts_total, 0) > 0 then
-          raise exception using errcode = '55000',
-            message = 'PRICING_V2_REQUIRES_CANONICAL_PART_ITEMS',
-            detail = format('Quote line %s has parts totals without canonical request items.', v_line.id);
-        end if;
         continue;
       end if;
-
-      update public.work_order_quote_lines
-      set parts_total = v_resolved_parts_total,
-          subtotal = round(coalesce(labor_total, 0) + v_resolved_parts_total, 2),
-          grand_total = round(coalesce(labor_total, 0) + v_resolved_parts_total + coalesce(tax_total, 0), 2),
-          updated_at = v_now
-      where id = v_line.id and shop_id = p_shop_id;
 
       v_provenance := jsonb_build_object(
         'version', 2,
@@ -663,9 +757,39 @@ begin
         'minimum_parts_margin_percent', v_agreement.minimum_parts_margin_percent,
         'parts_discount_percent', v_agreement.parts_discount_percent,
         'margin_floor_adjustment_total', v_floor_adjustment_total,
-        'resolved_at', v_now,
         'resolved_by', p_actor_user_id
       );
+
+      if coalesce(v_line.metadata -> 'customer_pricing_v2', '{}'::jsonb)
+           - 'snapshot_id' - 'resolved_at'
+           = v_provenance
+         and round(coalesce(v_line.parts_total, 0), 2) = v_resolved_parts_total
+         and not exists (
+           select 1
+           from jsonb_array_elements(v_part_prices) part(value)
+           join public.part_request_items item
+             on item.id = (part.value ->> 'request_item_id')::uuid
+            and item.shop_id = p_shop_id
+           where round(coalesce(item.quoted_price, item.unit_price, 0), 2)
+             is distinct from (part.value ->> 'resolved_unit_price')::numeric
+         ) then
+        v_v2_unchanged := v_v2_unchanged || jsonb_build_array(jsonb_build_object(
+          'quote_line_id', v_line.id,
+          'snapshot_id', v_line.customer_pricing_snapshot_id,
+          'resolved_parts_total', v_resolved_parts_total
+        ));
+        continue;
+      end if;
+
+      update public.work_order_quote_lines
+      set parts_total = v_resolved_parts_total,
+          subtotal = round(coalesce(labor_total, 0) + v_resolved_parts_total, 2),
+          tax_total = 0,
+          grand_total = round(coalesce(labor_total, 0) + v_resolved_parts_total, 2),
+          updated_at = v_now
+      where id = v_line.id and shop_id = p_shop_id;
+
+      v_provenance := v_provenance || jsonb_build_object('resolved_at', v_now);
 
       update public.work_order_quote_lines
       set metadata = jsonb_set(
@@ -678,7 +802,7 @@ begin
       v_resolution_hash := encode(
         extensions.digest(
           convert_to(jsonb_build_object(
-            'prior_snapshot_id', v_previous.id,
+            'prior_snapshot_id', v_current_snapshot.id,
             'parts', v_part_prices,
             'provenance', v_provenance,
             'resolved_parts_total', v_resolved_parts_total
@@ -698,7 +822,7 @@ begin
         resolved_at, created_at
       ) values (
         p_shop_id, v_previous.customer_id, p_work_order_id, v_line.id,
-        v_agreement.id, v_previous.id, v_previous.source_type,
+        v_agreement.id, v_current_snapshot.id, v_previous.source_type,
         v_previous.precedence_rank, v_previous.currency,
         v_previous.base_labor_rate, v_previous.resolved_labor_rate,
         v_previous.labor_discount_percent, v_previous.base_labor_total,
@@ -722,11 +846,25 @@ begin
       v_v2_applied := v_v2_applied || jsonb_build_array(jsonb_build_object(
         'quote_line_id', v_line.id,
         'snapshot_id', v_snapshot.id,
-        'supersedes_snapshot_id', v_previous.id,
+        'supersedes_snapshot_id', v_current_snapshot.id,
         'resolved_parts_total', v_resolved_parts_total,
         'margin_floor_adjustment_total', v_floor_adjustment_total
       ));
     end loop;
+  end if;
+
+  -- Any persisted line tax was calculated against the pre-V2 taxable base.
+  -- Invalidate the whole quote together so the canonical send path
+  -- recomputes tax once from the final labor, parts, and customer-fee totals.
+  if jsonb_array_length(v_v2_applied) > 0 then
+    update public.work_order_quote_lines quote_line
+    set tax_total = 0,
+        grand_total = round(
+          coalesce(quote_line.labor_total, 0) + coalesce(quote_line.parts_total, 0), 2
+        ),
+        updated_at = v_now
+    where quote_line.shop_id = p_shop_id
+      and quote_line.work_order_id = p_work_order_id;
   end if;
 
   select round(coalesce(sum(
@@ -744,12 +882,14 @@ begin
     when 'percentage' then v_fee_base * v_agreement.customer_fee_value / 100
     else 0
   end, 2);
-  if v_agreement.customer_fee_cap is not null then
+  if v_agreement.customer_fee_type = 'percentage'
+     and v_agreement.customer_fee_cap is not null then
     v_fee_total := least(v_fee_total, v_agreement.customer_fee_cap);
   end if;
 
   if v_agreement.customer_fee_type = 'none' then
     if v_work_order.customer_pricing_fee_agreement_id is not null then
+      v_fee_changed := true;
       update public.work_orders
       set shop_supplies_enabled_override = null,
           shop_supplies_amount_override = null,
@@ -760,19 +900,28 @@ begin
       where id = p_work_order_id and shop_id = p_shop_id;
     end if;
   else
-    update public.work_orders
-    set shop_supplies_enabled_override = true,
-        shop_supplies_amount_override = v_fee_total,
-        customer_pricing_fee_agreement_id = v_agreement.id,
-        customer_pricing_fee_total = v_fee_total,
-        customer_pricing_fee_resolved_at = v_now,
-        updated_at = v_now
-    where id = p_work_order_id and shop_id = p_shop_id;
+    v_fee_changed := v_work_order.customer_pricing_fee_agreement_id
+        is distinct from v_agreement.id
+      or round(coalesce(v_work_order.customer_pricing_fee_total, -1), 2)
+        is distinct from v_fee_total
+      or v_work_order.shop_supplies_enabled_override is distinct from true
+      or round(coalesce(v_work_order.shop_supplies_amount_override, -1), 2)
+        is distinct from v_fee_total;
+    if v_fee_changed then
+      update public.work_orders
+      set shop_supplies_enabled_override = true,
+          shop_supplies_amount_override = v_fee_total,
+          customer_pricing_fee_agreement_id = v_agreement.id,
+          customer_pricing_fee_total = v_fee_total,
+          customer_pricing_fee_resolved_at = v_now,
+          updated_at = v_now
+      where id = p_work_order_id and shop_id = p_shop_id;
+    end if;
   end if;
 
   insert into public.operational_events (
     shop_id, event_type, actor_user_id, entity_type, entity_id, source, metadata
-  ) values (
+  ) select
     p_shop_id, 'customer_pricing.v2_resolved', p_actor_user_id,
     'work_order', p_work_order_id, 'customer_pricing_engine',
     jsonb_build_object(
@@ -782,11 +931,12 @@ begin
       'customer_fee_base', v_fee_base,
       'customer_fee_total', v_fee_total
     )
-  );
+  where jsonb_array_length(v_v2_applied) > 0 or v_fee_changed;
 
   return v_base_result || jsonb_build_object(
     'pricing_v2', true,
     'v2_applied', v_v2_applied,
+    'v2_unchanged', v_v2_unchanged,
     'customer_fee_type', v_agreement.customer_fee_type,
     'customer_fee_total', v_fee_total
   );

--- a/supabase/migrations/20260812140518_customer_pricing_v2.sql
+++ b/supabase/migrations/20260812140518_customer_pricing_v2.sql
@@ -455,6 +455,8 @@ declare
   v_resolution_hash text;
   v_skip_v1 boolean := false;
   v_fee_changed boolean := false;
+  v_has_fee_targets boolean := false;
+  v_manual_supplies_override boolean := false;
   v_v2_applied jsonb := '[]'::jsonb;
   v_v2_unchanged jsonb := '[]'::jsonb;
 begin
@@ -510,6 +512,31 @@ begin
     raise exception using errcode = 'P0002', message = 'One or more quote lines were not found for this work order.';
   end if;
 
+  select exists (
+    select 1
+    from public.work_order_quote_lines quote_line
+    where quote_line.shop_id = p_shop_id
+      and quote_line.work_order_id = p_work_order_id
+      and (
+        coalesce(cardinality(p_quote_line_ids), 0) = 0
+        or quote_line.id = any(p_quote_line_ids)
+      )
+      and not public.quote_line_pricing_is_protected(
+        quote_line.status::text, quote_line.stage::text,
+        quote_line.sent_to_customer_at, quote_line.sent_at,
+        quote_line.approved_at, quote_line.declined_at,
+        quote_line.deferred_at, quote_line.converted_at,
+        quote_line.work_order_line_id
+      )
+  ) into v_has_fee_targets;
+
+  v_manual_supplies_override :=
+    v_work_order.customer_pricing_fee_agreement_id is null
+    and (
+      v_work_order.shop_supplies_enabled_override is not null
+      or v_work_order.shop_supplies_amount_override is not null
+    );
+
   select agreement.* into v_agreement
   from public.customer_pricing_agreements agreement
   where agreement.shop_id = p_shop_id
@@ -533,7 +560,8 @@ begin
     v_base_result := public.apply_customer_pricing_to_quote_atomic(
       p_shop_id, p_work_order_id, p_quote_line_ids, p_actor_user_id, v_now
     );
-    if v_work_order.customer_pricing_fee_agreement_id is not null then
+    if v_has_fee_targets
+       and v_work_order.customer_pricing_fee_agreement_id is not null then
       update public.work_orders
       set shop_supplies_enabled_override = null,
           shop_supplies_amount_override = null,
@@ -577,6 +605,13 @@ begin
     and (
       coalesce(cardinality(p_quote_line_ids), 0) = 0
       or quote_line.id = any(p_quote_line_ids)
+    )
+    and not public.quote_line_pricing_is_protected(
+      quote_line.status::text, quote_line.stage::text,
+      quote_line.sent_to_customer_at, quote_line.sent_at,
+      quote_line.approved_at, quote_line.declined_at,
+      quote_line.deferred_at, quote_line.converted_at,
+      quote_line.work_order_line_id
     );
 
   if v_skip_v1 then
@@ -604,6 +639,16 @@ begin
       order by quote_line.created_at, quote_line.id
       for update
     loop
+      if public.quote_line_pricing_is_protected(
+        v_line.status::text, v_line.stage::text,
+        v_line.sent_to_customer_at, v_line.sent_at,
+        v_line.approved_at, v_line.declined_at,
+        v_line.deferred_at, v_line.converted_at,
+        v_line.work_order_line_id
+      ) then
+        continue;
+      end if;
+
       select snapshot.* into v_previous
       from public.pricing_resolution_snapshots snapshot
       where snapshot.id = v_line.customer_pricing_snapshot_id
@@ -864,7 +909,14 @@ begin
         ),
         updated_at = v_now
     where quote_line.shop_id = p_shop_id
-      and quote_line.work_order_id = p_work_order_id;
+      and quote_line.work_order_id = p_work_order_id
+      and not public.quote_line_pricing_is_protected(
+        quote_line.status::text, quote_line.stage::text,
+        quote_line.sent_to_customer_at, quote_line.sent_at,
+        quote_line.approved_at, quote_line.declined_at,
+        quote_line.deferred_at, quote_line.converted_at,
+        quote_line.work_order_line_id
+      );
   end if;
 
   select round(coalesce(sum(
@@ -873,8 +925,16 @@ begin
   from public.work_order_quote_lines quote_line
   where quote_line.shop_id = p_shop_id
     and quote_line.work_order_id = p_work_order_id
-    and lower(coalesce(quote_line.status::text, '')) not in (
-      'cancelled', 'canceled', 'rejected', 'declined', 'voided'
+    and (
+      coalesce(cardinality(p_quote_line_ids), 0) = 0
+      or quote_line.id = any(p_quote_line_ids)
+    )
+    and not public.quote_line_pricing_is_protected(
+      quote_line.status::text, quote_line.stage::text,
+      quote_line.sent_to_customer_at, quote_line.sent_at,
+      quote_line.approved_at, quote_line.declined_at,
+      quote_line.deferred_at, quote_line.converted_at,
+      quote_line.work_order_line_id
     );
 
   v_fee_total := round(case v_agreement.customer_fee_type
@@ -887,7 +947,13 @@ begin
     v_fee_total := least(v_fee_total, v_agreement.customer_fee_cap);
   end if;
 
-  if v_agreement.customer_fee_type = 'none' then
+  if not v_has_fee_targets then
+    v_fee_total := coalesce(v_work_order.customer_pricing_fee_total, 0);
+  elsif v_manual_supplies_override then
+    -- An advisor explicitly owns the canonical supplies override. Agreement
+    -- fees remain visible in the contract, but must not silently replace it.
+    null;
+  elsif v_agreement.customer_fee_type = 'none' then
     if v_work_order.customer_pricing_fee_agreement_id is not null then
       v_fee_changed := true;
       update public.work_orders
@@ -928,6 +994,7 @@ begin
       'agreement_id', v_agreement.id,
       'quote_lines', v_v2_applied,
       'customer_fee_type', v_agreement.customer_fee_type,
+      'customer_fee_managed', not v_manual_supplies_override,
       'customer_fee_base', v_fee_base,
       'customer_fee_total', v_fee_total
     )
@@ -938,6 +1005,7 @@ begin
     'v2_applied', v_v2_applied,
     'v2_unchanged', v_v2_unchanged,
     'customer_fee_type', v_agreement.customer_fee_type,
+    'customer_fee_managed', not v_manual_supplies_override,
     'customer_fee_total', v_fee_total
   );
 end;

--- a/tests/customer-pricing-v2.test.ts
+++ b/tests/customer-pricing-v2.test.ts
@@ -15,6 +15,7 @@ const accountPanel = read(
 const quoteReview = read(
   "features/work-orders/quote-review/QuoteReviewView.tsx",
 );
+const quoteSend = read("app/api/quotes/send/route.ts");
 
 describe("customer Pricing V2", () => {
   it("versions matrices, fees, margins, and expiry settings with agreements", () => {
@@ -63,6 +64,10 @@ describe("customer Pricing V2", () => {
     expect(migration).toContain("shop_supplies_amount_override = v_fee_total");
     expect(migration).toContain("customer_pricing_fee_agreement_id");
     expect(quoteReview).toContain("marginFloorAdjustmentTotal");
+    expect(quoteSend).toContain('"apply_customer_pricing_v2_to_quote_atomic"');
+    expect(migration).toContain("v_v2_unchanged");
+    expect(migration).toContain("tax_total = 0");
+    expect(migration).toContain("if v_previous_part is null then continue");
   });
 
   it("exposes usable controls and contract-expiry warnings in the account center", () => {
@@ -71,5 +76,7 @@ describe("customer Pricing V2", () => {
     expect(accountPanel).toContain("Customer fee");
     expect(accountPanel).toContain("Expiry warning days");
     expect(accountPanel).toContain("Contract expiry:");
+    expect(accountPanel).toContain("key={tier.id}");
+    expect(accountPanel).toContain('draft.customerFeeType !== "percentage"');
   });
 });

--- a/tests/customer-pricing-v2.test.ts
+++ b/tests/customer-pricing-v2.test.ts
@@ -82,7 +82,9 @@ describe("customer Pricing V2", () => {
     expect(accountPanel).toContain("Contract expiry:");
     expect(accountPanel).toContain("key={tier.id}");
     expect(accountPanel).toContain('draft.customerFeeType !== "percentage"');
-    expect(quoteReview).toContain("customer_pricing_fee_agreement_id: null");
+    expect(migration).toContain(
+      "work_orders_clear_customer_pricing_fee_on_manual_supplies_override",
+    );
     expect(migration).toContain("v_manual_supplies_override");
   });
 });

--- a/tests/customer-pricing-v2.test.ts
+++ b/tests/customer-pricing-v2.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const migration = read(
+  "supabase/migrations/20260812140518_customer_pricing_v2.sql",
+);
+const customerRoute = read("app/api/customers/[id]/pricing/route.ts");
+const workOrderRoute = read(
+  "app/api/work-orders/[id]/customer-pricing/route.ts",
+);
+const accountPanel = read(
+  "features/customers/components/CustomerPricingPanel.tsx",
+);
+const quoteReview = read(
+  "features/work-orders/quote-review/QuoteReviewView.tsx",
+);
+
+describe("customer Pricing V2", () => {
+  it("versions matrices, fees, margins, and expiry settings with agreements", () => {
+    expect(migration).toContain("parts_markup_matrix jsonb");
+    expect(migration).toContain("minimum_parts_margin_percent");
+    expect(migration).toContain("customer_fee_type");
+    expect(migration).toContain("expiry_warning_days");
+    expect(migration).toContain(
+      "drop constraint customer_pricing_agreements_has_adjustment",
+    );
+    expect(migration).toContain("jsonb_array_length(parts_markup_matrix) > 0");
+    expect(migration).toContain("CUSTOMER_PRICING_AGREEMENT_TERMS_REQUIRE_A_NEW_VERSION");
+  });
+
+  it("keeps pricing writes atomic, tenant-scoped, and actor-attributed", () => {
+    expect(migration).toContain("create_customer_pricing_agreement_v2_atomic");
+    expect(migration).toContain("apply_customer_pricing_v2_to_quote_atomic");
+    expect(migration).toContain("PRICING_ACTOR_MISMATCH");
+    expect(migration).toContain("agreement.shop_id = p_shop_id");
+    expect(migration).toContain("p_actor_user_id");
+    expect(customerRoute).toContain(
+      '"create_customer_pricing_agreement_v2_atomic"',
+    );
+    expect(workOrderRoute).toContain(
+      '"apply_customer_pricing_v2_to_quote_atomic"',
+    );
+    expect(migration).toContain(
+      "currently deployed application remains compatible",
+    );
+  });
+
+  it("applies the matrix before discounts and the margin floor last", () => {
+    const matrixPosition = migration.indexOf("v_matrix_unit_price :=");
+    const discountPosition = migration.indexOf("v_discounted_unit_price :=");
+    const floorPosition = migration.indexOf("v_margin_floor_unit_price :=");
+    expect(matrixPosition).toBeGreaterThan(0);
+    expect(discountPosition).toBeGreaterThan(matrixPosition);
+    expect(floorPosition).toBeGreaterThan(discountPosition);
+    expect(migration).toContain("greatest(\n          v_discounted_unit_price");
+  });
+
+  it("preserves immutable quote provenance and canonical customer fees", () => {
+    expect(migration).toContain("supersedes_snapshot_id");
+    expect(migration).toContain("customer_pricing_v2");
+    expect(migration).toContain("margin_floor_adjustment_total");
+    expect(migration).toContain("shop_supplies_amount_override = v_fee_total");
+    expect(migration).toContain("customer_pricing_fee_agreement_id");
+    expect(quoteReview).toContain("marginFloorAdjustmentTotal");
+  });
+
+  it("exposes usable controls and contract-expiry warnings in the account center", () => {
+    expect(accountPanel).toContain("Parts matrix");
+    expect(accountPanel).toContain("Minimum parts margin %");
+    expect(accountPanel).toContain("Customer fee");
+    expect(accountPanel).toContain("Expiry warning days");
+    expect(accountPanel).toContain("Contract expiry:");
+  });
+});

--- a/tests/customer-pricing-v2.test.ts
+++ b/tests/customer-pricing-v2.test.ts
@@ -68,6 +68,10 @@ describe("customer Pricing V2", () => {
     expect(migration).toContain("v_v2_unchanged");
     expect(migration).toContain("tax_total = 0");
     expect(migration).toContain("if v_previous_part is null then continue");
+    expect(migration).toContain("v_has_fee_targets");
+    expect(migration).toContain("not public.quote_line_pricing_is_protected");
+    expect(quoteSend).toContain("p_quote_line_ids: pricingQuoteLineIds");
+    expect(quoteSend).toContain("resolvedSuppliesOverrides ?? wo");
   });
 
   it("exposes usable controls and contract-expiry warnings in the account center", () => {
@@ -78,5 +82,7 @@ describe("customer Pricing V2", () => {
     expect(accountPanel).toContain("Contract expiry:");
     expect(accountPanel).toContain("key={tier.id}");
     expect(accountPanel).toContain('draft.customerFeeType !== "percentage"');
+    expect(quoteReview).toContain("customer_pricing_fee_agreement_id: null");
+    expect(migration).toContain("v_manual_supplies_override");
   });
 });

--- a/tests/customer-specific-pricing-engine.test.ts
+++ b/tests/customer-specific-pricing-engine.test.ts
@@ -43,7 +43,7 @@ describe("customer-specific pricing engine contracts", () => {
     expect(quoteSend).toContain("apply_customer_pricing_v2_to_quote_atomic");
     expect(
       quoteSend.indexOf("apply_customer_pricing_v2_to_quote_atomic"),
-    ).toBeLessThan(quoteSend.indexOf('from("work_order_quote_lines")'));
+    ).toBeLessThan(quoteSend.indexOf("const { data: quoteLineRowsRaw"));
   });
 
   it("allows authenticated security-invoker pricing reads to normalize roles", () => {

--- a/tests/customer-specific-pricing-engine.test.ts
+++ b/tests/customer-specific-pricing-engine.test.ts
@@ -40,9 +40,9 @@ describe("customer-specific pricing engine contracts", () => {
     expect(quoteReview).toContain(
       "`/api/work-orders/${woId}/customer-pricing`",
     );
-    expect(quoteSend).toContain("apply_customer_pricing_to_quote_atomic");
+    expect(quoteSend).toContain("apply_customer_pricing_v2_to_quote_atomic");
     expect(
-      quoteSend.indexOf("apply_customer_pricing_to_quote_atomic"),
+      quoteSend.indexOf("apply_customer_pricing_v2_to_quote_atomic"),
     ).toBeLessThan(quoteSend.indexOf('from("work_order_quote_lines")'));
   });
 

--- a/tests/dispatch/dispatch-booking-ownership.runtime.sql
+++ b/tests/dispatch/dispatch-booking-ownership.runtime.sql
@@ -21,15 +21,16 @@ set user_id = excluded.user_id,
 insert into public.shops (
   id, owner_id, business_name, name, user_limit,
   accepts_online_booking, min_notice_minutes, max_lead_days,
-  location_type
+  location_type, billing_entitlement_override
 )
 values (
   '8b200000-0000-4000-8000-000000000001',
   '8a200000-0000-4000-8000-000000000001',
   'Dispatch Ownership Shop', 'Dispatch Ownership Shop', 10,
-  true, 0, 365, 'repair_facility'
+  true, 0, 365, 'repair_facility', 'internal_demo'
 )
-on conflict (id) do nothing;
+on conflict (id) do update
+set billing_entitlement_override = 'internal_demo';
 
 update public.profiles
 set shop_id = '8b200000-0000-4000-8000-000000000001'
@@ -38,6 +39,40 @@ where id in (
   '8a200000-0000-4000-8000-000000000002'
 );
 
+insert into public.mobile_service_settings (
+  shop_id, service_model, solo_mode, dispatch_enabled,
+  service_vehicles_enabled, field_operator_count_target,
+  onboarding_completed_at, configured_by
+)
+values (
+  '8b200000-0000-4000-8000-000000000001', 'mobile', false, true,
+  true, 2, now(), '8a200000-0000-4000-8000-000000000001'
+)
+on conflict (shop_id) do update
+set service_model = 'mobile',
+    solo_mode = false,
+    dispatch_enabled = true,
+    service_vehicles_enabled = true,
+    field_operator_count_target = 2,
+    onboarding_completed_at = now(),
+    configured_by = '8a200000-0000-4000-8000-000000000001';
+
+insert into public.mobile_field_operators (
+  shop_id, profile_id, enabled, created_by
+)
+values
+  (
+    '8b200000-0000-4000-8000-000000000001',
+    '8a200000-0000-4000-8000-000000000001', true,
+    '8a200000-0000-4000-8000-000000000001'
+  ),
+  (
+    '8b200000-0000-4000-8000-000000000001',
+    '8a200000-0000-4000-8000-000000000002', true,
+    '8a200000-0000-4000-8000-000000000001'
+  )
+on conflict (shop_id, profile_id) do update set enabled = true;
+
 insert into public.customers (id, shop_id, first_name, last_name, email)
 values (
   '8c200000-0000-4000-8000-000000000001',
@@ -45,6 +80,17 @@ values (
   'Dispatch', 'Lock', 'dispatch-lock-customer@example.com'
 )
 on conflict (id) do nothing;
+
+insert into public.vehicles (id, shop_id, customer_id, year, make, model, vin)
+values (
+  '8c210000-0000-4000-8000-000000000001',
+  '8b200000-0000-4000-8000-000000000001',
+  '8c200000-0000-4000-8000-000000000001',
+  2024, 'Test', 'Dispatch Ownership Unit', '1FTFW1E50NFB00001'
+)
+on conflict (id) do update
+set shop_id = excluded.shop_id,
+    customer_id = excluded.customer_id;
 
 insert into public.service_vehicles (id, shop_id, name, unit_number, active)
 values (
@@ -73,12 +119,14 @@ declare
   v_locked_end timestamptz;
   v_locked_status text;
   v_owner_visit_id uuid;
+  v_handoff jsonb;
+  v_work_order_id uuid;
 begin
   v_booking := public.scheduler_apply_booking_command_atomic(
     'create', null,
     '8b200000-0000-4000-8000-000000000001',
     '8c200000-0000-4000-8000-000000000001',
-    null,
+    '8c210000-0000-4000-8000-000000000001',
     '2099-04-01 09:00:00+00', '2099-04-01 10:00:00+00',
     'Dispatch ownership test',
     '8a200000-0000-4000-8000-000000000001', 'staff',
@@ -226,6 +274,23 @@ begin
     '8a200000-0000-4000-8000-000000000002',
     'dispatch-lock:arrived'
   );
+
+  v_handoff := public.mobile_materialize_service_visit_work_order_atomic(
+    '8b200000-0000-4000-8000-000000000001',
+    v_visit_id,
+    '8a200000-0000-4000-8000-000000000002',
+    'dispatch-lock:work-order'
+  );
+  v_work_order_id := (v_handoff ->> 'workOrderId')::uuid;
+  if v_work_order_id is null or not exists (
+    select 1 from public.service_visits visit
+    where visit.id = v_visit_id
+      and visit.shop_id = '8b200000-0000-4000-8000-000000000001'
+      and visit.work_order_id = v_work_order_id
+  ) then
+    raise exception 'Dispatch ownership assertion failed: arrived visit did not materialize its canonical work order';
+  end if;
+
   perform public.dispatch_transition_service_visit_atomic(
     '8b200000-0000-4000-8000-000000000001',
     v_visit_id, 'working', null, null, null,

--- a/tests/dispatch/mobile-dispatch.runtime.sql
+++ b/tests/dispatch/mobile-dispatch.runtime.sql
@@ -23,15 +23,16 @@ set user_id = excluded.user_id,
 insert into public.shops (
   id, owner_id, business_name, name, user_limit,
   accepts_online_booking, min_notice_minutes, max_lead_days,
-  location_type
+  location_type, billing_entitlement_override
 )
 values (
   '8b100000-0000-4000-8000-000000000001',
   '8a100000-0000-4000-8000-000000000001',
   'Dispatch Runtime Shop', 'Dispatch Runtime Shop', 10,
-  true, 0, 365, 'repair_facility'
+  true, 0, 365, 'repair_facility', 'internal_demo'
 )
-on conflict (id) do nothing;
+on conflict (id) do update
+set billing_entitlement_override = 'internal_demo';
 
 update public.profiles
 set shop_id = '8b100000-0000-4000-8000-000000000001'
@@ -40,6 +41,49 @@ where id in (
   '8a100000-0000-4000-8000-000000000002',
   '8a100000-0000-4000-8000-000000000003'
 );
+
+-- Mobile-mode Dispatch requires both the Field Service product entitlement
+-- and explicit operator assignment. Keep this runtime fixture aligned with
+-- the production authorization boundary instead of bypassing it through the
+-- service-role session used below.
+insert into public.mobile_service_settings (
+  shop_id, service_model, solo_mode, dispatch_enabled,
+  service_vehicles_enabled, field_operator_count_target,
+  onboarding_completed_at, configured_by
+)
+values (
+  '8b100000-0000-4000-8000-000000000001', 'mobile', false, true,
+  true, 3, now(), '8a100000-0000-4000-8000-000000000001'
+)
+on conflict (shop_id) do update
+set service_model = 'mobile',
+    solo_mode = false,
+    dispatch_enabled = true,
+    service_vehicles_enabled = true,
+    field_operator_count_target = 3,
+    onboarding_completed_at = now(),
+    configured_by = '8a100000-0000-4000-8000-000000000001';
+
+insert into public.mobile_field_operators (
+  shop_id, profile_id, enabled, created_by
+)
+values
+  (
+    '8b100000-0000-4000-8000-000000000001',
+    '8a100000-0000-4000-8000-000000000001', true,
+    '8a100000-0000-4000-8000-000000000001'
+  ),
+  (
+    '8b100000-0000-4000-8000-000000000001',
+    '8a100000-0000-4000-8000-000000000002', true,
+    '8a100000-0000-4000-8000-000000000001'
+  ),
+  (
+    '8b100000-0000-4000-8000-000000000001',
+    '8a100000-0000-4000-8000-000000000003', true,
+    '8a100000-0000-4000-8000-000000000001'
+  )
+on conflict (shop_id, profile_id) do update set enabled = true;
 
 insert into public.customers (id, shop_id, first_name, last_name, email, phone)
 values (

--- a/tests/dispatch/mobile-dispatch.runtime.sql
+++ b/tests/dispatch/mobile-dispatch.runtime.sql
@@ -93,6 +93,17 @@ values (
 )
 on conflict (id) do nothing;
 
+insert into public.vehicles (id, shop_id, customer_id, year, make, model, vin)
+values (
+  '8c200000-0000-4000-8000-000000000001',
+  '8b100000-0000-4000-8000-000000000001',
+  '8c100000-0000-4000-8000-000000000001',
+  2024, 'Test', 'Mobile Service Unit', '1FTFW1E50NFA00001'
+)
+on conflict (id) do update
+set shop_id = excluded.shop_id,
+    customer_id = excluded.customer_id;
+
 insert into public.service_vehicles (id, shop_id, name, unit_number, active)
 values
   ('8d100000-0000-4000-8000-000000000001', '8b100000-0000-4000-8000-000000000001', 'Service Truck 1', 'ST-1', true),
@@ -134,7 +145,8 @@ begin
   -- one unassigned Service Visit after the scheduler event is established.
   v_booking_a := public.scheduler_apply_booking_command_atomic(
     'create', null, '8b100000-0000-4000-8000-000000000001',
-    '8c100000-0000-4000-8000-000000000001', null,
+    '8c100000-0000-4000-8000-000000000001',
+    '8c200000-0000-4000-8000-000000000001',
     '2099-03-01 09:00:00+00', '2099-03-01 10:00:00+00', 'Mobile visit A',
     '8a100000-0000-4000-8000-000000000001', 'staff',
     'dispatch-runtime:booking:a', null, '2099-01-01 00:00:00+00', 'mobile', null

--- a/tests/dispatch/mobile-dispatch.runtime.sql
+++ b/tests/dispatch/mobile-dispatch.runtime.sql
@@ -117,6 +117,8 @@ declare
   v_visit_c_id uuid;
   v_visit_d_id uuid;
   v_create_result jsonb;
+  v_handoff jsonb;
+  v_work_order_id uuid;
   v_truck_a uuid;
   v_truck_b uuid;
   v_board jsonb;
@@ -258,6 +260,24 @@ begin
     '8b100000-0000-4000-8000-000000000001', v_visit_a_id, 'arrived', null, 12.8, null,
     '8a100000-0000-4000-8000-000000000002', 'dispatch-runtime:a:arrived'
   );
+
+  -- Arrival may precede repair creation, but physical work must always be
+  -- anchored to the canonical work order before the visit enters `working`.
+  v_handoff := public.mobile_materialize_service_visit_work_order_atomic(
+    '8b100000-0000-4000-8000-000000000001', v_visit_a_id,
+    '8a100000-0000-4000-8000-000000000002',
+    'dispatch-runtime:a:work-order'
+  );
+  v_work_order_id := (v_handoff ->> 'workOrderId')::uuid;
+  if v_work_order_id is null or not exists (
+    select 1 from public.service_visits visit
+    where visit.id = v_visit_a_id
+      and visit.shop_id = '8b100000-0000-4000-8000-000000000001'
+      and visit.work_order_id = v_work_order_id
+  ) then
+    raise exception 'Dispatch assertion failed: arrived visit did not materialize its canonical work order';
+  end if;
+
   perform public.dispatch_transition_service_visit_atomic(
     '8b100000-0000-4000-8000-000000000001', v_visit_a_id, 'working', null, null, null,
     '8a100000-0000-4000-8000-000000000002', 'dispatch-runtime:a:working'


### PR DESCRIPTION
## Summary

- add versioned customer pricing terms for cost-band parts markup matrices, minimum parts margin floors, customer fees, and expiry warnings
- resolve parts pricing in the explicit order matrix → customer discount → margin floor, with unknown-cost provenance and lifecycle locks
- reuse the canonical work-order shop-supplies override for customer fees while recording the responsible agreement, resolved amount, and timestamp
- supersede immutable pricing snapshots with V2 provenance and expose the new terms in Customer Account Center and Quote Review

## Migration

- `20260812140518_customer_pricing_v2.sql`
- additive/expand-compatible: the deployed V1 RPCs remain available during rollout while application routes move to V2
- do not apply manually with a generated migration version; merge deployment must preserve this exact ledger version

## Validation

- full Vitest suite: 2,147 passed, 2 skipped; 1 test file skipped
- focused Pricing V2 suite: 14 passed
- TypeScript typecheck: passed
- changed-file ESLint: passed
- production build: passed with CI placeholder environment
- API route boundary audit: passed (446 routes)
- regression inventory: 0 new errors; 7 known dynamic-RPC warnings
- local Supabase replay unavailable because the CLI cannot create its read-only home directory; Supabase Clean Replay CI is the authoritative SQL compilation gate

## Rollout

1. Supabase Clean Replay and universal PR checks must pass.
2. Review and merge the application plus exact forward migration together.
3. Verify the production migration ledger and Pricing V2 RPCs after deployment.
4. Retire authenticated V1 RPC access in a later contract migration after the V2 deploy is confirmed.