### PR TITLE
Build canonical Field Service truck inventory

### DIFF
--- a/.github/workflows/mobile-v1-validation.yml
+++ b/.github/workflows/mobile-v1-validation.yml
@@ -11,6 +11,8 @@ on:
       - "app/api/invoices/finalize/route.ts"
       - "app/api/payments/manual/route.ts"
       - "features/invoices/components/RecordManualPayment.tsx"
+      - "features/integrations/core/**"
+      - "features/integrations/parts/**"
       - "features/mobile/service/**"
       - "features/mobile/config/mobile-tiles.ts"
       - "features/shared/lib/offline/mutations.ts"
@@ -22,8 +24,15 @@ on:
       - "supabase/migrations/20260811020200_mobile_v1_followup_authorization_alignment.sql"
       - "supabase/migrations/20260811020300_mobile_v1_second_codex_review_hardening.sql"
       - "supabase/migrations/20260811160152_mobile_v1_end_to_end_repair_hardening.sql"
+      - "supabase/migrations/20260812230000_field_integration_identity_core.sql"
+      - "supabase/migrations/20260812230100_field_part_identity_commands.sql"
+      - "supabase/migrations/20260812230200_field_truck_inventory_snapshot.sql"
+      - "supabase/migrations/20260812230300_field_truck_inventory_movement_commands.sql"
+      - "supabase/migrations/20260812230400_field_truck_inventory_work_order_commands.sql"
+      - "tests/field-truck-inventory-contract.test.ts"
       - "tests/mobile-v1-productization.test.ts"
       - "tests/mobile-v1-post-merge-hardening.test.ts"
+      - "tests/mobile/field-truck-inventory.runtime.sql"
       - "tests/mobile/mobile-v1-fake-day.runtime.sql"
       - "tests/mobile/mobile-v1-team-dispatch.runtime.sql"
       - "tests/mobile/mobile-v1-codex-hardening.runtime.sql"
@@ -66,6 +75,7 @@ jobs:
       - name: Mobile V1 source contracts
         run: >-
           pnpm exec vitest run
+          tests/field-truck-inventory-contract.test.ts
           tests/mobile-v1-productization.test.ts
           tests/mobile-v1-post-merge-hardening.test.ts
           tests/mobile-service-shell.test.ts
@@ -118,6 +128,9 @@ jobs:
             echo "=== Post-merge end-to-end Mobile V1 day ==="
             psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
               -f tests/mobile/mobile-v1-post-merge-hardening.runtime.sql
+            echo "=== Field truck inventory runtime ==="
+            psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+              -f tests/mobile/field-truck-inventory.runtime.sql
           } 2>&1 | tee "$RUNNER_TEMP/mobile-v1-runtime.log"
 
       - name: Upload Mobile V1 runtime diagnostics

--- a/app/api/mobile/service/truck-inventory/_lib.ts
+++ b/app/api/mobile/service/truck-inventory/_lib.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from "next/server";
+
+import { toSafeDatabaseError } from "@/features/shared/lib/server/safeDatabaseError";
+
+export type FieldInventoryRpcError = {
+  code?: string | null;
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+};
+
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: FieldInventoryRpcError | null }>;
+};
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isUuid(value: unknown): value is string {
+  return typeof value === "string" && UUID_RE.test(value.trim());
+}
+
+export function positiveQuantity(value: unknown): number | null {
+  const quantity = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(quantity) && quantity > 0 ? quantity : null;
+}
+
+export function optionalUuid(value: unknown): string | null {
+  if (value == null || value === "") return null;
+  return isUuid(value) ? value.trim() : null;
+}
+
+export function operationKey(
+  request: Request,
+  body: Record<string, unknown>,
+): string {
+  const header = request.headers.get("idempotency-key")?.trim() ?? "";
+  const camel =
+    typeof body.operationKey === "string" ? body.operationKey.trim() : "";
+  const snake =
+    typeof body.operation_key === "string" ? body.operation_key.trim() : "";
+  return header || camel || snake;
+}
+
+export async function fieldInventoryRpc(
+  supabase: unknown,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ data: unknown; error: FieldInventoryRpcError | null }> {
+  return (supabase as RpcClient).rpc(name, args);
+}
+
+export function fieldInventoryErrorResponse(
+  error: FieldInventoryRpcError,
+  context: string,
+) {
+  const safe = toSafeDatabaseError(error, {
+    context,
+    fallback: "The Field Service inventory operation could not be completed.",
+    publicMessagePatterns: [
+      /^Authenticated actor mismatch\.?$/i,
+      /^Field (?:Service|inventory) access is required\.?$/i,
+      /^Parts (?:receiving )?permission is required\.?$/i,
+      /^This (?:truck|service visit|service call).*$/i,
+      /^The (?:service truck|assigned service truck).*$/i,
+      /^A stable operation key is required\.?$/i,
+      /^A barcode, provider id, SKU, or part number is required\.?$/i,
+      /^Part details are required.*$/i,
+      /^Part not found.*$/i,
+      /^Purchase order not found.*$/i,
+      /^No receivable purchase-order line.*$/i,
+      /^Source and truck inventory locations.*$/i,
+      /^A transfer location.*$/i,
+      /^Insufficient available stock.*$/i,
+      /^Arrive at the service call.*$/i,
+      /^Create or link the repair.*$/i,
+      /^Assign a service truck.*$/i,
+      /^The repair line.*$/i,
+      /^Work-order part not found.*$/i,
+      /^PART_[A-Z0-9_]+$/i,
+      /^FIELD_[A-Z0-9_]+$/i,
+    ],
+  });
+  const message = `${error.message} ${error.details ?? ""} ${error.hint ?? ""}`;
+  const status =
+    error.code === "42501"
+      ? 403
+      : error.code === "P0002"
+        ? 404
+        : error.code === "22023"
+          ? 400
+          : error.code === "23505" ||
+              error.code === "23514" ||
+              error.code === "40001" ||
+              error.code === "55000" ||
+              /CONFLICT|IN_PROGRESS|INSUFFICIENT|already|outside|assigned/i.test(
+                message,
+              )
+            ? 409
+            : safe.isPublicMessage
+              ? 400
+              : 500;
+
+  return NextResponse.json(
+    {
+      error: safe.message,
+      correlationId: safe.correlationId,
+    },
+    { status },
+  );
+}

--- a/app/api/mobile/service/truck-inventory/receive/route.ts
+++ b/app/api/mobile/service/truck-inventory/receive/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  fieldInventoryErrorResponse,
+  fieldInventoryRpc,
+  isUuid,
+  operationKey,
+  positiveQuantity,
+} from "../_lib";
+
+export async function POST(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageParts",
+  });
+  if (!access.ok) return access.response;
+
+  const body = (await request.json().catch(() => null)) as
+    | Record<string, unknown>
+    | null;
+  const payload = body ?? {};
+  const serviceVehicleId =
+    payload.serviceVehicleId ?? payload.service_vehicle_id;
+  const purchaseOrderId =
+    payload.purchaseOrderId ?? payload.purchase_order_id;
+  const purchaseOrderLineId =
+    payload.purchaseOrderLineId ?? payload.purchase_order_line_id;
+  const quantity = positiveQuantity(payload.quantity ?? payload.qty);
+  const key = operationKey(request, payload);
+
+  if (
+    !isUuid(serviceVehicleId) ||
+    !isUuid(purchaseOrderId) ||
+    !isUuid(purchaseOrderLineId) ||
+    quantity == null ||
+    !key
+  ) {
+    return NextResponse.json(
+      { error: "Truck, purchase-order line, quantity, and operation key are required." },
+      { status: 400 },
+   );
+  }
+
+  const { data, error } = await fieldInventoryRpc(
+    access.supabase,
+    "field_receive_po_part_to_truck_atomic",
+   {
+      p_shop_id: access.profile.shop_id,
+      p_service_vehicle_id: serviceVehicleId,
+      p_purchase_order_id: purchaseOrderId,
+      p_purchase_order_line_id: purchaseOrderLineId,
+      p_quantity: quantity,
+      p_actor_user_id: access.authUserId,
+      p_operation_key: key,
+    },
+  );
+  if (error) return fieldInventoryErrorResponse(error, "field-truck-inventory/receive");
+  return NextResponse.json(data);
+}

--- a/app/api/mobile/service/truck-inventory/resolve/route.ts
+++ b/app/api/mobile/service/truck-inventory/resolve/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  fieldInventoryErrorResponse,
+  fieldInventoryRpc,
+  operationKey,
+  optionalUuid,
+} from "../_lib";
+
+type Body = Record<string, unknown>;
+
+function text(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function optionalNumber(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : null;
+}
+
+export async function POST(request: Request) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  const body = (await request.json().catch(() => null)) as Body | null;
+  const payload = body ?? {};
+  const key = operationKey(request, payload);
+  const code = text(payload.code);
+  const externalId = text(payload.externalId ?? payload.external_id);
+  const partNumber = text(payload.partNumber ?? payload.part_number);
+  const supplierSku = text(payload.supplierSku ?? payload.supplier_sku);
+  const connectionId = optionalUuid(payload.connectionId ?? payload.connection_id);
+  const supplierId = optionalUuid(payload.supplierId ?? payload.supplier_id);
+  const packageQuantityRaw = payload.packageQuantity ?? payload.package_quantity;
+  const packageQuantity =
+    packageQuantityRaw == null || packageQuantityRaw === ""
+      ? 1
+      : Number(packageQuantityRaw);
+  const unitCost = optionalNumber(payload.unitCost ?? payload.unit_cost);
+  const unitSellPrice = optionalNumber(
+    payload.unitSellPrice ?? payload.unit_sell_price,
+  );
+
+  if ((!code && !externalId && !partNumber && !supplierSku) || !key) {
+    return NextResponse.json(
+      { error: "A part identity and stable operation key are required." },
+      { status: 400 },
+    );
+  }
+  if (!Number.isFinite(packageQuantity) || packageQuantity <= 0) {
+    return NextResponse.json(
+      { error: "Package quantity must be greater than zero." },
+      { status: 400 },
+    );
+  }
+  if (
+    (payload.connectionId || payload.connection_id) &&
+    !connectionId
+  ) {
+    return NextResponse.json({ error: "Invalid connection." }, { status: 400 });
+  }
+  if ((payload.supplierId || payload.supplier_id) && !supplierId) {
+    return NextResponse.json({ error: "Invalid supplier." }, { status: 400 });
+  }
+
+  const { data, error } = await fieldInventoryRpc(
+    access.supabase,
+    "field_resolve_or_create_part_identity_atomic",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_actor_user_id: access.authUserId,
+      p_code: code,
+      p_provider: text(payload.provider) ?? "manual",
+      p_external_id: externalId,
+      p_connection_id: connectionId,
+      p_supplier_id: supplierId,
+      p_name: text(payload.name),
+      p_manufacturer: text(payload.manufacturer),
+      p_part_number: partNumber,
+      p_supplier_sku: supplierSku,
+      p_unit_of_measure: text(payload.unitOfMeasure ?? payload.unit_of_measure),
+      p_package_quantity: packageQuantity,
+      p_create_if_missing: payload.createIfMissing === true || payload.create_if_missing === true,
+      p_unit_cost: unitCost,
+      p_unit_sell_price: unitSellPrice,
+      p_metadata:
+        payload.metadata && typeof payload.metadata === "object"
+          ? payload.metadata
+          : {},
+      p_operation_key: key,
+    },
+  );
+  if (error) return fieldInventoryErrorResponse(error, "field-truck-inventory/resolve");
+  return NextResponse.json(data);
+}

--- a/app/api/mobile/service/truck-inventory/return/route.ts
+++ b/app/api/mobile/service/truck-inventory/return/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+
+import { requireMobileServiceOperatorApiAccess } from "@/features/mobile/service/server/access";
+import {
+  fieldInventoryErrorResponse,
+  fieldInventoryRpc,
+  isUuid,
+  operationKey,
+  positiveQuantity,
+} from "../_lib";
+
+export async function POST(request: Request) {
+  const access = await requireMobileServiceOperatorApiAccess();
+  if (!access.ok) return access.response;
+
+  const body = (await request.json().catch(() => null)) as
+    | Record<string, unknown>
+    | null;
+  const payload = body ?? {};
+  const visitId = payload.visitId ?? payload.service_visit_id;
+  const workOrderPartId =
+    payload.workOrderPartId ?? payload.work_order_part_id;
+  const quantity = positiveQuantity(payload.quantity ?? payload.qty);
+  const key = operationKey(request, payload);
+
+  if (
+    !isUuid(visitId) ||
+    !isUuid(workOrderPartId) ||
+    quantity == null ||
+    !key
+  ) {
+    return NextResponse.json(
+      { error: "Visit, work-order part, quantity, and operation key are required." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await fieldInventoryRpc(
+    access.supabase,
+    "field_return_truck_part_atomic",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_service_visit_id: visitId,
+      p_work_order_part_id: workOrderPartId,
+      p_quantity: quantity,
+      p_actor_user_id: access.authUserId,
+      p_operation_key: key,
+    },
+  );
+  if (error) return fieldInventoryErrorResponse(error, "field-truck-inventory/return");
+  return NextResponse.json(data);
+}

--- a/app/api/mobile/service/truck-inventory/route.ts
+++ b/app/api/mobile/service/truck-inventory/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  fieldInventoryErrorResponse,
+  fieldInventoryRpc,
+  isUuid,
+} from "./_lib";
+
+export async function GET(request: NextRequest) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  const visitId = request.nextUrl.searchParams.get("visitId")?.trim() || null;
+  const serviceVehicleId =
+    request.nextUrl.searchParams.get("serviceVehicleId")?.trim() || null;
+  const query = request.nextUrl.searchParams.get("query")?.trim() || null;
+  if (visitId && !isUuid(visitId)) {
+    return NextResponse.json({ error: "Invalid service visit." }, { status: 400 });
+  }
+  if (serviceVehicleId && !isUuid(serviceVehicleId)) {
+    return NextResponse.json({ error: "Invalid service truck." }, { status: 400 });
+  }
+  if (query && query.length > 120) {
+    return NextResponse.json({ error: "Search is too long." }, { status: 400 });
+  }
+
+  const { data, error } = await fieldInventoryRpc(
+    access.supabase,
+    "field_truck_inventory_snapshot",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_actor_user_id: access.authUserId,
+      p_service_visit_id: visitId,
+      p_service_vehicle_id: serviceVehicleId,
+      p_query: query,
+    },
+  );
+  if (error) return fieldInventoryErrorResponse(error, "field-truck-inventory/snapshot");
+
+  return NextResponse.json(data, {
+    headers: { "Cache-Control": "private, no-store" },
+  });
+}

--- a/app/api/mobile/service/truck-inventory/transfer/route.ts
+++ b/app/api/mobile/service/truck-inventory/transfer/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  fieldInventoryErrorResponse,
+  fieldInventoryRpc,
+  isUuid,
+  operationKey,
+  positiveQuantity,
+} from "../_lib";
+
+export async function POST(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageParts",
+  });
+  if (!access.ok) return access.response;
+
+  const body = (await request.json().catch(() => null)) as
+    | Record<string, unknown>
+    | null;
+  const payload = body ?? {};
+  const serviceVehicleId =
+    payload.serviceVehicleId ?? payload.service_vehicle_id;
+  const sourceLocationId =
+    payload.sourceLocationId ?? payload.source_location_id;
+  const partId = payload.partId ?? payload.part_id;
+  const quantity = positiveQuantity(payload.quantity ?? payload.qty);
+  const key = operationKey(request, payload);
+
+  if (
+    !isUuid(serviceVehicleId) ||
+    !isUuid(sourceLocationId) ||
+    !isUuid(partId) ||
+    quantity == null ||
+    !key
+  ) {
+    return NextResponse.json(
+      { error: "Truck, source location, part, quantity, and operation key are required." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await fieldInventoryRpc(
+    access.supabase,
+    "field_transfer_stock_to_truck_atomic",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_service_vehicle_id: serviceVehicleId,
+      p_source_location_id: sourceLocationId,
+      p_part_id: partId,
+      p_quantity: quantity,
+      p_actor_user_id: access.authUserId,
+      p_operation_key: key,
+    },
+  );
+  if (error) return fieldInventoryErrorResponse(error, "field-truck-inventory/transfer");
+  return NextResponse.json(data);
+}

--- a/app/api/mobile/service/truck-inventory/use/route.ts
+++ b/app/api/mobile/service/truck-inventory/use/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { requireMobileServiceOperatorApiAccess } from "@/features/mobile/service/server/access";
+import {
+  fieldInventoryErrorResponse,
+  fieldInventoryRpc,
+  isUuid,
+  operationKey,
+  positiveQuantity,
+} from "../_lib";
+
+export async function POST(request: Request) {
+  const access = await requireMobileServiceOperatorApiAccess();
+  if (!access.ok) return access.response;
+
+  const body = (await request.json().catch(() => null)) as
+    | Record<string, unknown>
+    | null;
+  const payload = body ?? {};
+  const visitId = payload.visitId ?? payload.service_visit_id;
+  const lineId = payload.workOrderLineId ?? payload.work_order_line_id;
+  const partId = payload.partId ?? payload.part_id;
+  const quantity = positiveQuantity(payload.quantity ?? payload.qty);
+  const key = operationKey(request, payload);
+
+  if (
+    !isUuid(visitId) ||
+    !isUuid(lineId) ||
+    !isUuid(partId) ||
+    quantity == null ||
+    !key
+  ) {
+    return NextResponse.json(
+      { error: "Visit, repair line, part, quantity, and operation key are required." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await fieldInventoryRpc(
+    access.supabase,
+    "field_use_truck_part_atomic",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_service_visit_id: visitId,
+      p_work_order_line_id: lineId,
+      p_part_id: partId,
+      p_quantity: quantity,
+      p_actor_user_id: access.authUserId,
+      p_operation_key: key,
+    },
+  );
+  if (error) return fieldInventoryErrorResponse(error, "field-truck-inventory/use");
+  return NextResponse.json(data);
+}

--- a/app/mobile/service/truck-inventory/page.tsx
+++ b/app/mobile/service/truck-inventory/page.tsx
@@ -1,0 +1,5 @@
+import MobileTruckInventory from "@/features/mobile/service/MobileTruckInventory";
+
+export default function MobileTruckInventoryPage() {
+  return <MobileTruckInventory />;
+}

--- a/features/integrations/core/contracts.ts
+++ b/features/integrations/core/contracts.ts
@@ -1,0 +1,84 @@
+export type IntegrationConnectionStatus =
+  | "disconnected"
+  | "pending"
+  | "connected"
+  | "degraded"
+  | "error";
+
+export type IntegrationDirection = "inbound" | "outbound";
+export type IntegrationOperationStatus =
+  | "started"
+  | "succeeded"
+  | "failed"
+  | "dead_lettered";
+
+export type IntegrationConnection = {
+  id: string;
+  shopId: string;
+  provider: string;
+  displayName: string | null;
+  status: IntegrationConnectionStatus;
+  capabilities: string[];
+  config: Record<string, unknown>;
+  secretReference: string | null;
+  syncCursor: Record<string, unknown>;
+  lastSuccessAt: string | null;
+  lastErrorAt: string | null;
+  lastError: string | null;
+};
+
+export type ExternalObjectIdentity = {
+  provider: string;
+  objectType: string;
+  externalId: string;
+  canonicalTable: string;
+  canonicalId: string;
+  externalVersion?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+export type IntegrationOperation = {
+  provider: string;
+  direction: IntegrationDirection;
+  operation: string;
+  operationKey: string;
+  objectType?: string | null;
+  externalId?: string | null;
+  canonicalTable?: string | null;
+  canonicalId?: string | null;
+  status: IntegrationOperationStatus;
+  requestMetadata?: Record<string, unknown>;
+  responseMetadata?: Record<string, unknown>;
+  errorMessage?: string | null;
+};
+
+export interface IntegrationAdapter<Health = Record<string, unknown>> {
+  readonly provider: string;
+  readonly capabilities: readonly string[];
+  healthCheck(): Promise<Health>;
+}
+
+export class IntegrationRegistry<Adapter extends IntegrationAdapter> {
+  private readonly adapters = new Map<string, Adapter>();
+
+  register(adapter: Adapter): void {
+    const key = adapter.provider.trim().toLowerCase();
+    if (!key) throw new Error("Integration provider is required.");
+    if (this.adapters.has(key)) {
+      throw new Error(`Integration provider ${key} is already registered.`);
+    }
+    this.adapters.set(key, adapter);
+  }
+
+  unregister(provider: string): void {
+    this.adapters.delete(provider.trim().toLowerCase());
+  }
+
+  get(provider: string): Adapter | null {
+    return this.adapters.get(provider.trim().toLowerCase()) ?? null;
+  }
+
+  list(): Adapter[] {
+    return [...this.adapters.values()];
+  }
+}

--- a/features/integrations/core/index.ts
+++ b/features/integrations/core/index.ts
@@ -1,0 +1,1 @@
+export * from "./contracts";

--- a/features/integrations/index.ts
+++ b/features/integrations/index.ts
@@ -1,5 +1,5 @@
-
-//features/integrations/index.ts
+// features/integrations/index.ts
+export * as core from "./core";
 export * as ai from "./ai";
 export * as tax from "./tax";
 export * as parts from "./parts";

--- a/features/integrations/parts/index.ts
+++ b/features/integrations/parts/index.ts
@@ -1,37 +1,135 @@
 /**
- * Parts Integration Layer
- * Wrapper for PartsTech / WorldPac / NAPA inputs.
+ * Provider-neutral parts integration contract.
+ *
+ * Provider catalog identifiers are external identities only. Every selected
+ * result must resolve to one canonical ProFixIQ parts.id before it can be
+ * ordered, received, stocked, used on a work order, or invoiced.
  */
+
+import {
+  IntegrationRegistry,
+  type IntegrationAdapter,
+} from "@/features/integrations/core/contracts";
+
+export type PartsProviderCapability =
+  | "search"
+  | "availability"
+  | "quotes"
+  | "orders"
+  | "order_status"
+  | "cancellations"
+  | "supersessions"
+  | "fitment";
 
 export interface PartsSearchInput {
   vin?: string;
+  vehicleId?: string;
   keywords?: string;
+  partNumber?: string;
+  postalCode?: string;
+  supplierIds?: string[];
+}
+
+export interface ExternalPartIdentity {
+  provider: string;
+  externalId: string;
+  supplierId?: string | null;
+  supplierSku?: string | null;
+  manufacturer?: string | null;
+  partNumber?: string | null;
+  barcode?: string | null;
+  unitOfMeasure?: string | null;
+  packageQuantity?: number | null;
+  metadata?: Record<string, unknown>;
 }
 
 export interface PartResult {
   id: string;
+  provider: string;
+  externalId: string;
   supplier: string;
+  supplierId?: string | null;
   description: string;
+  manufacturer?: string | null;
+  partNumber?: string | null;
+  supplierSku?: string | null;
+  barcode?: string | null;
   price: number;
+  listPrice?: number | null;
+  coreCharge?: number | null;
   stock: number;
+  eta?: string | null;
+  identity: ExternalPartIdentity;
 }
 
-export interface PartsProvider {
+export interface PartsQuoteLine {
+  externalPartId: string;
+  supplierId?: string | null;
+  quantity: number;
+}
+
+export interface PartsQuote {
+  provider: string;
+  quoteId: string;
+  expiresAt?: string | null;
+  lines: Array<
+    PartsQuoteLine & {
+      unitCost: number;
+      availability?: number | null;
+      metadata?: Record<string, unknown>;
+    }
+  >;
+}
+
+export interface PartsOrderResult {
+  provider: string;
+  externalOrderId: string;
+  status: string;
+  submittedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PartsProvider extends IntegrationAdapter {
+  readonly provider: string;
+  readonly capabilities: readonly PartsProviderCapability[];
   search(input: PartsSearchInput): Promise<PartResult[]>;
+  quote?(lines: PartsQuoteLine[]): Promise<PartsQuote>;
+  submitOrder?(input: {
+    quoteId?: string | null;
+    purchaseOrderNumber: string;
+    shipTo?: Record<string, unknown>;
+    lines: PartsQuoteLine[];
+    idempotencyKey: string;
+  }): Promise<PartsOrderResult>;
+  getOrderStatus?(externalOrderId: string): Promise<PartsOrderResult>;
+  cancelOrder?(externalOrderId: string, idempotencyKey: string): Promise<void>;
 }
 
-class MockPartsProvider implements PartsProvider {
-  async search(input: PartsSearchInput): Promise<PartResult[]> {
-    return [
-      {
-        id: "demo-123",
-        supplier: "MockSupplier",
-        description: `Example part for ${input.keywords ?? input.vin}`,
-        price: 42,
-        stock: 3,
-      },
-    ];
+class PartsProviderRegistry extends IntegrationRegistry<PartsProvider> {
+  async search(
+    input: PartsSearchInput,
+    providers?: string[],
+  ): Promise<PartResult[]> {
+    const requested = providers?.length
+      ? providers
+          .map((provider) => this.get(provider))
+          .filter((provider): provider is PartsProvider => Boolean(provider))
+      : this.list();
+
+    const settled = await Promise.allSettled(
+      requested
+        .filter((provider) => provider.capabilities.includes("search"))
+        .map((provider) => provider.search(input)),
+    );
+    return settled.flatMap((result) =>
+      result.status === "fulfilled" ? result.value : [],
+    );
   }
 }
 
-export const Parts = new MockPartsProvider();
+/**
+ * Runtime adapters (Nexpart, PartsTech, etc.) register here only after their
+ * server-side connection is configured. An empty registry returns no fake
+ * catalog results; the manual canonical-part workflow remains available.
+ */
+export const Parts = new PartsProviderRegistry();

--- a/features/mobile/service/FieldBarcodeScanner.tsx
+++ b/features/mobile/service/FieldBarcodeScanner.tsx
@@ -60,8 +60,8 @@ export default function FieldBarcodeScanner({
 
     let quagga: QuaggaLike;
     try {
-      const module = await import("@ericblade/quagga2");
-      quagga = module.default as unknown as QuaggaLike;
+      const quaggaModule = await import("@ericblade/quagga2");
+      quagga = quaggaModule.default as unknown as QuaggaLike;
     } catch (loadError) {
       setError(
         loadError instanceof Error

--- a/features/mobile/service/FieldBarcodeScanner.tsx
+++ b/features/mobile/service/FieldBarcodeScanner.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { Camera, CameraOff } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type QuaggaResult = { codeResult?: { code?: string | null } | null };
+type QuaggaHandler = (result: QuaggaResult) => void;
+type QuaggaLike = {
+  init: (
+    config: {
+      inputStream: {
+        name: string;
+        type: "LiveStream";
+        target: HTMLElement;
+        constraints: { facingMode: string };
+      };
+      decoder: { readers: string[] };
+      locate: boolean;
+    },
+    callback: (error?: Error) => void,
+  ) => void;
+  start: () => void;
+  stop: () => void;
+  onDetected: (handler: QuaggaHandler) => void;
+  offDetected?: (handler: QuaggaHandler) => void;
+};
+
+export default function FieldBarcodeScanner({
+  disabled = false,
+  onDetected,
+}: {
+  disabled?: boolean;
+  onDetected: (code: string) => void;
+}) {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+  const quaggaRef = useRef<QuaggaLike | null>(null);
+  const handlerRef = useRef<QuaggaHandler | null>(null);
+  const lastCodeRef = useRef("");
+  const [scanning, setScanning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const stop = useCallback(() => {
+    const quagga = quaggaRef.current;
+    if (quagga && handlerRef.current && quagga.offDetected) {
+      quagga.offDetected(handlerRef.current);
+    }
+    try {
+      quagga?.stop();
+    } catch {
+      // Camera may already be stopped by the browser.
+    }
+    handlerRef.current = null;
+    setScanning(false);
+  }, []);
+
+  const start = useCallback(async () => {
+    if (disabled || scanning || !targetRef.current) return;
+    const target = targetRef.current;
+    setError(null);
+
+    let quagga: QuaggaLike;
+    try {
+      const module = await import("@ericblade/quagga2");
+      quagga = module.default as unknown as QuaggaLike;
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Barcode scanner could not be loaded.",
+      );
+      setScanning(false);
+      return;
+    }
+
+    quaggaRef.current = quagga;
+    quagga.init(
+      {
+        inputStream: {
+          name: "Field inventory scanner",
+          type: "LiveStream",
+          target,
+          constraints: { facingMode: "environment" },
+        },
+        decoder: {
+          readers: [
+            "upc_reader",
+            "upc_e_reader",
+            "ean_reader",
+            "ean_8_reader",
+            "code_128_reader",
+            "code_39_reader",
+          ],
+        },
+        locate: true,
+      },
+      (initError?: Error) => {
+        if (initError) {
+          setError(initError.message || "Camera scanner could not start.");
+          setScanning(false);
+          return;
+        }
+        const handler: QuaggaHandler = (result) => {
+          const code = result.codeResult?.code?.trim() ?? "";
+          if (!code || code === lastCodeRef.current) return;
+          lastCodeRef.current = code;
+          onDetected(code);
+          window.setTimeout(() => {
+            lastCodeRef.current = "";
+          }, 1200);
+        };
+        handlerRef.current = handler;
+        quagga.onDetected(handler);
+        quagga.start();
+        setScanning(true);
+      },
+    );
+  }, [disabled, onDetected, scanning]);
+
+  useEffect(() => stop, [stop]);
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => void (scanning ? stop() : start())}
+        className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 text-sm font-bold text-[color:var(--theme-text-primary)] disabled:opacity-50"
+      >
+        {scanning ? <CameraOff className="h-4 w-4" /> : <Camera className="h-4 w-4" />}
+        {scanning ? "Stop scanner" : "Scan part"}
+      </button>
+      <div
+        ref={targetRef}
+        className={[
+          "overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-black",
+          scanning ? "min-h-48" : "hidden",
+        ].join(" ")}
+        aria-label="Barcode camera preview"
+      />
+      {error ? <p className="text-xs text-red-300">{error}</p> : null}
+    </div>
+  );
+}

--- a/features/mobile/service/MobileServiceScopeGate.tsx
+++ b/features/mobile/service/MobileServiceScopeGate.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Boxes } from "lucide-react";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
@@ -107,8 +109,6 @@ export default function MobileServiceScopeGate() {
       setReady(true);
     })().catch(() => {
       if (!active) return;
-      // If access cannot be established, fail closed: do not render another
-      // actor's cached service-call snapshot or the Field Service shell.
       window.localStorage.removeItem(SNAPSHOT_CACHE_KEY);
       window.localStorage.removeItem(SNAPSHOT_SCOPE_KEY);
       router.replace("/mobile");
@@ -127,5 +127,23 @@ export default function MobileServiceScopeGate() {
     );
   }
 
-  return <MobileServiceShell />;
+  return (
+    <>
+      <div className="mx-auto w-full max-w-3xl px-3 pt-3 sm:px-4">
+        <Link
+          href="/mobile/service/truck-inventory"
+          className="flex min-h-12 items-center justify-between rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-4 text-sm font-extrabold text-[color:var(--theme-text-primary)] shadow-card"
+        >
+          <span className="inline-flex items-center gap-2">
+            <Boxes className="h-4 w-4 text-[color:var(--accent-copper)]" />
+            Truck inventory
+          </span>
+          <span className="text-xs text-[color:var(--theme-text-muted)]">
+            Receive · transfer · scan/use
+          </span>
+        </Link>
+      </div>
+      <MobileServiceShell />
+    </>
+  );
 }

--- a/features/mobile/service/MobileTruckInventory.tsx
+++ b/features/mobile/service/MobileTruckInventory.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+
+import MobileTruckInventoryScreen from "./MobileTruckInventoryScreen";
+import { useTruckInventorySnapshot } from "./useTruckInventorySnapshot";
+import { useTruckInventoryStocking } from "./useTruckInventoryStocking";
+import { useTruckInventoryUsage } from "./useTruckInventoryUsage";
+import type { TruckInventoryView } from "./truckInventoryUi";
+
+export default function MobileTruckInventory() {
+  const [view, setView] = useState<TruckInventoryView>("stock");
+  const state = useTruckInventorySnapshot();
+  const usage = useTruckInventoryUsage({
+    snapshot: state.snapshot,
+    setSnapshot: state.setSnapshot,
+    scope: state.scope,
+    online: state.online,
+    selectedLineId: state.selectedLineId,
+    query: state.query,
+    load: state.load,
+  });
+  const stocking = useTruckInventoryStocking({
+    snapshot: state.snapshot,
+    selectedPartId: usage.selectedPartId,
+    quantity: usage.quantity,
+    query: state.query,
+    load: state.load,
+  });
+  const busy = usage.usageBusy || stocking.stockingBusy;
+
+  const handleTruckChange = (truckId: string) => {
+    usage.setSelectedPartId(null);
+    stocking.setSelectedReceiptId("");
+    state.handleTruckChange(truckId);
+  };
+
+  return (
+    <MobileTruckInventoryScreen
+      snapshot={state.snapshot}
+      online={state.online}
+      view={view}
+      setView={setView}
+      loading={state.loading}
+      busy={busy}
+      error={state.error}
+      query={state.query}
+      setQuery={state.setQuery}
+      load={state.load}
+      selectedTruckId={state.selectedTruckId}
+      onTruckChange={handleTruckChange}
+      selectedPartId={usage.selectedPartId}
+      setSelectedPartId={usage.setSelectedPartId}
+      selectedLineId={state.selectedLineId}
+      setSelectedLineId={state.setSelectedLineId}
+      quantity={usage.quantity}
+      setQuantity={usage.setQuantity}
+      identityDraft={usage.identityDraft}
+      setIdentityDraft={usage.setIdentityDraft}
+      createIdentity={usage.createIdentity}
+      sourceLocationId={stocking.sourceLocationId}
+      setSourceLocationId={stocking.setSourceLocationId}
+      sourceOptions={stocking.sourceOptions}
+      selectedReceiptId={stocking.selectedReceiptId}
+      setSelectedReceiptId={stocking.setSelectedReceiptId}
+      selectedReceipt={stocking.selectedReceipt}
+      truckItemById={usage.truckItemById}
+      handleUse={usage.handleUse}
+      handleReturn={usage.handleReturn}
+      resolveCode={usage.resolveCode}
+      transferToTruck={stocking.transferToTruck}
+      receiveToTruck={stocking.receiveToTruck}
+    />
+  );
+}

--- a/features/mobile/service/MobileTruckInventoryScreen.tsx
+++ b/features/mobile/service/MobileTruckInventoryScreen.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import {
+  ArrowLeft,
+  Boxes,
+  ClipboardList,
+  Loader2,
+  MoveRight,
+  PackageCheck,
+  RefreshCw,
+  Truck,
+  WifiOff,
+} from "lucide-react";
+import Link from "next/link";
+import type { Dispatch, SetStateAction } from "react";
+
+import TruckHistoryPanel from "./TruckHistoryPanel";
+import TruckLoadPanel from "./TruckLoadPanel";
+import TruckReceivePanel from "./TruckReceivePanel";
+import TruckStockPanel from "./TruckStockPanel";
+import type {
+  FieldCatalogPart,
+  FieldOpenReceipt,
+  FieldRecentPartUse,
+  FieldTruckInventoryItem,
+  FieldTruckInventorySnapshot,
+} from "./truckInventoryContracts";
+import type { IdentityDraft, TruckInventoryView } from "./truckInventoryUi";
+import { actionClass } from "./truckInventoryUi";
+
+type Props = {
+  snapshot: FieldTruckInventorySnapshot | null;
+  online: boolean;
+  view: TruckInventoryView;
+  setView: Dispatch<SetStateAction<TruckInventoryView>>;
+  loading: boolean;
+  busy: boolean;
+  error: string | null;
+  query: string;
+  setQuery: Dispatch<SetStateAction<string>>;
+  load: (search?: string, serviceVehicleId?: string) => Promise<void>;
+  selectedTruckId: string;
+  onTruckChange: (truckId: string) => void;
+  selectedPartId: string | null;
+  setSelectedPartId: Dispatch<SetStateAction<string | null>>;
+  selectedLineId: string;
+  setSelectedLineId: Dispatch<SetStateAction<string>>;
+  quantity: number;
+  setQuantity: Dispatch<SetStateAction<number>>;
+  identityDraft: IdentityDraft | null;
+  setIdentityDraft: Dispatch<SetStateAction<IdentityDraft | null>>;
+  createIdentity: () => Promise<void>;
+  sourceLocationId: string;
+  setSourceLocationId: Dispatch<SetStateAction<string>>;
+  sourceOptions: FieldCatalogPart["locations"];
+  selectedReceiptId: string;
+  setSelectedReceiptId: Dispatch<SetStateAction<string>>;
+  selectedReceipt: FieldOpenReceipt | null;
+  truckItemById: Map<string, FieldTruckInventoryItem>;
+  handleUse: (partId: string) => Promise<void>;
+  handleReturn: (use: FieldRecentPartUse) => Promise<void>;
+  resolveCode: (code: string) => Promise<void>;
+  transferToTruck: () => Promise<void>;
+  receiveToTruck: () => Promise<void>;
+};
+
+export default function MobileTruckInventoryScreen(props: Props) {
+  const {
+    snapshot,
+    online,
+    view,
+    setView,
+    loading,
+    busy,
+    error,
+    query,
+    load,
+    selectedTruckId,
+    onTruckChange,
+  } = props;
+  const tabs: Array<{ key: TruckInventoryView; label: string; icon: typeof Boxes }> = [
+    { key: "stock", label: "Truck stock", icon: Boxes },
+    { key: "load", label: "Transfer", icon: MoveRight },
+    { key: "receive", label: "Receive", icon: PackageCheck },
+    { key: "history", label: "Used", icon: ClipboardList },
+  ];
+
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-4xl space-y-4 px-3 py-4 text-[color:var(--theme-text-primary)] sm:px-4">
+      <header className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-card">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <Link
+              href="/mobile/service"
+              className="inline-flex items-center gap-1 text-xs font-bold text-[color:var(--theme-text-muted)]"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" /> Field Service
+            </Link>
+            <h1 className="mt-2 flex items-center gap-2 text-2xl font-extrabold">
+              <Truck className="h-6 w-6 text-[color:var(--accent-copper)]" /> Truck inventory
+            </h1>
+            <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+              Receive or transfer onto the truck, then scan and use the same canonical part on the call.
+            </p>
+          </div>
+          <button
+            type="button"
+            className={actionClass}
+            disabled={loading || busy || !online}
+            onClick={() => void load(query)}
+            aria-label="Refresh truck inventory"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+          </button>
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2 text-xs">
+          <span className="rounded-full border border-[color:var(--theme-border-soft)] px-2.5 py-1">
+            {snapshot?.truck
+              ? `${snapshot.truck.name}${snapshot.truck.unitNumber ? ` · ${snapshot.truck.unitNumber}` : ""}`
+              : "No truck assigned"}
+          </span>
+          <span className="rounded-full border border-[color:var(--theme-border-soft)] px-2.5 py-1">
+            {snapshot?.visit ? `Call · ${snapshot.visit.status.replaceAll("_", " ")}` : "No active call"}
+          </span>
+          {!online ? (
+            <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2.5 py-1 text-amber-200">
+              <WifiOff className="h-3.5 w-3.5" /> Offline snapshot
+            </span>
+          ) : null}
+        </div>
+      </header>
+
+      {error ? (
+        <div className="rounded-2xl border border-amber-500/35 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+          {error}
+        </div>
+      ) : null}
+
+      {snapshot?.canManageParts && (snapshot.trucks ?? []).length > 0 ? (
+        <section className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3">
+          <label className="text-sm font-semibold">
+            Service truck
+            <select
+              value={selectedTruckId}
+              onChange={(event) => onTruckChange(event.target.value)}
+              className="mt-1 min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3"
+            >
+              <option value="">Select service truck</option>
+              {(snapshot.trucks ?? []).map((truck) => (
+                <option key={truck.id} value={truck.id}>
+                  {truck.name}{truck.unitNumber ? ` · ${truck.unitNumber}` : ""}
+                </option>
+              ))}
+            </select>
+          </label>
+        </section>
+      ) : null}
+
+      <nav className="grid grid-cols-4 gap-2" aria-label="Truck inventory views">
+        {tabs.map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setView(key)}
+            className={[
+              "min-h-16 rounded-2xl border px-2 py-2 text-xs font-bold",
+              view === key
+                ? "border-[color:var(--accent-copper)] bg-[color:var(--theme-surface-panel)]"
+                : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]",
+            ].join(" ")}
+          >
+            <Icon className="mx-auto mb-1 h-4 w-4" />
+            {label}
+          </button>
+        ))}
+      </nav>
+
+      {loading && !snapshot ? (
+        <div className="flex min-h-48 items-center justify-center rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]">
+          <Loader2 className="h-6 w-6 animate-spin" />
+        </div>
+      ) : null}
+
+      {snapshot && !snapshot.truck ? (
+        <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-6 text-center">
+          <Truck className="mx-auto h-8 w-8 text-[color:var(--theme-text-muted)]" />
+          <h2 className="mt-3 text-lg font-bold">Assign a service truck</h2>
+          <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+            The assigned truck must have its canonical stock location enabled in Field Service setup.
+          </p>
+        </section>
+      ) : null}
+
+      {snapshot?.truck && view === "stock" ? <TruckStockPanel {...props} snapshot={snapshot} /> : null}
+      {snapshot?.truck && view === "load" ? <TruckLoadPanel {...props} snapshot={snapshot} /> : null}
+      {snapshot?.truck && view === "receive" ? <TruckReceivePanel {...props} snapshot={snapshot} /> : null}
+      {snapshot?.truck && view === "history" ? <TruckHistoryPanel {...props} snapshot={snapshot} /> : null}
+    </main>
+  );
+}

--- a/features/mobile/service/TruckHistoryPanel.tsx
+++ b/features/mobile/service/TruckHistoryPanel.tsx
@@ -6,7 +6,7 @@ import type {
   FieldRecentPartUse,
   FieldTruckInventorySnapshot,
 } from "./truckInventoryContracts";
-import { numeric } from "./truckInventoryContracts";
+import { aggregateRecentPartUses, numeric } from "./truckInventoryContracts";
 import { actionClass, quantityLabel } from "./truckInventoryUi";
 
 type Props = {
@@ -16,9 +16,10 @@ type Props = {
 };
 
 export default function TruckHistoryPanel({ snapshot, busy, handleReturn }: Props) {
+  const recentUses = aggregateRecentPartUses(snapshot.recentUses);
   return (
     <section className="space-y-3">
-      {snapshot.recentUses.map((use) => {
+      {recentUses.map((use) => {
         const returnable = Math.max(
           0,
           numeric(use.quantity) - numeric(use.returnedQuantity),
@@ -56,7 +57,7 @@ export default function TruckHistoryPanel({ snapshot, busy, handleReturn }: Prop
           </article>
         );
       })}
-      {snapshot.recentUses.length === 0 ? (
+      {recentUses.length === 0 ? (
         <div className="rounded-2xl border border-dashed border-[color:var(--theme-border-soft)] p-8 text-center text-sm text-[color:var(--theme-text-muted)]">
           No truck parts have been used on this call yet.
         </div>

--- a/features/mobile/service/TruckHistoryPanel.tsx
+++ b/features/mobile/service/TruckHistoryPanel.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { RotateCcw } from "lucide-react";
+
+import type {
+  FieldRecentPartUse,
+  FieldTruckInventorySnapshot,
+} from "./truckInventoryContracts";
+import { numeric } from "./truckInventoryContracts";
+import { actionClass, quantityLabel } from "./truckInventoryUi";
+
+type Props = {
+  snapshot: FieldTruckInventorySnapshot;
+  busy: boolean;
+  handleReturn: (use: FieldRecentPartUse) => Promise<void>;
+};
+
+export default function TruckHistoryPanel({ snapshot, busy, handleReturn }: Props) {
+  return (
+    <section className="space-y-3">
+      {snapshot.recentUses.map((use) => {
+        const returnable = Math.max(
+          0,
+          numeric(use.quantity) - numeric(use.returnedQuantity),
+        );
+        return (
+          <article
+            key={use.stockMoveId}
+            className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="font-bold">{use.name}</h3>
+                <p className="text-xs text-[color:var(--theme-text-secondary)]">
+                  {use.partNumber || use.partId}
+                </p>
+              </div>
+              <div className="text-right text-sm">
+                <strong>{quantityLabel(use.quantity)} used</strong>
+                <div className="text-xs text-[color:var(--theme-text-muted)]">
+                  {new Date(use.createdAt).toLocaleString()}
+                </div>
+              </div>
+            </div>
+            <button
+              type="button"
+              className={`${actionClass} mt-3 w-full`}
+              disabled={busy || returnable <= 0}
+              onClick={() => void handleReturn(use)}
+            >
+              <RotateCcw className="h-4 w-4" />
+              {returnable > 0
+                ? `Return ${quantityLabel(returnable)} to truck`
+                : "Fully returned"}
+            </button>
+          </article>
+        );
+      })}
+      {snapshot.recentUses.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-[color:var(--theme-border-soft)] p-8 text-center text-sm text-[color:var(--theme-text-muted)]">
+          No truck parts have been used on this call yet.
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/features/mobile/service/TruckLoadPanel.tsx
+++ b/features/mobile/service/TruckLoadPanel.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { MoveRight } from "lucide-react";
+import type { Dispatch, SetStateAction } from "react";
+
+import type {
+  FieldCatalogPart,
+  FieldTruckInventorySnapshot,
+} from "./truckInventoryContracts";
+import { actionClass, primaryClass, quantityLabel } from "./truckInventoryUi";
+
+type Props = {
+  snapshot: FieldTruckInventorySnapshot;
+  online: boolean;
+  busy: boolean;
+  query: string;
+  setQuery: Dispatch<SetStateAction<string>>;
+  load: (search?: string, serviceVehicleId?: string) => Promise<void>;
+  selectedPartId: string | null;
+  setSelectedPartId: Dispatch<SetStateAction<string | null>>;
+  sourceLocationId: string;
+  setSourceLocationId: Dispatch<SetStateAction<string>>;
+  sourceOptions: FieldCatalogPart["locations"];
+  quantity: number;
+  setQuantity: Dispatch<SetStateAction<number>>;
+  transferToTruck: () => Promise<void>;
+};
+
+export default function TruckLoadPanel({
+  snapshot,
+  online,
+  busy,
+  query,
+  setQuery,
+  load,
+  selectedPartId,
+  setSelectedPartId,
+  sourceLocationId,
+  setSourceLocationId,
+  sourceOptions,
+  quantity,
+  setQuantity,
+  transferToTruck,
+}: Props) {
+  return (
+    <section className="space-y-4 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4">
+      <div>
+        <h2 className="text-lg font-bold">Transfer shop stock to truck</h2>
+        <p className="text-sm text-[color:var(--theme-text-secondary)]">
+          Both ledger moves share one transfer identity; the canonical part never changes.
+        </p>
+      </div>
+      {!snapshot.canManageParts ? (
+        <p className="rounded-2xl border border-amber-500/35 bg-amber-500/10 p-3 text-sm text-amber-100">
+          Parts-management permission is required to load a truck.
+        </p>
+      ) : (
+        <>
+          <div className="grid gap-2 sm:grid-cols-[1fr_auto]">
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search part to transfer"
+              className="min-h-11 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3"
+            />
+            <button className={actionClass} onClick={() => void load(query)} disabled={!online || busy}>
+              Search
+            </button>
+          </div>
+          <select
+            value={selectedPartId ?? ""}
+            onChange={(event) => {
+              setSelectedPartId(event.target.value || null);
+              setSourceLocationId("");
+            }}
+            className="min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3"
+          >
+            <option value="">Select part</option>
+            {snapshot.catalog.map((part) => (
+              <option key={part.partId} value={part.partId}>
+                {part.name} {part.partNumber ? `· ${part.partNumber}` : ""}
+              </option>
+            ))}
+          </select>
+          <select
+            value={sourceLocationId}
+            onChange={(event) => setSourceLocationId(event.target.value)}
+            className="min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3"
+          >
+            <option value="">Select source location</option>
+            {sourceOptions.map((location) => (
+              <option key={location.locationId} value={location.locationId}>
+                {location.code || location.name || "Stock"} · {quantityLabel(location.available)} available
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            min="0.01"
+            step="0.01"
+            value={quantity}
+            onChange={(event) => setQuantity(Number(event.target.value || 0))}
+            className="min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3"
+          />
+          <button
+            className={`${primaryClass} w-full`}
+            disabled={!online || busy || !selectedPartId || !sourceLocationId || quantity <= 0}
+            onClick={() => void transferToTruck()}
+          >
+            <MoveRight className="h-4 w-4" /> Transfer to {snapshot.truck?.name}
+          </button>
+        </>
+      )}
+    </section>
+  );
+}

--- a/features/mobile/service/TruckReceivePanel.tsx
+++ b/features/mobile/service/TruckReceivePanel.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { PackageCheck } from "lucide-react";
+import type { Dispatch, SetStateAction } from "react";
+
+import type {
+  FieldOpenReceipt,
+  FieldTruckInventorySnapshot,
+} from "./truckInventoryContracts";
+import { numeric } from "./truckInventoryContracts";
+import { primaryClass, quantityLabel } from "./truckInventoryUi";
+
+type Props = {
+  snapshot: FieldTruckInventorySnapshot;
+  online: boolean;
+  busy: boolean;
+  selectedReceiptId: string;
+  setSelectedReceiptId: Dispatch<SetStateAction<string>>;
+  selectedReceipt: FieldOpenReceipt | null;
+  quantity: number;
+  setQuantity: Dispatch<SetStateAction<number>>;
+  receiveToTruck: () => Promise<void>;
+};
+
+export default function TruckReceivePanel({
+  snapshot,
+  online,
+  busy,
+  selectedReceiptId,
+  setSelectedReceiptId,
+  selectedReceipt,
+  quantity,
+  setQuantity,
+  receiveToTruck,
+}: Props) {
+  return (
+    <section className="space-y-4 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4">
+      <div>
+        <h2 className="text-lg font-bold">Receive PO directly to truck</h2>
+        <p className="text-sm text-[color:var(--theme-text-secondary)]">
+          Receipt, request, work-order part, and inventory ledger retain the same part ID. Free-text PO lines are canonicalized here automatically.
+        </p>
+      </div>
+      {!snapshot.canManageParts ? (
+        <p className="rounded-2xl border border-amber-500/35 bg-amber-500/10 p-3 text-sm text-amber-100">
+          Parts receiving permission is required.
+        </p>
+      ) : (
+        <>
+          <select
+            value={selectedReceiptId}
+            onChange={(event) => {
+              setSelectedReceiptId(event.target.value);
+              const receipt = snapshot.openReceipts.find(
+                (item) => item.purchaseOrderLineId === event.target.value,
+              );
+              if (receipt) setQuantity(Math.min(1, numeric(receipt.remainingQuantity)) || 1);
+            }}
+            className="min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3"
+          >
+            <option value="">Select open PO line</option>
+            {snapshot.openReceipts.map((receipt) => (
+              <option key={receipt.purchaseOrderLineId} value={receipt.purchaseOrderLineId}>
+                {receipt.purchaseOrderNumber} · {receipt.description} · {quantityLabel(receipt.remainingQuantity)} remaining
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            min="0.01"
+            step="0.01"
+            max={selectedReceipt?.remainingQuantity ?? undefined}
+            value={quantity}
+            onChange={(event) => setQuantity(Number(event.target.value || 0))}
+            className="min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3"
+          />
+          <button
+            className={`${primaryClass} w-full`}
+            disabled={!online || busy || !selectedReceipt || quantity <= 0}
+            onClick={() => void receiveToTruck()}
+          >
+            <PackageCheck className="h-4 w-4" /> Receive to {snapshot.truck?.name}
+          </button>
+          {snapshot.openReceipts.length === 0 ? (
+            <p className="rounded-2xl border border-dashed border-[color:var(--theme-border-soft)] p-6 text-center text-sm text-[color:var(--theme-text-muted)]">
+              No purchase-order lines are waiting to be received.
+            </p>
+          ) : null}
+        </>
+      )}
+    </section>
+  );
+}

--- a/features/mobile/service/TruckStockPanel.tsx
+++ b/features/mobile/service/TruckStockPanel.tsx
@@ -8,6 +8,7 @@ import type {
   FieldTruckInventoryItem,
   FieldTruckInventorySnapshot,
 } from "./truckInventoryContracts";
+import { isActionableFieldWorkOrderLine } from "./truckInventoryContracts";
 import { numeric } from "./truckInventoryContracts";
 import type { IdentityDraft } from "./truckInventoryUi";
 import {
@@ -71,7 +72,7 @@ export default function TruckStockPanel({
               className="mt-1 min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3"
             >
               <option value="">Select repair line</option>
-              {snapshot.workOrderLines.map((line) => (
+              {snapshot.workOrderLines.filter(isActionableFieldWorkOrderLine).map((line) => (
                 <option key={line.id} value={line.id}>
                   {line.lineNumber ? `#${line.lineNumber} · ` : ""}
                   {line.description}

--- a/features/mobile/service/TruckStockPanel.tsx
+++ b/features/mobile/service/TruckStockPanel.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { Barcode, Search } from "lucide-react";
+import type { Dispatch, SetStateAction } from "react";
+
+import FieldBarcodeScanner from "./FieldBarcodeScanner";
+import type {
+  FieldTruckInventoryItem,
+  FieldTruckInventorySnapshot,
+} from "./truckInventoryContracts";
+import { numeric } from "./truckInventoryContracts";
+import type { IdentityDraft } from "./truckInventoryUi";
+import {
+  actionClass,
+  primaryClass,
+  quantityLabel,
+} from "./truckInventoryUi";
+
+type Props = {
+  snapshot: FieldTruckInventorySnapshot;
+  online: boolean;
+  busy: boolean;
+  query: string;
+  setQuery: Dispatch<SetStateAction<string>>;
+  load: (search?: string, serviceVehicleId?: string) => Promise<void>;
+  selectedPartId: string | null;
+  setSelectedPartId: Dispatch<SetStateAction<string | null>>;
+  selectedLineId: string;
+  setSelectedLineId: Dispatch<SetStateAction<string>>;
+  quantity: number;
+  setQuantity: Dispatch<SetStateAction<number>>;
+  identityDraft: IdentityDraft | null;
+  setIdentityDraft: Dispatch<SetStateAction<IdentityDraft | null>>;
+  createIdentity: () => Promise<void>;
+  truckItemById: Map<string, FieldTruckInventoryItem>;
+  handleUse: (partId: string) => Promise<void>;
+  resolveCode: (code: string) => Promise<void>;
+};
+
+export default function TruckStockPanel({
+  snapshot,
+  online,
+  busy,
+  query,
+  setQuery,
+  load,
+  selectedPartId,
+  setSelectedPartId,
+  selectedLineId,
+  setSelectedLineId,
+  quantity,
+  setQuantity,
+  identityDraft,
+  setIdentityDraft,
+  createIdentity,
+  truckItemById,
+  handleUse,
+  resolveCode,
+}: Props) {
+  const visibleParts = query.trim() ? snapshot.catalog : snapshot.items;
+
+  return (
+    <div className="space-y-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4">
+        <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+          <label className="text-sm font-semibold">
+            Repair line
+            <select
+              value={selectedLineId}
+              onChange={(event) => setSelectedLineId(event.target.value)}
+              className="mt-1 min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3"
+            >
+              <option value="">Select repair line</option>
+              {snapshot.workOrderLines.map((line) => (
+                <option key={line.id} value={line.id}>
+                  {line.lineNumber ? `#${line.lineNumber} · ` : ""}
+                  {line.description}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm font-semibold">
+            Quantity
+            <input
+              type="number"
+              min="0.01"
+              step="0.01"
+              value={quantity}
+              onChange={(event) => setQuantity(Number(event.target.value || 0))}
+              className="mt-1 min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 sm:w-28"
+            />
+          </label>
+        </div>
+        <div className="mt-3 grid gap-2 sm:grid-cols-[1fr_auto]">
+          <div className="relative">
+            <Search className="absolute left-3 top-3.5 h-4 w-4 text-[color:var(--theme-text-muted)]" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") void load(query);
+              }}
+              placeholder="Search truck or shop catalog"
+              className="min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] pl-10 pr-3"
+            />
+          </div>
+          <button
+            type="button"
+            className={actionClass}
+            disabled={!online || busy}
+            onClick={() => void load(query)}
+          >
+            Search
+          </button>
+        </div>
+        <div className="mt-3">
+          <FieldBarcodeScanner disabled={busy} onDetected={resolveCode} />
+        </div>
+      </section>
+
+      {identityDraft ? (
+        <section className="rounded-3xl border border-[color:var(--accent-copper)] bg-[color:var(--theme-surface-panel)] p-4">
+          <div className="flex items-center gap-2 text-sm font-bold">
+            <Barcode className="h-4 w-4 text-[color:var(--accent-copper)]" />
+            Confirm new canonical part
+          </div>
+          <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+            The barcode will be attached here. There is no separate stock-item setup step.
+          </p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            {[
+              ["Part name", "name"],
+              ["Part number", "partNumber"],
+              ["Manufacturer", "manufacturer"],
+              ["Unit cost", "unitCost"],
+              ["Sell price", "unitSellPrice"],
+            ].map(([label, field]) => (
+              <label key={field} className="text-sm font-semibold">
+                {label}
+                <input
+                  value={identityDraft[field as keyof IdentityDraft]}
+                  onChange={(event) =>
+                    setIdentityDraft((current) =>
+                      current ? { ...current, [field]: event.target.value } : current,
+                    )
+                  }
+                  className="mt-1 min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3"
+                />
+              </label>
+            ))}
+          </div>
+          <div className="mt-3 flex gap-2">
+            <button className={primaryClass} disabled={busy} onClick={() => void createIdentity()}>
+              Create and map part
+            </button>
+            <button className={actionClass} disabled={busy} onClick={() => setIdentityDraft(null)}>
+              Cancel
+            </button>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="space-y-3">
+        {visibleParts.map((part) => {
+          const truck = truckItemById.get(part.partId);
+          const available = numeric(truck?.available);
+          return (
+            <article
+              key={part.partId}
+              className={[
+                "rounded-2xl border bg-[color:var(--theme-surface-panel)] p-4",
+                selectedPartId === part.partId
+                  ? "border-[color:var(--accent-copper)]"
+                  : "border-[color:var(--theme-border-soft)]",
+              ].join(" ")}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <button
+                  type="button"
+                  className="min-w-0 text-left"
+                  onClick={() => setSelectedPartId(part.partId)}
+                >
+                  <h3 className="font-bold">{part.name}</h3>
+                  <p className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">
+                    {[part.manufacturer, part.partNumber || part.sku]
+                      .filter(Boolean)
+                      .join(" · ") || "Canonical part"}
+                  </p>
+                  <p className="mt-1 font-mono text-[10px] text-[color:var(--theme-text-muted)]">
+                    {part.partId}
+                  </p>
+                </button>
+                <div className="text-right">
+                  <div className="text-2xl font-extrabold tabular-nums">
+                    {quantityLabel(truck?.onHand ?? 0)}
+                  </div>
+                  <div className="text-[10px] uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">
+                    on truck
+                  </div>
+                </div>
+              </div>
+              <div className="mt-3 grid grid-cols-2 gap-2 text-center text-xs">
+                <div className="rounded-xl bg-[color:var(--theme-surface-subtle)] p-2">
+                  <span className="block text-[color:var(--theme-text-muted)]">Available</span>
+                  <strong>{quantityLabel(available)}</strong>
+                </div>
+                <div className="rounded-xl bg-[color:var(--theme-surface-subtle)] p-2">
+                  <span className="block text-[color:var(--theme-text-muted)]">Reserved</span>
+                  <strong>{quantityLabel(truck?.reserved ?? 0)}</strong>
+                </div>
+              </div>
+              <button
+                type="button"
+                className={`${primaryClass} mt-3 w-full`}
+                disabled={busy || !selectedLineId || available < quantity || quantity <= 0}
+                onClick={() => void handleUse(part.partId)}
+              >
+                <Barcode className="h-4 w-4" /> Use {quantityLabel(quantity)} on call
+              </button>
+            </article>
+          );
+        })}
+        {visibleParts.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-[color:var(--theme-border-soft)] p-8 text-center text-sm text-[color:var(--theme-text-muted)]">
+            {query ? "No matching canonical parts." : "This truck has no inventory yet."}
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/features/mobile/service/truckInventoryClient.ts
+++ b/features/mobile/service/truckInventoryClient.ts
@@ -1,0 +1,133 @@
+import type {
+  FieldCatalogPart,
+  FieldPartIdentityResult,
+  FieldTruckInventoryItem,
+  FieldTruckInventorySnapshot,
+} from "./truckInventoryContracts";
+import type { IdentityDraft } from "./truckInventoryUi";
+
+export function randomInventoryKey(prefix: string): string {
+  const entropy =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `${prefix}:${entropy}`;
+}
+
+async function responseJson<T>(response: Response): Promise<T> {
+  const body = (await response.json().catch(() => null)) as
+    | T
+    | { error?: string }
+    | null;
+  if (!response.ok) {
+    throw new Error(
+      body && typeof body === "object" && "error" in body && body.error
+        ? String(body.error)
+        : "Field inventory request failed.",
+    );
+  }
+  return body as T;
+}
+
+export function localPartByCode(
+  snapshot: FieldTruckInventorySnapshot,
+  code: string,
+): FieldTruckInventoryItem | FieldCatalogPart | null {
+  const normalized = code.trim().toLowerCase();
+  const all = [...snapshot.items, ...snapshot.catalog];
+  return (
+    all.find((part) =>
+      [part.partNumber, part.sku, ...part.barcodes]
+        .filter(Boolean)
+        .some((identity) => String(identity).trim().toLowerCase() === normalized),
+    ) ?? null
+  );
+}
+
+export async function fetchTruckInventorySnapshot(args: {
+  search?: string;
+  serviceVehicleId?: string;
+}): Promise<FieldTruckInventorySnapshot> {
+  const params = new URLSearchParams();
+  if (args.search?.trim()) params.set("query", args.search.trim());
+  if (args.serviceVehicleId) params.set("serviceVehicleId", args.serviceVehicleId);
+  const response = await fetch(
+    `/api/mobile/service/truck-inventory?${params.toString()}`,
+    { credentials: "include", cache: "no-store" },
+  );
+  return responseJson<FieldTruckInventorySnapshot>(response);
+}
+
+export async function resolveTruckPartCode(code: string): Promise<FieldPartIdentityResult> {
+  const response = await fetch("/api/mobile/service/truck-inventory/resolve", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": randomInventoryKey("field-part-resolve"),
+    },
+    body: JSON.stringify({ code, provider: "barcode" }),
+  });
+  return responseJson<FieldPartIdentityResult>(response);
+}
+
+export async function createTruckPartIdentity(
+  draft: IdentityDraft,
+): Promise<FieldPartIdentityResult> {
+  const response = await fetch("/api/mobile/service/truck-inventory/resolve", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": randomInventoryKey("field-part-create"),
+    },
+    body: JSON.stringify({
+      code: draft.code,
+      provider: "barcode",
+      name: draft.name,
+      partNumber: draft.partNumber || draft.code,
+      manufacturer: draft.manufacturer || null,
+      unitCost: draft.unitCost || null,
+      unitSellPrice: draft.unitSellPrice || null,
+      createIfMissing: true,
+      metadata: { source: "field_service_inline_scan" },
+    }),
+  });
+  return responseJson<FieldPartIdentityResult>(response);
+}
+
+export async function transferTruckPart(args: {
+  serviceVehicleId: string;
+  sourceLocationId: string;
+  partId: string;
+  quantity: number;
+}): Promise<void> {
+  const response = await fetch("/api/mobile/service/truck-inventory/transfer", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": randomInventoryKey("field-truck-transfer"),
+    },
+    body: JSON.stringify(args),
+  });
+  await responseJson<Record<string, unknown>>(response);
+}
+
+export async function receiveTruckPart(args: {
+  serviceVehicleId: string;
+  purchaseOrderId: string;
+  purchaseOrderLineId: string;
+  quantity: number;
+}): Promise<void> {
+  const response = await fetch("/api/mobile/service/truck-inventory/receive", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": randomInventoryKey("field-truck-receive"),
+    },
+    body: JSON.stringify(args),
+  });
+  await responseJson<Record<string, unknown>>(response);
+}

--- a/features/mobile/service/truckInventoryContracts.ts
+++ b/features/mobile/service/truckInventoryContracts.ts
@@ -73,6 +73,26 @@ export type FieldWorkOrderLine = {
   assignedTechnicianId: string | null;
 };
 
+const ACTIONABLE_FIELD_LINE_STATUSES = new Set([
+  "awaiting",
+  "assigned",
+  "queued",
+  "approved",
+  "in_progress",
+  "on_hold",
+  "paused",
+  "waiting_parts",
+]);
+
+export function isActionableFieldWorkOrderLine(line: FieldWorkOrderLine): boolean {
+  return (
+    String(line.approvalState ?? "").trim().toLowerCase() === "approved" &&
+    ACTIONABLE_FIELD_LINE_STATUSES.has(
+      String(line.status ?? "").trim().toLowerCase(),
+    )
+  );
+}
+
 export type FieldOpenReceipt = {
   purchaseOrderId: string;
   purchaseOrderNumber: string;
@@ -110,6 +130,32 @@ export type FieldRecentPartUse = {
   createdAt: string;
   returnedQuantity: number;
 };
+
+export function aggregateRecentPartUses(
+  uses: FieldRecentPartUse[],
+): FieldRecentPartUse[] {
+  const grouped = new Map<string, FieldRecentPartUse>();
+  for (const use of uses) {
+    const current = grouped.get(use.workOrderPartId);
+    if (!current) {
+      grouped.set(use.workOrderPartId, { ...use });
+      continue;
+    }
+    current.quantity = numeric(current.quantity) + numeric(use.quantity);
+    current.returnedQuantity = Math.max(
+      numeric(current.returnedQuantity),
+      numeric(use.returnedQuantity),
+    );
+    if (new Date(use.createdAt).getTime() > new Date(current.createdAt).getTime()) {
+      current.stockMoveId = use.stockMoveId;
+      current.createdAt = use.createdAt;
+    }
+  }
+  return [...grouped.values()].sort(
+    (left, right) =>
+      new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime(),
+  );
+}
 
 export type FieldTruckInventorySnapshot = {
   generatedAt: string;

--- a/features/mobile/service/truckInventoryContracts.ts
+++ b/features/mobile/service/truckInventoryContracts.ts
@@ -1,0 +1,178 @@
+export type FieldTruck = {
+  id: string;
+  name: string;
+  unitNumber: string | null;
+  stockLocationId: string | null;
+  primaryUserId: string | null;
+  active: boolean;
+};
+
+export type FieldInventoryVisit = {
+  id: string;
+  status: string;
+  mode: string;
+  workOrderId: string | null;
+  serviceVehicleId: string | null;
+  assignedTechnicianId: string | null;
+  scheduledStart: string | null;
+  scheduledEnd: string | null;
+};
+
+export type FieldInventoryIdentity = {
+  id: string;
+  provider: string;
+  externalId: string | null;
+  supplierId: string | null;
+  supplierSku: string | null;
+  barcode: string | null;
+  partNumber: string | null;
+  manufacturer: string | null;
+  unitOfMeasure: string | null;
+  packageQuantity: number;
+};
+
+export type FieldTruckInventoryItem = {
+  partId: string;
+  name: string;
+  description: string | null;
+  partNumber: string | null;
+  sku: string | null;
+  manufacturer: string | null;
+  supplier: string | null;
+  onHand: number;
+  reserved: number;
+  available: number;
+  barcodes: string[];
+  identities: FieldInventoryIdentity[];
+};
+
+export type FieldPartLocation = {
+  locationId: string;
+  code: string | null;
+  name: string | null;
+  onHand: number;
+  reserved: number;
+  available: number;
+  serviceVehicleId: string | null;
+  serviceVehicleName: string | null;
+};
+
+export type FieldCatalogPart = Omit<
+  FieldTruckInventoryItem,
+  "onHand" | "reserved" | "available" | "identities"
+> & {
+  locations: FieldPartLocation[];
+};
+
+export type FieldWorkOrderLine = {
+  id: string;
+  lineNumber: number | null;
+  description: string;
+  status: string | null;
+  approvalState: string | null;
+  assignedTechnicianId: string | null;
+};
+
+export type FieldOpenReceipt = {
+  purchaseOrderId: string;
+  purchaseOrderNumber: string;
+  purchaseOrderStatus: string | null;
+  purchaseOrderLineId: string;
+  partId: string | null;
+  requiresCanonicalIdentity: boolean;
+  description: string;
+  partNumber: string | null;
+  sku: string | null;
+  orderedQuantity: number;
+  receivedQuantity: number;
+  remainingQuantity: number;
+  targetLocationId: string | null;
+  truckTargeted: boolean;
+};
+
+export type FieldStockLocation = {
+  id: string;
+  code: string | null;
+  name: string | null;
+  serviceVehicleId: string | null;
+  serviceVehicleName: string | null;
+  serviceVehicleUnitNumber: string | null;
+};
+
+export type FieldRecentPartUse = {
+  stockMoveId: string;
+  workOrderPartId: string;
+  workOrderLineId: string | null;
+  partId: string;
+  name: string;
+  partNumber: string | null;
+  quantity: number;
+  createdAt: string;
+  returnedQuantity: number;
+};
+
+export type FieldTruckInventorySnapshot = {
+  generatedAt: string;
+  actorProfileId: string;
+  canManageParts: boolean;
+  hasFieldAccess: boolean;
+  visit: FieldInventoryVisit | null;
+  trucks: FieldTruck[];
+  truck: FieldTruck | null;
+  workOrderLines: FieldWorkOrderLine[];
+  items: FieldTruckInventoryItem[];
+  catalog: FieldCatalogPart[];
+  openReceipts: FieldOpenReceipt[];
+  locations: FieldStockLocation[];
+  recentUses: FieldRecentPartUse[];
+};
+
+export type FieldPartIdentityResult =
+  | {
+      ok: true;
+      idempotent: boolean;
+      found: false;
+      created: false;
+      requiresDetails: true;
+      code: string | null;
+      provider: string;
+      externalId: string | null;
+    }
+  | {
+      ok: true;
+      idempotent: boolean;
+      found?: true;
+      created: boolean;
+      partId: string;
+      identityId: string | null;
+      part: {
+        id: string;
+        name: string;
+        partNumber: string | null;
+        sku: string | null;
+        manufacturer: string | null;
+        cost: number | null;
+        price: number | null;
+      };
+    };
+
+export type FieldUseTruckPartPayload = {
+  visitId: string;
+  workOrderLineId: string;
+  partId: string;
+  quantity: number;
+  operationKey: string;
+  scannedCode?: string | null;
+};
+
+export type FieldReturnTruckPartPayload = {
+  visitId: string;
+  workOrderPartId: string;
+  quantity: number;
+  operationKey: string;
+};
+
+export function numeric(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/features/mobile/service/truckInventoryOffline.ts
+++ b/features/mobile/service/truckInventoryOffline.ts
@@ -15,6 +15,7 @@ import type {
   FieldTruckInventorySnapshot,
   FieldUseTruckPartPayload,
 } from "./truckInventoryContracts";
+import { numeric } from "./truckInventoryContracts";
 
 const SNAPSHOT_KIND = "field-truck-inventory";
 const SNAPSHOT_ID = "active-truck";
@@ -75,12 +76,63 @@ export async function cacheFieldTruckInventorySnapshot(args: {
 export async function loadCachedFieldTruckInventorySnapshot(args: {
   scope: OfflineMutationScope;
 }): Promise<FieldTruckInventorySnapshot | null> {
+  await hydrateOfflineMutationQueue();
   const stored = await getOfflineSnapshot<FieldTruckInventorySnapshot>({
     scope: args.scope,
     kind: SNAPSHOT_KIND,
     entityId: SNAPSHOT_ID,
   });
-  return stored?.data ?? null;
+  if (!stored?.data) return null;
+
+  return listPendingMutations(args.scope)
+    .filter((mutation) => mutation.status !== "conflicted")
+    .reduce<FieldTruckInventorySnapshot>((snapshot, mutation) => {
+      if (!mutation.payload || typeof mutation.payload !== "object") return snapshot;
+      if (mutation.actionType === "field-inventory:use-part") {
+        const payload = mutation.payload as FieldUseTruckPartPayload;
+        const quantity = numeric(payload.quantity);
+        return {
+          ...snapshot,
+          items: snapshot.items.map((item) =>
+            item.partId === payload.partId
+              ? {
+                  ...item,
+                  onHand: Math.max(0, numeric(item.onHand) - quantity),
+                  available: Math.max(0, numeric(item.available) - quantity),
+                }
+              : item,
+          ),
+        };
+      }
+      if (mutation.actionType === "field-inventory:return-part") {
+        const payload = mutation.payload as FieldReturnTruckPartPayload;
+        const quantity = numeric(payload.quantity);
+        const partId = snapshot.recentUses.find(
+          (use) => use.workOrderPartId === payload.workOrderPartId,
+        )?.partId;
+        return {
+          ...snapshot,
+          items: snapshot.items.map((item) =>
+            item.partId === partId
+              ? {
+                  ...item,
+                  onHand: numeric(item.onHand) + quantity,
+                  available: numeric(item.available) + quantity,
+                }
+              : item,
+          ),
+          recentUses: snapshot.recentUses.map((use) =>
+            use.workOrderPartId === payload.workOrderPartId
+              ? {
+                  ...use,
+                  returnedQuantity: numeric(use.returnedQuantity) + quantity,
+                }
+              : use,
+          ),
+        };
+      }
+      return snapshot;
+    }, stored.data);
 }
 
 export async function consumeFieldTruckPart(args: {
@@ -103,6 +155,7 @@ export async function consumeFieldTruckPart(args: {
     queueOnOffline: true,
     dependsOn: lastVisitMutationDependency(args.payload.visitId),
     orderKey: `service-visit:${args.payload.visitId}`,
+    bestEffortOnlineHistory: true,
     runner: async () => {
       const response = await fetch("/api/mobile/service/truck-inventory/use", {
         method: "POST",
@@ -140,6 +193,7 @@ export async function returnFieldTruckPart(args: {
     queueOnOffline: true,
     dependsOn: lastVisitMutationDependency(args.payload.visitId),
     orderKey: `service-visit:${args.payload.visitId}`,
+    bestEffortOnlineHistory: true,
     runner: async () => {
       const response = await fetch("/api/mobile/service/truck-inventory/return", {
         method: "POST",

--- a/features/mobile/service/truckInventoryOffline.ts
+++ b/features/mobile/service/truckInventoryOffline.ts
@@ -1,0 +1,158 @@
+"use client";
+
+import {
+  getOfflineSnapshot,
+  saveOfflineSnapshot,
+} from "@/features/shared/lib/offline/database";
+import {
+  hydrateOfflineMutationQueue,
+  listPendingMutations,
+  runMutationWithOfflineQueue,
+  type OfflineMutationScope,
+} from "@/features/shared/lib/offline/mutations";
+import type {
+  FieldReturnTruckPartPayload,
+  FieldTruckInventorySnapshot,
+  FieldUseTruckPartPayload,
+} from "./truckInventoryContracts";
+
+const SNAPSHOT_KIND = "field-truck-inventory";
+const SNAPSHOT_ID = "active-truck";
+const SNAPSHOT_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 3;
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+async function readError(response: Response): Promise<Error & { status?: number }> {
+  const body = (await response.json().catch(() => null)) as
+    | { error?: string }
+    | null;
+  const error = new Error(body?.error || "Field inventory update failed.") as Error & {
+    status?: number;
+  };
+  error.status = response.status;
+  return error;
+}
+
+function lastVisitMutationDependency(visitId: string): string[] | undefined {
+  const previous = listPendingMutations()
+    .filter((mutation) => {
+      if (
+        mutation.actionType !== "service-visit:transition" &&
+        mutation.actionType !== "field-inventory:use-part" &&
+        mutation.actionType !== "field-inventory:return-part"
+      ) {
+        return false;
+      }
+      const payload =
+        mutation.payload && typeof mutation.payload === "object"
+          ? (mutation.payload as Record<string, unknown>)
+          : {};
+      return text(payload.visitId) === visitId;
+    })
+    .sort(
+      (left, right) =>
+        new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime(),
+    )
+    .at(-1);
+  return previous ? [previous.clientMutationId] : undefined;
+}
+
+export async function cacheFieldTruckInventorySnapshot(args: {
+  scope: OfflineMutationScope;
+  snapshot: FieldTruckInventorySnapshot;
+}): Promise<void> {
+  await saveOfflineSnapshot({
+    scope: args.scope,
+    kind: SNAPSHOT_KIND,
+    entityId: SNAPSHOT_ID,
+    data: args.snapshot,
+    maxAgeMs: SNAPSHOT_MAX_AGE_MS,
+  });
+}
+
+export async function loadCachedFieldTruckInventorySnapshot(args: {
+  scope: OfflineMutationScope;
+}): Promise<FieldTruckInventorySnapshot | null> {
+  const stored = await getOfflineSnapshot<FieldTruckInventorySnapshot>({
+    scope: args.scope,
+    kind: SNAPSHOT_KIND,
+    entityId: SNAPSHOT_ID,
+  });
+  return stored?.data ?? null;
+}
+
+export async function useFieldTruckPart(args: {
+  scope: OfflineMutationScope;
+  payload: FieldUseTruckPartPayload;
+}): Promise<{
+  queued: boolean;
+  conflicted: boolean;
+  result: Record<string, unknown> | null;
+}> {
+  await hydrateOfflineMutationQueue();
+  const serverState: { result: Record<string, unknown> | null } = {
+    result: null,
+  };
+  const outcome = await runMutationWithOfflineQueue({
+    clientMutationId: args.payload.operationKey,
+    actionType: "field-inventory:use-part",
+    payload: args.payload,
+    scope: args.scope,
+    queueOnOffline: true,
+    dependsOn: lastVisitMutationDependency(args.payload.visitId),
+    orderKey: `service-visit:${args.payload.visitId}`,
+    runner: async () => {
+      const response = await fetch("/api/mobile/service/truck-inventory/use", {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": args.payload.operationKey,
+        },
+        body: JSON.stringify(args.payload),
+      });
+      if (!response.ok) throw await readError(response);
+      serverState.result = (await response.json()) as Record<string, unknown>;
+    },
+  });
+  return { ...outcome, result: serverState.result };
+}
+
+export async function returnFieldTruckPart(args: {
+  scope: OfflineMutationScope;
+  payload: FieldReturnTruckPartPayload;
+}): Promise<{
+  queued: boolean;
+  conflicted: boolean;
+  result: Record<string, unknown> | null;
+}> {
+  await hydrateOfflineMutationQueue();
+  const serverState: { result: Record<string, unknown> | null } = {
+    result: null,
+  };
+  const outcome = await runMutationWithOfflineQueue({
+    clientMutationId: args.payload.operationKey,
+    actionType: "field-inventory:return-part",
+    payload: args.payload,
+    scope: args.scope,
+    queueOnOffline: true,
+    dependsOn: lastVisitMutationDependency(args.payload.visitId),
+    orderKey: `service-visit:${args.payload.visitId}`,
+    runner: async () => {
+      const response = await fetch("/api/mobile/service/truck-inventory/return", {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": args.payload.operationKey,
+        },
+        body: JSON.stringify(args.payload),
+      });
+      if (!response.ok) throw await readError(response);
+      serverState.result = (await response.json()) as Record<string, unknown>;
+    },
+  });
+  return { ...outcome, result: serverState.result };
+}

--- a/features/mobile/service/truckInventoryOffline.ts
+++ b/features/mobile/service/truckInventoryOffline.ts
@@ -83,7 +83,7 @@ export async function loadCachedFieldTruckInventorySnapshot(args: {
   return stored?.data ?? null;
 }
 
-export async function useFieldTruckPart(args: {
+export async function consumeFieldTruckPart(args: {
   scope: OfflineMutationScope;
   payload: FieldUseTruckPartPayload;
 }): Promise<{

--- a/features/mobile/service/truckInventoryUi.ts
+++ b/features/mobile/service/truckInventoryUi.ts
@@ -1,0 +1,21 @@
+import { numeric } from "./truckInventoryContracts";
+
+export type TruckInventoryView = "stock" | "load" | "receive" | "history";
+
+export type IdentityDraft = {
+  code: string;
+  name: string;
+  partNumber: string;
+  manufacturer: string;
+  unitCost: string;
+  unitSellPrice: string;
+};
+
+export const actionClass =
+  "inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 text-sm font-bold text-[color:var(--theme-text-primary)] disabled:cursor-not-allowed disabled:opacity-45";
+export const primaryClass = `${actionClass} border-[color:var(--accent-copper)] bg-[color:var(--accent-copper)] text-white`;
+
+export function quantityLabel(value: unknown): string {
+  const number = numeric(value);
+  return Number.isInteger(number) ? number.toFixed(0) : number.toFixed(2);
+}

--- a/features/mobile/service/useTruckInventorySnapshot.ts
+++ b/features/mobile/service/useTruckInventorySnapshot.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  getOfflineMutationScope,
+  resolveOfflineMutationScope,
+  type OfflineMutationScope,
+} from "@/features/shared/lib/offline/mutations";
+import {
+  cacheFieldTruckInventorySnapshot,
+  loadCachedFieldTruckInventorySnapshot,
+} from "./truckInventoryOffline";
+import { fetchTruckInventorySnapshot } from "./truckInventoryClient";
+import type { FieldTruckInventorySnapshot } from "./truckInventoryContracts";
+
+export function useTruckInventorySnapshot() {
+  const [snapshot, setSnapshot] = useState<FieldTruckInventorySnapshot | null>(null);
+  const [scope, setScope] = useState<OfflineMutationScope | null>(null);
+  const [online, setOnline] = useState(
+    () => typeof navigator === "undefined" || navigator.onLine,
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const selectedTruckIdRef = useRef("");
+  const [selectedTruckId, setSelectedTruckId] = useState("");
+  const [selectedLineId, setSelectedLineId] = useState("");
+
+  const load = useCallback(
+    async (search = "", serviceVehicleId = selectedTruckIdRef.current) => {
+      setLoading(true);
+      setError(null);
+      try {
+        if (!online) throw new Error("offline");
+        const next = await fetchTruckInventorySnapshot({ search, serviceVehicleId });
+        setSnapshot(next);
+        const resolvedTruckId = next.truck?.id ?? serviceVehicleId ?? "";
+        selectedTruckIdRef.current = resolvedTruckId;
+        setSelectedTruckId(resolvedTruckId);
+        setSelectedLineId((current) => current || next.workOrderLines[0]?.id || "");
+        const resolvedScope =
+          scope ?? getOfflineMutationScope() ?? (await resolveOfflineMutationScope({}));
+        if (resolvedScope) {
+          setScope(resolvedScope);
+          await cacheFieldTruckInventorySnapshot({
+            scope: resolvedScope,
+            snapshot: next,
+          });
+        }
+      } catch (loadError) {
+        const resolvedScope = scope ?? getOfflineMutationScope();
+        const cached = resolvedScope
+          ? await loadCachedFieldTruckInventorySnapshot({ scope: resolvedScope })
+          : null;
+        if (cached) {
+          setSnapshot(cached);
+          const cachedTruckId = cached.truck?.id ?? serviceVehicleId ?? "";
+          selectedTruckIdRef.current = cachedTruckId;
+          setSelectedTruckId(cachedTruckId);
+          setSelectedLineId(
+            (current) => current || cached.workOrderLines[0]?.id || "",
+          );
+          setError(
+            online
+              ? "Live truck inventory could not load. Showing the last cached snapshot."
+              : "Offline — showing the last cached truck snapshot.",
+          );
+        } else {
+          setError(
+            loadError instanceof Error && loadError.message !== "offline"
+              ? loadError.message
+              : "This device has no cached truck inventory yet.",
+          );
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [online, scope],
+  );
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const handleOnline = () => {
+      setOnline(true);
+      void load();
+    };
+    const handleOffline = () => setOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, [load]);
+
+  const handleTruckChange = useCallback(
+    (truckId: string) => {
+      selectedTruckIdRef.current = truckId;
+      setSelectedTruckId(truckId);
+      setSelectedLineId("");
+      void load(query, truckId);
+    },
+    [load, query],
+  );
+
+  return {
+    snapshot,
+    setSnapshot,
+    scope,
+    online,
+    loading,
+    error,
+    query,
+    setQuery,
+    selectedTruckId,
+    selectedLineId,
+    setSelectedLineId,
+    load,
+    handleTruckChange,
+  };
+}

--- a/features/mobile/service/useTruckInventorySnapshot.ts
+++ b/features/mobile/service/useTruckInventorySnapshot.ts
@@ -13,6 +13,7 @@ import {
 } from "./truckInventoryOffline";
 import { fetchTruckInventorySnapshot } from "./truckInventoryClient";
 import type { FieldTruckInventorySnapshot } from "./truckInventoryContracts";
+import { isActionableFieldWorkOrderLine } from "./truckInventoryContracts";
 
 export function useTruckInventorySnapshot() {
   const [snapshot, setSnapshot] = useState<FieldTruckInventorySnapshot | null>(null);
@@ -38,7 +39,16 @@ export function useTruckInventorySnapshot() {
         const resolvedTruckId = next.truck?.id ?? serviceVehicleId ?? "";
         selectedTruckIdRef.current = resolvedTruckId;
         setSelectedTruckId(resolvedTruckId);
-        setSelectedLineId((current) => current || next.workOrderLines[0]?.id || "");
+        setSelectedLineId(
+          (current) => {
+            const actionable = next.workOrderLines.filter(
+              isActionableFieldWorkOrderLine,
+            );
+            return actionable.some((line) => line.id === current)
+              ? current
+              : actionable[0]?.id || "";
+          },
+        );
         const resolvedScope =
           scope ?? getOfflineMutationScope() ?? (await resolveOfflineMutationScope({}));
         if (resolvedScope) {
@@ -59,7 +69,14 @@ export function useTruckInventorySnapshot() {
           selectedTruckIdRef.current = cachedTruckId;
           setSelectedTruckId(cachedTruckId);
           setSelectedLineId(
-            (current) => current || cached.workOrderLines[0]?.id || "",
+            (current) => {
+              const actionable = cached.workOrderLines.filter(
+                isActionableFieldWorkOrderLine,
+              );
+              return actionable.some((line) => line.id === current)
+                ? current
+                : actionable[0]?.id || "";
+            },
           );
           setError(
             online

--- a/features/mobile/service/useTruckInventoryStocking.ts
+++ b/features/mobile/service/useTruckInventoryStocking.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import {
+  receiveTruckPart,
+  transferTruckPart,
+} from "./truckInventoryClient";
+import type { FieldTruckInventorySnapshot } from "./truckInventoryContracts";
+import { numeric } from "./truckInventoryContracts";
+
+type Args = {
+  snapshot: FieldTruckInventorySnapshot | null;
+  selectedPartId: string | null;
+  quantity: number;
+  query: string;
+  load: (search?: string, serviceVehicleId?: string) => Promise<void>;
+};
+
+export function useTruckInventoryStocking({
+  snapshot,
+  selectedPartId,
+  quantity,
+  query,
+  load,
+}: Args) {
+  const [sourceLocationId, setSourceLocationId] = useState("");
+  const [selectedReceiptId, setSelectedReceiptId] = useState("");
+  const [stockingBusy, setStockingBusy] = useState(false);
+
+  const selectedCatalogPart = useMemo(
+    () =>
+      selectedPartId
+        ? snapshot?.catalog.find((part) => part.partId === selectedPartId) ?? null
+        : null,
+    [selectedPartId, snapshot?.catalog],
+  );
+  const sourceOptions = useMemo(
+    () =>
+      (selectedCatalogPart?.locations ?? []).filter(
+        (location) =>
+          location.locationId !== snapshot?.truck?.stockLocationId &&
+          numeric(location.available) > 0,
+      ),
+    [selectedCatalogPart, snapshot?.truck?.stockLocationId],
+  );
+  const selectedReceipt = useMemo(
+    () =>
+      snapshot?.openReceipts.find(
+        (receipt) => receipt.purchaseOrderLineId === selectedReceiptId,
+      ) ?? null,
+    [selectedReceiptId, snapshot?.openReceipts],
+  );
+
+  const transferToTruck = useCallback(async () => {
+    if (!snapshot?.truck?.id || !selectedPartId || !sourceLocationId) {
+      toast.error("Select a part and source location.");
+      return;
+    }
+    setStockingBusy(true);
+    try {
+      await transferTruckPart({
+        serviceVehicleId: snapshot.truck.id,
+        sourceLocationId,
+        partId: selectedPartId,
+        quantity,
+      });
+      toast.success("Part transferred to truck.");
+      await load(query);
+    } catch (transferError) {
+      toast.error(
+        transferError instanceof Error
+          ? transferError.message
+          : "Unable to transfer the part.",
+      );
+    } finally {
+      setStockingBusy(false);
+    }
+  }, [load, query, quantity, selectedPartId, snapshot?.truck?.id, sourceLocationId]);
+
+  const receiveToTruck = useCallback(async () => {
+    if (!snapshot?.truck?.id || !selectedReceipt) {
+      toast.error("Select a purchase-order line.");
+      return;
+    }
+    const receiveQty = Math.min(quantity, numeric(selectedReceipt.remainingQuantity));
+    if (receiveQty <= 0) return;
+    setStockingBusy(true);
+    try {
+      await receiveTruckPart({
+        serviceVehicleId: snapshot.truck.id,
+        purchaseOrderId: selectedReceipt.purchaseOrderId,
+        purchaseOrderLineId: selectedReceipt.purchaseOrderLineId,
+        quantity: receiveQty,
+      });
+      toast.success("PO part received directly to truck.");
+      await load(query);
+    } catch (receiveError) {
+      toast.error(
+        receiveError instanceof Error ? receiveError.message : "Unable to receive the part.",
+      );
+    } finally {
+      setStockingBusy(false);
+    }
+  }, [load, query, quantity, selectedReceipt, snapshot?.truck?.id]);
+
+  return {
+    sourceLocationId,
+    setSourceLocationId,
+    sourceOptions,
+    selectedReceiptId,
+    setSelectedReceiptId,
+    selectedReceipt,
+    stockingBusy,
+    transferToTruck,
+    receiveToTruck,
+  };
+}

--- a/features/mobile/service/useTruckInventoryUsage.ts
+++ b/features/mobile/service/useTruckInventoryUsage.ts
@@ -17,7 +17,7 @@ import type {
 import { numeric } from "./truckInventoryContracts";
 import {
   returnFieldTruckPart,
-  useFieldTruckPart,
+  consumeFieldTruckPart,
 } from "./truckInventoryOffline";
 import type { IdentityDraft } from "./truckInventoryUi";
 
@@ -90,7 +90,7 @@ export function useTruckInventoryUsage({
 
       setUsageBusy(true);
       try {
-        const result = await useFieldTruckPart({
+        const result = await consumeFieldTruckPart({
           scope,
           payload: {
             visitId: snapshot.visit.id,

--- a/features/mobile/service/useTruckInventoryUsage.ts
+++ b/features/mobile/service/useTruckInventoryUsage.ts
@@ -1,0 +1,255 @@
+"use client";
+
+import { useCallback, useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import { toast } from "sonner";
+
+import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
+import {
+  createTruckPartIdentity,
+  localPartByCode,
+  randomInventoryKey,
+  resolveTruckPartCode,
+} from "./truckInventoryClient";
+import type {
+  FieldRecentPartUse,
+  FieldTruckInventorySnapshot,
+} from "./truckInventoryContracts";
+import { numeric } from "./truckInventoryContracts";
+import {
+  returnFieldTruckPart,
+  useFieldTruckPart,
+} from "./truckInventoryOffline";
+import type { IdentityDraft } from "./truckInventoryUi";
+
+type Args = {
+  snapshot: FieldTruckInventorySnapshot | null;
+  setSnapshot: Dispatch<SetStateAction<FieldTruckInventorySnapshot | null>>;
+  scope: OfflineMutationScope | null;
+  online: boolean;
+  selectedLineId: string;
+  query: string;
+  load: (search?: string, serviceVehicleId?: string) => Promise<void>;
+};
+
+export function useTruckInventoryUsage({
+  snapshot,
+  setSnapshot,
+  scope,
+  online,
+  selectedLineId,
+  query,
+  load,
+}: Args) {
+  const [selectedPartId, setSelectedPartId] = useState<string | null>(null);
+  const [quantity, setQuantity] = useState(1);
+  const [identityDraft, setIdentityDraft] = useState<IdentityDraft | null>(null);
+  const [usageBusy, setUsageBusy] = useState(false);
+
+  const truckItemById = useMemo(
+    () => new Map((snapshot?.items ?? []).map((part) => [part.partId, part])),
+    [snapshot?.items],
+  );
+
+  const applyOptimisticUse = useCallback(
+    (partId: string, qty: number) => {
+      setSnapshot((current) =>
+        current
+          ? {
+              ...current,
+              items: current.items.map((item) =>
+                item.partId === partId
+                  ? {
+                      ...item,
+                      onHand: Math.max(0, numeric(item.onHand) - qty),
+                      available: Math.max(0, numeric(item.available) - qty),
+                    }
+                  : item,
+              ),
+            }
+          : current,
+      );
+    },
+    [setSnapshot],
+  );
+
+  const handleUse = useCallback(
+    async (partId: string) => {
+      if (!scope || !snapshot?.visit?.id || !selectedLineId) {
+        toast.error("Open an assigned repair line before using a truck part.");
+        return;
+      }
+      if (!Number.isFinite(quantity) || quantity <= 0) {
+        toast.error("Quantity must be greater than zero.");
+        return;
+      }
+      const current = truckItemById.get(partId);
+      if (current && numeric(current.available) < quantity) {
+        toast.error("Truck quantity is lower than the requested use quantity.");
+        return;
+      }
+
+      setUsageBusy(true);
+      try {
+        const result = await useFieldTruckPart({
+          scope,
+          payload: {
+            visitId: snapshot.visit.id,
+            workOrderLineId: selectedLineId,
+            partId,
+            quantity,
+            operationKey: randomInventoryKey("field-inventory-use"),
+          },
+        });
+        applyOptimisticUse(partId, quantity);
+        toast.success(result.queued ? "Part use saved offline." : "Part used from truck.");
+        if (!result.queued) await load(query);
+      } catch (useError) {
+        toast.error(useError instanceof Error ? useError.message : "Unable to use the part.");
+      } finally {
+        setUsageBusy(false);
+      }
+    },
+    [
+      applyOptimisticUse,
+      load,
+      query,
+      quantity,
+      scope,
+      selectedLineId,
+      snapshot?.visit?.id,
+      truckItemById,
+    ],
+  );
+
+  const handleReturn = useCallback(
+    async (use: FieldRecentPartUse) => {
+      if (!scope || !snapshot?.visit?.id) return;
+      const returnable = Math.max(0, numeric(use.quantity) - numeric(use.returnedQuantity));
+      if (returnable <= 0) return;
+      setUsageBusy(true);
+      try {
+        const result = await returnFieldTruckPart({
+          scope,
+          payload: {
+            visitId: snapshot.visit.id,
+            workOrderPartId: use.workOrderPartId,
+            quantity: returnable,
+            operationKey: randomInventoryKey("field-inventory-return"),
+          },
+        });
+        setSnapshot((current) =>
+          current
+            ? {
+                ...current,
+                items: current.items.map((item) =>
+                  item.partId === use.partId
+                    ? {
+                        ...item,
+                        onHand: numeric(item.onHand) + returnable,
+                        available: numeric(item.available) + returnable,
+                      }
+                    : item,
+                ),
+                recentUses: current.recentUses.map((entry) =>
+                  entry.stockMoveId === use.stockMoveId
+                    ? { ...entry, returnedQuantity: numeric(entry.quantity) }
+                    : entry,
+                ),
+              }
+            : current,
+        );
+        toast.success(result.queued ? "Return saved offline." : "Part returned to truck.");
+        if (!result.queued) await load(query);
+      } catch (returnError) {
+        toast.error(
+          returnError instanceof Error ? returnError.message : "Unable to return the part.",
+        );
+      } finally {
+        setUsageBusy(false);
+      }
+    },
+    [load, query, scope, setSnapshot, snapshot?.visit?.id],
+  );
+
+  const resolveCode = useCallback(
+    async (code: string) => {
+      if (!snapshot) return;
+      const local = localPartByCode(snapshot, code);
+      if (!online) {
+        if (local) {
+          setSelectedPartId(local.partId);
+          toast.success(`${local.name} selected from cached truck data.`);
+        } else {
+          toast.error("That barcode is not in the cached truck catalog.");
+        }
+        return;
+      }
+
+      setUsageBusy(true);
+      try {
+        const result = await resolveTruckPartCode(code);
+        if (result.found === false) {
+          setIdentityDraft({
+            code,
+            name: "",
+            partNumber: code,
+            manufacturer: "",
+            unitCost: "",
+            unitSellPrice: "",
+          });
+          toast.message("Confirm the new part identity without leaving this call.");
+          return;
+        }
+        setSelectedPartId(result.partId);
+        await load(code);
+        toast.success(`${result.part.name} selected.`);
+      } catch (resolveError) {
+        toast.error(
+          resolveError instanceof Error ? resolveError.message : "Unable to resolve the barcode.",
+        );
+      } finally {
+        setUsageBusy(false);
+      }
+    },
+    [load, online, snapshot],
+  );
+
+  const createIdentity = useCallback(async () => {
+    if (!identityDraft?.code || !identityDraft.name.trim()) {
+      toast.error("Part name is required.");
+      return;
+    }
+    setUsageBusy(true);
+    try {
+      const result = await createTruckPartIdentity(identityDraft);
+      if (result.found === false) throw new Error("The part still needs identifying details.");
+      setIdentityDraft(null);
+      setSelectedPartId(result.partId);
+      await load(identityDraft.code);
+      toast.success("Canonical part created and barcode mapped.");
+    } catch (createError) {
+      toast.error(
+        createError instanceof Error
+          ? createError.message
+          : "Unable to create the part identity.",
+      );
+    } finally {
+      setUsageBusy(false);
+    }
+  }, [identityDraft, load]);
+
+  return {
+    selectedPartId,
+    setSelectedPartId,
+    quantity,
+    setQuantity,
+    identityDraft,
+    setIdentityDraft,
+    usageBusy,
+    truckItemById,
+    handleUse,
+    handleReturn,
+    resolveCode,
+    createIdentity,
+  };
+}

--- a/features/mobile/service/useTruckInventoryUsage.ts
+++ b/features/mobile/service/useTruckInventoryUsage.ts
@@ -192,7 +192,7 @@ export function useTruckInventoryUsage({
           setIdentityDraft({
             code,
             name: "",
-            partNumber: code,
+            partNumber: "",
             manufacturer: "",
             unitCost: "",
             unitSellPrice: "",

--- a/features/shared/lib/offline/replay.ts
+++ b/features/shared/lib/offline/replay.ts
@@ -171,6 +171,50 @@ const handlers: Record<string, OfflineMutationRunner> = {
       operationKey,
     );
   },
+  "field-inventory:use-part": async (mutation) => {
+    const payload = mutation.payload as ReplayPayload;
+    const visitId = text(payload.visitId);
+    const workOrderLineId = text(payload.workOrderLineId);
+    const partId = text(payload.partId);
+    const quantity = Number(payload.quantity);
+    const operationKey = text(payload.operationKey) || mutation.clientMutationId;
+    if (
+      !visitId ||
+      !workOrderLineId ||
+      !partId ||
+      !Number.isFinite(quantity) ||
+      quantity <= 0 ||
+      !operationKey
+    ) {
+      return { conflicted: "Truck-part use is missing required offline data." };
+    }
+    await apiPost(
+      "/api/mobile/service/truck-inventory/use",
+      { ...payload, operationKey },
+      operationKey,
+    );
+  },
+  "field-inventory:return-part": async (mutation) => {
+    const payload = mutation.payload as ReplayPayload;
+    const visitId = text(payload.visitId);
+    const workOrderPartId = text(payload.workOrderPartId);
+    const quantity = Number(payload.quantity);
+    const operationKey = text(payload.operationKey) || mutation.clientMutationId;
+    if (
+      !visitId ||
+      !workOrderPartId ||
+      !Number.isFinite(quantity) ||
+      quantity <= 0 ||
+      !operationKey
+    ) {
+      return { conflicted: "Truck-part return is missing required offline data." };
+    }
+    await apiPost(
+      "/api/mobile/service/truck-inventory/return",
+      { ...payload, operationKey },
+      operationKey,
+    );
+  },
   "service-visit:transition": async (mutation) => {
     const payload = mutation.payload as ReplayPayload;
     const visitId = text(payload.visitId);

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -7861,6 +7861,242 @@ export type Database = {
           },
         ]
       }
+      integration_connections: {
+        Row: {
+          capabilities: string[]
+          config: Json
+          created_at: string
+          created_by: string | null
+          display_name: string | null
+          id: string
+          last_error: string | null
+          last_error_at: string | null
+          last_success_at: string | null
+          provider: string
+          secret_reference: string | null
+          shop_id: string
+          status: string
+          sync_cursor: Json
+          updated_at: string
+        }
+        Insert: {
+          capabilities?: string[]
+          config?: Json
+          created_at?: string
+          created_by?: string | null
+          display_name?: string | null
+          id?: string
+          last_error?: string | null
+          last_error_at?: string | null
+          last_success_at?: string | null
+          provider: string
+          secret_reference?: string | null
+          shop_id: string
+          status?: string
+          sync_cursor?: Json
+          updated_at?: string
+        }
+        Update: {
+          capabilities?: string[]
+          config?: Json
+          created_at?: string
+          created_by?: string | null
+          display_name?: string | null
+          id?: string
+          last_error?: string | null
+          last_error_at?: string | null
+          last_success_at?: string | null
+          provider?: string
+          secret_reference?: string | null
+          shop_id?: string
+          status?: string
+          sync_cursor?: Json
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "integration_connections_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "integration_connections_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      integration_external_objects: {
+        Row: {
+          canonical_id: string
+          canonical_table: string
+          connection_id: string | null
+          created_at: string
+          external_id: string
+          external_version: string | null
+          first_seen_at: string
+          id: string
+          last_seen_at: string
+          metadata: Json
+          object_type: string
+          provider: string
+          shop_id: string
+          updated_at: string
+        }
+        Insert: {
+          canonical_id: string
+          canonical_table: string
+          connection_id?: string | null
+          created_at?: string
+          external_id: string
+          external_version?: string | null
+          first_seen_at?: string
+          id?: string
+          last_seen_at?: string
+          metadata?: Json
+          object_type: string
+          provider: string
+          shop_id: string
+          updated_at?: string
+        }
+        Update: {
+          canonical_id?: string
+          canonical_table?: string
+          connection_id?: string | null
+          created_at?: string
+          external_id?: string
+          external_version?: string | null
+          first_seen_at?: string
+          id?: string
+          last_seen_at?: string
+          metadata?: Json
+          object_type?: string
+          provider?: string
+          shop_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "integration_external_objects_connection_id_fkey"
+            columns: ["connection_id"]
+            isOneToOne: false
+            referencedRelation: "integration_connections"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "integration_external_objects_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "integration_external_objects_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      integration_sync_events: {
+        Row: {
+          attempt_count: number
+          canonical_id: string | null
+          canonical_table: string | null
+          completed_at: string | null
+          connection_id: string | null
+          created_at: string
+          created_by: string | null
+          direction: string
+          error_message: string | null
+          external_id: string | null
+          id: string
+          object_type: string | null
+          operation: string
+          operation_key: string
+          payload_hash: string | null
+          provider: string
+          request_metadata: Json
+          response_metadata: Json
+          shop_id: string
+          started_at: string
+          status: string
+        }
+        Insert: {
+          attempt_count?: number
+          canonical_id?: string | null
+          canonical_table?: string | null
+          completed_at?: string | null
+          connection_id?: string | null
+          created_at?: string
+          created_by?: string | null
+          direction: string
+          error_message?: string | null
+          external_id?: string | null
+          id?: string
+          object_type?: string | null
+          operation: string
+          operation_key: string
+          payload_hash?: string | null
+          provider: string
+          request_metadata?: Json
+          response_metadata?: Json
+          shop_id: string
+          started_at?: string
+          status?: string
+        }
+        Update: {
+          attempt_count?: number
+          canonical_id?: string | null
+          canonical_table?: string | null
+          completed_at?: string | null
+          connection_id?: string | null
+          created_at?: string
+          created_by?: string | null
+          direction?: string
+          error_message?: string | null
+          external_id?: string | null
+          id?: string
+          object_type?: string | null
+          operation?: string
+          operation_key?: string
+          payload_hash?: string | null
+          provider?: string
+          request_metadata?: Json
+          response_metadata?: Json
+          shop_id?: string
+          started_at?: string
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "integration_sync_events_connection_id_fkey"
+            columns: ["connection_id"]
+            isOneToOne: false
+            referencedRelation: "integration_connections"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "integration_sync_events_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "integration_sync_events_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       integrations: {
         Row: {
           config: Json
@@ -10721,6 +10957,112 @@ export type Database = {
             columns: ["part_id"]
             isOneToOne: false
             referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      part_external_identities: {
+        Row: {
+          active: boolean
+          barcode: string | null
+          connection_id: string | null
+          created_at: string
+          created_by: string | null
+          external_id: string | null
+          id: string
+          manufacturer: string | null
+          metadata: Json
+          package_quantity: number
+          part_id: string
+          part_number: string | null
+          provider: string
+          shop_id: string
+          supplier_id: string | null
+          supplier_sku: string | null
+          unit_of_measure: string | null
+          updated_at: string
+        }
+        Insert: {
+          active?: boolean
+          barcode?: string | null
+          connection_id?: string | null
+          created_at?: string
+          created_by?: string | null
+          external_id?: string | null
+          id?: string
+          manufacturer?: string | null
+          metadata?: Json
+          package_quantity?: number
+          part_id: string
+          part_number?: string | null
+          provider?: string
+          shop_id: string
+          supplier_id?: string | null
+          supplier_sku?: string | null
+          unit_of_measure?: string | null
+          updated_at?: string
+        }
+        Update: {
+          active?: boolean
+          barcode?: string | null
+          connection_id?: string | null
+          created_at?: string
+          created_by?: string | null
+          external_id?: string | null
+          id?: string
+          manufacturer?: string | null
+          metadata?: Json
+          package_quantity?: number
+          part_id?: string
+          part_number?: string | null
+          provider?: string
+          shop_id?: string
+          supplier_id?: string | null
+          supplier_sku?: string | null
+          unit_of_measure?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "part_external_identities_connection_id_fkey"
+            columns: ["connection_id"]
+            isOneToOne: false
+            referencedRelation: "integration_connections"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_external_identities_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "part_stock_summary"
+            referencedColumns: ["part_id"]
+          },
+          {
+            foreignKeyName: "part_external_identities_part_id_fkey"
+            columns: ["part_id"]
+            isOneToOne: false
+            referencedRelation: "parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_external_identities_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_external_identities_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "part_external_identities_supplier_id_fkey"
+            columns: ["supplier_id"]
+            isOneToOne: false
+            referencedRelation: "suppliers"
             referencedColumns: ["id"]
           },
         ]
@@ -27722,6 +28064,86 @@ export type Database = {
       fail_stripe_webhook_event: {
         Args: { p_claim_token: string; p_error: string; p_event_id: string }
         Returns: boolean
+      }
+      field_receive_po_part_to_truck_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_operation_key: string
+          p_purchase_order_id: string
+          p_purchase_order_line_id: string
+          p_quantity: number
+          p_service_vehicle_id: string
+          p_shop_id: string
+        }
+        Returns: Json
+      }
+      field_resolve_or_create_part_identity_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_code: string
+          p_connection_id?: string
+          p_create_if_missing?: boolean
+          p_external_id?: string
+          p_manufacturer?: string
+          p_metadata?: Json
+          p_name?: string
+          p_operation_key?: string
+          p_package_quantity?: number
+          p_part_number?: string
+          p_provider?: string
+          p_shop_id: string
+          p_supplier_id?: string
+          p_supplier_sku?: string
+          p_unit_cost?: number
+          p_unit_of_measure?: string
+          p_unit_sell_price?: number
+        }
+        Returns: Json
+      }
+      field_return_truck_part_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_operation_key: string
+          p_quantity: number
+          p_service_visit_id: string
+          p_shop_id: string
+          p_work_order_part_id: string
+        }
+        Returns: Json
+      }
+      field_transfer_stock_to_truck_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_operation_key: string
+          p_part_id: string
+          p_quantity: number
+          p_service_vehicle_id: string
+          p_shop_id: string
+          p_source_location_id: string
+        }
+        Returns: Json
+      }
+      field_truck_inventory_snapshot: {
+        Args: {
+          p_actor_user_id: string
+          p_query?: string
+          p_service_vehicle_id?: string
+          p_service_visit_id?: string
+          p_shop_id: string
+        }
+        Returns: Json
+      }
+      field_use_truck_part_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_operation_key: string
+          p_part_id: string
+          p_quantity: number
+          p_service_visit_id: string
+          p_shop_id: string
+          p_work_order_line_id: string
+        }
+        Returns: Json
       }
       finalize_estimate_send_atomic: {
         Args: {

--- a/supabase/migrations/20260812230000_field_integration_identity_core.sql
+++ b/supabase/migrations/20260812230000_field_integration_identity_core.sql
@@ -1,0 +1,463 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+set local check_function_bodies = false;
+
+-- Field Service integrations share one connection/mapping/event contract. The
+-- application stores only non-secret configuration here; provider credentials
+-- remain server-side and are addressed through secret_reference.
+create table if not exists public.integration_connections (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  provider text not null,
+  display_name text,
+  status text not null default 'disconnected'
+    check (status in ('disconnected','pending','connected','degraded','error')),
+  capabilities text[] not null default '{}'::text[],
+  config jsonb not null default '{}'::jsonb,
+  secret_reference text,
+  sync_cursor jsonb not null default '{}'::jsonb,
+  last_success_at timestamptz,
+  last_error_at timestamptz,
+  last_error text,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint integration_connections_provider_format
+    check (provider = lower(provider) and provider ~ '^[a-z0-9][a-z0-9_-]{1,63}$'),
+  constraint integration_connections_shop_provider_key unique (shop_id, provider)
+);
+
+create table if not exists public.integration_external_objects (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  connection_id uuid references public.integration_connections(id) on delete set null,
+  provider text not null,
+  object_type text not null,
+  external_id text not null,
+  canonical_table text not null,
+  canonical_id uuid not null,
+  external_version text,
+  metadata jsonb not null default '{}'::jsonb,
+  first_seen_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint integration_external_objects_provider_format
+    check (provider = lower(provider) and provider ~ '^[a-z0-9][a-z0-9_-]{1,63}$'),
+  constraint integration_external_objects_type_format
+    check (object_type ~ '^[a-z0-9][a-z0-9_-]{1,63}$'),
+  constraint integration_external_objects_table_format
+    check (canonical_table ~ '^[a-z][a-z0-9_]{1,62}$'),
+  constraint integration_external_objects_external_id_nonempty
+    check (length(trim(external_id)) between 1 and 512)
+);
+
+create unique index if not exists integration_external_objects_provider_key
+  on public.integration_external_objects (
+    shop_id,
+    provider,
+    object_type,
+    lower(external_id)
+  );
+create index if not exists integration_external_objects_canonical_idx
+  on public.integration_external_objects (
+    shop_id,
+    canonical_table,
+    canonical_id,
+    provider
+  );
+create index if not exists integration_external_objects_connection_idx
+  on public.integration_external_objects (connection_id, object_type, last_seen_at desc)
+  where connection_id is not null;
+
+create table if not exists public.integration_sync_events (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  connection_id uuid references public.integration_connections(id) on delete set null,
+  provider text not null,
+  direction text not null check (direction in ('inbound','outbound')),
+  operation text not null,
+  operation_key text not null,
+  object_type text,
+  external_id text,
+  canonical_table text,
+  canonical_id uuid,
+  status text not null default 'started'
+    check (status in ('started','succeeded','failed','dead_lettered')),
+  payload_hash text,
+  request_metadata jsonb not null default '{}'::jsonb,
+  response_metadata jsonb not null default '{}'::jsonb,
+  attempt_count integer not null default 1 check (attempt_count > 0),
+  error_message text,
+  started_at timestamptz not null default now(),
+  completed_at timestamptz,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  constraint integration_sync_events_operation_key_nonempty
+    check (length(trim(operation_key)) between 1 and 300),
+  constraint integration_sync_events_shop_operation_key unique (shop_id, operation_key)
+);
+
+create index if not exists integration_sync_events_connection_status_idx
+  on public.integration_sync_events (connection_id, status, created_at desc)
+  where connection_id is not null;
+create index if not exists integration_sync_events_object_idx
+  on public.integration_sync_events (
+    shop_id,
+    canonical_table,
+    canonical_id,
+    created_at desc
+  )
+  where canonical_id is not null;
+
+-- A provider result, supplier SKU, barcode, or external catalog id maps to the
+-- same canonical parts.id. Provider identities never replace the ProFixIQ part.
+create table if not exists public.part_external_identities (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  part_id uuid not null references public.parts(id) on delete cascade,
+  connection_id uuid references public.integration_connections(id) on delete set null,
+  provider text not null default 'manual',
+  external_id text,
+  supplier_id uuid references public.suppliers(id) on delete set null,
+  manufacturer text,
+  part_number text,
+  supplier_sku text,
+  barcode text,
+  unit_of_measure text,
+  package_quantity numeric(12,4) not null default 1
+    check (package_quantity > 0),
+  metadata jsonb not null default '{}'::jsonb,
+  active boolean not null default true,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint part_external_identities_provider_format
+    check (provider = lower(provider) and provider ~ '^[a-z0-9][a-z0-9_-]{1,63}$'),
+  constraint part_external_identities_has_identity
+    check (
+      nullif(trim(external_id), '') is not null
+      or nullif(trim(supplier_sku), '') is not null
+      or nullif(trim(barcode), '') is not null
+      or nullif(trim(part_number), '') is not null
+    )
+);
+
+create unique index if not exists part_external_identities_provider_external_key
+  on public.part_external_identities (
+    shop_id,
+    provider,
+    lower(external_id)
+  )
+  where active and external_id is not null and trim(external_id) <> '';
+create unique index if not exists part_external_identities_barcode_key
+  on public.part_external_identities (shop_id, lower(barcode))
+  where active and barcode is not null and trim(barcode) <> '';
+create index if not exists part_external_identities_part_idx
+  on public.part_external_identities (shop_id, part_id, active, updated_at desc);
+create index if not exists part_external_identities_supplier_sku_idx
+  on public.part_external_identities (shop_id, supplier_id, lower(supplier_sku))
+  where active and supplier_sku is not null and trim(supplier_sku) <> '';
+create index if not exists part_external_identities_part_number_idx
+  on public.part_external_identities (
+    shop_id,
+    lower(coalesce(manufacturer, '')),
+    lower(part_number)
+  )
+  where active and part_number is not null and trim(part_number) <> '';
+
+alter table public.integration_connections enable row level security;
+alter table public.integration_external_objects enable row level security;
+alter table public.integration_sync_events enable row level security;
+alter table public.part_external_identities enable row level security;
+
+create or replace function private.profixiq_field_inventory_actor_context(
+  p_shop_id uuid,
+  p_actor_user_id uuid
+) returns table (
+  profile_id uuid,
+  canonical_role text,
+  can_manage_parts boolean,
+  can_view_field boolean,
+  has_field_access boolean
+)
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select
+    p.id,
+    public.canonical_shop_membership_role(p.role::text),
+    public.profixiq_shop_has_product_access(p_shop_id, 'field_service')
+      and public.canonical_shop_membership_role(p.role::text) in (
+        'owner','admin','manager','parts','lead_hand','foreman'
+      ),
+    public.profixiq_shop_has_product_access(p_shop_id, 'field_service')
+      and (
+        public.canonical_shop_membership_role(p.role::text) in (
+          'owner','admin','manager','parts','advisor','service','lead_hand','foreman'
+        )
+        or public.mobile_actor_has_field_service_access(p_shop_id, p_actor_user_id)
+      ),
+    public.mobile_actor_has_field_service_access(p_shop_id, p_actor_user_id)
+  from public.profiles p
+  where p.shop_id = p_shop_id
+    and (p.id = p_actor_user_id or p.user_id = p_actor_user_id)
+  order by (p.id = p_actor_user_id) desc, p.id
+  limit 1;
+$$;
+
+create or replace function private.profixiq_field_inventory_actor_can_use_truck(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_service_vehicle_id uuid
+) returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  with actor as (
+    select *
+    from private.profixiq_field_inventory_actor_context(
+      p_shop_id,
+      p_actor_user_id
+    )
+  )
+  select exists (
+    select 1
+    from actor a
+    join public.service_vehicles vehicle
+      on vehicle.id = p_service_vehicle_id
+     and vehicle.shop_id = p_shop_id
+     and vehicle.active
+    where a.can_manage_parts
+       or (
+         a.has_field_access
+         and (
+           vehicle.primary_user_id = a.profile_id
+           or exists (
+             select 1
+             from public.service_visits visit
+             where visit.shop_id = p_shop_id
+               and visit.service_vehicle_id = vehicle.id
+               and visit.assigned_user_id = a.profile_id
+               and visit.status not in ('completed','cancelled')
+           )
+         )
+       )
+  );
+$$;
+
+create or replace function private.profixiq_validate_integration_scope()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  new.provider := lower(trim(new.provider));
+
+  if tg_table_name <> 'integration_connections' then
+    if new.connection_id is not null
+       and not exists (
+         select 1
+         from public.integration_connections connection
+         where connection.id = new.connection_id
+           and connection.shop_id = new.shop_id
+           and connection.provider = new.provider
+       ) then
+      raise exception using
+        errcode = '23503',
+        message = 'INTEGRATION_CONNECTION_SCOPE_MISMATCH';
+    end if;
+  end if;
+
+  if tg_table_name in ('integration_connections', 'integration_external_objects') then
+    new.updated_at := now();
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists integration_connections_validate on public.integration_connections;
+create trigger integration_connections_validate
+before insert or update on public.integration_connections
+for each row execute function private.profixiq_validate_integration_scope();
+
+drop trigger if exists integration_external_objects_validate on public.integration_external_objects;
+create trigger integration_external_objects_validate
+before insert or update on public.integration_external_objects
+for each row execute function private.profixiq_validate_integration_scope();
+
+drop trigger if exists integration_sync_events_validate on public.integration_sync_events;
+create trigger integration_sync_events_validate
+before insert or update on public.integration_sync_events
+for each row execute function private.profixiq_validate_integration_scope();
+
+create or replace function private.profixiq_validate_part_external_identity()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if not exists (
+    select 1
+    from public.parts part
+    where part.id = new.part_id
+      and part.shop_id = new.shop_id
+  ) then
+    raise exception using
+      errcode = '23503',
+      message = 'PART_EXTERNAL_IDENTITY_PART_SHOP_MISMATCH';
+  end if;
+
+  if new.connection_id is not null and not exists (
+    select 1
+    from public.integration_connections connection
+    where connection.id = new.connection_id
+      and connection.shop_id = new.shop_id
+      and connection.provider = new.provider
+  ) then
+    raise exception using
+      errcode = '23503',
+      message = 'PART_EXTERNAL_IDENTITY_CONNECTION_MISMATCH';
+  end if;
+
+  if new.supplier_id is not null and not exists (
+    select 1
+    from public.suppliers supplier
+    where supplier.id = new.supplier_id
+      and supplier.shop_id = new.shop_id
+  ) then
+    raise exception using
+      errcode = '23503',
+      message = 'PART_EXTERNAL_IDENTITY_SUPPLIER_MISMATCH';
+  end if;
+
+  new.provider := lower(trim(new.provider));
+  new.external_id := nullif(trim(new.external_id), '');
+  new.manufacturer := nullif(trim(new.manufacturer), '');
+  new.part_number := nullif(trim(new.part_number), '');
+  new.supplier_sku := nullif(trim(new.supplier_sku), '');
+  new.barcode := nullif(trim(new.barcode), '');
+  new.unit_of_measure := nullif(trim(new.unit_of_measure), '');
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists part_external_identities_validate on public.part_external_identities;
+create trigger part_external_identities_validate
+before insert or update on public.part_external_identities
+for each row execute function private.profixiq_validate_part_external_identity();
+
+-- Existing barcode mappings become canonical external identities without
+-- changing the current parts_barcodes contract.
+insert into public.part_external_identities (
+  shop_id,
+  part_id,
+  provider,
+  external_id,
+  supplier_id,
+  barcode,
+  metadata
+)
+select
+  barcode.shop_id,
+  barcode.part_id,
+  'barcode',
+  coalesce(nullif(trim(barcode.code), ''), barcode.barcode),
+  barcode.supplier_id,
+  barcode.barcode,
+  jsonb_build_object('source', 'parts_barcodes_backfill')
+from public.parts_barcodes barcode
+where nullif(trim(barcode.barcode), '') is not null
+on conflict do nothing;
+
+-- Same-shop members may read connection health and mappings. All writes go
+-- through server-side integration commands or service-role workers.
+drop policy if exists integration_connections_shop_read on public.integration_connections;
+create policy integration_connections_shop_read
+on public.integration_connections
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.shop_id = integration_connections.shop_id
+      and (profile.id = auth.uid() or profile.user_id = auth.uid())
+      and public.canonical_shop_membership_role(profile.role::text) in (
+        'owner','admin','manager','parts','lead_hand','foreman'
+      )
+  )
+);
+
+drop policy if exists integration_external_objects_shop_read on public.integration_external_objects;
+create policy integration_external_objects_shop_read
+on public.integration_external_objects
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.shop_id = integration_external_objects.shop_id
+      and (profile.id = auth.uid() or profile.user_id = auth.uid())
+      and public.canonical_shop_membership_role(profile.role::text) in (
+        'owner','admin','manager','parts','lead_hand','foreman'
+      )
+  )
+);
+
+drop policy if exists integration_sync_events_shop_read on public.integration_sync_events;
+create policy integration_sync_events_shop_read
+on public.integration_sync_events
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.shop_id = integration_sync_events.shop_id
+      and (profile.id = auth.uid() or profile.user_id = auth.uid())
+      and public.canonical_shop_membership_role(profile.role::text) in (
+        'owner','admin','manager','lead_hand','foreman'
+      )
+  )
+);
+
+drop policy if exists part_external_identities_shop_read on public.part_external_identities;
+create policy part_external_identities_shop_read
+on public.part_external_identities
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.shop_id = part_external_identities.shop_id
+      and (profile.id = auth.uid() or profile.user_id = auth.uid())
+  )
+);
+
+revoke all on table public.integration_connections from public, anon, authenticated;
+revoke all on table public.integration_external_objects from public, anon, authenticated;
+revoke all on table public.integration_sync_events from public, anon, authenticated;
+revoke all on table public.part_external_identities from public, anon, authenticated;
+grant select on table public.integration_connections to authenticated;
+grant select on table public.integration_external_objects to authenticated;
+grant select on table public.integration_sync_events to authenticated;
+grant select on table public.part_external_identities to authenticated;
+grant all on table public.integration_connections to service_role;
+grant all on table public.integration_external_objects to service_role;
+grant all on table public.integration_sync_events to service_role;
+grant all on table public.part_external_identities to service_role;
+
+
+commit;

--- a/supabase/migrations/20260812230100_field_part_identity_commands.sql
+++ b/supabase/migrations/20260812230100_field_part_identity_commands.sql
@@ -1,0 +1,403 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+set local check_function_bodies = false;
+
+create or replace function public.field_resolve_or_create_part_identity_atomic(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_code text,
+  p_provider text default 'manual',
+  p_external_id text default null,
+  p_connection_id uuid default null,
+  p_supplier_id uuid default null,
+  p_name text default null,
+  p_manufacturer text default null,
+  p_part_number text default null,
+  p_supplier_sku text default null,
+  p_unit_of_measure text default null,
+  p_package_quantity numeric default 1,
+  p_create_if_missing boolean default false,
+  p_unit_cost numeric default null,
+  p_unit_sell_price numeric default null,
+  p_metadata jsonb default '{}'::jsonb,
+  p_operation_key text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_provider text := lower(coalesce(nullif(trim(p_provider), ''), 'manual'));
+  v_code text := nullif(trim(p_code), '');
+  v_external_id text := nullif(trim(p_external_id), '');
+  v_part_number text := nullif(trim(p_part_number), '');
+  v_supplier_sku text := nullif(trim(p_supplier_sku), '');
+  v_manufacturer text := nullif(trim(p_manufacturer), '');
+  v_name text := nullif(trim(p_name), '');
+  v_operation_key text;
+  v_request jsonb;
+  v_request_hash text;
+  v_operation public.parts_operation_keys%rowtype;
+  v_part public.parts%rowtype;
+  v_barcode public.parts_barcodes%rowtype;
+  v_identity public.part_external_identities%rowtype;
+  v_created boolean := false;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.can_view_field then
+    raise exception using errcode = '42501', message = 'Field inventory access is required.';
+  end if;
+
+  if v_provider !~ '^[a-z0-9][a-z0-9_-]{1,63}$' then
+    raise exception using errcode = '22023', message = 'PART_PROVIDER_INVALID';
+  end if;
+  if v_code is null and v_external_id is null and v_part_number is null and v_supplier_sku is null then
+    raise exception using errcode = '22023', message = 'A barcode, provider id, SKU, or part number is required.';
+  end if;
+  if p_package_quantity is null or p_package_quantity <= 0 then
+    raise exception using errcode = '22023', message = 'Package quantity must be greater than zero.';
+  end if;
+  if p_unit_cost is not null and p_unit_cost < 0 then
+    raise exception using errcode = '22023', message = 'Part cost cannot be negative.';
+  end if;
+  if p_unit_sell_price is not null and p_unit_sell_price < 0 then
+    raise exception using errcode = '22023', message = 'Part sell price cannot be negative.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = '22023', message = 'A stable operation key is required.';
+  end if;
+
+  v_operation_key := p_shop_id::text || ':field-resolve:' || trim(p_operation_key);
+  if length(v_operation_key) > 280 then
+    raise exception using errcode = '22023', message = 'Part identity operation key is too long.';
+  end if;
+
+  v_request := jsonb_build_object(
+    'code', v_code,
+    'provider', v_provider,
+    'external_id', v_external_id,
+    'connection_id', p_connection_id,
+    'supplier_id', p_supplier_id,
+    'name', v_name,
+    'manufacturer', v_manufacturer,
+    'part_number', v_part_number,
+    'supplier_sku', v_supplier_sku,
+    'unit_of_measure', nullif(trim(p_unit_of_measure), ''),
+    'package_quantity', p_package_quantity,
+    'create_if_missing', p_create_if_missing,
+    'unit_cost', p_unit_cost,
+    'unit_sell_price', p_unit_sell_price
+  );
+  v_request_hash := encode(digest(v_request::text, 'sha256'), 'hex');
+
+  perform pg_advisory_xact_lock(hashtextextended(v_operation_key, 0));
+  select * into v_operation
+  from public.parts_operation_keys operation
+  where operation.shop_id = p_shop_id
+    and operation.operation_key = v_operation_key
+  for update;
+  if found then
+    if v_operation.operation_type <> 'field_resolve_part_identity'
+       or v_operation.aggregate_type <> 'shop'
+       or v_operation.aggregate_id <> p_shop_id
+       or coalesce(v_operation.result ->> '_request_hash', '') <> v_request_hash then
+      raise exception using errcode = '22023', message = 'FIELD_PART_IDENTITY_KEY_CONFLICT';
+    end if;
+    if v_operation.result is null or v_operation.completed_at is null then
+      raise exception using errcode = '55000', message = 'FIELD_PART_IDENTITY_OPERATION_IN_PROGRESS';
+    end if;
+    return v_operation.result || jsonb_build_object('idempotent', true);
+  end if;
+
+  insert into public.parts_operation_keys (
+    shop_id,
+    operation_key,
+    operation_type,
+    aggregate_type,
+    aggregate_id,
+    created_by
+  ) values (
+    p_shop_id,
+    v_operation_key,
+    'field_resolve_part_identity',
+    'shop',
+    p_shop_id,
+    v_actor.profile_id
+  ) returning * into v_operation;
+
+  if v_external_id is not null then
+    select part.* into v_part
+    from public.part_external_identities identity
+    join public.parts part
+      on part.id = identity.part_id
+     and part.shop_id = identity.shop_id
+    where identity.shop_id = p_shop_id
+      and identity.provider = v_provider
+      and lower(identity.external_id) = lower(v_external_id)
+      and identity.active
+    order by identity.updated_at desc, identity.id
+    limit 1
+    for share of part;
+  end if;
+
+  if v_part.id is null and v_code is not null then
+    select part.* into v_part
+    from public.parts_barcodes barcode
+    join public.parts part
+      on part.id = barcode.part_id
+     and part.shop_id = barcode.shop_id
+    where barcode.shop_id = p_shop_id
+      and (
+        lower(barcode.barcode) = lower(v_code)
+        or lower(coalesce(barcode.code, '')) = lower(v_code)
+      )
+    order by (lower(barcode.barcode) = lower(v_code)) desc, barcode.created_at, barcode.id
+    limit 1
+    for share of part;
+  end if;
+
+  if v_part.id is null and v_code is not null then
+    select part.* into v_part
+    from public.part_external_identities identity
+    join public.parts part
+      on part.id = identity.part_id
+     and part.shop_id = identity.shop_id
+    where identity.shop_id = p_shop_id
+      and identity.active
+      and lower(coalesce(identity.barcode, '')) = lower(v_code)
+    order by identity.updated_at desc, identity.id
+    limit 1
+    for share of part;
+  end if;
+
+  if v_part.id is null then
+    select part.* into v_part
+    from public.parts part
+    where part.shop_id = p_shop_id
+      and (
+        (
+          coalesce(v_supplier_sku, v_code) is not null
+          and lower(regexp_replace(coalesce(part.sku, ''), '[^a-zA-Z0-9]+', '', 'g')) =
+              lower(regexp_replace(coalesce(v_supplier_sku, v_code, ''), '[^a-zA-Z0-9]+', '', 'g'))
+        )
+        or (
+          coalesce(v_part_number, v_code) is not null
+          and lower(regexp_replace(coalesce(part.part_number, ''), '[^a-zA-Z0-9]+', '', 'g')) =
+              lower(regexp_replace(coalesce(v_part_number, v_code, ''), '[^a-zA-Z0-9]+', '', 'g'))
+          and (
+            v_manufacturer is null
+            or lower(coalesce(part.manufacturer, '')) = lower(v_manufacturer)
+          )
+        )
+      )
+    order by
+      (lower(coalesce(part.manufacturer, '')) = lower(coalesce(v_manufacturer, ''))) desc,
+      part.created_at desc nulls last,
+      part.id
+    limit 1
+    for share;
+  end if;
+
+  if v_part.id is null and not p_create_if_missing then
+    update public.parts_operation_keys
+    set result = jsonb_build_object(
+          'ok', true,
+          'idempotent', false,
+          'found', false,
+          'created', false,
+          'requiresDetails', true,
+          'code', v_code,
+          'provider', v_provider,
+          'externalId', v_external_id,
+          '_request_hash', v_request_hash
+        ),
+        completed_at = now()
+    where id = v_operation.id
+    returning * into v_operation;
+    return v_operation.result;
+  end if;
+
+  if v_part.id is null then
+    v_name := coalesce(v_name, v_part_number, v_supplier_sku, v_code);
+    if v_name is null then
+      raise exception using errcode = '22023', message = 'Part details are required before creating a new canonical part.';
+    end if;
+
+    insert into public.parts (
+      shop_id,
+      name,
+      part_number,
+      sku,
+      manufacturer,
+      supplier,
+      cost,
+      default_cost,
+      price,
+      default_price,
+      normalized_part_key
+    ) values (
+      p_shop_id,
+      v_name,
+      coalesce(v_part_number, case when v_provider = 'manual' then v_code else null end),
+      coalesce(v_supplier_sku, case when v_provider <> 'manual' then v_code else null end),
+      v_manufacturer,
+      v_provider,
+      p_unit_cost,
+      p_unit_cost,
+      p_unit_sell_price,
+      p_unit_sell_price,
+      nullif(
+        lower(regexp_replace(
+          coalesce(v_manufacturer, '') || ':' || coalesce(v_part_number, v_supplier_sku, v_code, ''),
+          '[^a-zA-Z0-9]+',
+          '',
+          'g'
+        )),
+        ''
+      )
+    ) returning * into v_part;
+    v_created := true;
+  end if;
+
+  if v_code is not null then
+    select * into v_barcode
+    from public.parts_barcodes barcode
+    where barcode.shop_id = p_shop_id
+      and lower(barcode.barcode) = lower(v_code)
+    for update;
+    if found and v_barcode.part_id <> v_part.id then
+      raise exception using errcode = '23505', message = 'PART_BARCODE_ALREADY_MAPPED';
+    end if;
+    if not found then
+      insert into public.parts_barcodes (
+        shop_id,
+        part_id,
+        barcode,
+        code,
+        supplier_id
+      ) values (
+        p_shop_id,
+        v_part.id,
+        v_code,
+        v_code,
+        p_supplier_id
+      );
+    end if;
+  end if;
+
+  if v_external_id is not null
+     or v_supplier_sku is not null
+     or v_code is not null
+     or v_part_number is not null then
+    select * into v_identity
+    from public.part_external_identities identity
+    where identity.shop_id = p_shop_id
+      and identity.active
+      and (
+        (
+          v_external_id is not null
+          and identity.provider = v_provider
+          and lower(identity.external_id) = lower(v_external_id)
+        )
+        or (
+          v_code is not null
+          and lower(coalesce(identity.barcode, '')) = lower(v_code)
+        )
+      )
+    order by identity.updated_at desc, identity.id
+    limit 1
+    for update;
+
+    if found and v_identity.part_id <> v_part.id then
+      raise exception using errcode = '23505', message = 'PART_EXTERNAL_IDENTITY_ALREADY_MAPPED';
+    end if;
+
+    if found then
+      update public.part_external_identities
+      set connection_id = coalesce(p_connection_id, connection_id),
+          supplier_id = coalesce(p_supplier_id, supplier_id),
+          external_id = coalesce(v_external_id, external_id),
+          manufacturer = coalesce(v_manufacturer, manufacturer),
+          part_number = coalesce(v_part_number, part_number),
+          supplier_sku = coalesce(v_supplier_sku, supplier_sku),
+          barcode = coalesce(v_code, barcode),
+          unit_of_measure = coalesce(nullif(trim(p_unit_of_measure), ''), unit_of_measure),
+          package_quantity = p_package_quantity,
+          metadata = coalesce(metadata, '{}'::jsonb) || coalesce(p_metadata, '{}'::jsonb),
+          updated_at = now()
+      where id = v_identity.id
+      returning * into v_identity;
+    else
+      insert into public.part_external_identities (
+        shop_id,
+        part_id,
+        connection_id,
+        provider,
+        external_id,
+        supplier_id,
+        manufacturer,
+        part_number,
+        supplier_sku,
+        barcode,
+        unit_of_measure,
+        package_quantity,
+        metadata,
+        created_by
+      ) values (
+        p_shop_id,
+        v_part.id,
+        p_connection_id,
+        v_provider,
+        coalesce(v_external_id, case when v_provider <> 'manual' then v_code else null end),
+        p_supplier_id,
+        v_manufacturer,
+        v_part_number,
+        v_supplier_sku,
+        v_code,
+        nullif(trim(p_unit_of_measure), ''),
+        p_package_quantity,
+        coalesce(p_metadata, '{}'::jsonb),
+        v_actor.profile_id
+      ) returning * into v_identity;
+    end if;
+  end if;
+
+  update public.parts_operation_keys
+  set result = jsonb_build_object(
+        'ok', true,
+        'idempotent', false,
+        'created', v_created,
+        'partId', v_part.id,
+        'identityId', v_identity.id,
+        'part', jsonb_build_object(
+          'id', v_part.id,
+          'name', v_part.name,
+          'partNumber', v_part.part_number,
+          'sku', v_part.sku,
+          'manufacturer', v_part.manufacturer,
+          'cost', v_part.cost,
+          'price', v_part.price
+        ),
+        '_request_hash', v_request_hash
+      ),
+      completed_at = now()
+  where id = v_operation.id
+  returning * into v_operation;
+
+  return v_operation.result;
+end;
+$$;
+
+
+commit;

--- a/supabase/migrations/20260812230200_field_truck_inventory_snapshot.sql
+++ b/supabase/migrations/20260812230200_field_truck_inventory_snapshot.sql
@@ -1,0 +1,433 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+set local check_function_bodies = false;
+
+create or replace function public.field_truck_inventory_snapshot(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_service_visit_id uuid default null,
+  p_service_vehicle_id uuid default null,
+  p_query text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_visit public.service_visits%rowtype;
+  v_truck public.service_vehicles%rowtype;
+  v_query text := nullif(trim(p_query), '');
+  v_items jsonb := '[]'::jsonb;
+  v_catalog jsonb := '[]'::jsonb;
+  v_lines jsonb := '[]'::jsonb;
+  v_receipts jsonb := '[]'::jsonb;
+  v_locations jsonb := '[]'::jsonb;
+  v_trucks jsonb := '[]'::jsonb;
+  v_recent_uses jsonb := '[]'::jsonb;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.can_view_field then
+    raise exception using errcode = '42501', message = 'Field inventory access is required.';
+  end if;
+
+  if p_service_visit_id is not null then
+    select * into v_visit
+    from public.service_visits visit
+    where visit.id = p_service_visit_id
+      and visit.shop_id = p_shop_id;
+    if not found then
+      raise exception using errcode = 'P0002', message = 'Service visit not found.';
+    end if;
+    if not v_actor.can_manage_parts
+       and (
+         v_visit.mode <> 'mobile'
+         or v_visit.assigned_user_id is distinct from v_actor.profile_id
+       ) then
+      raise exception using errcode = '42501', message = 'This Field Service visit is assigned to another technician.';
+    end if;
+  elsif v_actor.has_field_access then
+    select * into v_visit
+    from public.service_visits visit
+    where visit.shop_id = p_shop_id
+      and visit.assigned_user_id = v_actor.profile_id
+      and visit.mode = 'mobile'
+      and visit.status not in ('completed','cancelled')
+    order by
+      case visit.status
+        when 'working' then 0
+        when 'paused' then 1
+        when 'arrived' then 2
+        when 'en_route' then 3
+        when 'dispatched' then 4
+        else 5
+      end,
+      visit.scheduled_start nulls last,
+      visit.created_at
+    limit 1;
+  end if;
+
+  select coalesce(jsonb_agg(
+    jsonb_build_object(
+      'id', vehicle.id,
+      'name', vehicle.name,
+      'unitNumber', vehicle.unit_number,
+      'stockLocationId', vehicle.stock_location_id,
+      'primaryUserId', vehicle.primary_user_id,
+      'active', vehicle.active
+    ) order by vehicle.name, vehicle.unit_number, vehicle.id
+  ), '[]'::jsonb)
+  into v_trucks
+  from public.service_vehicles vehicle
+  where vehicle.shop_id = p_shop_id
+    and vehicle.active
+    and vehicle.stock_location_id is not null
+    and (
+      v_actor.can_manage_parts
+      or vehicle.primary_user_id = v_actor.profile_id
+      or exists (
+        select 1
+        from public.service_visits assigned_visit
+        where assigned_visit.shop_id = p_shop_id
+          and assigned_visit.mode = 'mobile'
+          and assigned_visit.assigned_user_id = v_actor.profile_id
+          and assigned_visit.service_vehicle_id = vehicle.id
+          and assigned_visit.status not in ('completed','cancelled')
+      )
+    );
+
+  if p_service_vehicle_id is not null then
+    if not private.profixiq_field_inventory_actor_can_use_truck(
+      p_shop_id,
+      p_actor_user_id,
+      p_service_vehicle_id
+    ) then
+      raise exception using errcode = '42501', message = 'This truck is not available to the authenticated actor.';
+    end if;
+    select * into v_truck
+    from public.service_vehicles vehicle
+    where vehicle.id = p_service_vehicle_id
+      and vehicle.shop_id = p_shop_id
+      and vehicle.active;
+  elsif v_visit.service_vehicle_id is not null then
+    select * into v_truck
+    from public.service_vehicles vehicle
+    where vehicle.id = v_visit.service_vehicle_id
+      and vehicle.shop_id = p_shop_id
+      and vehicle.active;
+  end if;
+
+  if v_truck.id is null then
+    select * into v_truck
+    from public.service_vehicles vehicle
+    where vehicle.shop_id = p_shop_id
+      and vehicle.primary_user_id = v_actor.profile_id
+      and vehicle.active
+    order by vehicle.updated_at desc, vehicle.id
+    limit 1;
+  end if;
+
+  select coalesce(jsonb_agg(
+    jsonb_build_object(
+      'id', location.id,
+      'code', location.code,
+      'name', location.name,
+      'serviceVehicleId', vehicle.id,
+      'serviceVehicleName', vehicle.name,
+      'serviceVehicleUnitNumber', vehicle.unit_number
+    ) order by location.code, location.name
+  ), '[]'::jsonb)
+  into v_locations
+  from public.stock_locations location
+  left join public.service_vehicles vehicle
+    on vehicle.shop_id = location.shop_id
+   and vehicle.stock_location_id = location.id
+   and vehicle.active
+  where location.shop_id = p_shop_id;
+
+  if v_truck.id is not null and v_truck.stock_location_id is not null then
+    select coalesce(jsonb_agg(item.payload order by item.sort_name), '[]'::jsonb)
+    into v_items
+    from (
+      select
+        lower(coalesce(part.name, part.part_number, part.sku, part.id::text)) as sort_name,
+        jsonb_build_object(
+          'partId', part.id,
+          'name', coalesce(nullif(trim(part.name), ''), 'Part'),
+          'description', part.description,
+          'partNumber', part.part_number,
+          'sku', part.sku,
+          'manufacturer', part.manufacturer,
+          'supplier', part.supplier,
+          'onHand', stock.qty_on_hand,
+          'reserved', stock.qty_reserved,
+          'available', stock.qty_available,
+          'barcodes', coalesce((
+            select jsonb_agg(distinct barcode.barcode)
+            from public.parts_barcodes barcode
+            where barcode.shop_id = p_shop_id
+              and barcode.part_id = part.id
+          ), '[]'::jsonb),
+          'identities', coalesce((
+            select jsonb_agg(
+              jsonb_build_object(
+                'id', identity.id,
+                'provider', identity.provider,
+                'externalId', identity.external_id,
+                'supplierId', identity.supplier_id,
+                'supplierSku', identity.supplier_sku,
+                'barcode', identity.barcode,
+                'partNumber', identity.part_number,
+                'manufacturer', identity.manufacturer,
+                'unitOfMeasure', identity.unit_of_measure,
+                'packageQuantity', identity.package_quantity
+              ) order by identity.provider, identity.updated_at desc
+            )
+            from public.part_external_identities identity
+            where identity.shop_id = p_shop_id
+              and identity.part_id = part.id
+              and identity.active
+          ), '[]'::jsonb)
+        ) as payload
+      from public.v_part_stock stock
+      join public.parts part
+        on part.id = stock.part_id
+       and part.shop_id = p_shop_id
+      where stock.location_id = v_truck.stock_location_id
+        and (
+          coalesce(stock.qty_on_hand, 0) <> 0
+          or coalesce(stock.qty_reserved, 0) <> 0
+        )
+      order by lower(coalesce(part.name, part.part_number, part.sku, part.id::text))
+      limit 300
+    ) item;
+
+    select coalesce(jsonb_agg(use_row.payload order by use_row.created_at desc), '[]'::jsonb)
+    into v_recent_uses
+    from (
+      select
+        move.created_at,
+        jsonb_build_object(
+          'stockMoveId', move.id,
+          'workOrderPartId', move.work_order_part_id,
+          'workOrderLineId', work_part.work_order_line_id,
+          'partId', move.part_id,
+          'name', coalesce(part.name, work_part.description_snapshot, 'Part'),
+          'partNumber', coalesce(part.part_number, work_part.part_number_snapshot),
+          'quantity', abs(move.qty_change),
+          'createdAt', move.created_at,
+          'returnedQuantity', coalesce((
+            select sum(return_move.qty_change)
+            from public.stock_moves return_move
+            where return_move.shop_id = move.shop_id
+              and return_move.work_order_part_id = move.work_order_part_id
+              and return_move.location_id = move.location_id
+              and return_move.reason = 'return'
+          ), 0)
+        ) as payload
+      from public.stock_moves move
+      join public.work_order_parts work_part
+        on work_part.id = move.work_order_part_id
+       and work_part.shop_id = move.shop_id
+      left join public.parts part
+        on part.id = move.part_id
+       and part.shop_id = move.shop_id
+      where move.shop_id = p_shop_id
+        and move.location_id = v_truck.stock_location_id
+        and move.reason = 'consume'
+        and (
+          v_visit.work_order_id is null
+          or work_part.work_order_id = v_visit.work_order_id
+        )
+      order by move.created_at desc
+      limit 30
+    ) use_row;
+  end if;
+
+  if v_visit.work_order_id is not null then
+    select coalesce(jsonb_agg(
+      jsonb_build_object(
+        'id', line.id,
+        'lineNumber', line.line_no,
+        'description', coalesce(
+          nullif(trim(line.description), ''),
+          nullif(trim(line.complaint), ''),
+          'Repair line'
+        ),
+        'status', coalesce(line.status, line.line_status),
+        'approvalState', line.approval_state,
+        'assignedTechnicianId', coalesce(line.assigned_tech_id, line.assigned_to)
+      ) order by line.line_no nulls last, line.created_at, line.id
+    ), '[]'::jsonb)
+    into v_lines
+    from public.work_order_lines line
+    where line.shop_id = p_shop_id
+      and line.work_order_id = v_visit.work_order_id
+      and line.voided_at is null;
+  end if;
+
+  if v_truck.id is not null and v_truck.stock_location_id is not null then
+    select coalesce(jsonb_agg(receipt.payload order by receipt.created_at, receipt.line_id), '[]'::jsonb)
+    into v_receipts
+    from (
+      select
+        line.created_at,
+        line.id as line_id,
+        jsonb_build_object(
+          'purchaseOrderId', purchase_order.id,
+          'purchaseOrderNumber', coalesce(purchase_order.po_number, purchase_order.id::text),
+          'purchaseOrderStatus', purchase_order.status,
+          'purchaseOrderLineId', line.id,
+          'partId', line.part_id,
+          'requiresCanonicalIdentity', line.part_id is null,
+          'description', coalesce(part.name, line.description, 'Part'),
+          'partNumber', part.part_number,
+          'sku', coalesce(line.sku, part.sku),
+          'orderedQuantity', line.qty,
+          'receivedQuantity', line.received_qty,
+          'remainingQuantity', greatest(
+            coalesce(line.qty, 0)
+              - coalesce(line.cancelled_qty, 0)
+              - coalesce(line.received_qty, 0),
+            0
+          ),
+          'targetLocationId', line.location_id,
+          'truckTargeted', line.location_id = v_truck.stock_location_id
+        ) as payload
+      from public.purchase_order_lines line
+      join public.purchase_orders purchase_order
+        on purchase_order.id = line.po_id
+       and purchase_order.shop_id = p_shop_id
+      left join public.parts part
+        on part.id = line.part_id
+       and part.shop_id = purchase_order.shop_id
+      where greatest(
+          coalesce(line.qty, 0)
+            - coalesce(line.cancelled_qty, 0)
+            - coalesce(line.received_qty, 0),
+          0
+        ) > 0
+        and lower(coalesce(purchase_order.status, '')) not in (
+          'received','closed','cancelled','canceled','void'
+        )
+      order by line.created_at, line.id
+      limit 100
+    ) receipt;
+  end if;
+
+  if v_query is not null then
+    select coalesce(jsonb_agg(catalog.payload order by catalog.sort_name), '[]'::jsonb)
+    into v_catalog
+    from (
+      select
+        lower(coalesce(part.name, part.part_number, part.sku, part.id::text)) as sort_name,
+        jsonb_build_object(
+          'partId', part.id,
+          'name', coalesce(nullif(trim(part.name), ''), 'Part'),
+          'description', part.description,
+          'partNumber', part.part_number,
+          'sku', part.sku,
+          'manufacturer', part.manufacturer,
+          'supplier', part.supplier,
+          'barcodes', coalesce((
+            select jsonb_agg(distinct barcode.barcode)
+            from public.parts_barcodes barcode
+            where barcode.shop_id = p_shop_id
+              and barcode.part_id = part.id
+          ), '[]'::jsonb),
+          'locations', coalesce((
+            select jsonb_agg(
+              jsonb_build_object(
+                'locationId', location.id,
+                'code', location.code,
+                'name', location.name,
+                'onHand', stock.qty_on_hand,
+                'reserved', stock.qty_reserved,
+                'available', stock.qty_available,
+                'serviceVehicleId', vehicle.id,
+                'serviceVehicleName', vehicle.name
+              ) order by location.code, location.name
+            )
+            from public.v_part_stock stock
+            join public.stock_locations location
+              on location.id = stock.location_id
+             and location.shop_id = p_shop_id
+            left join public.service_vehicles vehicle
+              on vehicle.shop_id = location.shop_id
+             and vehicle.stock_location_id = location.id
+             and vehicle.active
+            where stock.part_id = part.id
+              and (
+                coalesce(stock.qty_on_hand, 0) <> 0
+                or coalesce(stock.qty_reserved, 0) <> 0
+              )
+          ), '[]'::jsonb)
+        ) as payload
+      from public.parts part
+      where part.shop_id = p_shop_id
+        and lower(concat_ws(
+          ' ',
+          part.name,
+          part.description,
+          part.part_number,
+          part.sku,
+          part.manufacturer,
+          part.supplier
+        )) like '%' || lower(v_query) || '%'
+      order by lower(coalesce(part.name, part.part_number, part.sku, part.id::text))
+      limit 60
+    ) catalog;
+  end if;
+
+  return jsonb_build_object(
+    'generatedAt', now(),
+    'actorProfileId', v_actor.profile_id,
+    'canManageParts', v_actor.can_manage_parts,
+    'hasFieldAccess', v_actor.has_field_access,
+    'visit', case
+      when v_visit.id is null then null
+      else jsonb_build_object(
+        'id', v_visit.id,
+        'status', v_visit.status,
+        'mode', v_visit.mode,
+        'workOrderId', v_visit.work_order_id,
+        'serviceVehicleId', v_visit.service_vehicle_id,
+        'assignedTechnicianId', v_visit.assigned_user_id,
+        'scheduledStart', v_visit.scheduled_start,
+        'scheduledEnd', v_visit.scheduled_end
+      )
+    end,
+    'trucks', v_trucks,
+    'truck', case
+      when v_truck.id is null then null
+      else jsonb_build_object(
+        'id', v_truck.id,
+        'name', v_truck.name,
+        'unitNumber', v_truck.unit_number,
+        'stockLocationId', v_truck.stock_location_id,
+        'primaryUserId', v_truck.primary_user_id,
+        'active', v_truck.active
+      )
+    end,
+    'workOrderLines', v_lines,
+    'items', v_items,
+    'catalog', v_catalog,
+    'openReceipts', v_receipts,
+    'locations', v_locations,
+    'recentUses', v_recent_uses
+  );
+end;
+$$;
+
+
+commit;

--- a/supabase/migrations/20260812230300_field_truck_inventory_movement_commands.sql
+++ b/supabase/migrations/20260812230300_field_truck_inventory_movement_commands.sql
@@ -1,0 +1,444 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+set local check_function_bodies = false;
+
+create or replace function public.field_transfer_stock_to_truck_atomic(
+  p_shop_id uuid,
+  p_service_vehicle_id uuid,
+  p_source_location_id uuid,
+  p_part_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_truck public.service_vehicles%rowtype;
+  v_operation public.parts_operation_keys%rowtype;
+  v_request jsonb;
+  v_request_hash text;
+  v_scoped_key text;
+  v_out_move_id uuid;
+  v_in_move_id uuid;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found then
+    raise exception using errcode = '42501', message = 'Shop membership is required.';
+  end if;
+  if not private.profixiq_field_inventory_actor_can_use_truck(
+    p_shop_id,
+    p_actor_user_id,
+    p_service_vehicle_id
+  ) then
+    raise exception using errcode = '42501', message = 'This truck is not available to the authenticated actor.';
+  end if;
+
+  if p_quantity is null or p_quantity <= 0 or p_quantity <> round(p_quantity, 4) then
+    raise exception using errcode = '22023', message = 'Transfer quantity must be positive with at most four decimal places.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = '22023', message = 'A stable operation key is required.';
+  end if;
+
+  select * into v_truck
+  from public.service_vehicles vehicle
+  where vehicle.id = p_service_vehicle_id
+    and vehicle.shop_id = p_shop_id
+    and vehicle.active
+  for update;
+  if not found or v_truck.stock_location_id is null then
+    raise exception using errcode = '55000', message = 'The service truck does not have an inventory location.';
+  end if;
+  if v_truck.stock_location_id = p_source_location_id then
+    raise exception using errcode = '22023', message = 'Source and truck inventory locations must be different.';
+  end if;
+
+  perform 1
+  from public.parts part
+  where part.id = p_part_id
+    and part.shop_id = p_shop_id
+  for share;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Part not found for this shop.';
+  end if;
+
+  perform 1
+  from public.stock_locations location
+  where location.shop_id = p_shop_id
+    and location.id in (p_source_location_id, v_truck.stock_location_id)
+  order by location.id
+  for update;
+  if (select count(*)
+      from public.stock_locations location
+      where location.shop_id = p_shop_id
+        and location.id in (p_source_location_id, v_truck.stock_location_id)) <> 2 then
+    raise exception using errcode = '42501', message = 'A transfer location is outside this shop.';
+  end if;
+
+  v_scoped_key := p_shop_id::text || ':field-transfer:' || trim(p_operation_key);
+  if length(v_scoped_key) > 260 then
+    raise exception using errcode = '22023', message = 'Transfer operation key is too long.';
+  end if;
+  v_request := jsonb_build_object(
+    'service_vehicle_id', p_service_vehicle_id,
+    'source_location_id', p_source_location_id,
+    'destination_location_id', v_truck.stock_location_id,
+    'part_id', p_part_id,
+    'quantity', p_quantity
+  );
+  v_request_hash := encode(digest(v_request::text, 'sha256'), 'hex');
+
+  perform pg_advisory_xact_lock(hashtextextended(v_scoped_key, 0));
+  select * into v_operation
+  from public.parts_operation_keys operation
+  where operation.shop_id = p_shop_id
+    and operation.operation_key = v_scoped_key
+  for update;
+  if found then
+    if v_operation.operation_type <> 'field_transfer_to_truck'
+       or v_operation.aggregate_type <> 'service_vehicle'
+       or v_operation.aggregate_id <> p_service_vehicle_id
+       or coalesce(v_operation.result ->> '_request_hash', '') <> v_request_hash then
+      raise exception using errcode = '22023', message = 'FIELD_TRUCK_TRANSFER_KEY_CONFLICT';
+    end if;
+    if v_operation.result is null or v_operation.completed_at is null then
+      raise exception using errcode = '55000', message = 'FIELD_TRUCK_TRANSFER_IN_PROGRESS';
+    end if;
+    return v_operation.result || jsonb_build_object('idempotent', true);
+  end if;
+
+  if public.parts_available(
+    p_shop_id,
+    p_part_id,
+    p_source_location_id
+  ) < p_quantity then
+    raise exception using errcode = '23514', message = 'Insufficient available stock at the source location.';
+  end if;
+
+  insert into public.parts_operation_keys (
+    shop_id,
+    operation_key,
+    operation_type,
+    aggregate_type,
+    aggregate_id,
+    created_by
+  ) values (
+    p_shop_id,
+    v_scoped_key,
+    'field_transfer_to_truck',
+    'service_vehicle',
+    p_service_vehicle_id,
+    v_actor.profile_id
+  ) returning * into v_operation;
+
+  insert into public.stock_moves (
+    shop_id,
+    part_id,
+    location_id,
+    qty_change,
+    reason,
+    reference_kind,
+    reference_id,
+    created_by,
+    idempotency_key,
+    metadata,
+    lifecycle_quantity
+  ) values (
+    p_shop_id,
+    p_part_id,
+    p_source_location_id,
+    -p_quantity,
+    'transfer_out',
+    'field_truck_transfer',
+    v_operation.id,
+    v_actor.profile_id,
+    v_scoped_key || ':out',
+    jsonb_build_object(
+      'operation', 'field_transfer_to_truck',
+      'service_vehicle_id', p_service_vehicle_id,
+      'source_location_id', p_source_location_id,
+      'destination_location_id', v_truck.stock_location_id,
+      'quantity', p_quantity
+    ),
+    p_quantity
+  ) returning id into v_out_move_id;
+
+  insert into public.stock_moves (
+    shop_id,
+    part_id,
+    location_id,
+    qty_change,
+    reason,
+    reference_kind,
+    reference_id,
+    created_by,
+    idempotency_key,
+    metadata,
+    lifecycle_quantity
+  ) values (
+    p_shop_id,
+    p_part_id,
+    v_truck.stock_location_id,
+    p_quantity,
+    'transfer_in',
+    'field_truck_transfer',
+    v_operation.id,
+    v_actor.profile_id,
+    v_scoped_key || ':in',
+    jsonb_build_object(
+      'operation', 'field_transfer_to_truck',
+      'service_vehicle_id', p_service_vehicle_id,
+      'source_location_id', p_source_location_id,
+      'destination_location_id', v_truck.stock_location_id,
+      'quantity', p_quantity,
+      'paired_stock_move_id', v_out_move_id
+    ),
+    p_quantity
+  ) returning id into v_in_move_id;
+
+  update public.stock_moves
+  set metadata = metadata || jsonb_build_object('paired_stock_move_id', v_in_move_id)
+  where id = v_out_move_id;
+
+  update public.parts_operation_keys
+  set result = jsonb_build_object(
+        'ok', true,
+        'idempotent', false,
+        'serviceVehicleId', p_service_vehicle_id,
+        'partId', p_part_id,
+        'sourceLocationId', p_source_location_id,
+        'destinationLocationId', v_truck.stock_location_id,
+        'quantity', p_quantity,
+        'transferOutMoveId', v_out_move_id,
+        'transferInMoveId', v_in_move_id,
+        'sourceAvailableAfter', public.parts_available(
+          p_shop_id,
+          p_part_id,
+          p_source_location_id
+        ),
+        'truckOnHandAfter', public.parts_on_hand(
+          p_shop_id,
+          p_part_id,
+          v_truck.stock_location_id
+        ),
+        'truckAvailableAfter', public.parts_available(
+          p_shop_id,
+          p_part_id,
+          v_truck.stock_location_id
+        ),
+        '_request_hash', v_request_hash
+      ),
+      completed_at = now()
+  where id = v_operation.id
+  returning * into v_operation;
+
+  return v_operation.result;
+end;
+$$;
+
+create or replace function public.field_receive_po_part_to_truck_atomic(
+  p_shop_id uuid,
+  p_service_vehicle_id uuid,
+  p_purchase_order_id uuid,
+  p_purchase_order_line_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_truck public.service_vehicles%rowtype;
+  v_po public.purchase_orders%rowtype;
+  v_line public.purchase_order_lines%rowtype;
+  v_item public.part_request_items%rowtype;
+  v_part_id uuid;
+  v_work_order_part_id uuid;
+  v_supplier_name text;
+  v_identity_result jsonb;
+  v_result jsonb;
+  v_move_id uuid;
+  v_operation_id uuid;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.can_manage_parts then
+    raise exception using errcode = '42501', message = 'Parts receiving permission is required.';
+  end if;
+
+  if p_quantity is null or p_quantity <= 0 or p_quantity <> round(p_quantity, 2) then
+    raise exception using errcode = '22023', message = 'Receipt quantity must be positive with at most two decimal places.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = '22023', message = 'A stable operation key is required.';
+  end if;
+
+  select * into v_truck
+  from public.service_vehicles vehicle
+  where vehicle.id = p_service_vehicle_id
+    and vehicle.shop_id = p_shop_id
+    and vehicle.active
+  for update;
+  if not found or v_truck.stock_location_id is null then
+    raise exception using errcode = '55000', message = 'The service truck does not have an inventory location.';
+  end if;
+
+  select * into v_po
+  from public.purchase_orders purchase_order
+  where purchase_order.id = p_purchase_order_id
+    and purchase_order.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Purchase order not found for this shop.';
+  end if;
+
+  select * into v_line
+  from public.purchase_order_lines line
+  where line.id = p_purchase_order_line_id
+    and line.po_id = p_purchase_order_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Purchase-order line not found.';
+  end if;
+  if greatest(
+    coalesce(v_line.qty, 0)
+      - coalesce(v_line.cancelled_qty, 0)
+      - coalesce(v_line.received_qty, 0),
+    0
+  ) < p_quantity then
+    raise exception using errcode = '23514', message = 'Receipt quantity exceeds the selected purchase-order line.';
+  end if;
+
+  v_part_id := v_line.part_id;
+  if v_part_id is null then
+    select supplier.name into v_supplier_name
+    from public.suppliers supplier
+    where supplier.id = v_po.supplier_id
+      and supplier.shop_id = p_shop_id;
+
+    v_identity_result := public.field_resolve_or_create_part_identity_atomic(
+      p_shop_id,
+      p_actor_user_id,
+      coalesce(nullif(trim(v_line.sku), ''), 'po-line-' || v_line.id::text),
+      'purchase_order',
+      v_line.id::text,
+      null,
+      v_po.supplier_id,
+      coalesce(nullif(trim(v_line.description), ''), nullif(trim(v_line.sku), ''), 'Purchased part'),
+      null,
+      nullif(trim(v_line.sku), ''),
+      nullif(trim(v_line.sku), ''),
+      null,
+      1,
+      true,
+      v_line.unit_cost,
+      null,
+      jsonb_build_object(
+        'source', 'field_direct_po_receipt',
+        'purchase_order_id', v_po.id,
+        'purchase_order_line_id', v_line.id,
+        'supplier_name', v_supplier_name
+      ),
+      trim(p_operation_key) || ':identity'
+    );
+    v_part_id := nullif(v_identity_result ->> 'partId', '')::uuid;
+    if v_part_id is null then
+      raise exception using errcode = 'P0001', message = 'Unable to create the canonical part for this purchase-order line.';
+    end if;
+  end if;
+
+  if v_line.part_request_item_id is not null then
+    select * into v_item
+    from public.part_request_items item
+    where item.id = v_line.part_request_item_id
+      and item.shop_id = p_shop_id
+    for update;
+    if not found then
+      raise exception using errcode = 'P0002', message = 'Linked request item not found.';
+    end if;
+    if v_item.part_id is not null and v_item.part_id <> v_part_id then
+      raise exception using errcode = '23505', message = 'PURCHASE_ORDER_LINE_PART_IDENTITY_CONFLICT';
+    end if;
+    if v_item.part_id is null then
+      update public.part_request_items
+      set part_id = v_part_id,
+          description = coalesce(nullif(trim(description), ''), nullif(trim(v_line.description), ''), 'Part'),
+          updated_at = now()
+      where id = v_item.id;
+    end if;
+    v_work_order_part_id := public.parts_ensure_work_order_part(v_item.id);
+  else
+    v_work_order_part_id := v_line.work_order_part_id;
+  end if;
+
+  update public.purchase_order_lines
+  set part_id = v_part_id,
+      work_order_part_id = coalesce(work_order_part_id, v_work_order_part_id),
+      location_id = v_truck.stock_location_id
+  where id = v_line.id;
+
+  v_operation_id := md5(
+    p_shop_id::text || ':field-po-receive:' || trim(p_operation_key)
+  )::uuid;
+
+  v_result := public.receive_po_part_and_allocate(
+    p_purchase_order_id,
+    v_part_id,
+    v_truck.stock_location_id,
+    p_quantity,
+    v_operation_id
+  );
+
+  v_move_id := nullif(
+    coalesce(v_result ->> 'move_id', v_result ->> 'stock_move_id'),
+    ''
+  )::uuid;
+  if v_move_id is not null then
+    update public.stock_moves
+    set metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+      'field_service', true,
+      'service_vehicle_id', p_service_vehicle_id,
+      'truck_stock_location_id', v_truck.stock_location_id,
+      'direct_to_truck', true
+    )
+    where id = v_move_id
+      and shop_id = p_shop_id;
+  end if;
+
+  return v_result || jsonb_build_object(
+    'serviceVehicleId', p_service_vehicle_id,
+    'truckStockLocationId', v_truck.stock_location_id,
+    'purchaseOrderLineId', p_purchase_order_line_id,
+    'partId', v_part_id,
+    'workOrderPartId', v_work_order_part_id,
+    'directToTruck', true
+  );
+end;
+$$;
+
+
+commit;

--- a/supabase/migrations/20260812230400_field_truck_inventory_work_order_commands.sql
+++ b/supabase/migrations/20260812230400_field_truck_inventory_work_order_commands.sql
@@ -1,0 +1,284 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+set local check_function_bodies = false;
+
+create or replace function public.field_use_truck_part_atomic(
+  p_shop_id uuid,
+  p_service_visit_id uuid,
+  p_work_order_line_id uuid,
+  p_part_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_visit public.service_visits%rowtype;
+  v_truck public.service_vehicles%rowtype;
+  v_result jsonb;
+  v_stock_move_id uuid;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.has_field_access then
+    raise exception using errcode = '42501', message = 'Field Service access is required.';
+  end if;
+
+  if p_quantity is null or p_quantity <= 0 or p_quantity <> round(p_quantity, 4) then
+    raise exception using errcode = '22023', message = 'Use quantity must be positive with at most four decimal places.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = '22023', message = 'A stable operation key is required.';
+  end if;
+
+  select * into v_visit
+  from public.service_visits visit
+  where visit.id = p_service_visit_id
+    and visit.shop_id = p_shop_id
+  for update;
+  if not found
+     or v_visit.mode <> 'mobile'
+     or v_visit.assigned_user_id is distinct from v_actor.profile_id then
+    raise exception using errcode = '42501', message = 'The service call is not assigned to this field technician.';
+  end if;
+  if v_visit.status not in ('arrived','working','paused') then
+    raise exception using errcode = '55000', message = 'Arrive at the service call before using truck inventory.';
+  end if;
+  if v_visit.work_order_id is null then
+    raise exception using errcode = '55000', message = 'Create or link the repair before using a part.';
+  end if;
+  if v_visit.service_vehicle_id is null then
+    raise exception using errcode = '55000', message = 'Assign a service truck before using truck inventory.';
+  end if;
+
+  select * into v_truck
+  from public.service_vehicles vehicle
+  where vehicle.id = v_visit.service_vehicle_id
+    and vehicle.shop_id = p_shop_id
+    and vehicle.active
+  for update;
+  if not found or v_truck.stock_location_id is null then
+    raise exception using errcode = '55000', message = 'The assigned service truck has no inventory location.';
+  end if;
+
+  if not exists (
+    select 1
+    from public.work_order_lines line
+    where line.id = p_work_order_line_id
+      and line.shop_id = p_shop_id
+      and line.work_order_id = v_visit.work_order_id
+      and line.voided_at is null
+  ) then
+    raise exception using errcode = '42501', message = 'The repair line is outside this service call.';
+  end if;
+
+  v_result := public.parts_issue_by_line_part_atomic(
+    p_shop_id,
+    p_work_order_line_id,
+    p_part_id,
+    v_truck.stock_location_id,
+    p_quantity,
+    p_shop_id::text || ':field-use:' || trim(p_operation_key),
+    p_actor_user_id
+  );
+
+  v_stock_move_id := nullif(v_result ->> 'stock_move_id', '')::uuid;
+  if v_stock_move_id is not null then
+    update public.stock_moves
+    set metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+      'field_service', true,
+      'service_visit_id', p_service_visit_id,
+      'service_vehicle_id', v_truck.id,
+      'truck_stock_location_id', v_truck.stock_location_id,
+      'work_order_id', v_visit.work_order_id,
+      'work_order_line_id', p_work_order_line_id,
+      'canonical_part_id', p_part_id
+    )
+    where id = v_stock_move_id
+      and shop_id = p_shop_id;
+  end if;
+
+  return v_result || jsonb_build_object(
+    'serviceVisitId', p_service_visit_id,
+    'serviceVehicleId', v_truck.id,
+    'truckStockLocationId', v_truck.stock_location_id,
+    'workOrderId', v_visit.work_order_id,
+    'workOrderLineId', p_work_order_line_id,
+    'partId', p_part_id
+  );
+end;
+$$;
+
+create or replace function public.field_return_truck_part_atomic(
+  p_shop_id uuid,
+  p_service_visit_id uuid,
+  p_work_order_part_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_visit public.service_visits%rowtype;
+  v_truck public.service_vehicles%rowtype;
+  v_work_part public.work_order_parts%rowtype;
+  v_result jsonb;
+  v_stock_move_id uuid;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.has_field_access then
+    raise exception using errcode = '42501', message = 'Field Service access is required.';
+  end if;
+
+  if p_quantity is null or p_quantity <= 0 or p_quantity <> round(p_quantity, 4) then
+    raise exception using errcode = '22023', message = 'Return quantity must be positive with at most four decimal places.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = '22023', message = 'A stable operation key is required.';
+  end if;
+
+  select * into v_visit
+  from public.service_visits visit
+  where visit.id = p_service_visit_id
+    and visit.shop_id = p_shop_id
+  for update;
+  if not found
+     or v_visit.mode <> 'mobile'
+     or v_visit.assigned_user_id is distinct from v_actor.profile_id
+     or v_visit.work_order_id is null
+     or v_visit.service_vehicle_id is null then
+    raise exception using errcode = '42501', message = 'The service call is not assigned to this field technician.';
+  end if;
+
+  select * into v_truck
+  from public.service_vehicles vehicle
+  where vehicle.id = v_visit.service_vehicle_id
+    and vehicle.shop_id = p_shop_id
+    and vehicle.active
+  for update;
+  if not found or v_truck.stock_location_id is null then
+    raise exception using errcode = '55000', message = 'The assigned service truck has no inventory location.';
+  end if;
+
+  select * into v_work_part
+  from public.work_order_parts work_part
+  where work_part.id = p_work_order_part_id
+    and work_part.shop_id = p_shop_id
+    and work_part.work_order_id = v_visit.work_order_id
+    and work_part.is_active
+  for update;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Work-order part not found for this service call.';
+  end if;
+
+  v_result := public.parts_return_to_stock(
+    p_work_order_part_id,
+    v_truck.stock_location_id,
+    p_quantity,
+    p_shop_id::text || ':field-return:' || trim(p_operation_key)
+  );
+
+  v_stock_move_id := nullif(v_result ->> 'stock_move_id', '')::uuid;
+  if v_stock_move_id is not null then
+    update public.stock_moves
+    set metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+      'field_service', true,
+      'service_visit_id', p_service_visit_id,
+      'service_vehicle_id', v_truck.id,
+      'truck_stock_location_id', v_truck.stock_location_id,
+      'work_order_id', v_visit.work_order_id,
+      'work_order_part_id', p_work_order_part_id,
+      'canonical_part_id', v_work_part.part_id
+    )
+    where id = v_stock_move_id
+      and shop_id = p_shop_id;
+  end if;
+
+  return v_result || jsonb_build_object(
+    'serviceVisitId', p_service_visit_id,
+    'serviceVehicleId', v_truck.id,
+    'truckStockLocationId', v_truck.stock_location_id,
+    'workOrderId', v_visit.work_order_id,
+    'workOrderPartId', p_work_order_part_id,
+    'partId', v_work_part.part_id
+  );
+end;
+$$;
+
+revoke all on function private.profixiq_field_inventory_actor_context(uuid,uuid)
+  from public, anon, authenticated, service_role;
+revoke all on function private.profixiq_field_inventory_actor_can_use_truck(uuid,uuid,uuid)
+  from public, anon, authenticated, service_role;
+revoke all on function private.profixiq_validate_part_external_identity()
+  from public, anon, authenticated, service_role;
+revoke all on function private.profixiq_validate_integration_scope()
+  from public, anon, authenticated, service_role;
+
+revoke all on function public.field_resolve_or_create_part_identity_atomic(
+  uuid,uuid,text,text,text,uuid,uuid,text,text,text,text,text,numeric,boolean,numeric,numeric,jsonb,text
+) from public, anon;
+grant execute on function public.field_resolve_or_create_part_identity_atomic(
+  uuid,uuid,text,text,text,uuid,uuid,text,text,text,text,text,numeric,boolean,numeric,numeric,jsonb,text
+) to authenticated, service_role;
+
+revoke all on function public.field_truck_inventory_snapshot(uuid,uuid,uuid,uuid,text)
+  from public, anon;
+grant execute on function public.field_truck_inventory_snapshot(uuid,uuid,uuid,uuid,text)
+  to authenticated, service_role;
+
+revoke all on function public.field_transfer_stock_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) from public, anon;
+grant execute on function public.field_transfer_stock_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) to authenticated, service_role;
+
+revoke all on function public.field_receive_po_part_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) from public, anon;
+grant execute on function public.field_receive_po_part_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) to authenticated, service_role;
+
+revoke all on function public.field_use_truck_part_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) from public, anon;
+grant execute on function public.field_use_truck_part_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) to authenticated, service_role;
+
+revoke all on function public.field_return_truck_part_atomic(
+  uuid,uuid,uuid,numeric,uuid,text
+) from public, anon;
+grant execute on function public.field_return_truck_part_atomic(
+  uuid,uuid,uuid,numeric,uuid,text
+) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260815040500_field_part_identity_digest_search_path.sql
+++ b/supabase/migrations/20260815040500_field_part_identity_digest_search_path.sql
@@ -1,9 +1,8 @@
 begin;
 
-set local lock_timeout = '5s';
-set local statement_timeout = '10min';
-set local check_function_bodies = false;
-
+-- The preview branch already applied the original identity migration. Reinstall
+-- the RPC with pgcrypto explicitly schema-qualified so the hardened empty
+-- search_path remains safe and clean-database/runtime calls can hash requests.
 create or replace function public.field_resolve_or_create_part_identity_atomic(
   p_shop_id uuid,
   p_actor_user_id uuid,
@@ -401,6 +400,5 @@ begin
   return v_operation.result;
 end;
 $$;
-
 
 commit;

--- a/supabase/migrations/20260815042000_field_truck_receipt_replay.sql
+++ b/supabase/migrations/20260815042000_field_truck_receipt_replay.sql
@@ -1,9 +1,9 @@
 begin;
 
-set local lock_timeout = '5s';
-set local statement_timeout = '10min';
-set local check_function_bodies = false;
-
+-- The preview branch already applied the initial Field truck movement migration.
+-- Reinstall both commands so request hashing remains safe with the hardened
+-- search path and an exact receipt replay reaches the canonical idempotency
+-- check before the selected PO line's remaining-quantity guard.
 create or replace function public.field_transfer_stock_to_truck_atomic(
   p_shop_id uuid,
   p_service_vehicle_id uuid,
@@ -472,6 +472,5 @@ begin
   );
 end;
 $$;
-
 
 commit;

--- a/supabase/migrations/20260815050000_field_part_identity_review_hardening.sql
+++ b/supabase/migrations/20260815050000_field_part_identity_review_hardening.sql
@@ -1,0 +1,404 @@
+begin;
+
+-- Reinstall the identity command after the reviewed head. Barcode scans only
+-- resolve barcode identities unless the caller explicitly supplies another
+-- identity namespace, and field-only actors cannot set shop-wide prices.
+create or replace function public.field_resolve_or_create_part_identity_atomic(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_code text,
+  p_provider text default 'manual',
+  p_external_id text default null,
+  p_connection_id uuid default null,
+  p_supplier_id uuid default null,
+  p_name text default null,
+  p_manufacturer text default null,
+  p_part_number text default null,
+  p_supplier_sku text default null,
+  p_unit_of_measure text default null,
+  p_package_quantity numeric default 1,
+  p_create_if_missing boolean default false,
+  p_unit_cost numeric default null,
+  p_unit_sell_price numeric default null,
+  p_metadata jsonb default '{}'::jsonb,
+  p_operation_key text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_provider text := lower(coalesce(nullif(trim(p_provider), ''), 'manual'));
+  v_code text := nullif(trim(p_code), '');
+  v_external_id text := nullif(trim(p_external_id), '');
+  v_part_number text := nullif(trim(p_part_number), '');
+  v_supplier_sku text := nullif(trim(p_supplier_sku), '');
+  v_manufacturer text := nullif(trim(p_manufacturer), '');
+  v_name text := nullif(trim(p_name), '');
+  v_operation_key text;
+  v_request jsonb;
+  v_request_hash text;
+  v_operation public.parts_operation_keys%rowtype;
+  v_part public.parts%rowtype;
+  v_barcode public.parts_barcodes%rowtype;
+  v_identity public.part_external_identities%rowtype;
+  v_created boolean := false;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.can_view_field then
+    raise exception using errcode = '42501', message = 'Field inventory access is required.';
+  end if;
+
+  if v_provider !~ '^[a-z0-9][a-z0-9_-]{1,63}$' then
+    raise exception using errcode = '22023', message = 'PART_PROVIDER_INVALID';
+  end if;
+  if v_code is null and v_external_id is null and v_part_number is null and v_supplier_sku is null then
+    raise exception using errcode = '22023', message = 'A barcode, provider id, SKU, or part number is required.';
+  end if;
+  if p_package_quantity is null or p_package_quantity <= 0 then
+    raise exception using errcode = '22023', message = 'Package quantity must be greater than zero.';
+  end if;
+  if p_unit_cost is not null and p_unit_cost < 0 then
+    raise exception using errcode = '22023', message = 'Part cost cannot be negative.';
+  end if;
+  if p_unit_sell_price is not null and p_unit_sell_price < 0 then
+    raise exception using errcode = '22023', message = 'Part sell price cannot be negative.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = '22023', message = 'A stable operation key is required.';
+  end if;
+
+  v_operation_key := p_shop_id::text || ':field-resolve:' || trim(p_operation_key);
+  if length(v_operation_key) > 280 then
+    raise exception using errcode = '22023', message = 'Part identity operation key is too long.';
+  end if;
+
+  v_request := jsonb_build_object(
+    'code', v_code,
+    'provider', v_provider,
+    'external_id', v_external_id,
+    'connection_id', p_connection_id,
+    'supplier_id', p_supplier_id,
+    'name', v_name,
+    'manufacturer', v_manufacturer,
+    'part_number', v_part_number,
+    'supplier_sku', v_supplier_sku,
+    'unit_of_measure', nullif(trim(p_unit_of_measure), ''),
+    'package_quantity', p_package_quantity,
+    'create_if_missing', p_create_if_missing,
+    'unit_cost', p_unit_cost,
+    'unit_sell_price', p_unit_sell_price
+  );
+  v_request_hash := encode(
+    extensions.digest(convert_to(v_request::text, 'UTF8'), 'sha256'),
+    'hex'
+  );
+
+  perform pg_advisory_xact_lock(hashtextextended(v_operation_key, 0));
+  select * into v_operation
+  from public.parts_operation_keys operation
+  where operation.shop_id = p_shop_id
+    and operation.operation_key = v_operation_key
+  for update;
+  if found then
+    if v_operation.operation_type <> 'field_resolve_part_identity'
+       or v_operation.aggregate_type <> 'shop'
+       or v_operation.aggregate_id <> p_shop_id
+       or coalesce(v_operation.result ->> '_request_hash', '') <> v_request_hash then
+      raise exception using errcode = '22023', message = 'FIELD_PART_IDENTITY_KEY_CONFLICT';
+    end if;
+    if v_operation.result is null or v_operation.completed_at is null then
+      raise exception using errcode = '55000', message = 'FIELD_PART_IDENTITY_OPERATION_IN_PROGRESS';
+    end if;
+    return v_operation.result || jsonb_build_object('idempotent', true);
+  end if;
+
+  insert into public.parts_operation_keys (
+    shop_id,
+    operation_key,
+    operation_type,
+    aggregate_type,
+    aggregate_id,
+    created_by
+  ) values (
+    p_shop_id,
+    v_operation_key,
+    'field_resolve_part_identity',
+    'shop',
+    p_shop_id,
+    v_actor.profile_id
+  ) returning * into v_operation;
+
+  if v_external_id is not null then
+    select part.* into v_part
+    from public.part_external_identities identity
+    join public.parts part
+      on part.id = identity.part_id
+     and part.shop_id = identity.shop_id
+    where identity.shop_id = p_shop_id
+      and identity.provider = v_provider
+      and lower(identity.external_id) = lower(v_external_id)
+      and identity.active
+    order by identity.updated_at desc, identity.id
+    limit 1
+    for share of part;
+  end if;
+
+  if v_part.id is null and v_code is not null then
+    select part.* into v_part
+    from public.parts_barcodes barcode
+    join public.parts part
+      on part.id = barcode.part_id
+     and part.shop_id = barcode.shop_id
+    where barcode.shop_id = p_shop_id
+      and (
+        lower(barcode.barcode) = lower(v_code)
+        or lower(coalesce(barcode.code, '')) = lower(v_code)
+      )
+    order by (lower(barcode.barcode) = lower(v_code)) desc, barcode.created_at, barcode.id
+    limit 1
+    for share of part;
+  end if;
+
+  if v_part.id is null and v_code is not null then
+    select part.* into v_part
+    from public.part_external_identities identity
+    join public.parts part
+      on part.id = identity.part_id
+     and part.shop_id = identity.shop_id
+    where identity.shop_id = p_shop_id
+      and identity.active
+      and lower(coalesce(identity.barcode, '')) = lower(v_code)
+    order by identity.updated_at desc, identity.id
+    limit 1
+    for share of part;
+  end if;
+
+  if v_part.id is null and (v_supplier_sku is not null or v_part_number is not null) then
+    select part.* into v_part
+    from public.parts part
+    where part.shop_id = p_shop_id
+      and (
+        (
+          v_supplier_sku is not null
+          and lower(regexp_replace(coalesce(part.sku, ''), '[^a-zA-Z0-9]+', '', 'g')) =
+              lower(regexp_replace(v_supplier_sku, '[^a-zA-Z0-9]+', '', 'g'))
+        )
+        or (
+          v_part_number is not null
+          and lower(regexp_replace(coalesce(part.part_number, ''), '[^a-zA-Z0-9]+', '', 'g')) =
+              lower(regexp_replace(v_part_number, '[^a-zA-Z0-9]+', '', 'g'))
+          and (
+            v_manufacturer is null
+            or lower(coalesce(part.manufacturer, '')) = lower(v_manufacturer)
+          )
+        )
+      )
+    order by
+      (lower(coalesce(part.manufacturer, '')) = lower(coalesce(v_manufacturer, ''))) desc,
+      part.created_at desc nulls last,
+      part.id
+    limit 1
+    for share;
+  end if;
+
+  if v_part.id is null and not p_create_if_missing then
+    update public.parts_operation_keys
+    set result = jsonb_build_object(
+          'ok', true,
+          'idempotent', false,
+          'found', false,
+          'created', false,
+          'requiresDetails', true,
+          'code', v_code,
+          'provider', v_provider,
+          'externalId', v_external_id,
+          '_request_hash', v_request_hash
+        ),
+        completed_at = now()
+    where id = v_operation.id
+    returning * into v_operation;
+    return v_operation.result;
+  end if;
+
+  if v_part.id is null then
+    v_name := coalesce(v_name, v_part_number, v_supplier_sku, v_code);
+    if v_name is null then
+      raise exception using errcode = '22023', message = 'Part details are required before creating a new canonical part.';
+    end if;
+
+    insert into public.parts (
+      shop_id,
+      name,
+      part_number,
+      sku,
+      manufacturer,
+      supplier,
+      cost,
+      default_cost,
+      price,
+      default_price,
+      normalized_part_key
+    ) values (
+      p_shop_id,
+      v_name,
+      coalesce(v_part_number, case when v_provider = 'manual' then v_code else null end),
+      coalesce(v_supplier_sku, case when v_provider <> 'manual' then v_code else null end),
+      v_manufacturer,
+      v_provider,
+      case when v_actor.can_manage_parts then p_unit_cost else null end,
+      case when v_actor.can_manage_parts then p_unit_cost else null end,
+      case when v_actor.can_manage_parts then p_unit_sell_price else null end,
+      case when v_actor.can_manage_parts then p_unit_sell_price else null end,
+      nullif(
+        lower(regexp_replace(
+          coalesce(v_manufacturer, '') || ':' || coalesce(v_part_number, v_supplier_sku, v_code, ''),
+          '[^a-zA-Z0-9]+',
+          '',
+          'g'
+        )),
+        ''
+      )
+    ) returning * into v_part;
+    v_created := true;
+  end if;
+
+  if v_code is not null then
+    select * into v_barcode
+    from public.parts_barcodes barcode
+    where barcode.shop_id = p_shop_id
+      and lower(barcode.barcode) = lower(v_code)
+    for update;
+    if found and v_barcode.part_id <> v_part.id then
+      raise exception using errcode = '23505', message = 'PART_BARCODE_ALREADY_MAPPED';
+    end if;
+    if not found then
+      insert into public.parts_barcodes (
+        shop_id,
+        part_id,
+        barcode,
+        code,
+        supplier_id
+      ) values (
+        p_shop_id,
+        v_part.id,
+        v_code,
+        v_code,
+        p_supplier_id
+      );
+    end if;
+  end if;
+
+  if v_external_id is not null
+     or v_supplier_sku is not null
+     or v_code is not null
+     or v_part_number is not null then
+    select * into v_identity
+    from public.part_external_identities identity
+    where identity.shop_id = p_shop_id
+      and identity.active
+      and (
+        (
+          v_external_id is not null
+          and identity.provider = v_provider
+          and lower(identity.external_id) = lower(v_external_id)
+        )
+        or (
+          v_code is not null
+          and lower(coalesce(identity.barcode, '')) = lower(v_code)
+        )
+      )
+    order by identity.updated_at desc, identity.id
+    limit 1
+    for update;
+
+    if found and v_identity.part_id <> v_part.id then
+      raise exception using errcode = '23505', message = 'PART_EXTERNAL_IDENTITY_ALREADY_MAPPED';
+    end if;
+
+    if found then
+      update public.part_external_identities
+      set connection_id = coalesce(p_connection_id, connection_id),
+          supplier_id = coalesce(p_supplier_id, supplier_id),
+          external_id = coalesce(v_external_id, external_id),
+          manufacturer = coalesce(v_manufacturer, manufacturer),
+          part_number = coalesce(v_part_number, part_number),
+          supplier_sku = coalesce(v_supplier_sku, supplier_sku),
+          barcode = coalesce(v_code, barcode),
+          unit_of_measure = coalesce(nullif(trim(p_unit_of_measure), ''), unit_of_measure),
+          package_quantity = p_package_quantity,
+          metadata = coalesce(metadata, '{}'::jsonb) || coalesce(p_metadata, '{}'::jsonb),
+          updated_at = now()
+      where id = v_identity.id
+      returning * into v_identity;
+    else
+      insert into public.part_external_identities (
+        shop_id,
+        part_id,
+        connection_id,
+        provider,
+        external_id,
+        supplier_id,
+        manufacturer,
+        part_number,
+        supplier_sku,
+        barcode,
+        unit_of_measure,
+        package_quantity,
+        metadata,
+        created_by
+      ) values (
+        p_shop_id,
+        v_part.id,
+        p_connection_id,
+        v_provider,
+        coalesce(v_external_id, case when v_provider <> 'manual' then v_code else null end),
+        p_supplier_id,
+        v_manufacturer,
+        v_part_number,
+        v_supplier_sku,
+        v_code,
+        nullif(trim(p_unit_of_measure), ''),
+        p_package_quantity,
+        coalesce(p_metadata, '{}'::jsonb),
+        v_actor.profile_id
+      ) returning * into v_identity;
+    end if;
+  end if;
+
+  update public.parts_operation_keys
+  set result = jsonb_build_object(
+        'ok', true,
+        'idempotent', false,
+        'created', v_created,
+        'partId', v_part.id,
+        'identityId', v_identity.id,
+        'part', jsonb_build_object(
+          'id', v_part.id,
+          'name', v_part.name,
+          'partNumber', v_part.part_number,
+          'sku', v_part.sku,
+          'manufacturer', v_part.manufacturer,
+          'cost', v_part.cost,
+          'price', v_part.price
+        ),
+        '_request_hash', v_request_hash
+      ),
+      completed_at = now()
+  where id = v_operation.id
+  returning * into v_operation;
+
+  return v_operation.result;
+end;
+$$;
+
+commit;

--- a/supabase/migrations/20260815050100_field_truck_line_review_hardening.sql
+++ b/supabase/migrations/20260815050100_field_truck_line_review_hardening.sql
@@ -1,0 +1,295 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+set local check_function_bodies = false;
+
+create or replace function public.field_use_truck_part_atomic(
+  p_shop_id uuid,
+  p_service_visit_id uuid,
+  p_work_order_line_id uuid,
+  p_part_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_visit public.service_visits%rowtype;
+  v_truck public.service_vehicles%rowtype;
+  v_result jsonb;
+  v_stock_move_id uuid;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.has_field_access then
+    raise exception using errcode = '42501', message = 'Field Service access is required.';
+  end if;
+
+  if p_quantity is null or p_quantity <= 0 or p_quantity <> round(p_quantity, 4) then
+    raise exception using errcode = '22023', message = 'Use quantity must be positive with at most four decimal places.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = '22023', message = 'A stable operation key is required.';
+  end if;
+
+  select * into v_visit
+  from public.service_visits visit
+  where visit.id = p_service_visit_id
+    and visit.shop_id = p_shop_id
+  for update;
+  if not found
+     or v_visit.mode <> 'mobile'
+     or v_visit.assigned_user_id is distinct from v_actor.profile_id then
+    raise exception using errcode = '42501', message = 'The service call is not assigned to this field technician.';
+  end if;
+  if v_visit.status not in ('arrived','working','paused') then
+    raise exception using errcode = '55000', message = 'Arrive at the service call before using truck inventory.';
+  end if;
+  if v_visit.work_order_id is null then
+    raise exception using errcode = '55000', message = 'Create or link the repair before using a part.';
+  end if;
+  if v_visit.service_vehicle_id is null then
+    raise exception using errcode = '55000', message = 'Assign a service truck before using truck inventory.';
+  end if;
+
+  select * into v_truck
+  from public.service_vehicles vehicle
+  where vehicle.id = v_visit.service_vehicle_id
+    and vehicle.shop_id = p_shop_id
+    and vehicle.active
+  for update;
+  if not found or v_truck.stock_location_id is null then
+    raise exception using errcode = '55000', message = 'The assigned service truck has no inventory location.';
+  end if;
+
+  if not exists (
+    select 1
+    from public.work_order_lines line
+    where line.id = p_work_order_line_id
+      and line.shop_id = p_shop_id
+      and line.work_order_id = v_visit.work_order_id
+      and line.voided_at is null
+      and lower(coalesce(line.approval_state::text, '')) = 'approved'
+      and lower(coalesce(line.status::text, line.line_status::text, '')) in (
+        'awaiting',
+        'assigned',
+        'queued',
+        'approved',
+        'in_progress',
+        'on_hold',
+        'paused',
+        'waiting_parts'
+      )
+  ) then
+    raise exception using errcode = '55000', message = 'The repair line is not approved and actionable for part use.';
+  end if;
+
+  v_result := public.parts_issue_by_line_part_atomic(
+    p_shop_id,
+    p_work_order_line_id,
+    p_part_id,
+    v_truck.stock_location_id,
+    p_quantity,
+    p_shop_id::text || ':field-use:' || trim(p_operation_key),
+    p_actor_user_id
+  );
+
+  v_stock_move_id := nullif(v_result ->> 'stock_move_id', '')::uuid;
+  if v_stock_move_id is not null then
+    update public.stock_moves
+    set metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+      'field_service', true,
+      'service_visit_id', p_service_visit_id,
+      'service_vehicle_id', v_truck.id,
+      'truck_stock_location_id', v_truck.stock_location_id,
+      'work_order_id', v_visit.work_order_id,
+      'work_order_line_id', p_work_order_line_id,
+      'canonical_part_id', p_part_id
+    )
+    where id = v_stock_move_id
+      and shop_id = p_shop_id;
+  end if;
+
+  return v_result || jsonb_build_object(
+    'serviceVisitId', p_service_visit_id,
+    'serviceVehicleId', v_truck.id,
+    'truckStockLocationId', v_truck.stock_location_id,
+    'workOrderId', v_visit.work_order_id,
+    'workOrderLineId', p_work_order_line_id,
+    'partId', p_part_id
+  );
+end;
+$$;
+
+create or replace function public.field_return_truck_part_atomic(
+  p_shop_id uuid,
+  p_service_visit_id uuid,
+  p_work_order_part_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_visit public.service_visits%rowtype;
+  v_truck public.service_vehicles%rowtype;
+  v_work_part public.work_order_parts%rowtype;
+  v_result jsonb;
+  v_stock_move_id uuid;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.has_field_access then
+    raise exception using errcode = '42501', message = 'Field Service access is required.';
+  end if;
+
+  if p_quantity is null or p_quantity <= 0 or p_quantity <> round(p_quantity, 4) then
+    raise exception using errcode = '22023', message = 'Return quantity must be positive with at most four decimal places.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = '22023', message = 'A stable operation key is required.';
+  end if;
+
+  select * into v_visit
+  from public.service_visits visit
+  where visit.id = p_service_visit_id
+    and visit.shop_id = p_shop_id
+  for update;
+  if not found
+     or v_visit.mode <> 'mobile'
+     or v_visit.assigned_user_id is distinct from v_actor.profile_id
+     or v_visit.work_order_id is null
+     or v_visit.service_vehicle_id is null then
+    raise exception using errcode = '42501', message = 'The service call is not assigned to this field technician.';
+  end if;
+
+  select * into v_truck
+  from public.service_vehicles vehicle
+  where vehicle.id = v_visit.service_vehicle_id
+    and vehicle.shop_id = p_shop_id
+    and vehicle.active
+  for update;
+  if not found or v_truck.stock_location_id is null then
+    raise exception using errcode = '55000', message = 'The assigned service truck has no inventory location.';
+  end if;
+
+  select * into v_work_part
+  from public.work_order_parts work_part
+  where work_part.id = p_work_order_part_id
+    and work_part.shop_id = p_shop_id
+    and work_part.work_order_id = v_visit.work_order_id
+    and work_part.is_active
+  for update;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Work-order part not found for this service call.';
+  end if;
+
+  v_result := public.parts_return_to_stock(
+    p_work_order_part_id,
+    v_truck.stock_location_id,
+    p_quantity,
+    p_shop_id::text || ':field-return:' || trim(p_operation_key)
+  );
+
+  v_stock_move_id := nullif(v_result ->> 'stock_move_id', '')::uuid;
+  if v_stock_move_id is not null then
+    update public.stock_moves
+    set metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+      'field_service', true,
+      'service_visit_id', p_service_visit_id,
+      'service_vehicle_id', v_truck.id,
+      'truck_stock_location_id', v_truck.stock_location_id,
+      'work_order_id', v_visit.work_order_id,
+      'work_order_part_id', p_work_order_part_id,
+      'canonical_part_id', v_work_part.part_id
+    )
+    where id = v_stock_move_id
+      and shop_id = p_shop_id;
+  end if;
+
+  return v_result || jsonb_build_object(
+    'serviceVisitId', p_service_visit_id,
+    'serviceVehicleId', v_truck.id,
+    'truckStockLocationId', v_truck.stock_location_id,
+    'workOrderId', v_visit.work_order_id,
+    'workOrderPartId', p_work_order_part_id,
+    'partId', v_work_part.part_id
+  );
+end;
+$$;
+
+revoke all on function private.profixiq_field_inventory_actor_context(uuid,uuid)
+  from public, anon, authenticated, service_role;
+revoke all on function private.profixiq_field_inventory_actor_can_use_truck(uuid,uuid,uuid)
+  from public, anon, authenticated, service_role;
+revoke all on function private.profixiq_validate_part_external_identity()
+  from public, anon, authenticated, service_role;
+revoke all on function private.profixiq_validate_integration_scope()
+  from public, anon, authenticated, service_role;
+
+revoke all on function public.field_resolve_or_create_part_identity_atomic(
+  uuid,uuid,text,text,text,uuid,uuid,text,text,text,text,text,numeric,boolean,numeric,numeric,jsonb,text
+) from public, anon;
+grant execute on function public.field_resolve_or_create_part_identity_atomic(
+  uuid,uuid,text,text,text,uuid,uuid,text,text,text,text,text,numeric,boolean,numeric,numeric,jsonb,text
+) to authenticated, service_role;
+
+revoke all on function public.field_truck_inventory_snapshot(uuid,uuid,uuid,uuid,text)
+  from public, anon;
+grant execute on function public.field_truck_inventory_snapshot(uuid,uuid,uuid,uuid,text)
+  to authenticated, service_role;
+
+revoke all on function public.field_transfer_stock_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) from public, anon;
+grant execute on function public.field_transfer_stock_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) to authenticated, service_role;
+
+revoke all on function public.field_receive_po_part_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) from public, anon;
+grant execute on function public.field_receive_po_part_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) to authenticated, service_role;
+
+revoke all on function public.field_use_truck_part_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) from public, anon;
+grant execute on function public.field_use_truck_part_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) to authenticated, service_role;
+
+revoke all on function public.field_return_truck_part_atomic(
+  uuid,uuid,uuid,numeric,uuid,text
+) from public, anon;
+grant execute on function public.field_return_truck_part_atomic(
+  uuid,uuid,uuid,numeric,uuid,text
+) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260815050200_field_truck_receipt_review_hardening.sql
+++ b/supabase/migrations/20260815050200_field_truck_receipt_review_hardening.sql
@@ -1,0 +1,699 @@
+begin;
+
+-- The preview branch already applied the initial Field truck movement migration.
+-- Reinstall both commands so request hashing remains safe with the hardened
+-- search path and an exact receipt replay reaches the canonical idempotency
+-- check before the selected PO line's remaining-quantity guard.
+create or replace function public.field_transfer_stock_to_truck_atomic(
+  p_shop_id uuid,
+  p_service_vehicle_id uuid,
+  p_source_location_id uuid,
+  p_part_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_truck public.service_vehicles%rowtype;
+  v_operation public.parts_operation_keys%rowtype;
+  v_request jsonb;
+  v_request_hash text;
+  v_scoped_key text;
+  v_out_move_id uuid;
+  v_in_move_id uuid;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found then
+    raise exception using errcode = '42501', message = 'Shop membership is required.';
+  end if;
+  if not private.profixiq_field_inventory_actor_can_use_truck(
+    p_shop_id,
+    p_actor_user_id,
+    p_service_vehicle_id
+  ) then
+    raise exception using errcode = '42501', message = 'This truck is not available to the authenticated actor.';
+  end if;
+
+  if p_quantity is null or p_quantity <= 0 or p_quantity <> round(p_quantity, 4) then
+    raise exception using errcode = '22023', message = 'Transfer quantity must be positive with at most four decimal places.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = '22023', message = 'A stable operation key is required.';
+  end if;
+
+  select * into v_truck
+  from public.service_vehicles vehicle
+  where vehicle.id = p_service_vehicle_id
+    and vehicle.shop_id = p_shop_id
+    and vehicle.active
+  for update;
+  if not found or v_truck.stock_location_id is null then
+    raise exception using errcode = '55000', message = 'The service truck does not have an inventory location.';
+  end if;
+  if v_truck.stock_location_id = p_source_location_id then
+    raise exception using errcode = '22023', message = 'Source and truck inventory locations must be different.';
+  end if;
+
+  perform 1
+  from public.parts part
+  where part.id = p_part_id
+    and part.shop_id = p_shop_id
+  for share;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Part not found for this shop.';
+  end if;
+
+  perform 1
+  from public.stock_locations location
+  where location.shop_id = p_shop_id
+    and location.id in (p_source_location_id, v_truck.stock_location_id)
+  order by location.id
+  for update;
+  if (select count(*)
+      from public.stock_locations location
+      where location.shop_id = p_shop_id
+        and location.id in (p_source_location_id, v_truck.stock_location_id)) <> 2 then
+    raise exception using errcode = '42501', message = 'A transfer location is outside this shop.';
+  end if;
+
+  v_scoped_key := p_shop_id::text || ':field-transfer:' || trim(p_operation_key);
+  if length(v_scoped_key) > 260 then
+    raise exception using errcode = '22023', message = 'Transfer operation key is too long.';
+  end if;
+  v_request := jsonb_build_object(
+    'service_vehicle_id', p_service_vehicle_id,
+    'source_location_id', p_source_location_id,
+    'destination_location_id', v_truck.stock_location_id,
+    'part_id', p_part_id,
+    'quantity', p_quantity
+  );
+  v_request_hash := encode(
+    extensions.digest(convert_to(v_request::text, 'UTF8'), 'sha256'),
+    'hex'
+  );
+
+  perform pg_advisory_xact_lock(hashtextextended(v_scoped_key, 0));
+  select * into v_operation
+  from public.parts_operation_keys operation
+  where operation.shop_id = p_shop_id
+    and operation.operation_key = v_scoped_key
+  for update;
+  if found then
+    if v_operation.operation_type <> 'field_transfer_to_truck'
+       or v_operation.aggregate_type <> 'service_vehicle'
+       or v_operation.aggregate_id <> p_service_vehicle_id
+       or coalesce(v_operation.result ->> '_request_hash', '') <> v_request_hash then
+      raise exception using errcode = '22023', message = 'FIELD_TRUCK_TRANSFER_KEY_CONFLICT';
+    end if;
+    if v_operation.result is null or v_operation.completed_at is null then
+      raise exception using errcode = '55000', message = 'FIELD_TRUCK_TRANSFER_IN_PROGRESS';
+    end if;
+    return v_operation.result || jsonb_build_object('idempotent', true);
+  end if;
+
+  if public.parts_available(
+    p_shop_id,
+    p_part_id,
+    p_source_location_id
+  ) < p_quantity then
+    raise exception using errcode = '23514', message = 'Insufficient available stock at the source location.';
+  end if;
+
+  insert into public.parts_operation_keys (
+    shop_id,
+    operation_key,
+    operation_type,
+    aggregate_type,
+    aggregate_id,
+    created_by
+  ) values (
+    p_shop_id,
+    v_scoped_key,
+    'field_transfer_to_truck',
+    'service_vehicle',
+    p_service_vehicle_id,
+    v_actor.profile_id
+  ) returning * into v_operation;
+
+  insert into public.stock_moves (
+    shop_id,
+    part_id,
+    location_id,
+    qty_change,
+    reason,
+    reference_kind,
+    reference_id,
+    created_by,
+    idempotency_key,
+    metadata,
+    lifecycle_quantity
+  ) values (
+    p_shop_id,
+    p_part_id,
+    p_source_location_id,
+    -p_quantity,
+    'transfer_out',
+    'field_truck_transfer',
+    v_operation.id,
+    v_actor.profile_id,
+    v_scoped_key || ':out',
+    jsonb_build_object(
+      'operation', 'field_transfer_to_truck',
+      'service_vehicle_id', p_service_vehicle_id,
+      'source_location_id', p_source_location_id,
+      'destination_location_id', v_truck.stock_location_id,
+      'quantity', p_quantity
+    ),
+    p_quantity
+  ) returning id into v_out_move_id;
+
+  insert into public.stock_moves (
+    shop_id,
+    part_id,
+    location_id,
+    qty_change,
+    reason,
+    reference_kind,
+    reference_id,
+    created_by,
+    idempotency_key,
+    metadata,
+    lifecycle_quantity
+  ) values (
+    p_shop_id,
+    p_part_id,
+    v_truck.stock_location_id,
+    p_quantity,
+    'transfer_in',
+    'field_truck_transfer',
+    v_operation.id,
+    v_actor.profile_id,
+    v_scoped_key || ':in',
+    jsonb_build_object(
+      'operation', 'field_transfer_to_truck',
+      'service_vehicle_id', p_service_vehicle_id,
+      'source_location_id', p_source_location_id,
+      'destination_location_id', v_truck.stock_location_id,
+      'quantity', p_quantity,
+      'paired_stock_move_id', v_out_move_id
+    ),
+    p_quantity
+  ) returning id into v_in_move_id;
+
+  update public.stock_moves
+  set metadata = metadata || jsonb_build_object('paired_stock_move_id', v_in_move_id)
+  where id = v_out_move_id;
+
+  update public.parts_operation_keys
+  set result = jsonb_build_object(
+        'ok', true,
+        'idempotent', false,
+        'serviceVehicleId', p_service_vehicle_id,
+        'partId', p_part_id,
+        'sourceLocationId', p_source_location_id,
+        'destinationLocationId', v_truck.stock_location_id,
+        'quantity', p_quantity,
+        'transferOutMoveId', v_out_move_id,
+        'transferInMoveId', v_in_move_id,
+        'sourceAvailableAfter', public.parts_available(
+          p_shop_id,
+          p_part_id,
+          p_source_location_id
+        ),
+        'truckOnHandAfter', public.parts_on_hand(
+          p_shop_id,
+          p_part_id,
+          v_truck.stock_location_id
+        ),
+        'truckAvailableAfter', public.parts_available(
+          p_shop_id,
+          p_part_id,
+          v_truck.stock_location_id
+        ),
+        '_request_hash', v_request_hash
+      ),
+      completed_at = now()
+  where id = v_operation.id
+  returning * into v_operation;
+
+  return v_operation.result;
+end;
+$$;
+
+create or replace function private.profixiq_receive_po_line_to_location_atomic(
+  p_shop_id uuid,
+  p_purchase_order_id uuid,
+  p_purchase_order_line_id uuid,
+  p_part_id uuid,
+  p_location_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_id uuid
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_po public.purchase_orders%rowtype;
+  v_line public.purchase_order_lines%rowtype;
+  v_item public.part_request_items%rowtype;
+  v_move public.stock_moves%rowtype;
+  v_operation_key text;
+  v_line_received numeric;
+  v_target numeric;
+  v_item_received numeric;
+  v_allocated numeric := 0;
+  v_po_closed boolean := false;
+  v_result jsonb;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(p_shop_id, p_actor_user_id);
+  if not found or not v_actor.can_manage_parts then
+    raise exception using errcode = '42501', message = 'Parts receiving permission is required.';
+  end if;
+  if p_quantity is null or p_quantity <= 0 or p_quantity <> round(p_quantity, 2) then
+    raise exception using errcode = '22023', message = 'Receipt quantity must be positive with at most two decimal places.';
+  end if;
+
+  select * into v_po
+  from public.purchase_orders purchase_order
+  where purchase_order.id = p_purchase_order_id
+    and purchase_order.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Purchase order not found for this shop.';
+  end if;
+  select * into v_line
+  from public.purchase_order_lines line
+  where line.id = p_purchase_order_line_id
+    and line.po_id = p_purchase_order_id
+    and line.part_id = p_part_id
+  for update;
+  if not found then
+    raise exception using errcode = '22023', message = 'PARTS_PO_LINE_RECEIPT_TARGET_MISMATCH';
+  end if;
+
+  if not exists (
+    select 1 from public.stock_locations location
+    where location.id = p_location_id
+      and location.shop_id = p_shop_id
+  ) then
+    raise exception using errcode = '42501', message = 'Receipt location is outside this shop.';
+  end if;
+
+  v_operation_key := p_shop_id::text || ':po-receive:' || p_operation_id::text;
+  select * into v_move
+  from public.stock_moves move
+  where move.shop_id = p_shop_id
+    and move.idempotency_key = v_operation_key
+  for update;
+  if found then
+    if v_move.part_id is distinct from p_part_id
+       or v_move.location_id is distinct from p_location_id
+       or v_move.qty_change is distinct from p_quantity
+       or v_move.reference_kind is distinct from 'purchase_order'
+       or v_move.reference_id is distinct from p_purchase_order_id
+       or (
+         v_move.metadata ? 'purchase_order_line_id'
+         and nullif(v_move.metadata ->> 'purchase_order_line_id', '')::uuid
+           is distinct from p_purchase_order_line_id
+       ) then
+      raise exception using errcode = '22023', message = 'PO_RECEIVE_IDEMPOTENCY_CONFLICT';
+    end if;
+    return coalesce(v_move.metadata -> 'receipt_result', '{}'::jsonb)
+      || jsonb_build_object('ok', true, 'replayed', true, 'move_id', v_move.id);
+  end if;
+
+  if lower(coalesce(v_po.status::text, '')) in (
+    'received', 'closed', 'cancelled', 'canceled', 'void'
+  ) then
+    raise exception using errcode = '55000', message = 'PARTS_PO_NOT_RECEIVABLE';
+  end if;
+
+  v_line_received := coalesce(v_line.received_qty, 0) + p_quantity;
+  if v_line_received > greatest(
+    coalesce(v_line.qty, 0) - coalesce(v_line.cancelled_qty, 0),
+    0
+  ) then
+    raise exception using errcode = '23514', message = 'Receipt quantity exceeds the selected purchase-order line.';
+  end if;
+
+  if v_line.part_request_item_id is not null then
+    select * into v_item
+    from public.part_request_items item
+    where item.id = v_line.part_request_item_id
+      and item.shop_id = p_shop_id
+      and item.part_id = p_part_id
+    for update;
+    if not found then
+      raise exception using errcode = '22023', message = 'PARTS_PO_LINE_REQUEST_TARGET_MISMATCH';
+    end if;
+  end if;
+
+  insert into public.stock_moves (
+    shop_id, part_id, location_id, qty_change, reason, reference_kind,
+    reference_id, created_by, idempotency_key, metadata, lifecycle_quantity,
+    work_order_part_id
+  ) values (
+    p_shop_id, p_part_id, p_location_id, p_quantity, 'receive',
+    'purchase_order', p_purchase_order_id, v_actor.profile_id, v_operation_key,
+    jsonb_build_object(
+      'operation', 'purchase_order_line_receipt',
+      'operation_id', p_operation_id,
+      'po_id', p_purchase_order_id,
+      'purchase_order_line_id', p_purchase_order_line_id,
+      'part_request_item_id', v_line.part_request_item_id
+    ),
+    p_quantity,
+    v_line.work_order_part_id
+  ) returning * into v_move;
+
+  update public.purchase_order_lines
+  set received_qty = v_line_received
+  where id = p_purchase_order_line_id;
+
+  if v_line.part_request_item_id is not null then
+    v_target := greatest(
+      coalesce(v_item.qty_approved, 0),
+      coalesce(v_item.qty_requested, 0),
+      coalesce(v_item.qty, 0),
+      0
+    );
+    v_allocated := least(
+      p_quantity,
+      greatest(v_target - coalesce(v_item.qty_received, 0), 0)
+    );
+    v_item_received := coalesce(v_item.qty_received, 0) + v_allocated;
+    if v_allocated > 0 then
+      update public.part_request_items
+      set qty_received = v_item_received,
+          status = case
+            when v_item_received >= v_target
+              then 'received'::public.part_request_item_status
+            else 'partially_received'::public.part_request_item_status
+          end,
+          updated_at = now()
+      where id = v_item.id;
+    end if;
+  end if;
+
+  perform 1
+  from public.purchase_order_lines line
+  where line.po_id = p_purchase_order_id
+  order by line.created_at, line.id
+  for update;
+  if not exists (
+    select 1
+    from public.purchase_order_lines line
+    where line.po_id = p_purchase_order_id
+      and coalesce(line.received_qty, 0) < greatest(
+        coalesce(line.qty, 0) - coalesce(line.cancelled_qty, 0),
+        0
+      )
+  ) then
+    update public.purchase_orders
+    set status = 'received'
+    where id = p_purchase_order_id;
+    v_po_closed := true;
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'replayed', false,
+    'move_id', v_move.id,
+    'po_id', p_purchase_order_id,
+    'purchase_order_line_id', p_purchase_order_line_id,
+    'po_closed', v_po_closed,
+    'po_status', (
+      select purchase_order.status::text
+      from public.purchase_orders purchase_order
+      where purchase_order.id = p_purchase_order_id
+    ),
+    'part_id', p_part_id,
+    'qty_received_total', p_quantity,
+    'allocations', case
+      when v_line.part_request_item_id is not null and v_allocated > 0
+        then jsonb_build_array(jsonb_build_object(
+          'request_item_id', v_line.part_request_item_id,
+          'qty_allocated', v_allocated
+        ))
+      else '[]'::jsonb
+    end,
+    'unallocated_qty', greatest(p_quantity - v_allocated, 0)
+  );
+  update public.stock_moves
+  set metadata = coalesce(metadata, '{}'::jsonb)
+    || jsonb_build_object('receipt_result', v_result)
+  where id = v_move.id;
+  return v_result;
+end;
+$$;
+
+revoke all on function private.profixiq_receive_po_line_to_location_atomic(
+  uuid, uuid, uuid, uuid, uuid, numeric, uuid, uuid
+) from public, anon, authenticated;
+
+create or replace function public.field_receive_po_part_to_truck_atomic(
+  p_shop_id uuid,
+  p_service_vehicle_id uuid,
+  p_purchase_order_id uuid,
+  p_purchase_order_line_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_truck public.service_vehicles%rowtype;
+  v_po public.purchase_orders%rowtype;
+  v_line public.purchase_order_lines%rowtype;
+  v_item public.part_request_items%rowtype;
+  v_part_id uuid;
+  v_work_order_part_id uuid;
+  v_supplier_name text;
+  v_identity_result jsonb;
+  v_result jsonb;
+  v_move_id uuid;
+  v_operation_id uuid;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.can_manage_parts then
+    raise exception using errcode = '42501', message = 'Parts receiving permission is required.';
+  end if;
+
+  if p_quantity is null or p_quantity <= 0 or p_quantity <> round(p_quantity, 2) then
+    raise exception using errcode = '22023', message = 'Receipt quantity must be positive with at most two decimal places.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = '22023', message = 'A stable operation key is required.';
+  end if;
+
+  select * into v_truck
+  from public.service_vehicles vehicle
+  where vehicle.id = p_service_vehicle_id
+    and vehicle.shop_id = p_shop_id
+    and vehicle.active
+  for update;
+  if not found or v_truck.stock_location_id is null then
+    raise exception using errcode = '55000', message = 'The service truck does not have an inventory location.';
+  end if;
+
+  select * into v_po
+  from public.purchase_orders purchase_order
+  where purchase_order.id = p_purchase_order_id
+    and purchase_order.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Purchase order not found for this shop.';
+  end if;
+  select * into v_line
+  from public.purchase_order_lines line
+  where line.id = p_purchase_order_line_id
+    and line.po_id = p_purchase_order_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Purchase-order line not found.';
+  end if;
+
+  v_operation_id := md5(
+    p_shop_id::text || ':field-po-receive:' || trim(p_operation_key)
+  )::uuid;
+  if v_line.part_id is not null and exists (
+    select 1
+    from public.stock_moves move
+    where move.shop_id = p_shop_id
+      and move.idempotency_key =
+        p_shop_id::text || ':po-receive:' || v_operation_id::text
+  ) then
+    v_part_id := v_line.part_id;
+    v_work_order_part_id := v_line.work_order_part_id;
+    v_result := private.profixiq_receive_po_line_to_location_atomic(
+      p_shop_id,
+      p_purchase_order_id,
+      p_purchase_order_line_id,
+      v_part_id,
+      v_truck.stock_location_id,
+      p_quantity,
+      p_actor_user_id,
+      v_operation_id
+    );
+    return v_result || jsonb_build_object(
+      'serviceVehicleId', p_service_vehicle_id,
+      'truckStockLocationId', v_truck.stock_location_id,
+      'purchaseOrderLineId', p_purchase_order_line_id,
+      'partId', v_part_id,
+      'workOrderPartId', v_work_order_part_id,
+      'directToTruck', true
+    );
+  end if;
+
+  if greatest(
+    coalesce(v_line.qty, 0)
+      - coalesce(v_line.cancelled_qty, 0)
+      - coalesce(v_line.received_qty, 0),
+    0
+  ) < p_quantity then
+    raise exception using errcode = '23514', message = 'Receipt quantity exceeds the selected purchase-order line.';
+  end if;
+
+  v_part_id := v_line.part_id;
+  if v_part_id is null then
+    select supplier.name into v_supplier_name
+    from public.suppliers supplier
+    where supplier.id = v_po.supplier_id
+      and supplier.shop_id = p_shop_id;
+
+    v_identity_result := public.field_resolve_or_create_part_identity_atomic(
+      p_shop_id,
+      p_actor_user_id,
+      coalesce(nullif(trim(v_line.sku), ''), 'po-line-' || v_line.id::text),
+      'purchase_order',
+      v_line.id::text,
+      null,
+      v_po.supplier_id,
+      coalesce(nullif(trim(v_line.description), ''), nullif(trim(v_line.sku), ''), 'Purchased part'),
+      null,
+      nullif(trim(v_line.sku), ''),
+      nullif(trim(v_line.sku), ''),
+      null,
+      1,
+      true,
+      v_line.unit_cost,
+      null,
+      jsonb_build_object(
+        'source', 'field_direct_po_receipt',
+        'purchase_order_id', v_po.id,
+        'purchase_order_line_id', v_line.id,
+        'supplier_name', v_supplier_name
+      ),
+      trim(p_operation_key) || ':identity'
+    );
+    v_part_id := nullif(v_identity_result ->> 'partId', '')::uuid;
+    if v_part_id is null then
+      raise exception using errcode = 'P0001', message = 'Unable to create the canonical part for this purchase-order line.';
+    end if;
+  end if;
+
+  if v_line.part_request_item_id is not null then
+    select * into v_item
+    from public.part_request_items item
+    where item.id = v_line.part_request_item_id
+      and item.shop_id = p_shop_id
+    for update;
+    if not found then
+      raise exception using errcode = 'P0002', message = 'Linked request item not found.';
+    end if;
+    if v_item.part_id is not null and v_item.part_id <> v_part_id then
+      raise exception using errcode = '23505', message = 'PURCHASE_ORDER_LINE_PART_IDENTITY_CONFLICT';
+    end if;
+    if v_item.part_id is null then
+      update public.part_request_items
+      set part_id = v_part_id,
+          description = coalesce(nullif(trim(description), ''), nullif(trim(v_line.description), ''), 'Part'),
+          updated_at = now()
+      where id = v_item.id;
+    end if;
+    v_work_order_part_id := public.parts_ensure_work_order_part(v_item.id);
+  else
+    v_work_order_part_id := v_line.work_order_part_id;
+  end if;
+
+  update public.purchase_order_lines
+  set part_id = v_part_id,
+      work_order_part_id = coalesce(work_order_part_id, v_work_order_part_id),
+      location_id = v_truck.stock_location_id
+  where id = v_line.id;
+
+  v_operation_id := md5(
+    p_shop_id::text || ':field-po-receive:' || trim(p_operation_key)
+  )::uuid;
+
+  v_result := private.profixiq_receive_po_line_to_location_atomic(
+    p_shop_id,
+    p_purchase_order_id,
+    p_purchase_order_line_id,
+    v_part_id,
+    v_truck.stock_location_id,
+    p_quantity,
+    p_actor_user_id,
+    v_operation_id
+  );
+
+  v_move_id := nullif(
+    coalesce(v_result ->> 'move_id', v_result ->> 'stock_move_id'),
+    ''
+  )::uuid;
+  if v_move_id is not null then
+    update public.stock_moves
+    set metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+      'field_service', true,
+      'service_vehicle_id', p_service_vehicle_id,
+      'truck_stock_location_id', v_truck.stock_location_id,
+      'direct_to_truck', true
+    )
+    where id = v_move_id
+      and shop_id = p_shop_id;
+  end if;
+
+  return v_result || jsonb_build_object(
+    'serviceVehicleId', p_service_vehicle_id,
+    'truckStockLocationId', v_truck.stock_location_id,
+    'purchaseOrderLineId', p_purchase_order_line_id,
+    'partId', v_part_id,
+    'workOrderPartId', v_work_order_part_id,
+    'directToTruck', true
+  );
+end;
+$$;
+
+commit;

--- a/tests/field-truck-inventory-contract.test.ts
+++ b/tests/field-truck-inventory-contract.test.ts
@@ -1,0 +1,199 @@
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const migration = [
+  "supabase/migrations/20260812230000_field_integration_identity_core.sql",
+  "supabase/migrations/20260812230100_field_part_identity_commands.sql",
+  "supabase/migrations/20260812230200_field_truck_inventory_snapshot.sql",
+  "supabase/migrations/20260812230300_field_truck_inventory_movement_commands.sql",
+  "supabase/migrations/20260812230400_field_truck_inventory_work_order_commands.sql",
+]
+  .map(read)
+  .join("\n");
+const inventoryUi = [
+  "features/mobile/service/MobileTruckInventory.tsx",
+  "features/mobile/service/MobileTruckInventoryScreen.tsx",
+  "features/mobile/service/TruckStockPanel.tsx",
+  "features/mobile/service/TruckLoadPanel.tsx",
+  "features/mobile/service/TruckReceivePanel.tsx",
+  "features/mobile/service/TruckHistoryPanel.tsx",
+  "features/mobile/service/truckInventoryClient.ts",
+  "features/mobile/service/useTruckInventorySnapshot.ts",
+  "features/mobile/service/useTruckInventoryUsage.ts",
+  "features/mobile/service/useTruckInventoryStocking.ts",
+]
+  .map(read)
+  .join("\n");
+const scanner = read("features/mobile/service/FieldBarcodeScanner.tsx");
+const offline = read(
+  "features/mobile/service/truckInventoryOffline.ts",
+);
+const replay = read("features/shared/lib/offline/replay.ts");
+const integrationCore = read(
+  "features/integrations/core/contracts.ts",
+);
+const partsIntegration = read("features/integrations/parts/index.ts");
+const snapshotApi = read(
+  "app/api/mobile/service/truck-inventory/route.ts",
+);
+const useApi = read(
+  "app/api/mobile/service/truck-inventory/use/route.ts",
+);
+const transferApi = read(
+  "app/api/mobile/service/truck-inventory/transfer/route.ts",
+);
+const receiveApi = read(
+  "app/api/mobile/service/truck-inventory/receive/route.ts",
+);
+const runtime = read("tests/mobile/field-truck-inventory.runtime.sql");
+const workflow = read(".github/workflows/mobile-v1-validation.yml");
+const contracts = read(
+  "features/mobile/service/truckInventoryContracts.ts",
+);
+
+describe("Field Service truck inventory", () => {
+  it("uses one canonical part identity across providers, barcodes, PO, stock, work order, and invoice truth", () => {
+    expect(migration).toContain(
+      "create table if not exists public.part_external_identities",
+    );
+    expect(migration).toContain("part_id uuid not null references public.parts(id)");
+    expect(migration).toContain(
+      "field_resolve_or_create_part_identity_atomic",
+    );
+    expect(migration).toContain("insert into public.parts_barcodes");
+    expect(migration).toContain("'canonical_part_id', p_part_id");
+    expect(partsIntegration).toContain(
+      "Every selected result must resolve to one canonical ProFixIQ parts.id",
+    );
+    expect(partsIntegration).not.toContain("MockPartsProvider");
+    expect(partsIntegration).not.toContain("demo-123");
+  });
+
+  it("transfers physical stock onto the truck as one paired and idempotent ledger operation", () => {
+    expect(migration).toContain("field_transfer_stock_to_truck_atomic");
+    expect(migration).toContain("'transfer_out'");
+    expect(migration).toContain("'transfer_in'");
+    expect(migration).toContain("'paired_stock_move_id'");
+    expect(migration).toContain("FIELD_TRUCK_TRANSFER_KEY_CONFLICT");
+    expect(migration).toContain("public.parts_available(");
+    expect(transferApi).toContain('requiredCapability: "canManageParts"');
+    expect(transferApi).toContain("field_transfer_stock_to_truck_atomic");
+    expect(snapshotApi).toContain("p_service_vehicle_id");
+    expect(contracts).toContain("trucks: FieldTruck[]");
+    expect(inventoryUi).toContain("Select service truck");
+  });
+
+  it("receives canonical or free-text PO lines directly to the truck without a setup detour", () => {
+    expect(migration).toContain("field_receive_po_part_to_truck_atomic");
+    expect(migration).toContain("p_purchase_order_line_id uuid");
+    expect(migration).toContain("public.receive_po_part_and_allocate(");
+    expect(migration).toContain("'purchase_order'");
+    expect(migration).toContain("public.parts_ensure_work_order_part(");
+    expect(migration).toContain("'direct_to_truck', true");
+    expect(receiveApi).toContain("p_purchase_order_line_id");
+    expect(receiveApi).toContain("field_receive_po_part_to_truck_atomic");
+    expect(contracts).toContain("requiresCanonicalIdentity: boolean");
+    expect(inventoryUi).toContain("Receive PO directly to truck");
+    expect(inventoryUi).toContain(
+      "Free-text PO lines are canonicalized here automatically.",
+    );
+    expect(inventoryUi).toContain(
+      "Receipt, request, work-order part, and inventory ledger retain the same part ID.",
+    );
+  });
+
+  it("issues and returns parts through the existing exactly-once work-order lifecycle", () => {
+    expect(migration).toContain("field_use_truck_part_atomic");
+    expect(migration).toContain("public.parts_issue_by_line_part_atomic(");
+    expect(migration).toContain("field_return_truck_part_atomic");
+    expect(migration).toContain("public.parts_return_to_stock(");
+    expect(useApi).toContain("requireMobileServiceOperatorApiAccess");
+    expect(useApi).toContain("field_use_truck_part_atomic");
+    expect(inventoryUi).toContain("Use {quantityLabel(quantity)} on call");
+    expect(inventoryUi).toContain("Return {quantityLabel(returnable)} to truck");
+    expect(inventoryUi).not.toContain("Create stock item");
+    expect(inventoryUi).not.toContain("Map it in Parts");
+  });
+
+  it("makes barcode resolution inline instead of redirecting to inventory setup", () => {
+    expect(scanner).toContain('@ericblade/quagga2');
+    expect(scanner).toContain("Barcode scanner could not be loaded.");
+    expect(inventoryUi).toContain("Confirm new canonical part");
+    expect(inventoryUi).toContain("There is no separate stock-item setup step.");
+    expect(inventoryUi).toContain("createIfMissing: true");
+    expect(migration).toContain("'requiresDetails', true");
+  });
+
+  it("caches the assigned truck and replays use/return once in the visit dependency chain", () => {
+    expect(offline).toContain('const SNAPSHOT_KIND = "field-truck-inventory"');
+    expect(offline).toContain('actionType: "field-inventory:use-part"');
+    expect(offline).toContain('actionType: "field-inventory:return-part"');
+    expect(offline).toContain('orderKey: `service-visit:${args.payload.visitId}`');
+    expect(offline).toContain("lastVisitMutationDependency");
+    expect(replay).toContain('"field-inventory:use-part"');
+    expect(replay).toContain('"field-inventory:return-part"');
+    expect(replay).toContain("mutation.clientMutationId");
+    expect(inventoryUi).toContain("Offline — showing the last cached truck snapshot.");
+  });
+
+  it("adds a reusable integration core without storing provider secrets in the client contract", () => {
+    expect(migration).toContain(
+      "create table if not exists public.integration_connections",
+    );
+    expect(migration).toContain("secret_reference text");
+    expect(migration).toContain(
+      "create table if not exists public.integration_external_objects",
+    );
+    expect(migration).toContain(
+      "create table if not exists public.integration_sync_events",
+    );
+    expect(integrationCore).toContain("export class IntegrationRegistry");
+    expect(partsIntegration).toContain("PartsProviderRegistry");
+    expect(partsIntegration).toContain("Nexpart, PartsTech");
+  });
+
+  it("keeps physical inventory writes out of client and route code", () => {
+    for (const source of [inventoryUi, snapshotApi, useApi, transferApi, receiveApi]) {
+      expect(source).not.toContain('.from("stock_moves")');
+      expect(source).not.toContain('.insert({');
+    }
+  });
+
+  it("proves canonicalization, paired transfer, use, return, and exact replay on a clean database", () => {
+    expect(runtime).toContain("field_receive_po_part_to_truck_atomic");
+    expect(runtime).toContain("free-text PO line becomes a canonical part");
+    expect(runtime).toContain("field_transfer_stock_to_truck_atomic");
+    expect(runtime).toContain("field_use_truck_part_atomic");
+    expect(runtime).toContain("repeated use decremented inventory twice");
+    expect(runtime).toContain("field_return_truck_part_atomic");
+    expect(runtime).toContain("return replay changed inventory twice");
+    expect(runtime).toContain("field_truck_inventory_snapshot");
+    expect(workflow).toContain("tests/field-truck-inventory-contract.test.ts");
+    expect(workflow).toContain("tests/mobile/field-truck-inventory.runtime.sql");
+    expect(workflow).toContain("Field truck inventory runtime");
+  });
+
+  it("ships every route used by the field truck workflow", () => {
+    for (const path of [
+      "app/mobile/service/truck-inventory/page.tsx",
+      "app/api/mobile/service/truck-inventory/route.ts",
+      "app/api/mobile/service/truck-inventory/resolve/route.ts",
+      "app/api/mobile/service/truck-inventory/use/route.ts",
+      "app/api/mobile/service/truck-inventory/return/route.ts",
+      "app/api/mobile/service/truck-inventory/transfer/route.ts",
+      "app/api/mobile/service/truck-inventory/receive/route.ts",
+      "features/mobile/service/MobileTruckInventoryScreen.tsx",
+      "features/mobile/service/TruckStockPanel.tsx",
+      "features/mobile/service/TruckLoadPanel.tsx",
+      "features/mobile/service/TruckReceivePanel.tsx",
+      "features/mobile/service/TruckHistoryPanel.tsx",
+      "features/mobile/service/truckInventoryClient.ts",
+      "features/mobile/service/useTruckInventorySnapshot.ts",
+      "features/mobile/service/useTruckInventoryUsage.ts",
+      "features/mobile/service/useTruckInventoryStocking.ts",
+    ]) {
+      expect(existsSync(path), path).toBe(true);
+    }
+  });
+});

--- a/tests/field-truck-inventory-contract.test.ts
+++ b/tests/field-truck-inventory-contract.test.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
+import { aggregateRecentPartUses } from "@/features/mobile/service/truckInventoryContracts";
+
 const read = (path: string) => readFileSync(path, "utf8");
 const migration = [
   "supabase/migrations/20260812230000_field_integration_identity_core.sql",
@@ -8,6 +10,9 @@ const migration = [
   "supabase/migrations/20260812230200_field_truck_inventory_snapshot.sql",
   "supabase/migrations/20260812230300_field_truck_inventory_movement_commands.sql",
   "supabase/migrations/20260812230400_field_truck_inventory_work_order_commands.sql",
+  "supabase/migrations/20260815050000_field_part_identity_review_hardening.sql",
+  "supabase/migrations/20260815050100_field_truck_line_review_hardening.sql",
+  "supabase/migrations/20260815050200_field_truck_receipt_review_hardening.sql",
 ]
   .map(read)
   .join("\n");
@@ -51,6 +56,15 @@ const workflow = read(".github/workflows/mobile-v1-validation.yml");
 const contracts = read(
   "features/mobile/service/truckInventoryContracts.ts",
 );
+const identityReview = read(
+  "supabase/migrations/20260815050000_field_part_identity_review_hardening.sql",
+);
+const lineReview = read(
+  "supabase/migrations/20260815050100_field_truck_line_review_hardening.sql",
+);
+const receiptReview = read(
+  "supabase/migrations/20260815050200_field_truck_receipt_review_hardening.sql",
+);
 
 describe("Field Service truck inventory", () => {
   it("uses one canonical part identity across providers, barcodes, PO, stock, work order, and invoice truth", () => {
@@ -92,6 +106,9 @@ describe("Field Service truck inventory", () => {
     expect(migration).toContain("public.receive_po_part_and_allocate(");
     expect(migration).toContain("'purchase_order'");
     expect(migration).toContain("public.parts_ensure_work_order_part(");
+    expect(receiptReview).toContain("profixiq_receive_po_line_to_location_atomic");
+    expect(receiptReview).toContain("'purchase_order_line_id', p_purchase_order_line_id");
+    expect(receiptReview).toContain("PARTS_PO_NOT_RECEIVABLE");
     expect(migration).toContain("'direct_to_truck', true");
     expect(receiveApi).toContain("p_purchase_order_line_id");
     expect(receiveApi).toContain("field_receive_po_part_to_truck_atomic");
@@ -110,6 +127,8 @@ describe("Field Service truck inventory", () => {
     expect(migration).toContain("public.parts_issue_by_line_part_atomic(");
     expect(migration).toContain("field_return_truck_part_atomic");
     expect(migration).toContain("public.parts_return_to_stock(");
+    expect(lineReview).toContain("line.approval_state::text");
+    expect(lineReview).toContain("The repair line is not approved and actionable");
     expect(useApi).toContain("requireMobileServiceOperatorApiAccess");
     expect(useApi).toContain("field_use_truck_part_atomic");
     expect(inventoryUi).toContain("handleUse(part.partId)");
@@ -127,6 +146,11 @@ describe("Field Service truck inventory", () => {
     expect(inventoryUi).toContain("There is no separate stock-item setup step.");
     expect(inventoryUi).toContain("createIfMissing: true");
     expect(migration).toContain("'requiresDetails', true");
+    expect(identityReview).not.toContain("coalesce(v_supplier_sku, v_code)");
+    expect(identityReview).not.toContain("coalesce(v_part_number, v_code)");
+    expect(identityReview).toContain(
+      "case when v_actor.can_manage_parts then p_unit_cost else null end",
+    );
   });
 
   it("caches the assigned truck and replays use/return once in the visit dependency chain", () => {
@@ -135,10 +159,46 @@ describe("Field Service truck inventory", () => {
     expect(offline).toContain('actionType: "field-inventory:return-part"');
     expect(offline).toContain('orderKey: `service-visit:${args.payload.visitId}`');
     expect(offline).toContain("lastVisitMutationDependency");
+    expect(offline.match(/bestEffortOnlineHistory: true/g)).toHaveLength(2);
+    expect(offline).toContain("listPendingMutations(args.scope)");
     expect(replay).toContain('"field-inventory:use-part"');
     expect(replay).toContain('"field-inventory:return-part"');
     expect(replay).toContain("mutation.clientMutationId");
     expect(inventoryUi).toContain("Offline — showing the last cached truck snapshot.");
+  });
+
+  it("aggregates repeated issues before calculating the returnable quantity", () => {
+    const uses = aggregateRecentPartUses([
+      {
+        stockMoveId: "older",
+        workOrderPartId: "work-part",
+        workOrderLineId: "line",
+        partId: "part",
+        name: "Seal",
+        partNumber: "S-1",
+        quantity: 2,
+        createdAt: "2026-08-15T00:00:00.000Z",
+        returnedQuantity: 1,
+      },
+      {
+        stockMoveId: "newer",
+        workOrderPartId: "work-part",
+        workOrderLineId: "line",
+        partId: "part",
+        name: "Seal",
+        partNumber: "S-1",
+        quantity: 3,
+        createdAt: "2026-08-15T01:00:00.000Z",
+        returnedQuantity: 1,
+      },
+    ]);
+
+    expect(uses).toHaveLength(1);
+    expect(uses[0]).toMatchObject({
+      stockMoveId: "newer",
+      quantity: 5,
+      returnedQuantity: 1,
+    });
   });
 
   it("adds a reusable integration core without storing provider secrets in the client contract", () => {

--- a/tests/field-truck-inventory-contract.test.ts
+++ b/tests/field-truck-inventory-contract.test.ts
@@ -61,6 +61,7 @@ describe("Field Service truck inventory", () => {
     expect(migration).toContain(
       "field_resolve_or_create_part_identity_atomic",
     );
+    expect(migration).toContain("extensions.digest(");
     expect(migration).toContain("insert into public.parts_barcodes");
     expect(migration).toContain("'canonical_part_id', p_part_id");
     expect(partsIntegration.replace(/\s*\*\s*/g, " ")).toContain(

--- a/tests/field-truck-inventory-contract.test.ts
+++ b/tests/field-truck-inventory-contract.test.ts
@@ -63,8 +63,8 @@ describe("Field Service truck inventory", () => {
     );
     expect(migration).toContain("insert into public.parts_barcodes");
     expect(migration).toContain("'canonical_part_id', p_part_id");
-    expect(partsIntegration).toContain(
-      "Every selected result must resolve to one canonical ProFixIQ parts.id",
+    expect(partsIntegration).toMatch(
+      /Every selected[\\s*]+result must resolve to one canonical ProFixIQ parts\\.id/,
     );
     expect(partsIntegration).not.toContain("MockPartsProvider");
     expect(partsIntegration).not.toContain("demo-123");

--- a/tests/field-truck-inventory-contract.test.ts
+++ b/tests/field-truck-inventory-contract.test.ts
@@ -62,6 +62,7 @@ describe("Field Service truck inventory", () => {
       "field_resolve_or_create_part_identity_atomic",
     );
     expect(migration).toContain("extensions.digest(");
+    expect(migration).not.toContain("encode(digest(");
     expect(migration).toContain("insert into public.parts_barcodes");
     expect(migration).toContain("'canonical_part_id', p_part_id");
     expect(partsIntegration.replace(/\s*\*\s*/g, " ")).toContain(

--- a/tests/field-truck-inventory-contract.test.ts
+++ b/tests/field-truck-inventory-contract.test.ts
@@ -63,8 +63,8 @@ describe("Field Service truck inventory", () => {
     );
     expect(migration).toContain("insert into public.parts_barcodes");
     expect(migration).toContain("'canonical_part_id', p_part_id");
-    expect(partsIntegration).toMatch(
-      /Every selected[\\s*]+result must resolve to one canonical ProFixIQ parts\\.id/,
+    expect(partsIntegration.replace(/\s*\*\s*/g, " ")).toContain(
+      "Every selected result must resolve to one canonical ProFixIQ parts.id",
     );
     expect(partsIntegration).not.toContain("MockPartsProvider");
     expect(partsIntegration).not.toContain("demo-123");

--- a/tests/field-truck-inventory-contract.test.ts
+++ b/tests/field-truck-inventory-contract.test.ts
@@ -110,8 +110,10 @@ describe("Field Service truck inventory", () => {
     expect(migration).toContain("public.parts_return_to_stock(");
     expect(useApi).toContain("requireMobileServiceOperatorApiAccess");
     expect(useApi).toContain("field_use_truck_part_atomic");
-    expect(inventoryUi).toContain("Use {quantityLabel(quantity)} on call");
-    expect(inventoryUi).toContain("Return {quantityLabel(returnable)} to truck");
+    expect(inventoryUi).toContain("handleUse(part.partId)");
+    expect(inventoryUi).toMatch(/Use\s+\{quantityLabel\(quantity\)\}\s+on call/);
+    expect(inventoryUi).toContain("handleReturn(use)");
+    expect(inventoryUi).toContain("Return ${quantityLabel(returnable)} to truck");
     expect(inventoryUi).not.toContain("Create stock item");
     expect(inventoryUi).not.toContain("Map it in Parts");
   });

--- a/tests/mobile-service-shell.test.ts
+++ b/tests/mobile-service-shell.test.ts
@@ -51,7 +51,9 @@ describe("Mobile Service shell", () => {
     expect(scopeGate).toContain("setOfflineMutationScope");
     expect(scopeGate).toContain("cached?.userId === authUserId");
     expect(scopeGate).toContain("SNAPSHOT_SCOPE_KEY");
-    expect(scopeGate).toContain("fail closed");
+    expect(scopeGate).toMatch(
+      /\\.catch\\(\\(\\) => \\{[\\s\\S]*removeItem\\(SNAPSHOT_CACHE_KEY\\)[\\s\\S]*removeItem\\(SNAPSHOT_SCOPE_KEY\\)[\\s\\S]*router\\.replace\\("\\/mobile"\\)/,
+    );
   });
 
   it("exposes Field Service only to roles eligible for personal field assignment", () => {

--- a/tests/mobile-service-shell.test.ts
+++ b/tests/mobile-service-shell.test.ts
@@ -51,9 +51,14 @@ describe("Mobile Service shell", () => {
     expect(scopeGate).toContain("setOfflineMutationScope");
     expect(scopeGate).toContain("cached?.userId === authUserId");
     expect(scopeGate).toContain("SNAPSHOT_SCOPE_KEY");
-    expect(scopeGate).toMatch(
-      /\\.catch\\(\\(\\) => \\{[\\s\\S]*removeItem\\(SNAPSHOT_CACHE_KEY\\)[\\s\\S]*removeItem\\(SNAPSHOT_SCOPE_KEY\\)[\\s\\S]*router\\.replace\\("\\/mobile"\\)/,
+    expect(scopeGate).toContain("})().catch(() => {");
+    expect(scopeGate).toContain(
+      "window.localStorage.removeItem(SNAPSHOT_CACHE_KEY)",
     );
+    expect(scopeGate).toContain(
+      "window.localStorage.removeItem(SNAPSHOT_SCOPE_KEY)",
+    );
+    expect(scopeGate).toContain('router.replace("/mobile")');
   });
 
   it("exposes Field Service only to roles eligible for personal field assignment", () => {

--- a/tests/mobile/field-truck-inventory.runtime.sql
+++ b/tests/mobile/field-truck-inventory.runtime.sql
@@ -434,8 +434,7 @@ begin
     end if;
   end;
   update public.work_order_lines
-  set approval_state = 'approved',
-      status = 'approved'
+  set approval_state = 'approved'
   where id = v_line_id
     and shop_id = v_shop_id;
 

--- a/tests/mobile/field-truck-inventory.runtime.sql
+++ b/tests/mobile/field-truck-inventory.runtime.sql
@@ -418,6 +418,10 @@ begin
     raise exception 'Field truck runtime failed: repair handoff did not materialize';
   end if;
 
+  update public.work_order_lines
+  set approval_state = 'pending'
+  where id = v_line_id
+    and shop_id = v_shop_id;
   begin
     perform public.field_use_truck_part_atomic(
       v_shop_id, v_visit_id, v_line_id, v_part_id, 1,

--- a/tests/mobile/field-truck-inventory.runtime.sql
+++ b/tests/mobile/field-truck-inventory.runtime.sql
@@ -153,6 +153,7 @@ declare
   v_count integer;
   v_before numeric;
   v_after numeric;
+  v_truck_before_transfer numeric;
 begin
   perform public.mobile_configure_service_v1_atomic(
     v_shop_id,
@@ -288,6 +289,11 @@ begin
   end if;
 
   -- Seed MAIN and prove a transfer is one paired, exact-once operation.
+  v_truck_before_transfer := public.parts_on_hand(
+    v_shop_id,
+    v_part_id,
+    v_truck_location_id
+  );
   perform public.apply_stock_move(
     v_part_id,
     v_source_location_id,
@@ -306,7 +312,8 @@ begin
     'field-runtime:transfer'
   );
   if public.parts_on_hand(v_shop_id, v_part_id, v_source_location_id) <> 2
-     or public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id) <> 3 then
+     or public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id)
+       <> v_truck_before_transfer + 1 then
     raise exception 'Field truck runtime failed: paired transfer quantities are wrong';
   end if;
   v_transfer_replay := public.field_transfer_stock_to_truck_atomic(
@@ -320,7 +327,8 @@ begin
   );
   if coalesce((v_transfer_replay ->> 'idempotent')::boolean, false) is not true
      or public.parts_on_hand(v_shop_id, v_part_id, v_source_location_id) <> 2
-     or public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id) <> 3 then
+     or public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id)
+       <> v_truck_before_transfer + 1 then
     raise exception 'Field truck runtime failed: transfer replay changed inventory';
   end if;
   select count(*) into v_count

--- a/tests/mobile/field-truck-inventory.runtime.sql
+++ b/tests/mobile/field-truck-inventory.runtime.sql
@@ -1,0 +1,441 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values (
+  '9f100000-0000-4000-8000-000000000001',
+  'field-truck-runtime-owner@example.com',
+  '{"full_name":"Field Truck Runtime Owner"}'::jsonb
+)
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name, email, shop_id)
+values (
+  '9f100000-0000-4000-8000-000000000001',
+  '9f100000-0000-4000-8000-000000000001',
+  'owner',
+  'Field Truck Runtime Owner',
+  'field-truck-runtime-owner@example.com',
+  null
+)
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name,
+    email = excluded.email;
+
+insert into public.shops (
+  id,
+  owner_id,
+  business_name,
+  name,
+  user_limit,
+  accepts_online_booking,
+  min_notice_minutes,
+  max_lead_days,
+  location_type,
+  country,
+  billing_entitlement_override,
+  subscription_package
+)
+values (
+  '9f200000-0000-4000-8000-000000000001',
+  '9f100000-0000-4000-8000-000000000001',
+  'Field Truck Runtime',
+  'Field Truck Runtime',
+  10,
+  true,
+  0,
+  365,
+  'repair_facility',
+  'CA',
+  'internal_demo',
+  'complete_operations'
+)
+on conflict (id) do update
+set country = 'CA',
+    billing_entitlement_override = 'internal_demo',
+    subscription_package = 'complete_operations';
+
+update public.profiles
+set shop_id = '9f200000-0000-4000-8000-000000000001'
+where id = '9f100000-0000-4000-8000-000000000001';
+
+insert into public.suppliers (id, shop_id, name, is_active)
+values (
+  '9f300000-0000-4000-8000-000000000001',
+  '9f200000-0000-4000-8000-000000000001',
+  'Field Truck Supplier',
+  true
+)
+on conflict (id) do nothing;
+
+insert into public.purchase_orders (id, shop_id, supplier_id, status, po_number)
+values (
+  '9f400000-0000-4000-8000-000000000001',
+  '9f200000-0000-4000-8000-000000000001',
+  '9f300000-0000-4000-8000-000000000001',
+  'open',
+  'FIELD-TRUCK-PO-1'
+)
+on conflict (id) do nothing;
+
+insert into public.purchase_order_lines (
+  id,
+  po_id,
+  part_id,
+  sku,
+  description,
+  qty,
+  unit_cost,
+  received_qty,
+  cancelled_qty
+)
+values (
+  '9f500000-0000-4000-8000-000000000001',
+  '9f400000-0000-4000-8000-000000000001',
+  null,
+  'FT-SEAL-100',
+  'Field runtime wheel seal',
+  2,
+  42.50,
+  0,
+  0
+)
+on conflict (id) do nothing;
+
+insert into public.stock_locations (id, shop_id, code, name)
+values (
+  '9f600000-0000-4000-8000-000000000001',
+  '9f200000-0000-4000-8000-000000000001',
+  'MAIN-RUNTIME',
+  'Runtime Main Stock'
+)
+on conflict (id) do nothing;
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', '9f100000-0000-4000-8000-000000000001', true);
+set local role authenticated;
+
+do $$
+declare
+  v_shop_id constant uuid := '9f200000-0000-4000-8000-000000000001';
+  v_actor_id constant uuid := '9f100000-0000-4000-8000-000000000001';
+  v_source_location_id constant uuid := '9f600000-0000-4000-8000-000000000001';
+  v_po_id constant uuid := '9f400000-0000-4000-8000-000000000001';
+  v_po_line_id constant uuid := '9f500000-0000-4000-8000-000000000001';
+  v_truck_id uuid;
+  v_truck_location_id uuid;
+  v_receipt jsonb;
+  v_receipt_replay jsonb;
+  v_part_id uuid;
+  v_intake jsonb;
+  v_visit_id uuid;
+  v_visit public.service_visits%rowtype;
+  v_version integer;
+  v_handoff jsonb;
+  v_work_order_id uuid;
+  v_line_id uuid;
+  v_use jsonb;
+  v_use_replay jsonb;
+  v_return jsonb;
+  v_return_replay jsonb;
+  v_work_order_part_id uuid;
+  v_transfer jsonb;
+  v_transfer_replay jsonb;
+  v_snapshot jsonb;
+  v_count integer;
+  v_before numeric;
+  v_after numeric;
+begin
+  perform public.mobile_configure_service_v1_atomic(
+    v_shop_id,
+    'mobile',
+    true,
+    false,
+    true,
+    true,
+    60,
+    1,
+    true,
+    'Runtime Service Truck',
+    'RT-1',
+    v_actor_id
+  );
+
+  select vehicle.id, vehicle.stock_location_id
+    into v_truck_id, v_truck_location_id
+  from public.service_vehicles vehicle
+  where vehicle.shop_id = v_shop_id
+    and vehicle.primary_user_id = v_actor_id
+    and vehicle.active
+  order by vehicle.created_at desc, vehicle.id
+  limit 1;
+
+  if v_truck_id is null or v_truck_location_id is null then
+    raise exception 'Field truck runtime failed: setup did not create truck inventory';
+  end if;
+
+  -- A free-text PO line becomes a canonical part inside the receipt command.
+  v_receipt := public.field_receive_po_part_to_truck_atomic(
+    v_shop_id,
+    v_truck_id,
+    v_po_id,
+    v_po_line_id,
+    2,
+    v_actor_id,
+    'field-runtime:receive'
+  );
+  v_part_id := nullif(v_receipt ->> 'partId', '')::uuid;
+  if v_part_id is null then
+    raise exception 'Field truck runtime failed: receipt did not materialize canonical part';
+  end if;
+  if (select part_id from public.purchase_order_lines where id = v_po_line_id)
+       is distinct from v_part_id then
+    raise exception 'Field truck runtime failed: PO line lost canonical part identity';
+  end if;
+  if not exists (
+    select 1
+    from public.part_external_identities identity
+    where identity.shop_id = v_shop_id
+      and identity.part_id = v_part_id
+      and identity.provider = 'purchase_order'
+      and identity.external_id = v_po_line_id::text
+  ) then
+    raise exception 'Field truck runtime failed: purchase identity mapping missing';
+  end if;
+  if public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id) <> 2 then
+    raise exception 'Field truck runtime failed: direct truck receipt did not post quantity 2';
+  end if;
+
+  v_receipt_replay := public.field_receive_po_part_to_truck_atomic(
+    v_shop_id,
+    v_truck_id,
+    v_po_id,
+    v_po_line_id,
+    2,
+    v_actor_id,
+    'field-runtime:receive'
+  );
+  if coalesce((v_receipt_replay ->> 'replayed')::boolean, false) is not true
+     or public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id) <> 2 then
+    raise exception 'Field truck runtime failed: receipt replay changed truck quantity';
+  end if;
+  select count(*) into v_count
+  from public.stock_moves move
+  where move.shop_id = v_shop_id
+    and move.part_id = v_part_id
+    and move.location_id = v_truck_location_id
+    and move.reason = 'receive'
+    and move.reference_kind = 'purchase_order'
+    and move.reference_id = v_po_id;
+  if v_count <> 1 then
+    raise exception 'Field truck runtime failed: receipt replay produced % stock moves', v_count;
+  end if;
+
+  -- Seed MAIN and prove a transfer is one paired, exact-once operation.
+  perform public.apply_stock_move(
+    v_part_id,
+    v_source_location_id,
+    3,
+    'receive'::text,
+    'field_runtime_seed',
+    v_po_line_id
+  );
+  v_transfer := public.field_transfer_stock_to_truck_atomic(
+    v_shop_id,
+    v_truck_id,
+    v_source_location_id,
+    v_part_id,
+    1,
+    v_actor_id,
+    'field-runtime:transfer'
+  );
+  if public.parts_on_hand(v_shop_id, v_part_id, v_source_location_id) <> 2
+     or public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id) <> 3 then
+    raise exception 'Field truck runtime failed: paired transfer quantities are wrong';
+  end if;
+  v_transfer_replay := public.field_transfer_stock_to_truck_atomic(
+    v_shop_id,
+    v_truck_id,
+    v_source_location_id,
+    v_part_id,
+    1,
+    v_actor_id,
+    'field-runtime:transfer'
+  );
+  if coalesce((v_transfer_replay ->> 'idempotent')::boolean, false) is not true
+     or public.parts_on_hand(v_shop_id, v_part_id, v_source_location_id) <> 2
+     or public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id) <> 3 then
+    raise exception 'Field truck runtime failed: transfer replay changed inventory';
+  end if;
+  select count(*) into v_count
+  from public.stock_moves move
+  where move.shop_id = v_shop_id
+    and move.id in (
+      (v_transfer ->> 'transferOutMoveId')::uuid,
+      (v_transfer ->> 'transferInMoveId')::uuid
+    )
+    and move.reference_kind = 'field_truck_transfer'
+    and move.reason in ('transfer_out','transfer_in');
+  if v_count <> 2 then
+    raise exception 'Field truck runtime failed: transfer did not retain one paired identity';
+  end if;
+
+  -- Create the assigned field call and canonical repair.
+  v_intake := public.mobile_create_service_call_atomic(
+    v_shop_id,
+    null,
+    'Field Truck Runtime Customer',
+    '780-555-9901',
+    null,
+    2022,
+    'Ford',
+    'F-550',
+    'RT9901',
+    '100 Runtime Way',
+    'Calgary',
+    'AB',
+    'T1T 1T1',
+    'Replace leaking wheel seal',
+    '2099-10-01 15:00:00+00',
+    60,
+    null,
+    'CAD',
+    'mobile',
+    v_actor_id,
+    'field-runtime:intake'
+  );
+  v_visit_id := (v_intake ->> 'serviceVisitId')::uuid;
+
+  select * into v_visit
+  from public.service_visits visit
+  where visit.id = v_visit_id;
+  if v_visit.assigned_user_id is distinct from v_actor_id then
+    raise exception 'Field truck runtime failed: field call not assigned to operator';
+  end if;
+  if v_visit.service_vehicle_id is null then
+    perform public.dispatch_assign_service_visit_atomic(
+      v_shop_id,
+      v_visit_id,
+      v_actor_id,
+      v_truck_id,
+      v_visit.version,
+      v_actor_id,
+      'field-runtime:assign-truck'
+    );
+  elsif v_visit.service_vehicle_id is distinct from v_truck_id then
+    raise exception 'Field truck runtime failed: call assigned a different service truck';
+  end if;
+
+  select version into v_version from public.service_visits where id = v_visit_id;
+  perform public.mobile_replay_service_visit_transition_atomic(
+    v_shop_id, v_visit_id, 'scheduled', 'dispatched', v_version,
+    v_actor_id, 'field-runtime:dispatch'
+  );
+  select version into v_version from public.service_visits where id = v_visit_id;
+  perform public.mobile_replay_service_visit_transition_atomic(
+    v_shop_id, v_visit_id, 'dispatched', 'en_route', v_version,
+    v_actor_id, 'field-runtime:travel'
+  );
+  select version into v_version from public.service_visits where id = v_visit_id;
+  perform public.mobile_replay_service_visit_transition_atomic(
+    v_shop_id, v_visit_id, 'en_route', 'arrived', v_version,
+    v_actor_id, 'field-runtime:arrive'
+  );
+
+  v_handoff := public.mobile_materialize_service_visit_work_order_atomic(
+    v_shop_id,
+    v_visit_id,
+    v_actor_id,
+    'field-runtime:handoff'
+  );
+  v_work_order_id := (v_handoff ->> 'workOrderId')::uuid;
+  v_line_id := (v_handoff ->> 'initialWorkOrderLineId')::uuid;
+  if v_work_order_id is null or v_line_id is null then
+    raise exception 'Field truck runtime failed: repair handoff did not materialize';
+  end if;
+
+  v_before := public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id);
+  v_use := public.field_use_truck_part_atomic(
+    v_shop_id,
+    v_visit_id,
+    v_line_id,
+    v_part_id,
+    1,
+    v_actor_id,
+    'field-runtime:use'
+  );
+  v_work_order_part_id := (v_use ->> 'work_order_part_id')::uuid;
+  v_after := public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id);
+  if v_after <> v_before - 1 then
+    raise exception 'Field truck runtime failed: truck use did not decrement inventory once';
+  end if;
+  if not exists (
+    select 1
+    from public.work_order_parts work_part
+    where work_part.id = v_work_order_part_id
+      and work_part.work_order_id = v_work_order_id
+      and work_part.work_order_line_id = v_line_id
+      and work_part.part_id = v_part_id
+      and work_part.is_active
+  ) then
+    raise exception 'Field truck runtime failed: WO part identity differs from PO/stock identity';
+  end if;
+
+  v_use_replay := public.field_use_truck_part_atomic(
+    v_shop_id,
+    v_visit_id,
+    v_line_id,
+    v_part_id,
+    1,
+    v_actor_id,
+    'field-runtime:use'
+  );
+  if coalesce((v_use_replay ->> 'idempotent')::boolean, false) is not true
+     or public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id) <> v_after then
+    raise exception 'Field truck runtime failed: repeated use decremented inventory twice';
+  end if;
+
+  v_return := public.field_return_truck_part_atomic(
+    v_shop_id,
+    v_visit_id,
+    v_work_order_part_id,
+    1,
+    v_actor_id,
+    'field-runtime:return'
+  );
+  if public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id) <> v_before then
+    raise exception 'Field truck runtime failed: return did not restore truck quantity';
+  end if;
+  v_return_replay := public.field_return_truck_part_atomic(
+    v_shop_id,
+    v_visit_id,
+    v_work_order_part_id,
+    1,
+    v_actor_id,
+    'field-runtime:return'
+  );
+  if coalesce((v_return_replay ->> 'idempotent')::boolean, false) is not true
+     or public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id) <> v_before then
+    raise exception 'Field truck runtime failed: return replay changed inventory twice';
+  end if;
+
+  v_snapshot := public.field_truck_inventory_snapshot(
+    v_shop_id,
+    v_actor_id,
+    v_visit_id,
+    v_truck_id,
+    'FT-SEAL-100'
+  );
+  if v_snapshot -> 'truck' ->> 'id' is distinct from v_truck_id::text
+     or jsonb_array_length(coalesce(v_snapshot -> 'items', '[]'::jsonb)) < 1
+     or jsonb_array_length(coalesce(v_snapshot -> 'catalog', '[]'::jsonb)) < 1 then
+    raise exception 'Field truck runtime failed: assigned truck snapshot is incomplete';
+  end if;
+end;
+$$;
+
+reset role;
+rollback;

--- a/tests/mobile/field-truck-inventory.runtime.sql
+++ b/tests/mobile/field-truck-inventory.runtime.sql
@@ -125,6 +125,11 @@ declare
   v_source_location_id constant uuid := '9f600000-0000-4000-8000-000000000001';
   v_po_id constant uuid := '9f400000-0000-4000-8000-000000000001';
   v_po_line_id constant uuid := '9f500000-0000-4000-8000-000000000001';
+  v_terminal_po_id constant uuid := '9f400000-0000-4000-8000-000000000002';
+  v_terminal_line_id constant uuid := '9f500000-0000-4000-8000-000000000002';
+  v_scoped_po_id constant uuid := '9f400000-0000-4000-8000-000000000003';
+  v_scoped_line_one_id constant uuid := '9f500000-0000-4000-8000-000000000003';
+  v_scoped_line_two_id constant uuid := '9f500000-0000-4000-8000-000000000004';
   v_truck_id uuid;
   v_truck_location_id uuid;
   v_receipt jsonb;
@@ -232,6 +237,54 @@ begin
     and move.reference_id = v_po_id;
   if v_count <> 1 then
     raise exception 'Field truck runtime failed: receipt replay produced % stock moves', v_count;
+  end if;
+
+  insert into public.purchase_orders (id, shop_id, supplier_id, status, po_number)
+  values (
+    v_terminal_po_id, v_shop_id,
+    '9f300000-0000-4000-8000-000000000001', 'cancelled', 'FIELD-TRUCK-PO-CANCELLED'
+  );
+  insert into public.purchase_order_lines (
+    id, po_id, part_id, sku, description, qty, unit_cost, received_qty, cancelled_qty
+  ) values (
+    v_terminal_line_id, v_terminal_po_id, v_part_id, 'FT-SEAL-100',
+    'Cancelled receipt target', 1, 42.50, 0, 0
+  );
+  begin
+    perform public.field_receive_po_part_to_truck_atomic(
+      v_shop_id, v_truck_id, v_terminal_po_id, v_terminal_line_id,
+      1, v_actor_id, 'field-runtime:terminal-receipt'
+    );
+    raise exception 'Field truck runtime failed: terminal PO receipt was accepted';
+  exception when others then
+    if sqlerrm not like '%PARTS_PO_NOT_RECEIVABLE%' then
+      raise;
+    end if;
+  end;
+
+  insert into public.purchase_orders (id, shop_id, supplier_id, status, po_number)
+  values (
+    v_scoped_po_id, v_shop_id,
+    '9f300000-0000-4000-8000-000000000001', 'open', 'FIELD-TRUCK-PO-SCOPED'
+  );
+  insert into public.purchase_order_lines (
+    id, po_id, part_id, sku, description, qty, unit_cost, received_qty, cancelled_qty
+  ) values
+    (
+      v_scoped_line_one_id, v_scoped_po_id, v_part_id, 'FT-SEAL-100',
+      'First duplicate part line', 1, 42.50, 0, 0
+    ),
+    (
+      v_scoped_line_two_id, v_scoped_po_id, v_part_id, 'FT-SEAL-100',
+      'Selected duplicate part line', 1, 42.50, 0, 0
+    );
+  perform public.field_receive_po_part_to_truck_atomic(
+    v_shop_id, v_truck_id, v_scoped_po_id, v_scoped_line_two_id,
+    1, v_actor_id, 'field-runtime:scoped-receipt'
+  );
+  if (select received_qty from public.purchase_order_lines where id = v_scoped_line_one_id) <> 0
+     or (select received_qty from public.purchase_order_lines where id = v_scoped_line_two_id) <> 1 then
+    raise exception 'Field truck runtime failed: receipt was not scoped to the selected PO line';
   end if;
 
   -- Seed MAIN and prove a transfer is one paired, exact-once operation.
@@ -356,6 +409,23 @@ begin
   if v_work_order_id is null or v_line_id is null then
     raise exception 'Field truck runtime failed: repair handoff did not materialize';
   end if;
+
+  begin
+    perform public.field_use_truck_part_atomic(
+      v_shop_id, v_visit_id, v_line_id, v_part_id, 1,
+      v_actor_id, 'field-runtime:unapproved-use'
+    );
+    raise exception 'Field truck runtime failed: unapproved repair line accepted part use';
+  exception when others then
+    if sqlerrm not like '%not approved and actionable%' then
+      raise;
+    end if;
+  end;
+  update public.work_order_lines
+  set approval_state = 'approved',
+      status = 'approved'
+  where id = v_line_id
+    and shop_id = v_shop_id;
 
   v_before := public.parts_on_hand(v_shop_id, v_part_id, v_truck_location_id);
   v_use := public.field_use_truck_part_atomic(


### PR DESCRIPTION
## What changed

- Adds a provider-neutral Integration Core for shop-scoped connections, canonical external-object mappings, sync cursors/events, health state, and server-side secret references.
- Replaces the mock Parts provider with a real adapter registry contract for Nexpart, PartsTech, and later suppliers without allowing provider IDs to replace canonical ProFixIQ `parts.id`.
- Adds canonical external part identities for provider catalog IDs, supplier SKUs, manufacturer numbers, and barcodes.
- Resolves or creates the canonical part inline when receiving or scanning; the user is never redirected into a separate stock-item setup step.
- Adds a Field Service truck inventory workspace at `/mobile/service/truck-inventory` with assigned-truck stock, mobile scanning, direct PO receipt, paired transfers, work-order use/return, and offline replay.
- Reuses the canonical stock ledger, request/PO lifecycle, work-order part lifecycle, Pricing V2 path, invoice snapshot path, and existing exact-once parts commands.

## Review hardening

The follow-up at exact head `8194023c` addresses all eight Codex findings:

- direct receipts update only the selected PO line and its linked request item;
- cancelled, voided, closed, and received POs reject new receipts while exact replay remains safe;
- barcode scans do not silently fall back to SKU or part-number namespaces;
- field-only actors cannot set canonical part cost/sell defaults;
- only approved, actionable repair lines can consume stock, in both UI selection and the database command;
- repeated consumption rows are aggregated before returnable quantity is calculated;
- online use/return treats post-commit device-history persistence as best effort;
- cached truck quantities are derived through the durable pending queue after offline reload.

## Database

Adds ten forward-only migrations:

1. `20260812230000_field_integration_identity_core.sql`
2. `20260812230100_field_part_identity_commands.sql`
3. `20260812230200_field_truck_inventory_snapshot.sql`
4. `20260812230300_field_truck_inventory_movement_commands.sql`
5. `20260812230400_field_truck_inventory_work_order_commands.sql`
6. `20260815040500_field_part_identity_digest_search_path.sql`
7. `20260815042000_field_truck_receipt_replay.sql`
8. `20260815050000_field_part_identity_review_hardening.sql`
9. `20260815050100_field_truck_line_review_hardening.sql`
10. `20260815050200_field_truck_receipt_review_hardening.sql`

No production migration has been applied.

## Validation

- Local diff whitespace checks pass. The runtime assertions now derive the transfer baseline from ledger state and explicitly place the repair line in pending approval before proving rejection.
- New source contracts cover the review invariants and repeated-use aggregation.
- Mobile clean-database runtime now covers terminal-PO rejection, duplicate-part line-scoped receiving, unapproved-line rejection, and existing exact replay.
- Exact-head GitHub validation is green: typecheck, changed-file lint, complete test suite, production build, regression inventory, Mobile V1 source/runtime, Supabase migration application, generated types, full reset/replay, and all remaining domain workflows.

## Delivery state

- PR is currently Ready for review.
- No production migration was applied.
- No production data was changed.
- No external provider credentials or live connections were created.
- All 14 exact-head workflow runs are green at `8194023c`; all eight Codex review threads are resolved.