### PR TITLE
Fix Fleet Form Import Codex findings

### DIFF
--- a/app/inspections/custom-draft/page.tsx
+++ b/app/inspections/custom-draft/page.tsx
@@ -1,7 +1,7 @@
 // Server component wrapper (no "use client")
-import CustomRunPage from "@/features/inspections/app/inspection/custom-draft/page";
+import InspectionTemplateEditRouter from "@/features/inspections/components/InspectionTemplateEditRouter";
 
 export const dynamic = "force-dynamic"; // optional, if you need runtime params each load
 export default function Page() {
-  return <CustomRunPage />;
+  return <InspectionTemplateEditRouter />;
 }

--- a/app/mobile/inspections/[id]/page.tsx
+++ b/app/mobile/inspections/[id]/page.tsx
@@ -7,12 +7,24 @@ import { toast } from "sonner";
 import GenericInspectionScreen from "@/features/inspections/screens/GenericInspectionScreen";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-type SectionItem = { item: string; unit?: string | null };
+type SectionItem = {
+  item: string;
+  unit?: string | null;
+  fieldType?: string | null;
+};
 type Section = { title: string; items: SectionItem[] };
 
 const HYD_ITEM_RE = /^(LF|RF|LR|RR)\s+/i;
 const AIR_ITEM_RE =
   /^(Steer\s*\d*|Drive\s*\d+|Tag|Trailer\s*\d+)\s+(Left|Right)\s+/i;
+
+function hasImportedFormClassification(sections: Section[]): boolean {
+  return (sections ?? []).some((section) =>
+    (section.items ?? []).some(
+      (item) => typeof item.fieldType === "string" && item.fieldType.trim().length > 0,
+    ),
+  );
+}
 
 function looksLikeCornerTitle(title: string | undefined | null): boolean {
   if (!title) return false;
@@ -96,6 +108,7 @@ function prepareSectionsWithCornerGrid(
   gridParam: string | null,
 ): Section[] {
   const source = Array.isArray(sections) ? sections : [];
+  if (hasImportedFormClassification(source)) return source;
   if (source.some((section) => looksLikeCornerTitle(section.title))) {
     return source;
   }

--- a/features/inspections/components/InspectionReportView.tsx
+++ b/features/inspections/components/InspectionReportView.tsx
@@ -1,14 +1,6 @@
 import type { InspectionReport } from "@/features/inspections/lib/inspection/report";
 import InspectionPhotoGallery from "@/features/inspections/components/inspection/InspectionPhotoGallery";
 
-const labels = {
-  ok: "Pass",
-  fail: "Needs attention",
-  recommend: "Recommended",
-  na: "Not applicable",
-  not_checked: "Not checked",
-} as const;
-
 export function InspectionReportView({
   report,
   technicianName,
@@ -18,6 +10,38 @@ export function InspectionReportView({
   technicianName: string | null;
   finalizedAt: string | null;
 }) {
+  const genericPassed = Math.max(0, report.totals.ok - report.totals.noDefect);
+  const genericFailed = Math.max(
+    0,
+    report.totals.failed - report.totals.majorDefects,
+  );
+  const genericRecommended = Math.max(
+    0,
+    report.totals.recommended - report.totals.minorDefects,
+  );
+  const hasDefectClassification = report.totals.defectItems > 0;
+  const genericRowsPresent =
+    !hasDefectClassification ||
+    genericPassed > 0 ||
+    genericFailed > 0 ||
+    genericRecommended > 0;
+  const summaryTiles: Array<[string, number]> = [["Checked", report.totals.checked]];
+  if (genericRowsPresent) {
+    summaryTiles.push(
+      ["Passed", genericPassed],
+      ["Attention", genericFailed],
+      ["Recommended", genericRecommended],
+    );
+  }
+  if (hasDefectClassification) {
+    summaryTiles.push(
+      ["No defect", report.totals.noDefect],
+      ["Major", report.totals.majorDefects],
+      ["Minor", report.totals.minorDefects],
+    );
+  }
+  summaryTiles.push(["N/A", report.totals.notApplicable]);
+
   return (
     <article className="space-y-6">
       <header className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-6">
@@ -38,16 +62,10 @@ export function InspectionReportView({
         </div>
       </header>
 
-      <section className="grid grid-cols-2 gap-3 sm:grid-cols-5">
-        {[
-          ["Checked", report.totals.checked],
-          ["Passed", report.totals.ok],
-          ["Attention", report.totals.failed],
-          ["Recommended", report.totals.recommended],
-          ["N/A", report.totals.notApplicable],
-        ].map(([label, value]) => (
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-5">
+        {summaryTiles.map(([label, value]) => (
           <div
-            key={String(label)}
+            key={label}
             className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4"
           >
             <div className="text-xs uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
@@ -72,11 +90,14 @@ export function InspectionReportView({
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <h3 className="font-semibold">{item.label}</h3>
                   <span className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1 text-xs font-semibold">
-                    {labels[item.status]}
+                    {item.statusLabel}
                   </span>
                 </div>
                 {item.value ? (
-                  <div className="mt-2 text-sm">Measurement: {item.value}</div>
+                  <div className="mt-2 text-sm">
+                    Measurement: {item.value}
+                    {item.unit ? ` ${item.unit}` : ""}
+                  </div>
                 ) : null}
                 {item.note ? (
                   <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">

--- a/features/inspections/components/InspectionTemplateEditRouter.tsx
+++ b/features/inspections/components/InspectionTemplateEditRouter.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+
+import CustomDraftPage from "@/features/inspections/app/inspection/custom-draft/page";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+
+type ImportedFieldType = "check" | "defect" | "measurement";
+type ImportedItem = {
+  item: string;
+  unit: string | null;
+  fieldType: ImportedFieldType;
+};
+type ImportedSection = { title: string; items: ImportedItem[] };
+
+type TemplateRow = {
+  template_name: string | null;
+  sections: unknown;
+  vehicle_type: string | null;
+  labor_hours: number | null;
+  tags: string[] | null;
+};
+
+const FIELD_TYPES = new Set<ImportedFieldType>([
+  "check",
+  "defect",
+  "measurement",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizedSections(value: unknown): ImportedSection[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((rawSection) => {
+      if (!isRecord(rawSection)) return null;
+      const title = String(rawSection.title ?? "").trim();
+      if (!title || !Array.isArray(rawSection.items)) return null;
+      const items = rawSection.items
+        .map((rawItem) => {
+          if (!isRecord(rawItem)) return null;
+          const item = String(rawItem.item ?? rawItem.name ?? "").trim();
+          if (!item) return null;
+          const unit =
+            typeof rawItem.unit === "string" && rawItem.unit.trim()
+              ? rawItem.unit.trim()
+              : null;
+          const rawFieldType = String(rawItem.fieldType ?? "").trim().toLowerCase();
+          // Imported templates created before this repair can have their
+          // fieldType stripped by the old generic editor. The durable
+          // customer-form tag still routes them here; keep every row visible
+          // and give it a safe editable fallback rather than deleting it.
+          const fieldType = FIELD_TYPES.has(rawFieldType as ImportedFieldType)
+            ? (rawFieldType as ImportedFieldType)
+            : unit
+              ? "measurement"
+              : "check";
+          return { item, unit, fieldType } satisfies ImportedItem;
+        })
+        .filter((item): item is ImportedItem => item !== null);
+      return items.length ? ({ title, items } satisfies ImportedSection) : null;
+    })
+    .filter((section): section is ImportedSection => section !== null);
+}
+
+function ImportedFleetTemplateEditor({
+  templateId,
+  initial,
+}: {
+  templateId: string;
+  initial: TemplateRow;
+}) {
+  const router = useRouter();
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const [title, setTitle] = useState(initial.template_name ?? "Imported fleet form");
+  const [vehicleType, setVehicleType] = useState(initial.vehicle_type ?? "");
+  const [laborHours, setLaborHours] = useState(
+    typeof initial.labor_hours === "number" ? String(initial.labor_hours) : "",
+  );
+  const [sections, setSections] = useState<ImportedSection[]>(() =>
+    normalizedSections(initial.sections),
+  );
+  const [saving, setSaving] = useState(false);
+
+  const updateSection = (
+    sectionIndex: number,
+    updater: (section: ImportedSection) => ImportedSection,
+  ) => {
+    setSections((current) =>
+      current.map((section, index) =>
+        index === sectionIndex ? updater(section) : section,
+      ),
+    );
+  };
+
+  const updateItem = (
+    sectionIndex: number,
+    itemIndex: number,
+    patch: Partial<ImportedItem>,
+  ) => {
+    updateSection(sectionIndex, (section) => ({
+      ...section,
+      items: section.items.map((item, index) =>
+        index === itemIndex ? { ...item, ...patch } : item,
+      ),
+    }));
+  };
+
+  const save = async () => {
+    const cleaned = sections
+      .map((section) => ({
+        title: section.title.trim(),
+        items: section.items
+          .map((item) => ({
+            item: item.item.trim(),
+            unit: item.unit?.trim() || null,
+            fieldType: item.fieldType,
+          }))
+          .filter((item) => item.item.length > 0),
+      }))
+      .filter((section) => section.title && section.items.length > 0);
+    if (!title.trim() || !cleaned.length) {
+      toast.error("A template name and at least one inspection row are required.");
+      return;
+    }
+
+    const parsedLabor = laborHours.trim() ? Number(laborHours) : null;
+    if (parsedLabor != null && (!Number.isFinite(parsedLabor) || parsedLabor < 0)) {
+      toast.error("Labor hours must be a positive number.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const { error } = await supabase
+        .from("inspection_templates")
+        .update({
+          template_name: title.trim(),
+          sections: cleaned,
+          vehicle_type: vehicleType.trim() || null,
+          labor_hours: parsedLabor,
+        } as never)
+        .eq("id", templateId);
+      if (error) throw error;
+      toast.success("Imported fleet template saved.");
+      setSections(cleaned);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Unable to save imported template.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-5xl space-y-5 px-4 py-6 text-[color:var(--theme-text-primary)]">
+      <header className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] p-5 shadow-[var(--theme-shadow-medium)]">
+        <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper)]">
+          Fleet Form Import
+        </div>
+        <div className="mt-2 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold">Edit imported inspection template</h1>
+            <p className="mt-1 max-w-2xl text-sm text-[color:var(--theme-text-secondary)]">
+              Imported row types are preserved here so defect classifications and measurements keep the source form&apos;s meaning.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => router.push("/inspections/templates")}
+            className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold"
+          >
+            Back to templates
+          </button>
+        </div>
+      </header>
+
+      <section className="grid gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 sm:grid-cols-3">
+        <label className="text-xs text-[color:var(--theme-text-secondary)] sm:col-span-3">
+          Template name
+          <input
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2.5 text-sm"
+          />
+        </label>
+        <label className="text-xs text-[color:var(--theme-text-secondary)] sm:col-span-2">
+          Vehicle type
+          <input
+            value={vehicleType}
+            onChange={(event) => setVehicleType(event.target.value)}
+            className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2.5 text-sm"
+          />
+        </label>
+        <label className="text-xs text-[color:var(--theme-text-secondary)]">
+          Labor hours
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            value={laborHours}
+            onChange={(event) => setLaborHours(event.target.value)}
+            className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2.5 text-sm"
+          />
+        </label>
+      </section>
+
+      <div className="space-y-4">
+        {sections.map((section, sectionIndex) => (
+          <section
+            key={sectionIndex}
+            className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4"
+          >
+            <div className="flex gap-2">
+              <input
+                value={section.title}
+                onChange={(event) =>
+                  updateSection(sectionIndex, (current) => ({
+                    ...current,
+                    title: event.target.value,
+                  }))
+                }
+                className="min-w-0 flex-1 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 font-semibold"
+              />
+              <button
+                type="button"
+                disabled={sections.length === 1}
+                onClick={() =>
+                  setSections((current) =>
+                    current.filter((_, index) => index !== sectionIndex),
+                  )
+                }
+                className="rounded-xl px-3 text-xs text-red-400 disabled:opacity-30"
+              >
+                Remove
+              </button>
+            </div>
+
+            <div className="mt-3 space-y-2">
+              {section.items.map((item, itemIndex) => (
+                <div
+                  key={itemIndex}
+                  className="grid gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2 sm:grid-cols-[minmax(0,1fr)_130px_100px_auto]"
+                >
+                  <input
+                    value={item.item}
+                    onChange={(event) =>
+                      updateItem(sectionIndex, itemIndex, { item: event.target.value })
+                    }
+                    aria-label="Inspection item"
+                    className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-2 py-2 text-sm"
+                  />
+                  <select
+                    value={item.fieldType}
+                    onChange={(event) =>
+                      updateItem(sectionIndex, itemIndex, {
+                        fieldType: event.target.value as ImportedFieldType,
+                      })
+                    }
+                    aria-label="Imported row type"
+                    className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-2 py-2 text-xs"
+                  >
+                    <option value="check">Check</option>
+                    <option value="defect">Defect</option>
+                    <option value="measurement">Measurement</option>
+                  </select>
+                  <input
+                    value={item.unit ?? ""}
+                    disabled={item.fieldType !== "measurement"}
+                    onChange={(event) =>
+                      updateItem(sectionIndex, itemIndex, {
+                        unit: event.target.value || null,
+                      })
+                    }
+                    aria-label="Measurement unit"
+                    placeholder="Unit"
+                    className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-2 py-2 text-xs disabled:opacity-45"
+                  />
+                  <button
+                    type="button"
+                    onClick={() =>
+                      updateSection(sectionIndex, (current) => ({
+                        ...current,
+                        items: current.items.filter((_, index) => index !== itemIndex),
+                      }))
+                    }
+                    className="rounded-lg px-2 text-xs text-red-400"
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            <button
+              type="button"
+              onClick={() =>
+                updateSection(sectionIndex, (current) => ({
+                  ...current,
+                  items: [
+                    ...current.items,
+                    { item: "New inspection item", unit: null, fieldType: "check" },
+                  ],
+                }))
+              }
+              className="mt-3 rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold"
+            >
+              + Add item
+            </button>
+          </section>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={() =>
+            setSections((current) => [
+              ...current,
+              {
+                title: "New section",
+                items: [{ item: "New inspection item", unit: null, fieldType: "check" }],
+              },
+            ])
+          }
+          className="rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-2 text-sm font-semibold"
+        >
+          + Add section
+        </button>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => void save()}
+          className="rounded-xl bg-[var(--accent-copper)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+        >
+          {saving ? "Saving…" : "Save changes"}
+        </button>
+      </div>
+    </main>
+  );
+}
+
+export default function InspectionTemplateEditRouter() {
+  const searchParams = useSearchParams();
+  const templateId = searchParams.get("templateId");
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const [checking, setChecking] = useState(Boolean(templateId));
+  const [importedTemplate, setImportedTemplate] = useState<TemplateRow | null>(null);
+  const [checkError, setCheckError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!templateId) {
+      setChecking(false);
+      setImportedTemplate(null);
+      setCheckError(null);
+      return;
+    }
+
+    let active = true;
+    setChecking(true);
+    setCheckError(null);
+    void supabase
+      .from("inspection_templates")
+      .select("template_name, sections, vehicle_type, labor_hours, tags")
+      .eq("id", templateId)
+      .maybeSingle<TemplateRow>()
+      .then(({ data, error }) => {
+        if (!active) return;
+        if (error || !data) {
+          setImportedTemplate(null);
+          setCheckError(error?.message || "Template not found.");
+          setChecking(false);
+          return;
+        }
+        const taggedImported = Array.isArray(data.tags) && data.tags.includes("customer-form");
+        setImportedTemplate(taggedImported ? data : null);
+        setChecking(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [supabase, templateId]);
+
+  if (checking) {
+    return (
+      <div className="p-6 text-sm text-[color:var(--theme-text-secondary)]">
+        Loading template editor…
+      </div>
+    );
+  }
+
+  if (checkError) {
+    return (
+      <div className="m-6 rounded-xl border border-red-500/40 bg-red-950/20 p-4 text-sm text-red-300">
+        Unable to load this template safely: {checkError}
+      </div>
+    );
+  }
+
+  if (templateId && importedTemplate) {
+    return (
+      <ImportedFleetTemplateEditor
+        templateId={templateId}
+        initial={importedTemplate}
+      />
+    );
+  }
+
+  return <CustomDraftPage />;
+}

--- a/features/inspections/lib/form-import.ts
+++ b/features/inspections/lib/form-import.ts
@@ -5,6 +5,8 @@ export type InspectionFormImportState =
   | "failed"
   | "approved";
 
+export const INSPECTION_FORM_IMPORT_FORMAT_VERSION = 2;
+
 export type InspectionFormFieldType =
   | "check"
   | "defect"
@@ -153,27 +155,64 @@ export function normalizeInspectionFormSections(
 }
 
 /**
- * Convert structural OCR into the subset that the canonical inspection runner
- * can execute. New imports are classified by the vision model, so branding,
- * legal copy, identity fields, signatures, free-text summary boxes and trip
- * logs are intentionally excluded instead of being turned into OK/FAIL rows.
- *
- * Old already-processed imports did not carry fieldType. Preserve those rows so
- * reviewing an existing job does not destructively rewrite historical data.
+ * Strict V2 structural OCR contract. Every returned row must carry a recognized
+ * classification. This deliberately rejects partially or wholly unclassified
+ * model output instead of silently falling back to the legacy "every row is an
+ * inspection item" behavior.
+ */
+export function normalizeInspectionFormSectionsV2(
+  value: unknown,
+): InspectionFormSection[] | null {
+  if (!Array.isArray(value)) return null;
+
+  const sections: InspectionFormSection[] = [];
+  let sourceItemCount = 0;
+
+  for (const sectionValue of value) {
+    const section = record(sectionValue);
+    const title = text(section.title) || "Section";
+    const rawItems = Array.isArray(section.items) ? section.items : [];
+    const items: InspectionFormItem[] = [];
+
+    for (const itemValue of rawItems) {
+      sourceItemCount += 1;
+      const item = record(itemValue);
+      const label = text(item.item ?? item.label ?? item.name);
+      const fieldType = normalizeInspectionFormFieldType(
+        item.fieldType ?? item.field_type ?? item.kind,
+      );
+      if (!label || !fieldType) return null;
+      items.push({
+        item: label,
+        unit: nullableText(item.unit),
+        fieldType,
+      });
+    }
+
+    if (items.length) sections.push({ title, items });
+  }
+
+  return sourceItemCount > 0 && sections.length > 0 ? sections : null;
+}
+
+/**
+ * Convert one persisted OCR page into the subset the canonical inspection
+ * runner can execute. The persisted page format version is authoritative:
+ * legacy pages preserve unclassified rows for rolling-deploy compatibility,
+ * while V2 pages require and filter by structural classifications.
  */
 export function selectRunnableInspectionFormSections(
   value: unknown,
+  formatVersion = 1,
 ): InspectionFormSection[] {
   const sections = normalizeInspectionFormSections(value);
-  const hasClassifiedItems = sections.some((section) =>
-    section.items.some((item) => Boolean(item.fieldType)),
-  );
+  const classified = formatVersion >= INSPECTION_FORM_IMPORT_FORMAT_VERSION;
 
   return sections
     .map((section) => ({
       ...section,
       items: section.items.filter((item) => {
-        if (!hasClassifiedItems) return true;
+        if (!classified) return true;
         return Boolean(
           item.fieldType &&
             RUNNABLE_INSPECTION_FORM_FIELD_TYPES.has(item.fieldType),

--- a/features/inspections/lib/inspection/InspectionItemCard.tsx
+++ b/features/inspections/lib/inspection/InspectionItemCard.tsx
@@ -3,11 +3,12 @@
 "use client";
 
 import type React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import type {
   InspectionItem,
   InspectionItemStatus,
 } from "@inspections/lib/inspection/types";
+import { InspectionFormCtx } from "@inspections/lib/inspection/ui/InspectionFormContext";
 import StatusButtons from "./StatusButtons";
 import PhotoUploadButton from "./PhotoUploadButton";
 
@@ -97,6 +98,7 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
     showStatusControls = true,
     showEvidenceFields = false,
   } = props;
+  const formContext = useContext(InspectionFormCtx);
 
   const label = getItemLabel(item);
   const nameLower = label.toLowerCase();
@@ -112,15 +114,16 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
     nameLower.includes("labor hours") ||
     nameLower.includes("hours");
 
-  const measurementValue =
-    isImportedMeasurement && !onUpdateValue
-      ? getNotesValue(item)
-      : String(item.value ?? "");
+  const measurementValue = String(item.value ?? "");
+  const canPersistImportedMeasurement =
+    !isImportedMeasurement || Boolean(onUpdateValue || formContext?.updateItem);
   const updateMeasurementValue = (value: string) => {
     if (onUpdateValue) {
       onUpdateValue(sectionIndex, itemIndex, value);
-    } else if (isImportedMeasurement) {
-      onUpdateNote(sectionIndex, itemIndex, value);
+      return;
+    }
+    if (isImportedMeasurement && formContext?.updateItem) {
+      formContext.updateItem(sectionIndex, itemIndex, { value });
     }
   };
 
@@ -219,11 +222,12 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
                   type="number"
                   inputMode="decimal"
                   value={measurementValue}
+                  disabled={!canPersistImportedMeasurement}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     updateMeasurementValue(e.target.value)
                   }
                   placeholder="Value"
-                  className="h-9 w-24 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-[12px] text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/60"
+                  className="h-9 w-24 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-[12px] text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/60 disabled:opacity-60"
                 />
                 <input
                   type="text"
@@ -341,11 +345,12 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
               type="number"
               inputMode="decimal"
               value={measurementValue}
+              disabled={!canPersistImportedMeasurement}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 updateMeasurementValue(e.target.value)
               }
               placeholder="Value"
-              className="w-24 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-[12px] text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/60"
+              className="w-24 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-[12px] text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/60 disabled:opacity-60"
             />
             <input
               type="text"

--- a/features/inspections/lib/inspection/pdf.ts
+++ b/features/inspections/lib/inspection/pdf.ts
@@ -29,6 +29,7 @@ type FindingRow = {
   sectionTitle: string;
   itemLabel: string;
   status: InspectionItemStatus | undefined;
+  fieldType?: string;
   value?: string;
   unit?: string;
   notes?: string;
@@ -88,8 +89,22 @@ function compactCsv(parts: Array<string | undefined>): string {
     .join(", ");
 }
 
-function statusLabel(status: InspectionItemStatus | undefined): string {
+function itemFieldType(item: InspectionItem): string {
+  const value = (item as InspectionItem & { fieldType?: unknown }).fieldType;
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function statusLabel(
+  status: InspectionItemStatus | undefined,
+  fieldType?: string,
+): string {
   if (!status) return "—";
+  if (fieldType === "defect") {
+    if (status === "ok") return "NO DEFECT";
+    if (status === "fail") return "MAJOR DEFECT";
+    if (status === "recommend") return "MINOR DEFECT";
+    if (status === "na") return "N/A";
+  }
   if (status === "ok") return "OK";
   if (status === "fail") return "FAIL";
   if (status === "recommend") return "RECOMMEND";
@@ -150,6 +165,10 @@ function collectFindings(sections: InspectionSection[]): {
   failCount: number;
   recommendCount: number;
   naCount: number;
+  defectItemCount: number;
+  noDefectCount: number;
+  majorDefectCount: number;
+  minorDefectCount: number;
 } {
   const failRows: FindingRow[] = [];
   const recommendRows: FindingRow[] = [];
@@ -159,6 +178,10 @@ function collectFindings(sections: InspectionSection[]): {
   let failCount = 0;
   let recommendCount = 0;
   let naCount = 0;
+  let defectItemCount = 0;
+  let noDefectCount = 0;
+  let majorDefectCount = 0;
+  let minorDefectCount = 0;
 
   for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex += 1) {
     const section = sections[sectionIndex];
@@ -168,15 +191,24 @@ function collectFindings(sections: InspectionSection[]): {
     const items = Array.isArray(section.items) ? section.items : [];
     for (const item of items) {
       const status = item.status;
+      const fieldType = itemFieldType(item);
       if (status === "ok") okCount += 1;
       else if (status === "fail") failCount += 1;
       else if (status === "recommend") recommendCount += 1;
       else if (status === "na") naCount += 1;
 
+      if (fieldType === "defect") {
+        defectItemCount += 1;
+        if (status === "ok") noDefectCount += 1;
+        else if (status === "fail") majorDefectCount += 1;
+        else if (status === "recommend") minorDefectCount += 1;
+      }
+
       const row: FindingRow = {
         sectionTitle,
         itemLabel: getItemLabel(item),
         status,
+        fieldType,
         value: normalizeOptionalText(item.value),
         unit: normalizeOptionalText(item.unit),
         notes: normalizeOptionalText(item.notes ?? item.note),
@@ -204,6 +236,10 @@ function collectFindings(sections: InspectionSection[]): {
     failCount,
     recommendCount,
     naCount,
+    defectItemCount,
+    noDefectCount,
+    majorDefectCount,
+    minorDefectCount,
   };
 }
 
@@ -465,8 +501,8 @@ export async function generateInspectionPDF(
       color: COLOR_TEXT,
     });
 
-    drawText(statusLabel(row.status), PAGE_W - MARGIN_X - 90, y - 30, {
-      size: 10,
+    drawText(statusLabel(row.status, row.fieldType), PAGE_W - MARGIN_X - 110, y - 30, {
+      size: 9,
       bold: true,
       color: badgeColor,
     });
@@ -535,7 +571,17 @@ export async function generateInspectionPDF(
     failCount,
     recommendCount,
     naCount,
+    defectItemCount,
+    noDefectCount,
+    majorDefectCount,
+    minorDefectCount,
   } = collectFindings(sections);
+  const genericOkCount = Math.max(0, okCount - noDefectCount);
+  const genericFailCount = Math.max(0, failCount - majorDefectCount);
+  const genericRecommendCount = Math.max(
+    0,
+    recommendCount - minorDefectCount,
+  );
 
   const shopName = safeStr(brand?.shopName).trim() || "ProFixIQ";
   const templateName = safeStr(session.templateName).trim() || "—";
@@ -627,33 +673,51 @@ export async function generateInspectionPDF(
 
   drawSectionHeader("Overview");
 
+  const summaryTiles: Array<{ title: string; value: number; fill: PdfRgb }> = [];
+  const hasDefectClassification = defectItemCount > 0;
+  const hasGenericStatuses =
+    !hasDefectClassification ||
+    genericOkCount > 0 ||
+    genericFailCount > 0 ||
+    genericRecommendCount > 0;
+
+  if (hasDefectClassification) {
+    summaryTiles.push(
+      { title: "NO DEFECT", value: noDefectCount, fill: rgb(0.12, 0.55, 0.3) },
+      { title: "MAJOR", value: majorDefectCount, fill: rgb(0.78, 0.18, 0.18) },
+      { title: "MINOR", value: minorDefectCount, fill: COLOR_PRIMARY },
+    );
+  }
+  if (hasGenericStatuses) {
+    summaryTiles.push(
+      { title: "FAIL", value: genericFailCount, fill: rgb(0.78, 0.18, 0.18) },
+      { title: "RECOMMEND", value: genericRecommendCount, fill: COLOR_PRIMARY },
+      { title: "OK", value: genericOkCount, fill: rgb(0.12, 0.55, 0.3) },
+    );
+  }
+  summaryTiles.push({ title: "N/A", value: naCount, fill: rgb(0.47, 0.5, 0.56) });
+
   const tileGap = 10;
-  const tileWidth = (CONTENT_W - tileGap * 3) / 4;
-
-  drawSummaryTile(MARGIN_X, tileWidth, "FAIL", String(failCount), rgb(0.78, 0.18, 0.18));
-  drawSummaryTile(
-    MARGIN_X + tileWidth + tileGap,
-    tileWidth,
-    "RECOMMEND",
-    String(recommendCount),
-    COLOR_PRIMARY,
-  );
-  drawSummaryTile(
-    MARGIN_X + (tileWidth + tileGap) * 2,
-    tileWidth,
-    "OK",
-    String(okCount),
-    rgb(0.12, 0.55, 0.3),
-  );
-  drawSummaryTile(
-    MARGIN_X + (tileWidth + tileGap) * 3,
-    tileWidth,
-    "N/A",
-    String(naCount),
-    rgb(0.47, 0.5, 0.56),
-  );
-
-  y -= 60;
+  const tilesPerRow = 4;
+  const tileWidth = (CONTENT_W - tileGap * (tilesPerRow - 1)) / tilesPerRow;
+  const summaryRowCount = Math.ceil(summaryTiles.length / tilesPerRow);
+  ensureSpace(summaryRowCount * 60);
+  for (let index = 0; index < summaryTiles.length; index += 1) {
+    const column = index % tilesPerRow;
+    const row = Math.floor(index / tilesPerRow);
+    const baseY = y;
+    y = baseY - row * 60;
+    const tile = summaryTiles[index];
+    drawSummaryTile(
+      MARGIN_X + column * (tileWidth + tileGap),
+      tileWidth,
+      tile.title,
+      String(tile.value),
+      tile.fill,
+    );
+    y = baseY;
+  }
+  y -= summaryRowCount * 60;
 
   drawMetaRow("Shop", shopName);
   drawMetaRow("Template", templateName);
@@ -698,7 +762,9 @@ export async function generateInspectionPDF(
 
   if (!hasActionable) {
     drawWrappedParagraph(
-      "No failures or recommended items were captured in this inspection.",
+      hasDefectClassification
+        ? "No major or minor defects were captured in this inspection."
+        : "No failures or recommended items were captured in this inspection.",
       {
         widthChars: 82,
         size: 10,
@@ -723,12 +789,21 @@ export async function generateInspectionPDF(
   drawRule();
   drawSectionHeader("Appendix");
   drawMetaRow("Sections", String(sections.length));
-  drawMetaRow("Fail Items", String(failCount));
-  drawMetaRow("Recommended Items", String(recommendCount));
-  drawMetaRow("OK Items", String(okCount));
+  if (hasDefectClassification) {
+    drawMetaRow("No Defect Items", String(noDefectCount));
+    drawMetaRow("Major Defects", String(majorDefectCount));
+    drawMetaRow("Minor Defects", String(minorDefectCount));
+  }
+  if (hasGenericStatuses) {
+    drawMetaRow("Fail Items", String(genericFailCount));
+    drawMetaRow("Recommended Items", String(genericRecommendCount));
+    drawMetaRow("OK Items", String(genericOkCount));
+  }
   drawMetaRow("N/A Items", String(naCount));
   drawWrappedParagraph(
-    "Rendering Mode: Actionable findings only. OK and N/A checklist items are summarized, not fully listed.",
+    hasDefectClassification
+      ? "Rendering Mode: Actionable findings only. No-defect and N/A checklist items are summarized, not fully listed."
+      : "Rendering Mode: Actionable findings only. OK and N/A checklist items are summarized, not fully listed.",
     {
       widthChars: 82,
       size: 10,

--- a/features/inspections/lib/inspection/prepareSectionsWithCornerGrid.ts
+++ b/features/inspections/lib/inspection/prepareSectionsWithCornerGrid.ts
@@ -1,11 +1,26 @@
 // features/inspections/lib/inspection/prepareSectionsWithCornerGrid.ts
 
-export type CornerGridItem = { item?: string; unit?: string | null; name?: string | null };
+export type CornerGridItem = {
+  item?: string;
+  unit?: string | null;
+  name?: string | null;
+  fieldType?: string | null;
+};
 export type CornerGridSection = { title: string; items: CornerGridItem[] };
 
 const HYD_ITEM_RE = /^(LF|RF|LR|RR)\s+/i;
 const AIR_ITEM_RE =
   /^(Steer\s*\d*|Drive\s*\d+|Rear\s*\d+|Tag|Trailer\s*\d+)\s+(Left|Right)\s+/i;
+
+function hasImportedFormClassification<T extends CornerGridSection>(
+  sections: T[],
+): boolean {
+  return sections.some((section) =>
+    (section.items ?? []).some(
+      (item) => typeof item.fieldType === "string" && item.fieldType.trim().length > 0,
+    ),
+  );
+}
 
 // Brake/corner-only signals (NOT tires)
 function isBrakeCornerMetric(label: string): boolean {
@@ -191,6 +206,11 @@ export function prepareSectionsWithCornerGrid<T extends CornerGridSection>(
   gridParam: string | null,
 ): T[] {
   const s0 = Array.isArray(sections) ? sections : [];
+
+  // Classified Fleet Form Import rows describe the customer's source form.
+  // They are authoritative: never strip or inject brake/corner grids around
+  // them, even when a caller passes grid=none.
+  if (hasImportedFormClassification(s0)) return s0;
 
   // ✅ Fix bad upstream titles BEFORE we do the early “has corner grid” check.
   const s = normalizeMisTitledCornerSections(s0);

--- a/features/inspections/lib/inspection/report.test.ts
+++ b/features/inspections/lib/inspection/report.test.ts
@@ -36,7 +36,7 @@ function session(): InspectionSession {
       {
         title: "Brakes",
         items: [
-          { item: "Front pads", status: "ok", value: "8 mm" },
+          { item: "Front pads", status: "ok", value: "8", unit: "mm" },
           {
             item: "Rear pads",
             status: "fail",
@@ -54,11 +54,19 @@ function session(): InspectionSession {
 }
 
 describe("assembleInspectionReport", () => {
-  it("preserves technician evidence and recommendations", () => {
+  it("preserves technician evidence, measurements and recommendations", () => {
     const report = assembleInspectionReport(session());
+    expect(report.sections[0].items[0]).toMatchObject({
+      label: "Front pads",
+      status: "ok",
+      statusLabel: "Pass",
+      value: "8",
+      unit: "mm",
+    });
     expect(report.sections[0].items[1]).toMatchObject({
       label: "Rear pads",
       status: "fail",
+      statusLabel: "Needs attention",
       note: "Below service limit",
       recommendations: ["Replace rear pads"],
       photoUrls: ["https://example.test/evidence.jpg"],
@@ -72,6 +80,39 @@ describe("assembleInspectionReport", () => {
       failed: 1,
       recommended: 1,
       notApplicable: 1,
+      defectItems: 0,
+      noDefect: 0,
+      majorDefects: 0,
+      minorDefects: 0,
+    });
+  });
+
+  it("preserves imported minor and major defect semantics", () => {
+    const source = session();
+    source.sections = [
+      {
+        title: "Defect checklist",
+        items: [
+          { item: "Steering", status: "ok", fieldType: "defect" },
+          { item: "Suspension", status: "fail", fieldType: "defect" },
+          { item: "Tires", status: "recommend", fieldType: "defect" },
+          { item: "Wipers", status: "na", fieldType: "defect" },
+        ],
+      },
+    ] as unknown as InspectionSession["sections"];
+
+    const report = assembleInspectionReport(source);
+    expect(report.sections[0].items.map((item) => item.statusLabel)).toEqual([
+      "No defect",
+      "Major defect",
+      "Minor defect",
+      "Not applicable",
+    ]);
+    expect(report.totals).toMatchObject({
+      defectItems: 4,
+      noDefect: 1,
+      majorDefects: 1,
+      minorDefects: 1,
     });
   });
 

--- a/features/inspections/lib/inspection/report.ts
+++ b/features/inspections/lib/inspection/report.ts
@@ -6,7 +6,9 @@ import type {
 export type InspectionReportItem = {
   label: string;
   status: InspectionItemStatus | "not_checked";
+  statusLabel: string;
   value: string | null;
+  unit: string | null;
   note: string | null;
   recommendations: string[];
   photoUrls: string[];
@@ -26,6 +28,10 @@ export type InspectionReport = {
     failed: number;
     recommended: number;
     notApplicable: number;
+    defectItems: number;
+    noDefect: number;
+    majorDefects: number;
+    minorDefects: number;
   };
 };
 
@@ -33,6 +39,30 @@ function text(value: unknown): string | null {
   if (value == null) return null;
   const normalized = String(value).trim();
   return normalized || null;
+}
+
+function itemFieldType(item: unknown): string {
+  if (!item || typeof item !== "object") return "";
+  const value = (item as Record<string, unknown>).fieldType;
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function displayStatusLabel(
+  status: InspectionReportItem["status"],
+  fieldType: string,
+): string {
+  if (fieldType === "defect") {
+    if (status === "ok") return "No defect";
+    if (status === "fail") return "Major defect";
+    if (status === "recommend") return "Minor defect";
+    if (status === "na") return "Not applicable";
+    return "Not checked";
+  }
+  if (status === "ok") return "Pass";
+  if (status === "fail") return "Needs attention";
+  if (status === "recommend") return "Recommended";
+  if (status === "na") return "Not applicable";
+  return "Not checked";
 }
 
 export function assembleInspectionReport(
@@ -44,21 +74,34 @@ export function assembleInspectionReport(
     failed: 0,
     recommended: 0,
     notApplicable: 0,
+    defectItems: 0,
+    noDefect: 0,
+    majorDefects: 0,
+    minorDefects: 0,
   };
   const sections = (session.sections ?? []).map((section, sectionIndex) => ({
     title: text(section.title) ?? `Section ${sectionIndex + 1}`,
     items: (section.items ?? []).map((item) => {
       const status: InspectionReportItem["status"] =
         item.status ?? "not_checked";
+      const fieldType = itemFieldType(item);
       if (status !== "not_checked") totals.checked += 1;
       if (status === "ok") totals.ok += 1;
       if (status === "fail") totals.failed += 1;
       if (status === "recommend") totals.recommended += 1;
       if (status === "na") totals.notApplicable += 1;
+      if (fieldType === "defect") {
+        totals.defectItems += 1;
+        if (status === "ok") totals.noDefect += 1;
+        if (status === "fail") totals.majorDefects += 1;
+        if (status === "recommend") totals.minorDefects += 1;
+      }
       return {
         label: text(item.item ?? item.name) ?? "Inspection item",
         status,
+        statusLabel: displayStatusLabel(status, fieldType),
         value: text(item.value),
+        unit: text(item.unit),
         note: text(item.notes ?? item.note),
         recommendations: Array.isArray(item.recommend)
           ? item.recommend.map(text).filter((value): value is string => !!value)

--- a/features/inspections/server/inspection-form-import-job.ts
+++ b/features/inspections/server/inspection-form-import-job.ts
@@ -4,8 +4,10 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import type { Database } from "@shared/types/types/supabase";
 import {
+  INSPECTION_FORM_IMPORT_FORMAT_VERSION,
   normalizeInspectionFormImportSummary,
   normalizeInspectionFormSections,
+  normalizeInspectionFormSectionsV2,
   selectRunnableInspectionFormSections,
   type InspectionFormSection,
 } from "@/features/inspections/lib/form-import";
@@ -31,6 +33,7 @@ type PagePayload = {
   storagePath: string;
   originalName: string;
   mime: string;
+  formatVersion?: number;
   extractedText?: string;
   parsedSections?: InspectionFormSection[];
 };
@@ -55,10 +58,15 @@ function asPagePayload(value: unknown): PagePayload | null {
   const originalName = String(row.originalName ?? "").trim();
   const mime = String(row.mime ?? "").trim();
   if (!storagePath || !originalName || !mime) return null;
+  const rawFormatVersion = Number(row.formatVersion);
   return {
     storagePath,
     originalName,
     mime,
+    formatVersion:
+      Number.isInteger(rawFormatVersion) && rawFormatVersion > 0
+        ? rawFormatVersion
+        : undefined,
     extractedText:
       typeof row.extractedText === "string" ? row.extractedText : undefined,
     parsedSections: normalizeInspectionFormSections(row.parsedSections),
@@ -94,7 +102,7 @@ async function parsePage(
             type: "text",
             text: [
               "Read this single page of a customer vehicle inspection form.",
-              '{"extracted_text":"...","sections":[{"title":"...","items":[{"item":"...","unit":null,"field_type":"check"}]}]}.',
+              `Return {"format_version":${INSPECTION_FORM_IMPORT_FORMAT_VERSION},"extracted_text":"...","sections":[{"title":"...","items":[{"item":"...","unit":null,"field_type":"check"}]}]}.`,
               "field_type is REQUIRED for every item and must be one of: check, defect, measurement, text, instruction, identity, signature, trip, branding.",
               "Classification rules:",
               "- check: a real vehicle/component condition row intended to be marked pass/fail/okay/not-applicable.",
@@ -127,12 +135,15 @@ async function parsePage(
   if (!content) throw new Error("The form reader returned no result.");
 
   const result = JSON.parse(content) as VisionResult;
-  const sections = normalizeInspectionFormSections(result.sections);
-  if (!sections.length) {
-    throw new Error("No readable form elements were found on this page.");
+  const sections = normalizeInspectionFormSectionsV2(result.sections);
+  if (!sections) {
+    throw new Error(
+      "The form reader returned an invalid structured result. Every detected row must be classified before this page can be imported.",
+    );
   }
 
   return {
+    formatVersion: INSPECTION_FORM_IMPORT_FORMAT_VERSION,
     extractedText:
       typeof result.extracted_text === "string"
         ? result.extracted_text.trim()
@@ -162,11 +173,17 @@ async function finalizeJob(
       message: page.error_message || "This page could not be read.",
     }));
 
-  const sections = successful.flatMap((page) => {
+  // Apply the format contract per persisted page. A page completed by an older
+  // worker remains legacy even when a later page is V2, which makes rolling
+  // deployments lossless instead of dropping the earlier page's rows.
+  const draftSections = successful.flatMap((page) => {
     const payload = asPagePayload(page.raw_row);
-    return payload?.parsedSections ?? [];
+    if (!payload?.parsedSections?.length) return [];
+    return selectRunnableInspectionFormSections(
+      payload.parsedSections,
+      payload.formatVersion ?? 1,
+    );
   });
-  const draftSections = selectRunnableInspectionFormSections(sections);
   const extractedText = successful
     .map((page) => asPagePayload(page.raw_row)?.extractedText || "")
     .filter(Boolean)

--- a/tests/inspection-form-import-shaping.test.ts
+++ b/tests/inspection-form-import-shaping.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  INSPECTION_FORM_IMPORT_FORMAT_VERSION,
   normalizeInspectionFormSections,
+  normalizeInspectionFormSectionsV2,
   selectRunnableInspectionFormSections,
 } from "../features/inspections/lib/form-import";
+import { prepareSectionsWithCornerGrid } from "../features/inspections/lib/inspection/prepareSectionsWithCornerGrid";
 
 describe("inspection form import shaping", () => {
   it("keeps Rundle-style defect rows and removes filled/admin paper-form content", () => {
@@ -90,7 +93,10 @@ describe("inspection form import shaping", () => {
       fieldType: "identity",
     });
 
-    const runnable = selectRunnableInspectionFormSections(source);
+    const runnable = selectRunnableInspectionFormSections(
+      source,
+      INSPECTION_FORM_IMPORT_FORMAT_VERSION,
+    );
     expect(runnable).toEqual([
       {
         title: "Defect checklist",
@@ -123,16 +129,19 @@ describe("inspection form import shaping", () => {
   });
 
   it("keeps physical measurements but rejects administrative readings", () => {
-    const runnable = selectRunnableInspectionFormSections([
-      {
-        title: "Measurements",
-        items: [
-          { item: "Brake lining thickness", unit: "mm", kind: "measurement" },
-          { item: "Push rod travel", unit: "in", kind: "measurement" },
-          { item: "Odometer Reading", unit: "km", kind: "identity" },
-        ],
-      },
-    ]);
+    const runnable = selectRunnableInspectionFormSections(
+      [
+        {
+          title: "Measurements",
+          items: [
+            { item: "Brake lining thickness", unit: "mm", kind: "measurement" },
+            { item: "Push rod travel", unit: "in", kind: "measurement" },
+            { item: "Odometer Reading", unit: "km", kind: "identity" },
+          ],
+        },
+      ],
+      INSPECTION_FORM_IMPORT_FORMAT_VERSION,
+    );
 
     expect(runnable).toEqual([
       {
@@ -151,6 +160,83 @@ describe("inspection form import shaping", () => {
         ],
       },
     ]);
+  });
+
+  it("rejects new OCR pages when any row lacks a valid classification", () => {
+    expect(
+      normalizeInspectionFormSectionsV2([
+        {
+          title: "Header",
+          items: [
+            { item: "Rundle College Society", field_type: "branding" },
+            { item: "Attention to Excellence" },
+          ],
+        },
+      ]),
+    ).toBeNull();
+
+    expect(
+      normalizeInspectionFormSectionsV2([
+        {
+          title: "Checklist",
+          items: [{ item: "Brakes", field_type: "deefct" }],
+        },
+      ]),
+    ).toBeNull();
+  });
+
+  it("preserves old pages during rolling deployments while filtering V2 pages", () => {
+    const legacyPage = selectRunnableInspectionFormSections([
+      {
+        title: "Legacy checks",
+        items: [{ item: "Brakes" }, { item: "Lights" }],
+      },
+    ]);
+    const v2Page = selectRunnableInspectionFormSections(
+      [
+        {
+          title: "New page",
+          items: [
+            { item: "Rundle College", field_type: "branding" },
+            { item: "Steering", field_type: "defect" },
+          ],
+        },
+      ],
+      INSPECTION_FORM_IMPORT_FORMAT_VERSION,
+    );
+
+    expect([...legacyPage, ...v2Page]).toEqual([
+      {
+        title: "Legacy checks",
+        items: [
+          { item: "Brakes", unit: null },
+          { item: "Lights", unit: null },
+        ],
+      },
+      {
+        title: "New page",
+        items: [{ item: "Steering", unit: null, fieldType: "defect" }],
+      },
+    ]);
+  });
+
+  it("never strips or injects grids around classified source brake measurements", () => {
+    const source = [
+      {
+        title: "Brake Measurements",
+        items: [
+          { item: "LF Brake Pad", unit: "mm", fieldType: "measurement" },
+          {
+            item: "Steer 1 Left Push Rod Travel",
+            unit: "in",
+            fieldType: "measurement",
+          },
+        ],
+      },
+    ];
+
+    expect(prepareSectionsWithCornerGrid(source, "truck", null)).toEqual(source);
+    expect(prepareSectionsWithCornerGrid(source, "truck", "none")).toEqual(source);
   });
 
   it("preserves old unclassified imports for backward-compatible review", () => {

--- a/tests/mobile-inspection-form-import.test.ts
+++ b/tests/mobile-inspection-form-import.test.ts
@@ -122,7 +122,12 @@ describe("mobile inspection form imports", () => {
     const worker = read(
       "features/inspections/server/inspection-form-import-job.ts",
     );
+    const formImport = read("features/inspections/lib/form-import.ts");
     const runPage = read("features/inspections/app/inspection/run/page.tsx");
+    const sharedGrid = read(
+      "features/inspections/lib/inspection/prepareSectionsWithCornerGrid.ts",
+    );
+    const mobileRunner = read("app/mobile/inspections/[id]/page.tsx");
     const statusButtons = read(
       "features/inspections/lib/inspection/StatusButtons.tsx",
     );
@@ -130,15 +135,38 @@ describe("mobile inspection form imports", () => {
       "features/inspections/lib/inspection/InspectionItemCard.tsx",
     );
 
-    expect(worker).toContain("selectRunnableInspectionFormSections");
+    expect(worker).toContain("formatVersion");
+    expect(worker).toContain("normalizeInspectionFormSectionsV2");
     expect(worker).toContain("field_type is REQUIRED");
     expect(worker).toContain("Never append handwritten or filled-in sample values");
     expect(worker).not.toContain("replaceFleetTireSectionWithGrid");
+    expect(formImport).toContain("INSPECTION_FORM_IMPORT_FORMAT_VERSION = 2");
     expect(runPage).toContain('mergedParams.grid = "none"');
-    expect(runPage).toContain('resolvedGridOverride = importedFleetForm ? "none"');
+    expect(sharedGrid).toContain("hasImportedFormClassification");
+    expect(sharedGrid).toContain("return s0");
+    expect(mobileRunner).toContain("hasImportedFormClassification");
     expect(statusButtons).toContain('toLowerCase() === "defect"');
     expect(statusButtons).toContain('? "Major" : "Fail"');
     expect(statusButtons).toContain('? "Minor" : "Rec"');
     expect(itemCard).toContain('toLowerCase() === "measurement"');
+    expect(itemCard).toContain("formContext.updateItem");
+    expect(itemCard).not.toContain("onUpdateNote(sectionIndex, itemIndex, value)");
+  });
+
+  it("keeps import semantics through template editing and report output", () => {
+    const editRouter = read(
+      "features/inspections/components/InspectionTemplateEditRouter.tsx",
+    );
+    const route = read("app/inspections/custom-draft/page.tsx");
+    const report = read("features/inspections/lib/inspection/report.ts");
+    const pdf = read("features/inspections/lib/inspection/pdf.ts");
+
+    expect(route).toContain("InspectionTemplateEditRouter");
+    expect(editRouter).toContain("fieldType");
+    expect(editRouter).toContain('data.tags.includes("customer-form")');
+    expect(report).toContain("Major defect");
+    expect(report).toContain("Minor defect");
+    expect(pdf).toContain("MAJOR DEFECT");
+    expect(pdf).toContain("MINOR DEFECT");
   });
 });


### PR DESCRIPTION
## Summary
- fixes all six Codex findings raised after PR #1416 merged
- persists imported physical measurements in `item.value` instead of overloading notes
- adds an explicit V2 structural-OCR contract and rejects unclassified/malformed new OCR output
- versions persisted import pages so rolling deployments preserve legacy pages while filtering V2 pages independently
- bypasses generic corner-grid stripping/injection for classified imported forms on desktop and mobile runners
- preserves source-form Minor/Major/No defect semantics in inspection reports and PDFs while keeping canonical status values underneath
- routes durable `customer-form` templates to a scoped imported-template editor so field classifications survive future edits

## Regression coverage
- strict V2 classification validation and malformed output rejection
- mixed legacy/V2 page behavior during rolling deployments
- imported brake measurement sections remain intact with no injected grid
- imported measurement values remain separate from notes
- report totals and labels preserve No defect / Major defect / Minor defect semantics
- imported template editing remains keyed by the durable `customer-form` tag

## Validation
Agent PR Checks passed on `e9c6b637285d006d757ab1bc4264acbe7c4e8511`:
- full-app regression inventory generated successfully
- type-check passed
- changed-file lint passed
- complete test suite passed
- production application build passed
- regression-inventory enforcement step was skipped by the draft-PR workflow condition, not failed

## Scope
Fleet Form Import, imported-template editing, and downstream rendering of those imported inspection semantics only. No schema or migration changes.