### PR TITLE
Add Ops deployments and release health

### DIFF
--- a/app/ops/deployments/page.tsx
+++ b/app/ops/deployments/page.tsx
@@ -1,0 +1,10 @@
+import OpsReleaseHealth from "@/features/ops/components/OpsReleaseHealth";
+import { getOpsReleaseHealth } from "@/features/ops/server/get-release-health";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function OpsDeploymentsPage() {
+  const snapshot = await getOpsReleaseHealth();
+  return <OpsReleaseHealth snapshot={snapshot} />;
+}

--- a/features/ops/components/OpsDashboard.tsx
+++ b/features/ops/components/OpsDashboard.tsx
@@ -1,11 +1,13 @@
 import Link from "next/link";
 import {
+  Activity,
   AlertTriangle,
   ArrowRight,
   Bot,
   CheckCircle2,
   CircleDot,
   Database,
+  GitBranch,
   GitPullRequest,
   ShieldCheck,
 } from "lucide-react";
@@ -74,6 +76,26 @@ export default function OpsDashboard({
       tone: "text-rose-300",
     },
   ];
+  const controlSurfaces = [
+    {
+      href: "/ops/system-health",
+      label: "System Health",
+      detail: "Live service and generation checks",
+      icon: Activity,
+    },
+    {
+      href: "/ops/deployments",
+      label: "Deployments",
+      detail: "Production SHA, CI and migration parity",
+      icon: GitBranch,
+    },
+    {
+      href: "/ops/agent-control",
+      label: "Agent Work",
+      detail: "Cases, approvals, retries and execution",
+      icon: Bot,
+    },
+  ] as const;
 
   return (
     <div className="mx-auto max-w-7xl space-y-6">
@@ -119,6 +141,25 @@ export default function OpsDashboard({
               {metric.detail}
             </p>
           </div>
+        ))}
+      </section>
+
+      <section className="grid gap-3 sm:grid-cols-3" aria-label="Operations control surfaces">
+        {controlSurfaces.map(({ href, label, detail, icon: Icon }) => (
+          <Link
+            key={href}
+            href={href}
+            className="group flex items-center gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card transition hover:border-orange-500/40 hover:bg-orange-500/5"
+          >
+            <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-orange-500/10 text-orange-400">
+              <Icon className="h-5 w-5" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-bold">{label}</p>
+              <p className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">{detail}</p>
+            </div>
+            <ArrowRight className="h-4 w-4 shrink-0 text-[color:var(--theme-text-muted)] transition group-hover:translate-x-0.5 group-hover:text-orange-400" />
+          </Link>
         ))}
       </section>
 

--- a/features/ops/components/OpsReleaseHealth.tsx
+++ b/features/ops/components/OpsReleaseHealth.tsx
@@ -1,0 +1,295 @@
+import Link from "next/link";
+import {
+  Bot,
+  CheckCircle2,
+  CircleAlert,
+  Database,
+  GitBranch,
+  GitPullRequest,
+  RefreshCw,
+  Server,
+  ShieldCheck,
+  Workflow,
+  XCircle,
+} from "lucide-react";
+import type { OpsReleaseHealthSnapshot } from "@/features/ops/server/get-release-health";
+import { cn } from "@shared/lib/utils";
+
+type ReleaseState = OpsReleaseHealthSnapshot["overall"];
+
+function stateLabel(state: ReleaseState): string {
+  if (state === "healthy") return "Healthy";
+  if (state === "degraded") return "Needs attention";
+  return "Blocked";
+}
+
+function stateTone(state: ReleaseState): string {
+  if (state === "healthy") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+  if (state === "degraded") return "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+  return "border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300";
+}
+
+function StateIcon({ state }: { state: ReleaseState }) {
+  if (state === "healthy") return <CheckCircle2 className="h-4 w-4" />;
+  if (state === "degraded") return <CircleAlert className="h-4 w-4" />;
+  return <XCircle className="h-4 w-4" />;
+}
+
+function shortSha(value: string | null): string {
+  return value ? value.slice(0, 12) : "Unavailable";
+}
+
+function shortId(value: string | null): string {
+  if (!value) return "Unavailable";
+  return value.length > 22 ? `${value.slice(0, 22)}…` : value;
+}
+
+function formatTime(value: string | null): string {
+  if (!value) return "Unavailable";
+  return new Intl.DateTimeFormat("en-CA", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "America/Edmonton",
+  }).format(new Date(value));
+}
+
+function StatusPill({ state }: { state: ReleaseState }) {
+  return (
+    <span className={cn(
+      "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em]",
+      stateTone(state),
+    )}>
+      <StateIcon state={state} />
+      {stateLabel(state)}
+    </span>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 bg-[color:var(--theme-surface-inset)] px-4 py-3">
+      <dt className="text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">{label}</dt>
+      <dd className="mt-1 truncate font-mono text-xs text-[color:var(--theme-text-primary)]" title={value}>{value}</dd>
+    </div>
+  );
+}
+
+function migrationStatusLabel(status: OpsReleaseHealthSnapshot["migrations"]["status"]): string {
+  if (status === "not_required") return "Not required";
+  if (status === "applied") return "Applied / coherent";
+  if (status === "pending") return "Pending";
+  if (status === "drift") return "Ledger drift";
+  if (status === "failed") return "Failed";
+  return "Unknown";
+}
+
+export default function OpsReleaseHealth({ snapshot }: { snapshot: OpsReleaseHealthSnapshot }) {
+  const migrationSummary = snapshot.migrations.status === "pending"
+    ? `${snapshot.migrations.pending.length} repository migration${snapshot.migrations.pending.length === 1 ? "" : "s"} not applied in production.`
+    : snapshot.migrations.status === "drift"
+      ? `${snapshot.migrations.drift.length} production ledger version${snapshot.migrations.drift.length === 1 ? "" : "s"} are missing from main.`
+      : snapshot.migrations.status === "failed"
+        ? "The Supabase release check reports a failure."
+        : snapshot.migrations.status === "not_required"
+          ? "The deployed release did not add a migration and the ledger matches main."
+          : snapshot.migrations.status === "applied"
+            ? "Repository migrations and the production migration ledger are coherent."
+            : "Migration evidence is unavailable.";
+
+  const failureSummary = snapshot.failures.countSinceRelease === null
+    ? "Production failure evidence is unavailable."
+    : snapshot.failures.countSinceRelease === 0
+      ? "No operational capture failures have been recorded since this release."
+      : `${snapshot.failures.countSinceRelease} operational capture failure${snapshot.failures.countSinceRelease === 1 ? "" : "s"} recorded since this release.`;
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6">
+      <section className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.18em] text-orange-500">
+            <GitBranch className="h-4 w-4" />
+            Release evidence
+          </div>
+          <h1 className="text-2xl font-black tracking-tight sm:text-3xl">Deployments &amp; release health</h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+            Correlates the live Vercel runtime, GitHub main and CI, the Agent generation,
+            and the production Supabase migration ledger. This page is read-only.
+          </p>
+        </div>
+        <a
+          href="/ops/deployments"
+          className="inline-flex items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-2.5 text-sm font-bold transition hover:border-orange-500/50 hover:bg-orange-500/10"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh release health
+        </a>
+      </section>
+
+      <section className={cn("rounded-2xl border p-4 shadow-card sm:p-5", stateTone(snapshot.overall))}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <span className="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-black/5 dark:bg-black/10">
+              <StateIcon state={snapshot.overall} />
+            </span>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.14em]">Release posture</p>
+              <p className="mt-1 text-lg font-black">{stateLabel(snapshot.overall)}</p>
+            </div>
+          </div>
+          <p className="text-xs font-semibold opacity-80">Checked {formatTime(snapshot.checkedAt)} MT</p>
+        </div>
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-2">
+        <article className="overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-card">
+          <div className="flex items-start justify-between gap-4 border-b border-[color:var(--theme-border-soft)] p-4 sm:p-5">
+            <div className="flex items-start gap-3">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-orange-500/10 text-orange-500"><Server className="h-5 w-5" /></span>
+              <div>
+                <h2 className="text-sm font-bold">ProFixIQ production</h2>
+                <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                  {snapshot.production.behindMain === false
+                    ? "The live application SHA matches GitHub main."
+                    : snapshot.production.behindMain === true
+                      ? "Production is serving an older SHA than GitHub main."
+                      : "Runtime/main parity could not be verified."}
+                </p>
+              </div>
+            </div>
+            <StatusPill state={snapshot.production.state} />
+          </div>
+          <dl className="grid gap-px bg-[color:var(--theme-border-soft)] sm:grid-cols-2">
+            <Detail label="Production commit" value={shortSha(snapshot.production.commitSha)} />
+            <Detail label="Expected main" value={shortSha(snapshot.production.expectedMainSha)} />
+            <Detail label="Deployment" value={shortId(snapshot.production.deploymentId)} />
+            <Detail label="Environment" value={snapshot.production.environment} />
+            <Detail label="Release commit time" value={formatTime(snapshot.production.releaseCommitAt)} />
+            <Detail label="Release PR" value={snapshot.production.releasePr ? `#${snapshot.production.releasePr.number} ${snapshot.production.releasePr.title}` : "Unavailable"} />
+          </dl>
+        </article>
+
+        <article className="overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-card">
+          <div className="flex items-start justify-between gap-4 border-b border-[color:var(--theme-border-soft)] p-4 sm:p-5">
+            <div className="flex items-start gap-3">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/10 text-sky-500"><Bot className="h-5 w-5" /></span>
+              <div>
+                <h2 className="text-sm font-bold">ProFixIQ Agent production</h2>
+                <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                  {snapshot.agent.generationVerified
+                    ? "The Agent is reachable and its production generation is cryptographically fingerprinted."
+                    : "The Agent generation cannot currently be verified."}
+                </p>
+              </div>
+            </div>
+            <StatusPill state={snapshot.agent.state} />
+          </div>
+          <dl className="grid gap-px bg-[color:var(--theme-border-soft)] sm:grid-cols-2">
+            <Detail label="Agent commit" value={shortSha(snapshot.agent.commitSha)} />
+            <Detail label="Deployment" value={shortId(snapshot.agent.deploymentId)} />
+            <Detail label="Generation" value={snapshot.agent.generationVerified ? "Verified" : "Unverified"} />
+            <Detail label="Fingerprint" value={snapshot.agent.fingerprint ? snapshot.agent.fingerprint.slice(0, 20) : "Unavailable"} />
+          </dl>
+        </article>
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-3">
+        <article className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
+          <div className="flex items-start justify-between gap-3">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-violet-500/10 text-violet-500"><Workflow className="h-5 w-5" /></span>
+            <StatusPill state={snapshot.ci.state} />
+          </div>
+          <h2 className="mt-4 text-sm font-bold">Latest release CI</h2>
+          <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+            Canonical check: {snapshot.ci.canonicalName}. {snapshot.ci.failingChecks === 0 ? "No completed checks are failing." : `${snapshot.ci.failingChecks} completed checks failed.`}
+          </p>
+          <div className="mt-4 grid gap-2 text-xs">
+            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Conclusion</span><span className="font-mono">{snapshot.ci.conclusion ?? "Unavailable"}</span></div>
+            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Completed</span><span>{formatTime(snapshot.ci.completedAt)}</span></div>
+          </div>
+        </article>
+
+        <article className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
+          <div className="flex items-start justify-between gap-3">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-500"><Database className="h-5 w-5" /></span>
+            <StatusPill state={snapshot.migrations.state} />
+          </div>
+          <h2 className="mt-4 text-sm font-bold">Migration release state</h2>
+          <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">{migrationSummary}</p>
+          <div className="mt-4 grid gap-2 text-xs">
+            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Status</span><span className="font-semibold">{migrationStatusLabel(snapshot.migrations.status)}</span></div>
+            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Release migrations</span><span className="font-mono">{snapshot.migrations.releaseMigrationCount}</span></div>
+            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Main / production</span><span className="font-mono">{snapshot.migrations.repoCount} / {snapshot.migrations.appliedCount}</span></div>
+            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Supabase check</span><span className="font-mono">{snapshot.migrations.supabaseCheck ?? "Unavailable"}</span></div>
+          </div>
+        </article>
+
+        <article className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
+          <div className="flex items-start justify-between gap-3">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-amber-500/10 text-amber-600 dark:text-amber-400"><ShieldCheck className="h-5 w-5" /></span>
+            <StatusPill state={snapshot.failures.state} />
+          </div>
+          <h2 className="mt-4 text-sm font-bold">Failures since release</h2>
+          <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">{failureSummary}</p>
+          <div className="mt-4 grid gap-2 text-xs">
+            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Since</span><span>{formatTime(snapshot.failures.since)}</span></div>
+            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Unresolved total</span><span className="font-mono">{snapshot.failures.unresolved ?? "Unavailable"}</span></div>
+            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Latest captured</span><span>{formatTime(snapshot.failures.latestAt)}</span></div>
+          </div>
+        </article>
+      </section>
+
+      {(snapshot.migrations.pending.length > 0 || snapshot.migrations.drift.length > 0) ? (
+        <section className="rounded-2xl border border-amber-500/30 bg-amber-500/5 p-4 shadow-card sm:p-5">
+          <h2 className="text-sm font-bold">Migration reconciliation required</h2>
+          {snapshot.migrations.pending.length > 0 ? (
+            <p className="mt-2 break-words font-mono text-xs text-[color:var(--theme-text-secondary)]">Pending: {snapshot.migrations.pending.join(", ")}</p>
+          ) : null}
+          {snapshot.migrations.drift.length > 0 ? (
+            <p className="mt-2 break-words font-mono text-xs text-[color:var(--theme-text-secondary)]">Production-only: {snapshot.migrations.drift.join(", ")}</p>
+          ) : null}
+        </section>
+      ) : null}
+
+      <section className="overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-card">
+        <div className="flex flex-col gap-3 border-b border-[color:var(--theme-border-soft)] p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+          <div>
+            <div className="flex items-center gap-2"><GitPullRequest className="h-4 w-4 text-orange-500" /><h2 className="text-sm font-bold">Open PRs waiting on main</h2></div>
+            <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">{snapshot.pullRequests.ready} review-ready · {snapshot.pullRequests.draft} draft · {snapshot.pullRequests.total} total</p>
+          </div>
+          <a href="https://github.com/EdwardLakin/ProFixIQ/pulls" target="_blank" rel="noreferrer" className="text-xs font-bold text-orange-500 hover:text-orange-400">Open GitHub PRs</a>
+        </div>
+        <div className="divide-y divide-[color:var(--theme-border-soft)]">
+          {snapshot.pullRequests.recent.length === 0 ? (
+            <p className="p-5 text-sm text-[color:var(--theme-text-secondary)]">No open pull requests against main.</p>
+          ) : snapshot.pullRequests.recent.map((pull) => (
+            <a key={pull.number} href={pull.url} target="_blank" rel="noreferrer" className="flex flex-col gap-2 px-4 py-3 transition hover:bg-[color:var(--theme-surface-subtle)] sm:flex-row sm:items-center sm:justify-between sm:px-5">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-semibold">#{pull.number} {pull.title}</p>
+                <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">Updated {formatTime(pull.updatedAt)}</p>
+              </div>
+              <span className={cn("w-fit rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide", pull.draft ? "border-slate-400/30 bg-slate-500/10 text-[color:var(--theme-text-secondary)]" : "border-sky-500/30 bg-sky-500/10 text-sky-600 dark:text-sky-300")}>{pull.draft ? "Draft" : "Ready"}</span>
+            </a>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-3 sm:grid-cols-3" aria-label="Release evidence sources">
+        {[
+          { label: "GitHub release evidence", state: snapshot.sources.github },
+          { label: "Supabase release evidence", state: snapshot.sources.database },
+          { label: "Agent runtime evidence", state: snapshot.sources.agent },
+        ].map((source) => (
+          <div key={source.label} className="flex items-center justify-between gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
+            <span className="text-xs font-semibold">{source.label}</span>
+            <StatusPill state={source.state} />
+          </div>
+        ))}
+      </section>
+
+      <div className="text-xs text-[color:var(--theme-text-muted)]">
+        <Link href="/ops/system-health" className="font-semibold text-orange-500 hover:text-orange-400">System Health</Link>
+        <span> remains the live service-availability view; this page answers release/version parity.</span>
+      </div>
+    </div>
+  );
+}

--- a/features/ops/components/OpsShell.tsx
+++ b/features/ops/components/OpsShell.tsx
@@ -3,13 +3,14 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useState, type ReactNode } from "react";
-import { Activity, Bot, Gauge, LogOut, Menu, ShieldCheck, X } from "lucide-react";
+import { Activity, Bot, Gauge, GitBranch, LogOut, Menu, ShieldCheck, X } from "lucide-react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { cn } from "@shared/lib/utils";
 
 const NAVIGATION = [
   { href: "/ops", label: "Overview", icon: Gauge },
   { href: "/ops/system-health", label: "System Health", icon: Activity },
+  { href: "/ops/deployments", label: "Deployments", icon: GitBranch },
   { href: "/ops/agent-control", label: "Agent Control", icon: Bot },
 ] as const;
 

--- a/features/ops/server/get-release-health.ts
+++ b/features/ops/server/get-release-health.ts
@@ -1,0 +1,559 @@
+import "server-only";
+
+import { requireOpsOperatorPageAccess } from "@/features/ops/server/operator-access";
+import { resolveAgentApiSecrets } from "@/features/shared/lib/server/agent-api-secrets";
+
+const GITHUB_REPOSITORY = "EdwardLakin/ProFixIQ";
+const GITHUB_API = `https://api.github.com/repos/${GITHUB_REPOSITORY}`;
+const GITHUB_CACHE_SECONDS = 60;
+
+type ReleaseState = "healthy" | "degraded" | "down";
+
+type GithubCommit = {
+  sha: string;
+  commit: {
+    message: string;
+    author: { date: string | null } | null;
+    committer: { date: string | null } | null;
+  };
+  parents: Array<{ sha: string }>;
+};
+
+type GithubPull = {
+  number: number;
+  title: string;
+  draft: boolean;
+  html_url: string;
+  updated_at: string;
+  head: { sha: string };
+};
+
+type GithubCheck = {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  details_url: string | null;
+  app?: { slug?: string | null } | null;
+};
+
+type GithubChecks = { check_runs: GithubCheck[] };
+
+type GithubContentItem = {
+  name: string;
+  path: string;
+  type: "file" | "dir" | string;
+};
+
+type AgentRuntime = {
+  commitSha?: string | null;
+  deploymentId?: string | null;
+  fingerprint?: string | null;
+  verifiable?: boolean;
+};
+
+type AgentReleaseEvidencePayload = {
+  status?: string;
+  runtime?: AgentRuntime;
+  database?: {
+    configured?: boolean;
+    projectRef?: string | null;
+    checkedAt?: string | null;
+    since?: string | null;
+    migrations?: Array<{ version?: unknown; name?: unknown }>;
+    failuresSince?: unknown;
+    unresolvedFailures?: unknown;
+    latestFailureAt?: unknown;
+    error?: unknown;
+  };
+};
+
+type DatabaseMigration = { version: string; name: string };
+
+type DatabaseReleaseSnapshot = {
+  checkedAt: string | null;
+  projectRef: string | null;
+  since: string | null;
+  migrations: DatabaseMigration[];
+  failuresSince: number;
+  unresolvedFailures: number;
+  latestFailureAt: string | null;
+};
+
+type AgentReleaseEvidenceResult = {
+  agent: OpsReleaseHealthSnapshot["agent"];
+  database: {
+    state: ReleaseState;
+    data: DatabaseReleaseSnapshot | null;
+  };
+};
+
+export type OpsReleaseHealthSnapshot = {
+  checkedAt: string;
+  overall: ReleaseState;
+  production: {
+    state: ReleaseState;
+    commitSha: string | null;
+    deploymentId: string | null;
+    deploymentUrl: string | null;
+    environment: string;
+    expectedMainSha: string | null;
+    behindMain: boolean | null;
+    deploymentSucceeded: boolean | null;
+    vercelCheck: string | null;
+    releaseCommitAt: string | null;
+    releasePr: { number: number; title: string; url: string; headSha: string } | null;
+  };
+  agent: {
+    state: ReleaseState;
+    commitSha: string | null;
+    deploymentId: string | null;
+    fingerprint: string | null;
+    generationVerified: boolean;
+  };
+  ci: {
+    state: ReleaseState;
+    canonicalName: string;
+    status: string;
+    conclusion: string | null;
+    completedAt: string | null;
+    detailsUrl: string | null;
+    failingChecks: number;
+  };
+  migrations: {
+    state: ReleaseState;
+    status: "applied" | "not_required" | "pending" | "drift" | "failed" | "unknown";
+    requiredForRelease: boolean | null;
+    releaseMigrationCount: number;
+    repoCount: number;
+    appliedCount: number;
+    pending: string[];
+    drift: string[];
+    latestRepoVersion: string | null;
+    latestAppliedVersion: string | null;
+    supabaseCheck: string | null;
+  };
+  pullRequests: {
+    total: number;
+    ready: number;
+    draft: number;
+    recent: Array<{ number: number; title: string; draft: boolean; url: string; updatedAt: string }>;
+  };
+  failures: {
+    state: ReleaseState;
+    since: string | null;
+    countSinceRelease: number | null;
+    unresolved: number | null;
+    latestAt: string | null;
+  };
+  sources: {
+    github: ReleaseState;
+    database: ReleaseState;
+    agent: ReleaseState;
+  };
+};
+
+function text(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function numberValue(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseReleasePrNumber(message: string | null): number | null {
+  const match = message?.match(/Merge pull request #(\d+)/i);
+  return match ? Number(match[1]) : null;
+}
+
+function migrationVersion(filename: string): string | null {
+  const match = filename.match(/^(\d+)_.*\.sql$/);
+  return match?.[1] ?? null;
+}
+
+function latest(values: string[]): string | null {
+  return values.length ? [...values].sort().at(-1) ?? null : null;
+}
+
+function statusState(conclusion: string | null): ReleaseState {
+  if (conclusion === "success" || conclusion === "neutral" || conclusion === "skipped") return "healthy";
+  if (!conclusion) return "degraded";
+  return "down";
+}
+
+function isSuccessfulConclusion(conclusion: string | null): boolean {
+  return conclusion === "success" || conclusion === "neutral" || conclusion === "skipped";
+}
+
+async function githubJson<T>(path: string): Promise<{ ok: boolean; status: number; data: T | null }> {
+  const token = text(process.env.OPS_GITHUB_TOKEN) ?? text(process.env.GITHUB_TOKEN);
+  try {
+    const response = await fetch(`${GITHUB_API}${path}`, {
+      headers: {
+        accept: "application/vnd.github+json",
+        "user-agent": "ProFixIQ-Ops",
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      next: { revalidate: GITHUB_CACHE_SECONDS },
+    });
+    const data = response.ok ? (await response.json()) as T : null;
+    return { ok: response.ok, status: response.status, data };
+  } catch {
+    return { ok: false, status: 0, data: null };
+  }
+}
+
+function normalizeAgentRuntime(runtime: AgentRuntime | undefined): OpsReleaseHealthSnapshot["agent"] {
+  const fingerprint = text(runtime?.fingerprint);
+  const verified = runtime?.verifiable === true && Boolean(fingerprint);
+  return {
+    state: verified ? "healthy" : runtime ? "degraded" : "down",
+    commitSha: text(runtime?.commitSha),
+    deploymentId: text(runtime?.deploymentId),
+    fingerprint,
+    generationVerified: verified,
+  };
+}
+
+async function publicAgentRuntime(baseUrl: string): Promise<OpsReleaseHealthSnapshot["agent"]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 4_000);
+  try {
+    const response = await fetch(`${baseUrl}/health`, {
+      cache: "no-store",
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+    const raw = await response.text();
+    let payload: { runtime?: AgentRuntime } | null = null;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      payload = isRecord(parsed) ? parsed as { runtime?: AgentRuntime } : null;
+    } catch {
+      payload = null;
+    }
+    return normalizeAgentRuntime(payload?.runtime);
+  } catch {
+    return normalizeAgentRuntime(undefined);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function agentReleaseEvidence(since: string): Promise<AgentReleaseEvidenceResult> {
+  const baseUrl = text(process.env.PROFIXIQ_AGENT_URL)?.replace(/\/+$/, "") ?? null;
+  if (!baseUrl) {
+    return {
+      agent: normalizeAgentRuntime(undefined),
+      database: { state: "degraded", data: null },
+    };
+  }
+
+  const secret = resolveAgentApiSecrets().primary;
+  if (!secret) {
+    return {
+      agent: await publicAgentRuntime(baseUrl),
+      database: { state: "degraded", data: null },
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 18_000);
+  try {
+    const response = await fetch(
+      `${baseUrl}/ops/release-evidence?since=${encodeURIComponent(since)}`,
+      {
+        method: "GET",
+        cache: "no-store",
+        signal: controller.signal,
+        headers: {
+          accept: "application/json",
+          "x-agent-api-secret": secret,
+        },
+      },
+    );
+    const raw = await response.text();
+    let payload: AgentReleaseEvidencePayload | null = null;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      payload = isRecord(parsed) ? parsed as AgentReleaseEvidencePayload : null;
+    } catch {
+      payload = null;
+    }
+
+    if (!payload) {
+      return {
+        agent: await publicAgentRuntime(baseUrl),
+        database: { state: "degraded", data: null },
+      };
+    }
+
+    const agent = normalizeAgentRuntime(payload.runtime);
+    const database = payload.database;
+    const databaseError = text(database?.error);
+    const migrations = Array.isArray(database?.migrations)
+      ? database.migrations.flatMap((entry) => {
+          const version = text(entry?.version);
+          const name = text(entry?.name);
+          return version && name ? [{ version, name }] : [];
+        })
+      : [];
+    const databaseHealthy = response.ok
+      && payload.status === "ok"
+      && database?.configured === true
+      && !databaseError;
+
+    return {
+      agent,
+      database: {
+        state: databaseHealthy ? "healthy" : "degraded",
+        data: database ? {
+          checkedAt: text(database.checkedAt),
+          projectRef: text(database.projectRef),
+          since: text(database.since),
+          migrations,
+          failuresSince: numberValue(database.failuresSince),
+          unresolvedFailures: numberValue(database.unresolvedFailures),
+          latestFailureAt: text(database.latestFailureAt),
+        } : null,
+      },
+    };
+  } catch {
+    return {
+      agent: await publicAgentRuntime(baseUrl),
+      database: { state: "degraded", data: null },
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function overallState(states: ReleaseState[]): ReleaseState {
+  if (states.includes("down")) return "down";
+  if (states.includes("degraded")) return "degraded";
+  return "healthy";
+}
+
+export async function getOpsReleaseHealth(): Promise<OpsReleaseHealthSnapshot> {
+  await requireOpsOperatorPageAccess();
+
+  const checkedAt = new Date().toISOString();
+  const deployedSha = text(process.env.VERCEL_GIT_COMMIT_SHA);
+  const deploymentId = text(process.env.VERCEL_DEPLOYMENT_ID);
+  const deploymentUrl = text(process.env.VERCEL_URL);
+  const environment = text(process.env.VERCEL_ENV) ?? text(process.env.NODE_ENV) ?? "unknown";
+
+  const [mainResult, openPullsResult, mainMigrationsResult] = await Promise.all([
+    githubJson<GithubCommit>("/commits/main"),
+    githubJson<GithubPull[]>("/pulls?state=open&base=main&per_page=100&sort=updated&direction=desc"),
+    githubJson<GithubContentItem[]>("/contents/supabase/migrations?ref=main"),
+  ]);
+
+  const mainCommit = mainResult.data;
+  const mainSha = text(mainCommit?.sha);
+  const deployedCommitResult = deployedSha && deployedSha !== mainSha
+    ? await githubJson<GithubCommit>(`/commits/${encodeURIComponent(deployedSha)}`)
+    : mainResult;
+  const deployedCommit = deployedCommitResult.data;
+  const deployedCommitAt = text(deployedCommit?.commit.committer?.date) ?? text(deployedCommit?.commit.author?.date);
+  const since = deployedCommitAt ?? new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  const releasePrNumber = parseReleasePrNumber(text(deployedCommit?.commit.message));
+  const releasePrResult = releasePrNumber
+    ? await githubJson<GithubPull>(`/pulls/${releasePrNumber}`)
+    : { ok: true, status: 200, data: null as GithubPull | null };
+  const releasePr = releasePrResult.data;
+  const parentSha = deployedCommit?.parents?.[0]?.sha ?? null;
+
+  const [releaseChecksResult, mergeChecksResult, deployedMigrationsResult, parentMigrationsResult, infrastructure] = await Promise.all([
+    releasePr?.head.sha
+      ? githubJson<GithubChecks>(`/commits/${encodeURIComponent(releasePr.head.sha)}/check-runs?per_page=100`)
+      : Promise.resolve({ ok: true, status: 200, data: { check_runs: [] } as GithubChecks }),
+    deployedSha
+      ? githubJson<GithubChecks>(`/commits/${encodeURIComponent(deployedSha)}/check-runs?per_page=100`)
+      : Promise.resolve({ ok: false, status: 0, data: null as GithubChecks | null }),
+    deployedSha && deployedSha !== mainSha
+      ? githubJson<GithubContentItem[]>(`/contents/supabase/migrations?ref=${encodeURIComponent(deployedSha)}`)
+      : Promise.resolve(mainMigrationsResult),
+    parentSha
+      ? githubJson<GithubContentItem[]>(`/contents/supabase/migrations?ref=${encodeURIComponent(parentSha)}`)
+      : Promise.resolve({ ok: true, status: 200, data: [] as GithubContentItem[] }),
+    agentReleaseEvidence(since),
+  ]);
+
+  const releaseChecks = releaseChecksResult.data?.check_runs ?? [];
+  const canonicalCheck = [...releaseChecks]
+    .filter((check) => check.name === "checks" && check.app?.slug === "github-actions")
+    .sort((a, b) => Date.parse(b.completed_at ?? "") - Date.parse(a.completed_at ?? ""))[0]
+    ?? [...releaseChecks]
+      .filter((check) => check.app?.slug === "github-actions" && check.status === "completed")
+      .sort((a, b) => Date.parse(b.completed_at ?? "") - Date.parse(a.completed_at ?? ""))[0]
+    ?? null;
+  const failingChecks = releaseChecks.filter(
+    (check) => check.status === "completed" && !isSuccessfulConclusion(check.conclusion),
+  ).length;
+  const ciState = canonicalCheck ? statusState(canonicalCheck.conclusion) : "degraded";
+
+  const mergeChecks = mergeChecksResult.data?.check_runs ?? [];
+  const supabaseCheck = [...mergeChecks]
+    .filter((check) => check.app?.slug === "supabase")
+    .sort((a, b) => Date.parse(b.completed_at ?? "") - Date.parse(a.completed_at ?? ""))[0] ?? null;
+  const vercelCheck = [...mergeChecks]
+    .filter((check) => check.app?.slug === "vercel" || check.name.toLowerCase() === "vercel")
+    .sort((a, b) => Date.parse(b.completed_at ?? "") - Date.parse(a.completed_at ?? ""))[0] ?? null;
+
+  const repoMigrationFiles = (mainMigrationsResult.data ?? []).filter(
+    (item) => item.type === "file" && migrationVersion(item.name),
+  );
+  const deployedMigrationFiles = (deployedMigrationsResult.data ?? []).filter(
+    (item) => item.type === "file" && migrationVersion(item.name),
+  );
+  const parentMigrationNames = new Set((parentMigrationsResult.data ?? []).map((item) => item.name));
+  const releaseMigrationFiles = deployedMigrationFiles.filter((item) => !parentMigrationNames.has(item.name));
+
+  const repoVersions = repoMigrationFiles.flatMap((item) => {
+    const version = migrationVersion(item.name);
+    return version ? [version] : [];
+  });
+  const appliedVersions = infrastructure.database.data?.migrations.map((migration) => migration.version) ?? [];
+  const repoSet = new Set(repoVersions);
+  const appliedSet = new Set(appliedVersions);
+  const pending = repoVersions.filter((version) => !appliedSet.has(version)).sort();
+  const drift = appliedVersions.filter((version) => !repoSet.has(version)).sort();
+  const migrationsRequired = parentSha ? releaseMigrationFiles.length > 0 : null;
+
+  let migrationStatus: OpsReleaseHealthSnapshot["migrations"]["status"] = "unknown";
+  if (infrastructure.database.state !== "healthy") migrationStatus = "unknown";
+  else if (supabaseCheck?.conclusion && !isSuccessfulConclusion(supabaseCheck.conclusion)) migrationStatus = "failed";
+  else if (drift.length > 0) migrationStatus = "drift";
+  else if (pending.length > 0) migrationStatus = "pending";
+  else if (migrationsRequired === false) migrationStatus = "not_required";
+  else migrationStatus = "applied";
+
+  const migrationState: ReleaseState = migrationStatus === "applied" || migrationStatus === "not_required"
+    ? "healthy"
+    : migrationStatus === "pending" || migrationStatus === "unknown"
+      ? "degraded"
+      : "down";
+
+  const behindMain = deployedSha && mainSha ? deployedSha !== mainSha : null;
+  const runtimeServing = Boolean(deployedSha && deploymentId);
+  const deploymentSucceeded = runtimeServing
+    ? vercelCheck?.conclusion && !isSuccessfulConclusion(vercelCheck.conclusion)
+      ? false
+      : true
+    : null;
+  const productionState: ReleaseState = !runtimeServing
+    ? "down"
+    : deploymentSucceeded === false
+      ? "down"
+      : behindMain === true
+        ? "degraded"
+        : "healthy";
+
+  const pulls = openPullsResult.data ?? [];
+  const recentPulls = pulls.slice(0, 8).map((pull) => ({
+    number: pull.number,
+    title: pull.title,
+    draft: pull.draft,
+    url: pull.html_url,
+    updatedAt: pull.updated_at,
+  }));
+
+  const failureState: ReleaseState = infrastructure.database.state !== "healthy"
+    ? "degraded"
+    : (infrastructure.database.data?.failuresSince ?? 0) > 0
+      ? "degraded"
+      : "healthy";
+
+  const githubHealthy = mainResult.ok
+    && openPullsResult.ok
+    && mainMigrationsResult.ok
+    && deployedCommitResult.ok
+    && releasePrResult.ok
+    && releaseChecksResult.ok
+    && mergeChecksResult.ok;
+  const githubState: ReleaseState = githubHealthy ? "healthy" : mainResult.ok ? "degraded" : "down";
+
+  const states = [
+    productionState,
+    infrastructure.agent.state,
+    ciState,
+    migrationState,
+    failureState,
+    githubState,
+    infrastructure.database.state,
+  ];
+
+  return {
+    checkedAt,
+    overall: overallState(states),
+    production: {
+      state: productionState,
+      commitSha: deployedSha,
+      deploymentId,
+      deploymentUrl,
+      environment,
+      expectedMainSha: mainSha,
+      behindMain,
+      deploymentSucceeded,
+      vercelCheck: vercelCheck?.conclusion ?? null,
+      releaseCommitAt: deployedCommitAt,
+      releasePr: releasePr
+        ? {
+            number: releasePr.number,
+            title: releasePr.title,
+            url: releasePr.html_url,
+            headSha: releasePr.head.sha,
+          }
+        : null,
+    },
+    agent: infrastructure.agent,
+    ci: {
+      state: ciState,
+      canonicalName: canonicalCheck?.name ?? "Unavailable",
+      status: canonicalCheck?.status ?? "unknown",
+      conclusion: canonicalCheck?.conclusion ?? null,
+      completedAt: canonicalCheck?.completed_at ?? null,
+      detailsUrl: canonicalCheck?.details_url ?? null,
+      failingChecks,
+    },
+    migrations: {
+      state: migrationState,
+      status: migrationStatus,
+      requiredForRelease: migrationsRequired,
+      releaseMigrationCount: releaseMigrationFiles.length,
+      repoCount: repoVersions.length,
+      appliedCount: appliedVersions.length,
+      pending,
+      drift,
+      latestRepoVersion: latest(repoVersions),
+      latestAppliedVersion: latest(appliedVersions),
+      supabaseCheck: supabaseCheck?.conclusion ?? null,
+    },
+    pullRequests: {
+      total: pulls.length,
+      ready: pulls.filter((pull) => !pull.draft).length,
+      draft: pulls.filter((pull) => pull.draft).length,
+      recent: recentPulls,
+    },
+    failures: {
+      state: failureState,
+      since: infrastructure.database.data?.since ?? deployedCommitAt,
+      countSinceRelease: infrastructure.database.data?.failuresSince ?? null,
+      unresolved: infrastructure.database.data?.unresolvedFailures ?? null,
+      latestAt: infrastructure.database.data?.latestFailureAt ?? null,
+    },
+    sources: {
+      github: githubState,
+      database: infrastructure.database.state,
+      agent: infrastructure.agent.state,
+    },
+  };
+}

--- a/tests/ops-release-health.test.ts
+++ b/tests/ops-release-health.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("Ops deployments and release health", () => {
+  it("adds a force-dynamic owner Ops deployments route", () => {
+    const page = source("app/ops/deployments/page.tsx");
+    const server = source("features/ops/server/get-release-health.ts");
+    expect(page).toContain('export const dynamic = "force-dynamic"');
+    expect(page).toContain("getOpsReleaseHealth");
+    expect(page).toContain("<OpsReleaseHealth snapshot={snapshot} />");
+    expect(server).toContain("await requireOpsOperatorPageAccess()");
+  });
+
+  it("correlates Vercel runtime identity with GitHub main, PRs, CI, and migration inventory", () => {
+    const server = source("features/ops/server/get-release-health.ts");
+    expect(server).toContain("VERCEL_GIT_COMMIT_SHA");
+    expect(server).toContain("VERCEL_DEPLOYMENT_ID");
+    expect(server).toContain('githubJson<GithubCommit>("/commits/main")');
+    expect(server).toContain('"/pulls?state=open&base=main&per_page=100&sort=updated&direction=desc"');
+    expect(server).toContain("/check-runs?per_page=100");
+    expect(server).toContain('"/contents/supabase/migrations?ref=main"');
+    expect(server).toContain("behindMain");
+    expect(server).toContain("deploymentSucceeded");
+    expect(server).toContain("vercelCheck");
+  });
+
+  it("keeps privileged production database inspection behind the authenticated Agent boundary", () => {
+    const server = source("features/ops/server/get-release-health.ts");
+    expect(server).toContain("resolveAgentApiSecrets");
+    expect(server).toContain("/ops/release-evidence?since=");
+    expect(server).toContain('"x-agent-api-secret": secret');
+    expect(server).toContain("publicAgentRuntime");
+    expect(server).not.toContain("ops_release_database_snapshot");
+    expect(server).not.toContain("SUPABASE_SERVICE_ROLE_KEY");
+    expect(server).not.toContain("PROFIXIQ_SUPABASE_MANAGEMENT_TOKEN");
+    expect(server).not.toContain("api.supabase.com");
+    expect(server).not.toContain("createClient(");
+  });
+
+  it("reports migration parity and release failures from sanitized Agent evidence", () => {
+    const server = source("features/ops/server/get-release-health.ts");
+    expect(server).toContain("pending = repoVersions.filter");
+    expect(server).toContain("drift = appliedVersions.filter");
+    expect(server).toContain('migrationStatus = "pending"');
+    expect(server).toContain('migrationStatus = "drift"');
+    expect(server).toContain("failuresSince");
+    expect(server).toContain("unresolvedFailures");
+    expect(server).toContain("latestFailureAt");
+  });
+
+  it("surfaces Deployments in desktop/mobile Ops navigation and the Overview control surfaces", () => {
+    const shell = source("features/ops/components/OpsShell.tsx");
+    const dashboard = source("features/ops/components/OpsDashboard.tsx");
+    expect(shell).toContain('{ href: "/ops/deployments", label: "Deployments", icon: GitBranch }');
+    expect(shell.match(/aria-label="Operations navigation"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(dashboard).toContain('href: "/ops/system-health"');
+    expect(dashboard).toContain('href: "/ops/deployments"');
+    expect(dashboard).toContain('href: "/ops/agent-control"');
+    expect(dashboard).toContain("Operations control surfaces");
+  });
+
+  it("keeps the release page read-only and explicit about evidence sources", () => {
+    const component = source("features/ops/components/OpsReleaseHealth.tsx");
+    expect(component).toContain("Deployments &amp; release health");
+    expect(component).toContain("This page is read-only");
+    expect(component).toContain("Open PRs waiting on main");
+    expect(component).toContain("Migration release state");
+    expect(component).toContain("Failures since release");
+    expect(component).toContain("Release evidence sources");
+  });
+});


### PR DESCRIPTION
## Outcome

Adds the next Ops control-plane slice at `/ops/deployments`, answering production version, release CI, main/deployment parity, migration coherence, open PR pressure, Agent version, and captured failures since the deployed release.

## Architecture

Infrastructure inspection stays outside the tenant application.

ProFixIQ Ops correlates:
- its own live Vercel runtime identity
- GitHub `main`, PR, check-run, and repository migration evidence
- authenticated read-only infrastructure evidence from ProFixIQ-Agent PR #52

Agent #52 owns the Supabase Management API boundary and returns only sanitized migration-ledger identity plus aggregate operational-capture failure counters. **This ProFixIQ PR has no database migration and introduces no service-role or Supabase Management credential.**

## What changed

- adds owner-only `/ops/deployments`
- adds Deployments to desktop and mobile Ops navigation
- adds real Overview control surfaces for System Health, Deployments, and Agent Work
- correlates the live Vercel runtime SHA/deployment ID with GitHub `main`
- resolves the deployed merge PR and its canonical GitHub Actions check result
- correlates the Vercel deployment check when GitHub exposes it
- shows open PR counts split into review-ready and draft, plus the most recently updated PRs
- reads the Agent generation through the authenticated release-evidence boundary, with public `/health` only as a runtime fallback
- compares repository migration versions on `main` with the sanitized production migration ledger returned by Agent #52
- detects pending repository migrations and production-only ledger drift
- detects whether the deployed release itself introduced migrations
- correlates the Supabase GitHub check for the deployed merge commit
- reports aggregate durable operational-event capture failures since the deployed commit time
- keeps every Ops surface read-only

## Release evidence model

The page answers:

1. production ProFixIQ SHA/deployment
2. production Agent SHA/deployment generation
3. whether the current ProFixIQ deployment is serving successfully
4. whether production is behind `main`
5. open PRs waiting on `main`
6. latest deployed PR CI result
7. migration required/applied/not-required/pending/drift/failed state
8. deployed application SHA vs expected `main` SHA
9. repository migration inventory vs production Supabase ledger coherence
10. durable operational-capture failures recorded since the deployed release

Broader Vercel runtime-error history is intentionally reserved for the upcoming **Incidents** slice; the existing Agent Vercel log reader is a bounded live stream and is not misrepresented here as historical post-deploy coverage.

## Safety

- existing owner-only Ops authorization remains mandatory
- no Supabase service-role health bypass
- no Supabase Management token in ProFixIQ
- no Vercel API token is introduced into ProFixIQ
- GitHub data is read-only and cached briefly; optional `OPS_GITHUB_TOKEN`/`GITHUB_TOKEN` may raise rate limits but is not required for public-repository reads
- Agent infrastructure evidence uses the existing shared Agent secret boundary
- public Agent `/health` is only a fail-safe runtime-version fallback
- page exposes no write/retry/deploy/migration controls

## Database

**No ProFixIQ migration or backfill.**

The earlier tenant-side release-ledger RPC was removed before final review. Privileged production database inspection is owned by ProFixIQ-Agent PR #52 using its existing read-only Supabase Management API contract.

A Supabase preview created from the abandoned first implementation had already applied temporary version `20260813020500 ops_release_health_snapshot`. After that migration was removed from the PR, the stale preview correctly reported a remote/local migration mismatch. The disposable preview branch was deleted before the final push. On final head `49ddf5c9…`, no Supabase preview branch/check is created because this PR contains zero Supabase files. Production was never given the temporary migration.

## Validation coverage

Adds `tests/ops-release-health.test.ts` covering:

- force-dynamic owner Ops route
- Vercel runtime → GitHub main/PR/check correlation
- explicit deployment-success/parity evidence
- authenticated Agent release-evidence usage
- absence of service-role/Management-API access in ProFixIQ
- pending/drift/failure classification from sanitized Agent evidence
- desktop/mobile navigation
- Overview control-surface routing
- read-only UI/evidence labeling

## Final validation

Final review head: `49ddf5c92f1441e24194fff201f70565aa447b88`.

`Agent PR Checks / checks` passed on this exact head, including:
- full-app regression inventory
- TypeScript type-check
- changed-file ESLint
- complete Vitest suite
- production Next.js build

GitGuardian passed. Unrelated specialized workflows were skipped by scope as expected.

## Delivery state

- one commit ahead of post-#1418 `main`
- zero commits behind at final review
- six intended app/test files changed
- no Supabase files changed
- no production migration required
- depends on Agent PR #52 for full migration-ledger evidence
- draft only
- merge order: Agent #52 first, verify production, then #1420
- merge remains an explicit human action