### PR TITLE
Add assigned truck inventory for Field Service

### DIFF
--- a/app/api/mobile/service-visits/truck-inventory/route.ts
+++ b/app/api/mobile/service-visits/truck-inventory/route.ts
@@ -1,0 +1,148 @@
+import { NextResponse } from "next/server";
+
+import { getMobileActiveJobs } from "@/features/dispatch/server/commands";
+import { requireMobileServiceOperatorApiAccess } from "@/features/mobile/service/server/access";
+
+type StockRow = {
+  part_id: string | null;
+  location_id: string | null;
+  qty_available: number | string | null;
+  qty_on_hand: number | string | null;
+  qty_reserved: number | string | null;
+};
+
+type PartRow = {
+  id: string;
+  sku: string | null;
+  part_number: string | null;
+  name: string | null;
+  description: string | null;
+  category: string | null;
+};
+
+function quantity(value: number | string | null | undefined): number {
+  const parsed = typeof value === "number" ? value : Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export async function GET() {
+  const access = await requireMobileServiceOperatorApiAccess();
+  if (!access.ok) return access.response;
+
+  try {
+    const snapshot = await getMobileActiveJobs({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id,
+      actorUserId: access.profile.id,
+    });
+    const visit = snapshot.activeJob ?? snapshot.nextJob;
+    const truck = visit?.serviceVehicle ?? null;
+    const stockLocationId = truck?.stockLocationId ?? null;
+
+    if (!visit || !truck || !stockLocationId) {
+      return NextResponse.json(
+        {
+          serverNow: snapshot.serverNow,
+          visit: visit
+            ? {
+                id: visit.id,
+                workOrderId: visit.workOrderId ?? null,
+                workOrderNumber: visit.workOrderNumber ?? null,
+                status: visit.status,
+                kind: snapshot.activeJob ? "active" : "next",
+              }
+            : null,
+          truck: truck
+            ? {
+                id: truck.id,
+                name: truck.name,
+                unitNumber: truck.unitNumber ?? null,
+                stockLocationId,
+              }
+            : null,
+          items: [],
+        },
+        { headers: { "Cache-Control": "private, no-store" } },
+      );
+    }
+
+    const { data: stockData, error: stockError } = await access.supabase
+      .from("v_part_stock")
+      .select(
+        "part_id,location_id,qty_available,qty_on_hand,qty_reserved",
+      )
+      .eq("location_id", stockLocationId);
+    if (stockError) throw new Error(stockError.message);
+
+    const stockRows = ((stockData ?? []) as StockRow[]).filter(
+      (row) =>
+        Boolean(row.part_id) &&
+        (quantity(row.qty_on_hand) !== 0 || quantity(row.qty_reserved) !== 0),
+    );
+    const partIds = Array.from(
+      new Set(
+        stockRows
+          .map((row) => row.part_id)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+
+    let parts: PartRow[] = [];
+    if (partIds.length > 0) {
+      const { data: partData, error: partError } = await access.supabase
+        .from("parts")
+        .select("id,sku,part_number,name,description,category")
+        .eq("shop_id", access.profile.shop_id)
+        .in("id", partIds);
+      if (partError) throw new Error(partError.message);
+      parts = (partData ?? []) as PartRow[];
+    }
+
+    const partsById = new Map(parts.map((part) => [part.id, part]));
+    const items = stockRows
+      .map((stock) => {
+        const partId = stock.part_id as string;
+        const part = partsById.get(partId);
+        return {
+          partId,
+          sku: part?.sku ?? null,
+          partNumber: part?.part_number ?? null,
+          name: part?.name ?? part?.description ?? "Inventory part",
+          description: part?.description ?? null,
+          category: part?.category ?? null,
+          qtyOnHand: quantity(stock.qty_on_hand),
+          qtyReserved: quantity(stock.qty_reserved),
+          qtyAvailable: quantity(stock.qty_available),
+        };
+      })
+      .sort((a, b) =>
+        `${a.name} ${a.sku ?? ""}`.localeCompare(`${b.name} ${b.sku ?? ""}`),
+      );
+
+    return NextResponse.json(
+      {
+        serverNow: snapshot.serverNow,
+        visit: {
+          id: visit.id,
+          workOrderId: visit.workOrderId ?? null,
+          workOrderNumber: visit.workOrderNumber ?? null,
+          status: visit.status,
+          kind: snapshot.activeJob ? "active" : "next",
+        },
+        truck: {
+          id: truck.id,
+          name: truck.name,
+          unitNumber: truck.unitNumber ?? null,
+          stockLocationId,
+        },
+        items,
+      },
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Unable to load assigned truck inventory." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/mobile/service-visits/truck-inventory/route.ts
+++ b/app/api/mobile/service-visits/truck-inventory/route.ts
@@ -27,7 +27,15 @@ function quantity(value: number | string | null | undefined): number {
 
 export async function GET() {
   const access = await requireMobileServiceOperatorApiAccess();
-  if (!access.ok) return access.response;
+  if (!access.ok) {
+    if (access.response.status === 403) {
+      return NextResponse.json(
+        { error: "Truck inventory is available to assigned Field Service operators." },
+        { status: 403 },
+      );
+    }
+    return access.response;
+  }
 
   try {
     const snapshot = await getMobileActiveJobs({

--- a/app/mobile/parts/page.tsx
+++ b/app/mobile/parts/page.tsx
@@ -1,4 +1,4 @@
-import { Boxes, ChevronRight, PackageCheck, PackageOpen } from "lucide-react";
+import { Boxes, ChevronRight, PackageCheck, PackageOpen, Truck } from "lucide-react";
 import Link from "next/link";
 
 import MobilePartsWorkflow from "@/features/parts/mobile/MobilePartsWorkflow";
@@ -54,6 +54,23 @@ export default function MobilePartsPage() {
             </span>
             <span className="mt-1 block text-xs text-[color:var(--theme-text-secondary)]">
               Release to tech
+            </span>
+          </span>
+          <ChevronRight className="h-4 w-4 shrink-0 text-[color:var(--accent-copper)]" />
+        </Link>
+        <Link
+          href="/mobile/parts/truck"
+          className="mobile-command-row col-span-2 flex min-h-[5rem] items-center gap-3 border p-3"
+        >
+          <span className="inline-grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-sky-500/10 text-sky-600 dark:text-sky-300">
+            <Truck aria-hidden className="h-5 w-5" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-bold text-[color:var(--theme-text-primary)]">
+              Truck inventory
+            </span>
+            <span className="mt-1 block text-xs text-[color:var(--theme-text-secondary)]">
+              Assigned Field Service vehicle stock
             </span>
           </span>
           <ChevronRight className="h-4 w-4 shrink-0 text-[color:var(--accent-copper)]" />

--- a/app/mobile/parts/truck/page.tsx
+++ b/app/mobile/parts/truck/page.tsx
@@ -1,0 +1,36 @@
+import { ArrowLeft, Truck } from "lucide-react";
+import Link from "next/link";
+
+import MobileTruckInventory from "@/features/parts/mobile/MobileTruckInventory";
+
+export const dynamic = "force-dynamic";
+
+export default function MobileTruckInventoryPage() {
+  return (
+    <main className="mx-auto w-full max-w-4xl space-y-3 px-3 py-3 sm:px-4">
+      <Link
+        href="/mobile/parts"
+        className="inline-flex min-h-11 items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-3 text-sm font-bold text-[color:var(--theme-text-primary)]"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to parts
+      </Link>
+
+      <section className="mobile-dashboard-hero">
+        <div className="flex items-start gap-3">
+          <span className="inline-grid h-11 w-11 shrink-0 place-items-center rounded-2xl border border-white/15 bg-white/10 text-[#8ed4ff]">
+            <Truck aria-hidden className="h-5 w-5" />
+          </span>
+          <div className="min-w-0">
+            <div className="mobile-dashboard-hero__eyebrow">Field Service</div>
+            <h1 className="mobile-dashboard-hero__title">Truck inventory</h1>
+            <p className="mobile-dashboard-hero__subtitle">
+              See the canonical on-hand, reserved and available stock on the service vehicle assigned to your current call.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <MobileTruckInventory />
+    </main>
+  );
+}

--- a/features/mobile/config/mobile-tiles.ts
+++ b/features/mobile/config/mobile-tiles.ts
@@ -92,6 +92,13 @@ export const MOBILE_TILES: MobileTile[] = [
     scopes: ["home", "jobs", "work_orders", "all"],
   },
   {
+    href: "/mobile/parts/truck",
+    title: "Truck Inventory",
+    subtitle: "Stock on your assigned service truck",
+    roles: ["mechanic", "lead_hand", "foreman"],
+    scopes: ["home", "jobs", "work_orders", "all"],
+  },
+  {
     href: "/mobile/service",
     title: "Field Service",
     subtitle: "Field setup, calls and closeout",

--- a/features/parts/mobile/MobileTruckInventory.tsx
+++ b/features/parts/mobile/MobileTruckInventory.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { Boxes, RefreshCw, Search, Truck } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type TruckInventoryItem = {
+  partId: string;
+  sku: string | null;
+  partNumber: string | null;
+  name: string;
+  description: string | null;
+  category: string | null;
+  qtyOnHand: number;
+  qtyReserved: number;
+  qtyAvailable: number;
+};
+
+type TruckInventorySnapshot = {
+  serverNow: string;
+  visit: {
+    id: string;
+    workOrderId: string | null;
+    workOrderNumber: string | null;
+    status: string;
+    kind: "active" | "next";
+  } | null;
+  truck: {
+    id: string;
+    name: string;
+    unitNumber: string | null;
+    stockLocationId: string | null;
+  } | null;
+  items: TruckInventoryItem[];
+  error?: string;
+};
+
+function formatQty(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(0) : value.toFixed(2);
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3">
+      <div className="text-[0.65rem] font-bold uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
+        {label}
+      </div>
+      <div className="mt-1 text-xl font-extrabold text-[color:var(--theme-text-primary)]">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export default function MobileTruckInventory() {
+  const [snapshot, setSnapshot] = useState<TruckInventorySnapshot | null>(null);
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/mobile/service-visits/truck-inventory", {
+        credentials: "include",
+        cache: "no-store",
+      });
+      const body = (await response.json().catch(() => null)) as
+        | TruckInventorySnapshot
+        | null;
+      if (!response.ok || !body || body.error) {
+        throw new Error(body?.error || "Unable to load assigned truck inventory.");
+      }
+      setSnapshot(body);
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Unable to load assigned truck inventory.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const filteredItems = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return snapshot?.items ?? [];
+    return (snapshot?.items ?? []).filter((item) =>
+      [
+        item.name,
+        item.sku,
+        item.partNumber,
+        item.description,
+        item.category,
+      ]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(term)),
+    );
+  }, [query, snapshot?.items]);
+
+  const totals = useMemo(() => {
+    const items = snapshot?.items ?? [];
+    return {
+      skuCount: items.length,
+      onHand: items.reduce((sum, item) => sum + item.qtyOnHand, 0),
+      available: items.reduce((sum, item) => sum + item.qtyAvailable, 0),
+    };
+  }, [snapshot?.items]);
+
+  if (loading && !snapshot) {
+    return (
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-5 text-sm text-[color:var(--theme-text-secondary)]">
+        Loading assigned truck inventory…
+      </section>
+    );
+  }
+
+  if (error && !snapshot) {
+    return (
+      <section className="rounded-3xl border border-red-500/35 bg-red-500/10 p-5">
+        <p className="text-sm font-semibold text-red-700 dark:text-red-200">{error}</p>
+        <button
+          type="button"
+          className="mt-3 inline-flex min-h-11 items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-4 text-sm font-bold text-[color:var(--theme-text-primary)]"
+          onClick={() => void load()}
+        >
+          <RefreshCw className="h-4 w-4" /> Retry
+        </button>
+      </section>
+    );
+  }
+
+  if (!snapshot?.visit) {
+    return (
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-5">
+        <div className="flex items-start gap-3">
+          <Boxes className="mt-0.5 h-5 w-5 text-[color:var(--accent-copper)]" />
+          <div>
+            <h2 className="font-bold text-[color:var(--theme-text-primary)]">No assigned service call</h2>
+            <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+              Truck inventory appears here when you have an active or next Field Service visit.
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (!snapshot.truck?.stockLocationId) {
+    return (
+      <section className="rounded-3xl border border-amber-500/35 bg-amber-500/10 p-5">
+        <div className="flex items-start gap-3">
+          <Truck className="mt-0.5 h-5 w-5 text-amber-700 dark:text-amber-200" />
+          <div>
+            <h2 className="font-bold text-amber-800 dark:text-amber-100">No truck stock location assigned</h2>
+            <p className="mt-1 text-sm text-amber-800/80 dark:text-amber-100/80">
+              This service call needs a service vehicle with a linked stock location before truck inventory can be shown.
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-[0.65rem] font-bold uppercase tracking-[0.16em] text-[color:var(--accent-copper)]">
+              {snapshot.visit.kind === "active" ? "Active service call" : "Next service call"}
+            </div>
+            <h2 className="mt-1 flex items-center gap-2 text-xl font-extrabold text-[color:var(--theme-text-primary)]">
+              <Truck className="h-5 w-5 shrink-0" />
+              <span className="truncate">{snapshot.truck.name}</span>
+            </h2>
+            <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+              {snapshot.truck.unitNumber ? `Unit ${snapshot.truck.unitNumber} · ` : ""}
+              {snapshot.visit.workOrderNumber || "Service visit"}
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Refresh truck inventory"
+            disabled={loading}
+            onClick={() => void load()}
+            className="inline-flex min-h-11 shrink-0 items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 text-sm font-bold text-[color:var(--theme-text-primary)] disabled:opacity-50"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            <span className="hidden sm:inline">Refresh</span>
+          </button>
+        </div>
+
+        <div className="mt-4 grid grid-cols-3 gap-2">
+          <Metric label="SKUs" value={String(totals.skuCount)} />
+          <Metric label="On hand" value={formatQty(totals.onHand)} />
+          <Metric label="Available" value={formatQty(totals.available)} />
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <label htmlFor="truck-inventory-search" className="text-sm font-bold text-[color:var(--theme-text-primary)]">
+          Search truck stock
+        </label>
+        <div className="relative mt-2">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--theme-text-muted)]" />
+          <input
+            id="truck-inventory-search"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Part, SKU, number or category"
+            className="min-h-12 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] pl-10 pr-3 text-base text-[color:var(--theme-text-primary)]"
+          />
+        </div>
+
+        {error ? (
+          <p className="mt-3 text-sm text-red-700 dark:text-red-200">{error}</p>
+        ) : null}
+
+        {!loading && snapshot.items.length === 0 ? (
+          <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 text-sm text-[color:var(--theme-text-secondary)]">
+            This truck has no physical stock or reserved parts in the canonical inventory ledger.
+          </div>
+        ) : null}
+
+        {!loading && snapshot.items.length > 0 && filteredItems.length === 0 ? (
+          <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 text-sm text-[color:var(--theme-text-secondary)]">
+            No truck-stock items match that search.
+          </div>
+        ) : null}
+
+        <div className="mt-4 grid gap-2">
+          {filteredItems.map((item) => (
+            <article
+              key={item.partId}
+              className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-extrabold text-[color:var(--theme-text-primary)]">
+                    {item.name}
+                  </h3>
+                  <p className="mt-0.5 truncate text-xs text-[color:var(--theme-text-secondary)]">
+                    {[item.sku || item.partNumber, item.category].filter(Boolean).join(" · ") || "Inventory part"}
+                  </p>
+                </div>
+                <span className="shrink-0 rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-2.5 py-1 text-xs font-bold text-[color:var(--theme-text-primary)]">
+                  {formatQty(item.qtyAvailable)} available
+                </span>
+              </div>
+              <div className="mt-3 grid grid-cols-3 gap-1.5 text-center text-[10px] text-[color:var(--theme-text-secondary)]">
+                {[
+                  ["On hand", item.qtyOnHand],
+                  ["Reserved", item.qtyReserved],
+                  ["Available", item.qtyAvailable],
+                ].map(([label, value]) => (
+                  <div
+                    key={String(label)}
+                    className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2"
+                  >
+                    <span className="block">{label}</span>
+                    <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
+                      {formatQty(Number(value))}
+                    </strong>
+                  </div>
+                ))}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/tests/mobile-truck-inventory-ui.test.tsx
+++ b/tests/mobile-truck-inventory-ui.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import MobileTruckInventory from "@/features/parts/mobile/MobileTruckInventory";
+
+type Snapshot = {
+  serverNow: string;
+  visit: {
+    id: string;
+    workOrderId: string | null;
+    workOrderNumber: string | null;
+    status: string;
+    kind: "active" | "next";
+  } | null;
+  truck: {
+    id: string;
+    name: string;
+    unitNumber: string | null;
+    stockLocationId: string | null;
+  } | null;
+  items: Array<{
+    partId: string;
+    sku: string | null;
+    partNumber: string | null;
+    name: string;
+    description: string | null;
+    category: string | null;
+    qtyOnHand: number;
+    qtyReserved: number;
+    qtyAvailable: number;
+  }>;
+  error?: string;
+};
+
+function mockFetch(body: Snapshot | { error: string }, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: vi.fn().mockResolvedValue(body),
+    }),
+  );
+}
+
+function assignedSnapshot(): Snapshot {
+  return {
+    serverNow: "2026-08-13T02:40:00.000Z",
+    visit: {
+      id: "visit-1",
+      workOrderId: "wo-1",
+      workOrderNumber: "EL00118",
+      status: "working",
+      kind: "active",
+    },
+    truck: {
+      id: "truck-1",
+      name: "Service Truck 3",
+      unitNumber: "ST-03",
+      stockLocationId: "location-3",
+    },
+    items: [
+      {
+        partId: "part-filter",
+        sku: "FLT-100",
+        partNumber: "LF14000NN",
+        name: "Oil Filter",
+        description: "Heavy-duty engine oil filter",
+        category: "Filters",
+        qtyOnHand: 4,
+        qtyReserved: 1,
+        qtyAvailable: 3,
+      },
+      {
+        partId: "part-brake",
+        sku: "BRK-200",
+        partNumber: "4707Q",
+        name: "Brake Shoe Kit",
+        description: "16.5 inch brake shoe kit",
+        category: "Brakes",
+        qtyOnHand: 2,
+        qtyReserved: 0,
+        qtyAvailable: 2,
+      },
+    ],
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("MobileTruckInventory rendered behavior", () => {
+  it("renders the assigned truck, work order and canonical quantity totals", async () => {
+    mockFetch(assignedSnapshot());
+    render(<MobileTruckInventory />);
+
+    expect(await screen.findByText("Service Truck 3")).toBeInTheDocument();
+    expect(screen.getByText(/ST-03 · EL00118/)).toBeInTheDocument();
+    expect(screen.getByText("Oil Filter")).toBeInTheDocument();
+    expect(screen.getByText("Brake Shoe Kit")).toBeInTheDocument();
+    expect(screen.getByText("5", { selector: "div" })).toBeInTheDocument();
+  });
+
+  it("filters truck stock by part number as the technician types", async () => {
+    mockFetch(assignedSnapshot());
+    const user = userEvent.setup();
+    render(<MobileTruckInventory />);
+
+    await screen.findByText("Oil Filter");
+    await user.type(screen.getByLabelText("Search truck stock"), "4707Q");
+
+    expect(screen.queryByText("Oil Filter")).not.toBeInTheDocument();
+    expect(screen.getByText("Brake Shoe Kit")).toBeInTheDocument();
+  });
+
+  it("shows an explicit no-assignment state instead of a false empty inventory", async () => {
+    mockFetch({
+      serverNow: "2026-08-13T02:40:00.000Z",
+      visit: null,
+      truck: null,
+      items: [],
+    });
+    render(<MobileTruckInventory />);
+
+    expect(await screen.findByText("No assigned service call")).toBeInTheDocument();
+  });
+
+  it("shows a missing stock-location warning when the visit has a truck without inventory scope", async () => {
+    const snapshot = assignedSnapshot();
+    snapshot.truck = { ...snapshot.truck!, stockLocationId: null };
+    snapshot.items = [];
+    mockFetch(snapshot);
+    render(<MobileTruckInventory />);
+
+    expect(
+      await screen.findByText("No truck stock location assigned"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the Field Service authorization message for non-operators", async () => {
+    mockFetch(
+      { error: "Truck inventory is available to assigned Field Service operators." },
+      403,
+    );
+    render(<MobileTruckInventory />);
+
+    expect(
+      await screen.findByText(
+        "Truck inventory is available to assigned Field Service operators.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("refreshes the same canonical endpoint on demand", async () => {
+    mockFetch(assignedSnapshot());
+    const user = userEvent.setup();
+    render(<MobileTruckInventory />);
+
+    await screen.findByText("Service Truck 3");
+    await user.click(screen.getByRole("button", { name: "Refresh truck inventory" }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      "/api/mobile/service-visits/truck-inventory",
+      expect.objectContaining({ credentials: "include", cache: "no-store" }),
+    );
+  });
+});

--- a/tests/mobile-truck-inventory.test.ts
+++ b/tests/mobile-truck-inventory.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const api = read("app/api/mobile/service-visits/truck-inventory/route.ts");
+const page = read("app/mobile/parts/truck/page.tsx");
+const partsPage = read("app/mobile/parts/page.tsx");
+const ui = read("features/parts/mobile/MobileTruckInventory.tsx");
+
+describe("Mobile assigned-truck inventory", () => {
+  it("derives truck inventory from the authenticated Field Service assignment", () => {
+    expect(api).toContain("requireMobileServiceOperatorApiAccess");
+    expect(api).toContain("getMobileActiveJobs");
+    expect(api).toContain("snapshot.activeJob ?? snapshot.nextJob");
+    expect(api).toContain("visit?.serviceVehicle");
+    expect(api).toContain("stockLocationId");
+  });
+
+  it("reads the canonical inventory availability projection without adding a second stock model", () => {
+    expect(api).toContain('.from("v_part_stock")');
+    expect(api).toContain("qty_available");
+    expect(api).toContain("qty_on_hand");
+    expect(api).toContain("qty_reserved");
+    expect(api).toContain('.eq("location_id", stockLocationId)');
+    expect(api).not.toContain('.from("part_stock")');
+    expect(api).not.toContain('.from("stock_moves").insert');
+  });
+
+  it("keeps canonical part identity and explicit shop scoping", () => {
+    expect(api).toContain('.from("parts")');
+    expect(api).toContain('.eq("shop_id", access.profile.shop_id)');
+    expect(api).toContain("partId");
+    expect(api).toContain("part_number");
+  });
+
+  it("exposes a touch-friendly Field Service truck stock surface", () => {
+    expect(page).toContain("Truck inventory");
+    expect(page).toContain("MobileTruckInventory");
+    expect(partsPage).toContain('href="/mobile/parts/truck"');
+    expect(ui).toContain('fetch("/api/mobile/service-visits/truck-inventory"');
+    expect(ui).toContain("On hand");
+    expect(ui).toContain("Reserved");
+    expect(ui).toContain("Available");
+    expect(ui).toContain("Search truck stock");
+  });
+
+  it("handles no-call and missing-truck states explicitly", () => {
+    expect(ui).toContain("No assigned service call");
+    expect(ui).toContain("No truck stock location assigned");
+    expect(api).toContain("items: []");
+  });
+});

--- a/tests/mobile-truck-inventory.test.ts
+++ b/tests/mobile-truck-inventory.test.ts
@@ -6,6 +6,7 @@ const api = read("app/api/mobile/service-visits/truck-inventory/route.ts");
 const page = read("app/mobile/parts/truck/page.tsx");
 const partsPage = read("app/mobile/parts/page.tsx");
 const ui = read("features/parts/mobile/MobileTruckInventory.tsx");
+const mobileTiles = read("features/mobile/config/mobile-tiles.ts");
 
 describe("Mobile assigned-truck inventory", () => {
   it("derives truck inventory from the authenticated Field Service assignment", () => {
@@ -37,6 +38,9 @@ describe("Mobile assigned-truck inventory", () => {
     expect(page).toContain("Truck inventory");
     expect(page).toContain("MobileTruckInventory");
     expect(partsPage).toContain('href="/mobile/parts/truck"');
+    expect(mobileTiles).toContain('href: "/mobile/parts/truck"');
+    expect(mobileTiles).toContain('title: "Truck Inventory"');
+    expect(mobileTiles).toContain('roles: ["mechanic", "lead_hand", "foreman"]');
     expect(ui).toContain('fetch("/api/mobile/service-visits/truck-inventory"');
     expect(ui).toContain("On hand");
     expect(ui).toContain("Reserved");

--- a/vercel.json
+++ b/vercel.json
@@ -28,7 +28,6 @@
   "git": {
     "deploymentEnabled": {
       "main": true,
-      "agent/mobile-truck-inventory-read": true,
       "*": false
     }
   }

--- a/vercel.json
+++ b/vercel.json
@@ -28,6 +28,7 @@
   "git": {
     "deploymentEnabled": {
       "main": true,
+      "agent/mobile-truck-inventory-read": true,
       "*": false
     }
   }


### PR DESCRIPTION
## Outcome

Adds the first Field Service truck-inventory slice as a read-only, migration-free surface so we can prove the existing assignment → service vehicle → canonical stock-location → inventory projection chain before introducing inventory mutations.

## What changed

- adds `/mobile/parts/truck`
- adds an authenticated Field Service API at `/api/mobile/service-visits/truck-inventory`
- derives the effective visit from the existing mobile active-job contract
- derives the service truck and `stockLocationId` from the existing Dispatch snapshot
- reads physical/reserved/available quantities from canonical `v_part_stock`
- retains canonical `part_id` and reads part identity from `parts`
- adds search, refresh, no-assignment, no-truck-location, empty-stock and error states
- links Truck Inventory from the existing mobile Parts surface
- adds a focused source-contract regression test

## Safety

- no database migration
- no new inventory table or ledger
- no stock writes
- no direct `service_visits` writes
- Field Service entitlement/operator authorization remains mandatory
- part reads are explicitly scoped to the authenticated shop
- inventory location comes only from the authenticated operator's active/next assigned service visit

## Validation plan

- exact published diff review
- Agent PR Checks / TypeScript / lint as configured for draft PRs
- Vercel preview build
- live UI verification of `/mobile/parts` and `/mobile/parts/truck`
- authenticated Field operator test where available
- negative authorization/no-assignment states

## Database

None.

## Delivery state

Draft only. Do not merge until the preview UI and runtime contract are tested and any findings repaired.