### PR TITLE
Fix Fleet Form Import generated inspection output

### DIFF
--- a/features/inspections/app/inspection/run/page.tsx
+++ b/features/inspections/app/inspection/run/page.tsx
@@ -13,8 +13,18 @@ import Card from "@/features/shared/components/ui/Card";
 type DB = Database;
 type TemplateRow = DB["public"]["Tables"]["inspection_templates"]["Row"];
 
-type SectionItem = { item: string; unit?: string | null };
+type SectionItem = {
+  item: string;
+  unit?: string | null;
+  fieldType?: string | null;
+};
 type Section = { title: string; items: SectionItem[] };
+
+function isImportedFleetForm(sections: Section[]): boolean {
+  return sections.some((section) =>
+    (section.items ?? []).some((item) => Boolean(item.fieldType)),
+  );
+}
 
 export default function RunInspectionPage() {
   const sp = useSearchParams();
@@ -53,6 +63,7 @@ export default function RunInspectionPage() {
       }
 
       const title = stagedTitle || "Inspection";
+      const importedFleetForm = isImportedFleetForm(sections);
 
       const currentParams: Record<string, string> = {};
       sp.forEach((value, key) => {
@@ -77,10 +88,17 @@ export default function RunInspectionPage() {
         sessionStorage.getItem("inspection:vehicleType") ||
         "";
 
-      const grid =
-        mergedParams.grid ||
-        gridOverride ||
-        sessionStorage.getItem("customInspection:gridMode");
+      const grid = importedFleetForm
+        ? "none"
+        : mergedParams.grid ||
+          gridOverride ||
+          sessionStorage.getItem("customInspection:gridMode");
+
+      if (importedFleetForm) {
+        // Fleet form imports describe the customer's source form. Never inject
+        // ProFixIQ's generic brake/corner grid unless it was actually imported.
+        mergedParams.grid = "none";
+      }
 
       // ✅ Single canonical normalizer (shared with other flows)
       const normalizedSections = prepareSectionsWithCornerGrid(
@@ -127,12 +145,14 @@ export default function RunInspectionPage() {
       const rawSections = (data.sections ?? []) as Section[];
       const title = data.template_name ?? "Inspection";
       const vehicleType = String(data.vehicle_type ?? "");
+      const importedFleetForm = isImportedFleetForm(rawSections);
+      const resolvedGridOverride = importedFleetForm ? "none" : gridOverride;
 
       // ✅ Single canonical normalizer (shared with other flows)
       const sections = prepareSectionsWithCornerGrid(
         rawSections,
         vehicleType,
-        gridOverride,
+        resolvedGridOverride,
       ) as unknown as Section[];
 
       if (typeof window !== "undefined") {
@@ -145,6 +165,7 @@ export default function RunInspectionPage() {
         params.template = params.template || "generic";
         params.vehicleType = vehicleType;
         params.mode = params.mode || "run";
+        if (importedFleetForm) params.grid = "none";
 
         sessionStorage.setItem("inspection:sections", JSON.stringify(sections));
         sessionStorage.setItem("inspection:title", title);

--- a/features/inspections/lib/form-import.ts
+++ b/features/inspections/lib/form-import.ts
@@ -5,9 +5,21 @@ export type InspectionFormImportState =
   | "failed"
   | "approved";
 
+export type InspectionFormFieldType =
+  | "check"
+  | "defect"
+  | "measurement"
+  | "text"
+  | "instruction"
+  | "identity"
+  | "signature"
+  | "trip"
+  | "branding";
+
 export type InspectionFormItem = {
   item: string;
   unit?: string | null;
+  fieldType?: InspectionFormFieldType;
 };
 
 export type InspectionFormSection = {
@@ -52,6 +64,24 @@ export type InspectionFormImportView = {
   approvedAt: string | null;
 };
 
+const INSPECTION_FORM_FIELD_TYPES = new Set<InspectionFormFieldType>([
+  "check",
+  "defect",
+  "measurement",
+  "text",
+  "instruction",
+  "identity",
+  "signature",
+  "trip",
+  "branding",
+]);
+
+const RUNNABLE_INSPECTION_FORM_FIELD_TYPES = new Set<InspectionFormFieldType>([
+  "check",
+  "defect",
+  "measurement",
+]);
+
 function record(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null
     ? (value as Record<string, unknown>)
@@ -67,6 +97,33 @@ function nullableText(value: unknown): string | null {
   return valueText || null;
 }
 
+function normalizeInspectionFormFieldType(
+  value: unknown,
+): InspectionFormFieldType | undefined {
+  const normalized = text(value).toLowerCase().replaceAll("-", "_");
+  if (!normalized) return undefined;
+  const aliases: Record<string, InspectionFormFieldType> = {
+    checklist: "check",
+    pass_fail: "check",
+    condition: "check",
+    defect_check: "defect",
+    defect_classification: "defect",
+    numeric: "measurement",
+    number: "measurement",
+    textarea: "text",
+    free_text: "text",
+    header: "branding",
+    admin: "identity",
+    administrative: "identity",
+    certification: "signature",
+    trip_log: "trip",
+  };
+  const candidate = aliases[normalized] ?? normalized;
+  return INSPECTION_FORM_FIELD_TYPES.has(candidate as InspectionFormFieldType)
+    ? (candidate as InspectionFormFieldType)
+    : undefined;
+}
+
 export function normalizeInspectionFormSections(
   value: unknown,
 ): InspectionFormSection[] {
@@ -80,11 +137,50 @@ export function normalizeInspectionFormSections(
     for (const itemValue of rawItems) {
       const item = record(itemValue);
       const label = text(item.item ?? item.label ?? item.name);
-      if (label) items.push({ item: label, unit: nullableText(item.unit) });
+      if (!label) continue;
+      const fieldType = normalizeInspectionFormFieldType(
+        item.fieldType ?? item.field_type ?? item.kind,
+      );
+      items.push({
+        item: label,
+        unit: nullableText(item.unit),
+        ...(fieldType ? { fieldType } : {}),
+      });
     }
     if (items.length) sections.push({ title, items });
   }
   return sections;
+}
+
+/**
+ * Convert structural OCR into the subset that the canonical inspection runner
+ * can execute. New imports are classified by the vision model, so branding,
+ * legal copy, identity fields, signatures, free-text summary boxes and trip
+ * logs are intentionally excluded instead of being turned into OK/FAIL rows.
+ *
+ * Old already-processed imports did not carry fieldType. Preserve those rows so
+ * reviewing an existing job does not destructively rewrite historical data.
+ */
+export function selectRunnableInspectionFormSections(
+  value: unknown,
+): InspectionFormSection[] {
+  const sections = normalizeInspectionFormSections(value);
+  const hasClassifiedItems = sections.some((section) =>
+    section.items.some((item) => Boolean(item.fieldType)),
+  );
+
+  return sections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => {
+        if (!hasClassifiedItems) return true;
+        return Boolean(
+          item.fieldType &&
+            RUNNABLE_INSPECTION_FORM_FIELD_TYPES.has(item.fieldType),
+        );
+      }),
+    }))
+    .filter((section) => section.items.length > 0);
 }
 
 export function inspectionFormImportState(

--- a/features/inspections/lib/inspection/InspectionItemCard.tsx
+++ b/features/inspections/lib/inspection/InspectionItemCard.tsx
@@ -49,6 +49,10 @@ interface InspectionItemCardProps {
   showEvidenceFields?: boolean;
 }
 
+type ImportedFormItem = InspectionItem & {
+  fieldType?: string | null;
+};
+
 function getItemLabel(raw: InspectionItem): string {
   const it = raw as unknown as {
     item?: unknown;
@@ -96,12 +100,29 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
 
   const label = getItemLabel(item);
   const nameLower = label.toLowerCase();
+  const isImportedMeasurement =
+    String((item as ImportedFormItem).fieldType ?? "")
+      .trim()
+      .toLowerCase() === "measurement";
 
   const isMeasurementItem =
+    isImportedMeasurement ||
     nameLower.includes("wheel torque") ||
     nameLower.includes("park lining") ||
     nameLower.includes("labor hours") ||
     nameLower.includes("hours");
+
+  const measurementValue =
+    isImportedMeasurement && !onUpdateValue
+      ? getNotesValue(item)
+      : String(item.value ?? "");
+  const updateMeasurementValue = (value: string) => {
+    if (onUpdateValue) {
+      onUpdateValue(sectionIndex, itemIndex, value);
+    } else if (isImportedMeasurement) {
+      onUpdateNote(sectionIndex, itemIndex, value);
+    }
+  };
 
   const status = String(item.status ?? "").toLowerCase();
   const isFail = status === "fail";
@@ -197,9 +218,9 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
                 <input
                   type="number"
                   inputMode="decimal"
-                  value={item.value ?? ""}
+                  value={measurementValue}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    onUpdateValue?.(sectionIndex, itemIndex, e.target.value)
+                    updateMeasurementValue(e.target.value)
                   }
                   placeholder="Value"
                   className="h-9 w-24 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-[12px] text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/60"
@@ -207,6 +228,7 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
                 <input
                   type="text"
                   value={item.unit ?? ""}
+                  readOnly={isImportedMeasurement && !onUpdateUnit}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     onUpdateUnit?.(sectionIndex, itemIndex, e.target.value)
                   }
@@ -318,9 +340,9 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
             <input
               type="number"
               inputMode="decimal"
-              value={item.value ?? ""}
+              value={measurementValue}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                onUpdateValue?.(sectionIndex, itemIndex, e.target.value)
+                updateMeasurementValue(e.target.value)
               }
               placeholder="Value"
               className="w-24 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-[12px] text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/60"
@@ -328,6 +350,7 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
             <input
               type="text"
               value={item.unit ?? ""}
+              readOnly={isImportedMeasurement && !onUpdateUnit}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 onUpdateUnit?.(sectionIndex, itemIndex, e.target.value)
               }

--- a/features/inspections/lib/inspection/StatusButtons.tsx
+++ b/features/inspections/lib/inspection/StatusButtons.tsx
@@ -28,6 +28,10 @@ type StatusButtonsProps = {
   wrap?: boolean;
 };
 
+type ImportedFormItem = InspectionItem & {
+  fieldType?: string | null;
+};
+
 /**
  * Glassy, metallic status pills with clear status colors:
  * - OK        → green
@@ -52,6 +56,10 @@ export default function StatusButtons(_props: StatusButtonsProps) {
   } = _props as StatusButtonsProps;
 
   const selected = item.status;
+  const isDefectClassification =
+    String((item as ImportedFormItem).fieldType ?? "")
+      .trim()
+      .toLowerCase() === "defect";
 
   const size = compact
     ? "h-8 px-2.5 text-[10px]"
@@ -135,9 +143,9 @@ export default function StatusButtons(_props: StatusButtonsProps) {
         onClick={() => choose("ok")}
         onKeyDown={(e) => keyActivate("ok", e)}
         aria-pressed={selected === "ok"}
-        title="Mark OK"
+        title={isDefectClassification ? "Mark no defect" : "Mark OK"}
       >
-        OK
+        {isDefectClassification ? "None" : "OK"}
       </button>
 
       <button
@@ -147,9 +155,9 @@ export default function StatusButtons(_props: StatusButtonsProps) {
         onClick={() => choose("fail")}
         onKeyDown={(e) => keyActivate("fail", e)}
         aria-pressed={selected === "fail"}
-        title="Mark FAIL"
+        title={isDefectClassification ? "Mark major defect" : "Mark FAIL"}
       >
-        Fail
+        {isDefectClassification ? "Major" : "Fail"}
       </button>
 
       <button
@@ -159,9 +167,9 @@ export default function StatusButtons(_props: StatusButtonsProps) {
         onClick={() => choose("recommend")}
         onKeyDown={(e) => keyActivate("recommend", e)}
         aria-pressed={selected === "recommend"}
-        title="Mark Recommend"
+        title={isDefectClassification ? "Mark minor defect" : "Mark Recommend"}
       >
-        Rec
+        {isDefectClassification ? "Minor" : "Rec"}
       </button>
 
       <button

--- a/features/inspections/server/inspection-form-import-job.ts
+++ b/features/inspections/server/inspection-form-import-job.ts
@@ -6,9 +6,9 @@ import type { Database } from "@shared/types/types/supabase";
 import {
   normalizeInspectionFormImportSummary,
   normalizeInspectionFormSections,
+  selectRunnableInspectionFormSections,
   type InspectionFormSection,
 } from "@/features/inspections/lib/form-import";
-import { replaceFleetTireSectionWithGrid } from "@/features/inspections/lib/fleet/replaceFleetTireSectionWithGrid";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
@@ -85,7 +85,7 @@ async function parsePage(
       {
         role: "system",
         content:
-          "You perform OCR on vehicle inspection forms. Return strict JSON only and preserve every visible section and checklist row.",
+          "You perform structural OCR on vehicle and fleet inspection forms. Return strict JSON only. Preserve visible content, but classify every form element so administrative text is never converted into an inspection checklist row.",
       },
       {
         role: "user",
@@ -94,8 +94,21 @@ async function parsePage(
             type: "text",
             text: [
               "Read this single page of a customer vehicle inspection form.",
-              'Return {"extracted_text":"...","sections":[{"title":"...","items":[{"item":"...","unit":null}]}]}.',
-              "Keep printed order. Include fill-in fields and measurement rows. Do not invent content.",
+              '{"extracted_text":"...","sections":[{"title":"...","items":[{"item":"...","unit":null,"field_type":"check"}]}]}.',
+              "field_type is REQUIRED for every item and must be one of: check, defect, measurement, text, instruction, identity, signature, trip, branding.",
+              "Classification rules:",
+              "- check: a real vehicle/component condition row intended to be marked pass/fail/okay/not-applicable.",
+              "- defect: a real vehicle/component checklist row where the source form classifies defects as minor/major, V/X, or equivalent. If a source legend defines minor and major defects, use defect for all rows governed by that legend.",
+              "- measurement: a physical component inspection measurement such as brake lining, push-rod travel, tire pressure, tread depth, or rotor/drum measurement. Do NOT classify odometer, engine hours, trip distance, dates, or administrative readings as measurement.",
+              "- text: a standalone free-text response box such as a general defect-details paragraph.",
+              "- instruction: legal, regulatory, safety, explanatory, or procedural wording that the person reads but does not inspect.",
+              "- identity: vehicle/unit/VIN/licence plate/location/odometer/driver/person/date/time fields and similar record metadata.",
+              "- signature: printed-name, signature, certification, attestation, completion, or sign-off fields.",
+              "- trip: trip log/table fields such as driver, odometer start/finish, kilometres driven, route, or observations for a trip.",
+              "- branding: organization names, logos, slogans, mottos, addresses, or decorative headings that are not inspection sections.",
+              "Keep printed order and printed section titles. Do not invent content.",
+              "For label/value pairs, return the reusable printed label only. Never append handwritten or filled-in sample values to the item label.",
+              "Do not turn organization names, slogans, instructions, legal statements, filled answers, vehicle identifiers, signature lines, completion fields, or trip tables into check/defect rows.",
               `Vehicle type hint: ${hints.vehicleType || "unknown"}`,
               `Duty class hint: ${hints.dutyClass || "unknown"}`,
               `Template title hint: ${hints.title || "unknown"}`,
@@ -116,7 +129,7 @@ async function parsePage(
   const result = JSON.parse(content) as VisionResult;
   const sections = normalizeInspectionFormSections(result.sections);
   if (!sections.length) {
-    throw new Error("No readable inspection rows were found on this page.");
+    throw new Error("No readable form elements were found on this page.");
   }
 
   return {
@@ -153,16 +166,7 @@ async function finalizeJob(
     const payload = asPagePayload(page.raw_row);
     return payload?.parsedSections ?? [];
   });
-  const draftSections = replaceFleetTireSectionWithGrid({
-    sections,
-    vehicleType: hints.vehicleType,
-    dutyClass:
-      hints.dutyClass === "light" ||
-      hints.dutyClass === "medium" ||
-      hints.dutyClass === "heavy"
-        ? hints.dutyClass
-        : "",
-  });
+  const draftSections = selectRunnableInspectionFormSections(sections);
   const extractedText = successful
     .map((page) => asPagePayload(page.raw_row)?.extractedText || "")
     .filter(Boolean)
@@ -174,7 +178,7 @@ async function finalizeJob(
       .update({
         status: "failed",
         failed_count: failedPages.length || pages.length,
-        error_message: "No uploaded pages contained readable inspection rows.",
+        error_message: "No uploaded pages contained reusable inspection rows.",
         completed_at: new Date().toISOString(),
         summary: { ...hints, state: "failed", failedPages },
       })

--- a/tests/inspection-form-import-shaping.test.ts
+++ b/tests/inspection-form-import-shaping.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeInspectionFormSections,
+  selectRunnableInspectionFormSections,
+} from "../features/inspections/lib/form-import";
+
+describe("inspection form import shaping", () => {
+  it("keeps Rundle-style defect rows and removes filled/admin paper-form content", () => {
+    const source = [
+      {
+        title: "Header",
+        items: [
+          { item: "Rundle College Society", field_type: "branding" },
+          { item: "Attention to Excellence", field_type: "branding" },
+        ],
+      },
+      {
+        title: "Vehicle Daily Inspection Report",
+        items: [
+          {
+            item: "Vehicle's Name or Unit Number",
+            field_type: "identity",
+          },
+          { item: "Licence Plate Number", field_type: "identity" },
+          { item: "Odometer Reading", field_type: "identity" },
+        ],
+      },
+      {
+        title: "Inspection statement",
+        items: [
+          {
+            item: "I performed an inspection of the vehicle noted above",
+            field_type: "instruction",
+          },
+          {
+            item: "No defect was found that would likely affect safety",
+            field_type: "instruction",
+          },
+        ],
+      },
+      {
+        title: "Defect checklist",
+        items: [
+          { item: "1. Accessibility Devices", field_type: "defect" },
+          { item: "2. Air Brake System", field_type: "defect" },
+          { item: "23. Tires", field_type: "defect" },
+          {
+            item: "24. Wheels, Hubs and fasteners",
+            field_type: "defect",
+          },
+        ],
+      },
+      {
+        title: "Provide details of defect(s)",
+        items: [
+          { item: "Provide details of defect(s)", field_type: "text" },
+        ],
+      },
+      {
+        title: "Completion",
+        items: [
+          {
+            item: "Name of person completing inspection (PRINT)",
+            field_type: "signature",
+          },
+          {
+            item: "Signature of person completing inspection",
+            field_type: "signature",
+          },
+          { item: "Date and time completed", field_type: "signature" },
+        ],
+      },
+      {
+        title: "Trips Taken on This Day",
+        items: [
+          { item: "Driver Name", field_type: "trip" },
+          { item: "Odometer Start", field_type: "trip" },
+          { item: "Odometer Finish", field_type: "trip" },
+          { item: "Kilometres Driven", field_type: "trip" },
+          { item: "Observations", field_type: "trip" },
+        ],
+      },
+    ];
+
+    const normalized = normalizeInspectionFormSections(source);
+    expect(normalized[1]?.items[0]).toMatchObject({
+      item: "Vehicle's Name or Unit Number",
+      unit: null,
+      fieldType: "identity",
+    });
+
+    const runnable = selectRunnableInspectionFormSections(source);
+    expect(runnable).toEqual([
+      {
+        title: "Defect checklist",
+        items: [
+          {
+            item: "1. Accessibility Devices",
+            unit: null,
+            fieldType: "defect",
+          },
+          {
+            item: "2. Air Brake System",
+            unit: null,
+            fieldType: "defect",
+          },
+          { item: "23. Tires", unit: null, fieldType: "defect" },
+          {
+            item: "24. Wheels, Hubs and fasteners",
+            unit: null,
+            fieldType: "defect",
+          },
+        ],
+      },
+    ]);
+
+    const runnableText = JSON.stringify(runnable);
+    expect(runnableText).not.toContain("Rundle College");
+    expect(runnableText).not.toContain("Odometer Start");
+    expect(runnableText).not.toContain("Signature of person");
+    expect(runnableText).not.toContain("No defect was found");
+  });
+
+  it("keeps physical measurements but rejects administrative readings", () => {
+    const runnable = selectRunnableInspectionFormSections([
+      {
+        title: "Measurements",
+        items: [
+          { item: "Brake lining thickness", unit: "mm", kind: "measurement" },
+          { item: "Push rod travel", unit: "in", kind: "measurement" },
+          { item: "Odometer Reading", unit: "km", kind: "identity" },
+        ],
+      },
+    ]);
+
+    expect(runnable).toEqual([
+      {
+        title: "Measurements",
+        items: [
+          {
+            item: "Brake lining thickness",
+            unit: "mm",
+            fieldType: "measurement",
+          },
+          {
+            item: "Push rod travel",
+            unit: "in",
+            fieldType: "measurement",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("preserves old unclassified imports for backward-compatible review", () => {
+    const legacy = [
+      { title: "General", items: [{ item: "Brakes" }, { item: "Lights" }] },
+    ];
+
+    expect(selectRunnableInspectionFormSections(legacy)).toEqual([
+      {
+        title: "General",
+        items: [
+          { item: "Brakes", unit: null },
+          { item: "Lights", unit: null },
+        ],
+      },
+    ]);
+  });
+});

--- a/tests/mobile-inspection-form-import.test.ts
+++ b/tests/mobile-inspection-form-import.test.ts
@@ -117,4 +117,28 @@ describe("mobile inspection form imports", () => {
       read("features/inspections/components/FleetFormImportCard.tsx"),
     ).not.toContain("sessionStorage");
   });
+
+  it("shapes imported paper forms without inventing ProFixIQ grids", () => {
+    const worker = read(
+      "features/inspections/server/inspection-form-import-job.ts",
+    );
+    const runPage = read("features/inspections/app/inspection/run/page.tsx");
+    const statusButtons = read(
+      "features/inspections/lib/inspection/StatusButtons.tsx",
+    );
+    const itemCard = read(
+      "features/inspections/lib/inspection/InspectionItemCard.tsx",
+    );
+
+    expect(worker).toContain("selectRunnableInspectionFormSections");
+    expect(worker).toContain("field_type is REQUIRED");
+    expect(worker).toContain("Never append handwritten or filled-in sample values");
+    expect(worker).not.toContain("replaceFleetTireSectionWithGrid");
+    expect(runPage).toContain('mergedParams.grid = "none"');
+    expect(runPage).toContain('resolvedGridOverride = importedFleetForm ? "none"');
+    expect(statusButtons).toContain('toLowerCase() === "defect"');
+    expect(statusButtons).toContain('? "Major" : "Fail"');
+    expect(statusButtons).toContain('? "Minor" : "Rec"');
+    expect(itemCard).toContain('toLowerCase() === "measurement"');
+  });
 });


### PR DESCRIPTION
## Summary
- make Fleet Form Import use structural OCR instead of treating every visible paper-form label as an inspection item
- classify imported form elements and only carry runnable checks/defect rows/physical measurements into the generated inspection
- strip branding, instructions/legal text, sample identity values, signatures, defect-detail summary boxes and trip-log fields from runnable inspection rows
- stop Fleet Form Import from injecting the canonical tire/corner grid when the source form did not contain one
- preserve minor/major defect semantics in imported checklist controls while retaining canonical ProFixIQ status values underneath
- keep classified physical measurements editable without changing normal inspection behavior

## Regression coverage
- adds a Rundle-style form shaping fixture proving branding, unit/plate/odometer metadata, legal copy, signatures and trip rows do not become checklist items
- verifies physical measurements remain runnable while administrative readings are excluded
- preserves backward compatibility for older unclassified import jobs
- adds source-flow assertions that imported forms force `grid=none` and no longer call `replaceFleetTireSectionWithGrid`

## Scope
Fleet Form Import and the conditional rendering needed for its generated templates only. No database schema or migration changes.