### PR TITLE
Add Ops System Health control plane

### DIFF
--- a/app/ops/system-health/page.tsx
+++ b/app/ops/system-health/page.tsx
@@ -1,0 +1,10 @@
+import OpsSystemHealth from "@/features/ops/components/OpsSystemHealth";
+import { getOpsSystemHealth } from "@/features/ops/server/get-system-health";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function OpsSystemHealthPage() {
+  const snapshot = await getOpsSystemHealth();
+  return <OpsSystemHealth snapshot={snapshot} />;
+}

--- a/features/ops/components/OpsDashboard.tsx
+++ b/features/ops/components/OpsDashboard.tsx
@@ -186,13 +186,22 @@ export default function OpsDashboard({
         </section>
 
         <section className="space-y-3">
-          <h2 className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
-            Control plane health
-          </h2>
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+              Operations signals
+            </h2>
+            <Link
+              href="/ops/system-health"
+              className="inline-flex items-center gap-1 text-[11px] font-bold text-orange-300 transition hover:text-orange-200"
+            >
+              Live health
+              <ArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
           {[
             {
               icon: Database,
-              label: "Agent database",
+              label: "Agent requests",
               detail: `${metrics.total} requests available`,
             },
             {

--- a/features/ops/components/OpsShell.tsx
+++ b/features/ops/components/OpsShell.tsx
@@ -3,12 +3,13 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState, type ReactNode } from "react";
-import { Bot, Gauge, LogOut, Menu, ShieldCheck, X } from "lucide-react";
+import { Activity, Bot, Gauge, LogOut, Menu, ShieldCheck, X } from "lucide-react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { cn } from "@shared/lib/utils";
 
 const NAVIGATION = [
   { href: "/ops", label: "Overview", icon: Gauge },
+  { href: "/ops/system-health", label: "System Health", icon: Activity },
   { href: "/ops/agent-control", label: "Agent Control", icon: Bot },
 ] as const;
 

--- a/features/ops/components/OpsSystemHealth.tsx
+++ b/features/ops/components/OpsSystemHealth.tsx
@@ -1,0 +1,207 @@
+import {
+  Activity,
+  Bot,
+  CheckCircle2,
+  CircleAlert,
+  Database,
+  RefreshCw,
+  Server,
+  ShieldAlert,
+  XCircle,
+} from "lucide-react";
+import type {
+  OpsHealthService,
+  OpsHealthState,
+  OpsSystemHealthSnapshot,
+} from "@/features/ops/server/get-system-health";
+import { cn } from "@shared/lib/utils";
+
+function stateLabel(state: OpsHealthState): string {
+  if (state === "healthy") return "Healthy";
+  if (state === "degraded") return "Degraded";
+  return "Down";
+}
+
+function stateTone(state: OpsHealthState): string {
+  if (state === "healthy") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-300";
+  if (state === "degraded") return "border-amber-500/40 bg-amber-500/10 text-amber-300";
+  return "border-red-500/40 bg-red-500/10 text-red-300";
+}
+
+function stateIcon(state: OpsHealthState) {
+  if (state === "healthy") return CheckCircle2;
+  if (state === "degraded") return CircleAlert;
+  return XCircle;
+}
+
+function serviceIcon(service: OpsHealthService) {
+  if (service.key === "application") return Server;
+  if (service.key === "database") return Database;
+  return Bot;
+}
+
+function formatChecked(value: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    dateStyle: "medium",
+    timeStyle: "medium",
+    timeZone: "America/Edmonton",
+  }).format(new Date(value));
+}
+
+function ServiceCard({ service }: { service: OpsHealthService }) {
+  const Icon = serviceIcon(service);
+  const StateIcon = stateIcon(service.state);
+
+  return (
+    <article className="overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-card">
+      <div className="flex items-start justify-between gap-4 border-b border-[color:var(--theme-border-soft)] p-4 sm:p-5">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-orange-500/10 text-orange-300">
+            <Icon className="h-5 w-5" />
+          </span>
+          <div className="min-w-0">
+            <h2 className="text-sm font-bold">{service.label}</h2>
+            <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+              {service.summary}
+            </p>
+          </div>
+        </div>
+        <span
+          className={cn(
+            "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em]",
+            stateTone(service.state),
+          )}
+        >
+          <StateIcon className="h-3.5 w-3.5" />
+          {stateLabel(service.state)}
+        </span>
+      </div>
+
+      <dl className="grid gap-px bg-[color:var(--theme-border-soft)] sm:grid-cols-2">
+        {service.details.map((detail) => (
+          <div
+            key={`${service.key}-${detail.label}`}
+            className="min-w-0 bg-[color:var(--theme-surface-inset)] px-4 py-3"
+          >
+            <dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">
+              {detail.label}
+            </dt>
+            <dd className="mt-1 truncate font-mono text-xs text-[color:var(--theme-text-primary)]" title={detail.value}>
+              {detail.value}
+            </dd>
+          </div>
+        ))}
+        <div className="bg-[color:var(--theme-surface-inset)] px-4 py-3">
+          <dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">
+            Check latency
+          </dt>
+          <dd className="mt-1 font-mono text-xs text-[color:var(--theme-text-primary)]">
+            {service.latencyMs === null ? "Local" : `${service.latencyMs} ms`}
+          </dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+export default function OpsSystemHealth({
+  snapshot,
+}: {
+  snapshot: OpsSystemHealthSnapshot;
+}) {
+  const OverallIcon = stateIcon(snapshot.overall);
+  const unhealthyCount = snapshot.services.filter((service) => service.state !== "healthy").length;
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6">
+      <section className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-orange-400">
+            <Activity className="h-4 w-4" />
+            Production evidence
+          </div>
+          <h1 className="text-2xl font-black tracking-tight sm:text-3xl">
+            System health
+          </h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+            Live, read-only checks for the ProFixIQ application, authenticated Supabase access,
+            and the Agent worker generation. A configured integration is not treated as healthy
+            unless the runtime check succeeds.
+          </p>
+        </div>
+        <a
+          href="/ops/system-health"
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-2.5 text-sm font-bold transition hover:border-orange-500/50 hover:bg-orange-500/10"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh health
+        </a>
+      </section>
+
+      <section
+        className={cn(
+          "flex flex-col gap-4 rounded-2xl border p-4 shadow-card sm:flex-row sm:items-center sm:justify-between sm:p-5",
+          stateTone(snapshot.overall),
+        )}
+        aria-label="Overall production health"
+      >
+        <div className="flex items-center gap-3">
+          <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-black/10">
+            <OverallIcon className="h-6 w-6" />
+          </span>
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.14em]">Overall control-plane status</p>
+            <p className="mt-1 text-lg font-black">{stateLabel(snapshot.overall)}</p>
+          </div>
+        </div>
+        <div className="text-xs sm:text-right">
+          <p className="font-semibold">
+            {unhealthyCount === 0
+              ? "All live checks passed"
+              : `${unhealthyCount} service${unhealthyCount === 1 ? "" : "s"} need attention`}
+          </p>
+          <p className="mt-1 opacity-80">Checked {formatChecked(snapshot.checkedAt)} MT</p>
+        </div>
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-3" aria-label="Production service health">
+        {snapshot.services.map((service) => (
+          <ServiceCard key={service.key} service={service} />
+        ))}
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
+          <div className="flex items-start gap-3">
+            <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-sky-500/10 text-sky-300">
+              <ShieldAlert className="h-5 w-5" />
+            </span>
+            <div>
+              <h2 className="text-sm font-bold">Mission approval safety</h2>
+              <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                Agent generation must report as verified before mission approval is considered
+                healthy. This prevents work compiled by an older deployment from becoming an
+                actionable approval package.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
+          <div className="flex items-start gap-3">
+            <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-300">
+              <Database className="h-5 w-5" />
+            </span>
+            <div>
+              <h2 className="text-sm font-bold">Database check semantics</h2>
+              <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                The database card performs an authenticated owner-scoped read through the same
+                Supabase path used by Ops. It does not bypass RLS with a service-role health probe.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/features/ops/server/get-system-health.ts
+++ b/features/ops/server/get-system-health.ts
@@ -91,6 +91,20 @@ function normalizeAgentRuntime(value: unknown): OpsRuntimeGeneration | null {
   };
 }
 
+function agentDetails(
+  responseStatus: number,
+  runtime: OpsRuntimeGeneration | null,
+  generationVerifiable: boolean,
+): Array<{ label: string; value: string }> {
+  return [
+    { label: "HTTP", value: String(responseStatus) },
+    { label: "Generation", value: generationVerifiable ? "Verified" : "Unverified" },
+    { label: "Commit", value: shortSha(runtime?.commitSha ?? null) },
+    { label: "Deployment", value: runtime?.deploymentId ?? "Unavailable" },
+    { label: "Fingerprint", value: runtime?.fingerprint ? runtime.fingerprint.slice(0, 16) : "Unavailable" },
+  ];
+}
+
 async function agentHealth(): Promise<OpsHealthService> {
   const baseUrl = text(process.env.PROFIXIQ_AGENT_URL)?.replace(/\/+$/, "") ?? null;
   if (!baseUrl) {
@@ -127,32 +141,39 @@ async function agentHealth(): Promise<OpsHealthService> {
     const runtime = normalizeAgentRuntime(payload?.runtime);
     const serviceStatus = text(payload?.status);
     const generationVerifiable = runtime?.verifiable === true;
-    const state: OpsHealthState = response.ok && serviceStatus === "ok" && generationVerifiable
-      ? "healthy"
-      : !payload
-        ? "down"
-        : "degraded";
-    const summary = state === "healthy"
-      ? "Agent worker and deployment generation are verifiable."
-      : state === "down"
-        ? `Agent health returned HTTP ${response.status} without a valid health payload.`
-        : !generationVerifiable
-          ? "Agent is reachable, but its deployment generation is not yet verifiable."
-          : text(payload?.error) ?? `Agent health returned HTTP ${response.status}.`;
+    const details = agentDetails(response.status, runtime, generationVerifiable);
+
+    if (response.ok && serviceStatus === "ok" && generationVerifiable) {
+      return {
+        key: "agent",
+        label: "ProFixIQ Agent",
+        state: "healthy",
+        summary: "Agent worker and deployment generation are verifiable.",
+        latencyMs,
+        details,
+      };
+    }
+
+    if (!payload) {
+      return {
+        key: "agent",
+        label: "ProFixIQ Agent",
+        state: "down",
+        summary: `Agent health returned HTTP ${response.status} without a valid health payload.`,
+        latencyMs,
+        details,
+      };
+    }
 
     return {
       key: "agent",
       label: "ProFixIQ Agent",
-      state,
-      summary,
+      state: "degraded",
+      summary: !generationVerifiable
+        ? "Agent is reachable, but its deployment generation is not yet verifiable."
+        : text(payload.error) ?? `Agent health returned HTTP ${response.status}.`,
       latencyMs,
-      details: [
-        { label: "HTTP", value: String(response.status) },
-        { label: "Generation", value: generationVerifiable ? "Verified" : "Unverified" },
-        { label: "Commit", value: shortSha(runtime?.commitSha ?? null) },
-        { label: "Deployment", value: runtime?.deploymentId ?? "Unavailable" },
-        { label: "Fingerprint", value: runtime?.fingerprint ? runtime.fingerprint.slice(0, 16) : "Unavailable" },
-      ],
+      details,
     };
   } catch (error) {
     const latencyMs = Date.now() - started;

--- a/features/ops/server/get-system-health.ts
+++ b/features/ops/server/get-system-health.ts
@@ -1,0 +1,232 @@
+import "server-only";
+
+import { requireOpsOperatorPageAccess } from "@/features/ops/server/operator-access";
+
+export type OpsHealthState = "healthy" | "degraded" | "down";
+
+export type OpsRuntimeGeneration = {
+  schemaVersion?: number | null;
+  commitSha: string | null;
+  deploymentId: string | null;
+  deploymentUrl: string | null;
+  explicitGeneration: string | null;
+  fingerprint: string | null;
+  verifiable: boolean;
+};
+
+export type OpsHealthService = {
+  key: "application" | "database" | "agent";
+  label: string;
+  state: OpsHealthState;
+  summary: string;
+  latencyMs: number | null;
+  details: Array<{ label: string; value: string }>;
+};
+
+export type OpsSystemHealthSnapshot = {
+  checkedAt: string;
+  overall: OpsHealthState;
+  services: OpsHealthService[];
+};
+
+function text(value: unknown): string | null {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized || null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function shortSha(value: string | null): string {
+  return value ? value.slice(0, 12) : "Unavailable";
+}
+
+function projectRefFromUrl(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).hostname.split(".")[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+function currentApplicationHealth(): OpsHealthService {
+  const environment = text(process.env.VERCEL_ENV) ?? text(process.env.NODE_ENV) ?? "unknown";
+  const commitSha = text(process.env.VERCEL_GIT_COMMIT_SHA);
+  const deploymentId = text(process.env.VERCEL_DEPLOYMENT_ID);
+  const deploymentUrl = text(process.env.VERCEL_URL);
+  const runtimeIdentified = Boolean(commitSha || deploymentId || deploymentUrl);
+  const production = environment === "production";
+  const state: OpsHealthState = production && !runtimeIdentified ? "degraded" : "healthy";
+
+  return {
+    key: "application",
+    label: "ProFixIQ application",
+    state,
+    summary: state === "healthy"
+      ? "The Ops server route is executing normally."
+      : "The application is responding, but production deployment identity is unavailable.",
+    latencyMs: null,
+    details: [
+      { label: "Environment", value: environment },
+      { label: "Commit", value: shortSha(commitSha) },
+      { label: "Deployment", value: deploymentId ?? "Unavailable" },
+      { label: "Runtime URL", value: deploymentUrl ?? "Unavailable" },
+    ],
+  };
+}
+
+function normalizeAgentRuntime(value: unknown): OpsRuntimeGeneration | null {
+  if (!isRecord(value)) return null;
+  const fingerprint = text(value.fingerprint);
+  return {
+    schemaVersion: Number.isFinite(Number(value.schemaVersion)) ? Number(value.schemaVersion) : null,
+    commitSha: text(value.commitSha),
+    deploymentId: text(value.deploymentId),
+    deploymentUrl: text(value.deploymentUrl),
+    explicitGeneration: text(value.explicitGeneration),
+    fingerprint,
+    verifiable: value.verifiable === true && Boolean(fingerprint),
+  };
+}
+
+async function agentHealth(): Promise<OpsHealthService> {
+  const baseUrl = text(process.env.PROFIXIQ_AGENT_URL)?.replace(/\/+$/, "") ?? null;
+  if (!baseUrl) {
+    return {
+      key: "agent",
+      label: "ProFixIQ Agent",
+      state: "down",
+      summary: "PROFIXIQ_AGENT_URL is not configured for this environment.",
+      latencyMs: null,
+      details: [{ label: "Endpoint", value: "Not configured" }],
+    };
+  }
+
+  const started = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 4_000);
+  try {
+    const response = await fetch(`${baseUrl}/health`, {
+      method: "GET",
+      cache: "no-store",
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    });
+    const latencyMs = Date.now() - started;
+    const raw = await response.text();
+    let payload: Record<string, unknown> | null = null;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      payload = isRecord(parsed) ? parsed : null;
+    } catch {
+      payload = null;
+    }
+
+    const runtime = normalizeAgentRuntime(payload?.runtime);
+    const serviceStatus = text(payload?.status);
+    const generationVerifiable = runtime?.verifiable === true;
+    const state: OpsHealthState = response.ok && serviceStatus === "ok" && generationVerifiable
+      ? "healthy"
+      : !payload
+        ? "down"
+        : "degraded";
+    const summary = state === "healthy"
+      ? "Agent worker and deployment generation are verifiable."
+      : state === "down"
+        ? `Agent health returned HTTP ${response.status} without a valid health payload.`
+        : !generationVerifiable
+          ? "Agent is reachable, but its deployment generation is not yet verifiable."
+          : text(payload?.error) ?? `Agent health returned HTTP ${response.status}.`;
+
+    return {
+      key: "agent",
+      label: "ProFixIQ Agent",
+      state,
+      summary,
+      latencyMs,
+      details: [
+        { label: "HTTP", value: String(response.status) },
+        { label: "Generation", value: generationVerifiable ? "Verified" : "Unverified" },
+        { label: "Commit", value: shortSha(runtime?.commitSha ?? null) },
+        { label: "Deployment", value: runtime?.deploymentId ?? "Unavailable" },
+        { label: "Fingerprint", value: runtime?.fingerprint ? runtime.fingerprint.slice(0, 16) : "Unavailable" },
+      ],
+    };
+  } catch (error) {
+    const latencyMs = Date.now() - started;
+    const message = error instanceof Error && error.name === "AbortError"
+      ? "Agent health request timed out."
+      : "Agent health endpoint is unreachable.";
+    return {
+      key: "agent",
+      label: "ProFixIQ Agent",
+      state: "down",
+      summary: message,
+      latencyMs,
+      details: [{ label: "Endpoint", value: baseUrl }],
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function databaseHealth(): Promise<OpsHealthService> {
+  const access = await requireOpsOperatorPageAccess();
+  const started = Date.now();
+  const result = await access.supabase
+    .from("agent_requests")
+    .select("id", { count: "exact", head: true });
+  const latencyMs = Date.now() - started;
+  const projectRef = projectRefFromUrl(text(process.env.NEXT_PUBLIC_SUPABASE_URL));
+
+  if (result.error) {
+    return {
+      key: "database",
+      label: "Supabase production data",
+      state: "down",
+      summary: `Authenticated database read failed: ${result.error.message}`,
+      latencyMs,
+      details: [
+        { label: "Project", value: projectRef ?? "Unavailable" },
+        { label: "Authenticated read", value: "Failed" },
+      ],
+    };
+  }
+
+  return {
+    key: "database",
+    label: "Supabase production data",
+    state: "healthy",
+    summary: "Owner-scoped authenticated data access is responding.",
+    latencyMs,
+    details: [
+      { label: "Project", value: projectRef ?? "Unavailable" },
+      { label: "Agent requests", value: String(result.count ?? 0) },
+      { label: "Authenticated read", value: "Passed" },
+    ],
+  };
+}
+
+function overallState(services: OpsHealthService[]): OpsHealthState {
+  if (services.some((service) => service.state === "down")) return "down";
+  if (services.some((service) => service.state === "degraded")) return "degraded";
+  return "healthy";
+}
+
+export async function getOpsSystemHealth(): Promise<OpsSystemHealthSnapshot> {
+  const checkedAt = new Date().toISOString();
+  const application = currentApplicationHealth();
+  const [database, agent] = await Promise.all([
+    databaseHealth(),
+    agentHealth(),
+  ]);
+  const services = [application, database, agent];
+
+  return {
+    checkedAt,
+    overall: overallState(services),
+    services,
+  };
+}

--- a/tests/ops-system-health.test.ts
+++ b/tests/ops-system-health.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("Ops System Health", () => {
+  it("adds a force-dynamic owner Ops route", () => {
+    const page = source("app/ops/system-health/page.tsx");
+    expect(page).toContain('export const dynamic = "force-dynamic"');
+    expect(page).toContain("getOpsSystemHealth");
+    expect(page).toContain("<OpsSystemHealth snapshot={snapshot} />");
+  });
+
+  it("uses the authenticated Ops Supabase path instead of a service-role health bypass", () => {
+    const server = source("features/ops/server/get-system-health.ts");
+    expect(server).toContain("requireOpsOperatorPageAccess");
+    expect(server).toContain('.from("agent_requests")');
+    expect(server).toContain('{ count: "exact", head: true }');
+    expect(server).not.toContain("SUPABASE_SERVICE_ROLE_KEY");
+    expect(server).not.toContain("createClient(");
+  });
+
+  it("treats Agent deployment generation as required health evidence", () => {
+    const server = source("features/ops/server/get-system-health.ts");
+    expect(server).toContain('`${baseUrl}/health`');
+    expect(server).toContain("generationVerifiable");
+    expect(server).toContain('state: "down"');
+    expect(server).toContain('state: "degraded"');
+    expect(server).toContain("Agent is reachable, but its deployment generation is not yet verifiable.");
+  });
+
+  it("surfaces System Health in both desktop and mobile Ops navigation and makes it the canonical live-health destination", () => {
+    const shell = source("features/ops/components/OpsShell.tsx");
+    const dashboard = source("features/ops/components/OpsDashboard.tsx");
+    expect(shell).toContain('{ href: "/ops/system-health", label: "System Health", icon: Activity }');
+    expect(shell.match(/aria-label="Operations navigation"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(dashboard).toContain("Operations signals");
+    expect(dashboard).toContain('href="/ops/system-health"');
+    expect(dashboard).toContain("Live health");
+    expect(dashboard).not.toContain("Control plane health");
+  });
+
+  it("explains the approval and database health semantics to the operator", () => {
+    const component = source("features/ops/components/OpsSystemHealth.tsx");
+    expect(component).toContain("Mission approval safety");
+    expect(component).toContain("Database check semantics");
+    expect(component).toContain("A configured integration is not treated as healthy");
+    expect(component).toContain("Refresh health");
+  });
+});


### PR DESCRIPTION
## Outcome

Expands `ops.profixiq.com` from Overview + Agent Control into the first real production health surface.

## What changed

- adds owner-only `/ops/system-health`
- adds System Health to desktop and mobile Ops navigation
- makes System Health the canonical live-health destination from the Ops Overview; the previous request-count cards are correctly labeled **Operations signals**
- performs a live authenticated Supabase read through the existing Ops/RLS boundary
- calls the ProFixIQ-Agent `/health` endpoint read-only with a bounded timeout and records reachability/latency
- treats Agent deployment-generation provenance as required health evidence
- classifies Agent health explicitly as healthy / degraded / down; missing/non-JSON health responses are down, while a reachable Agent with unverifiable generation is degraded
- shows ProFixIQ runtime environment, commit/deployment identity when Vercel exposes it, Supabase project/read status, and Agent generation fingerprint
- computes healthy/degraded/down from actual checks rather than configuration presence
- forces a fresh server request when the operator selects **Refresh health**

## Security

- retains the existing owner-only `requireOpsOperatorPageAccess` boundary
- database health uses the authenticated Ops Supabase client and current RLS; no service-role health bypass
- no secrets are rendered or sent to the client
- Agent health is GET-only and no mutation/control endpoint is called

## Validation coverage

Adds source-contract regressions proving:
- `/ops/system-health` is force-dynamic
- authenticated Ops Supabase access is used
- no service-role client is introduced
- Agent generation verification affects health state
- System Health exists in both desktop/mobile Ops navigation
- Overview routes live health to the canonical page rather than labeling request metrics as health
- operator-facing approval/database health semantics remain explicit

## Final validation

Final review head: `f9d6da900c068ce65da7719a53f7619939159b8e`.

`Agent PR Checks / checks` passed on this exact head, including:
- full-app regression inventory
- TypeScript type-check
- changed-file ESLint
- complete Vitest suite
- production Next.js build

GitGuardian passed. The only annotation is GitHub's Node 20 actions deprecation warning; it is non-blocking and unrelated to this slice.

## Database

No migration or backfill. Supabase Preview correctly skips this PR because no `supabase` files change.

## Rollout verification

Agent PR #51 is now merged and deployed to production.

Production Agent verification:
- Vercel production deployment: READY
- merge commit: `91a09ee80725184786327124d3de25330f053754`
- `/health`: HTTP 200 / `status=ok`
- `runtime.verifiable=true`
- runtime generation fingerprint present
- queue/runtime/OpenAI/GitHub readiness all report configured

After this PR deploys, System Health can therefore verify the current Agent generation instead of intentionally degrading for the pre-#51 runtime.

Draft only. Merge remains an explicit human approval action.