### PR TITLE
Repair Ops release evidence production integration

### DIFF
--- a/features/ops/components/OpsReleaseHealth.tsx
+++ b/features/ops/components/OpsReleaseHealth.tsx
@@ -218,7 +218,7 @@ export default function OpsReleaseHealth({ snapshot }: { snapshot: OpsReleaseHea
           <div className="mt-4 grid gap-2 text-xs">
             <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Status</span><span className="font-semibold">{migrationStatusLabel(snapshot.migrations.status)}</span></div>
             <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Release migrations</span><span className="font-mono">{snapshot.migrations.releaseMigrationCount}</span></div>
-            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Main / production</span><span className="font-mono">{snapshot.migrations.repoCount} / {snapshot.migrations.appliedCount}</span></div>
+            <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Main / production</span><span className="font-mono">{snapshot.migrations.repoCount} / {snapshot.migrations.appliedCount ?? "Unavailable"}</span></div>
             <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Supabase check</span><span className="font-mono">{snapshot.migrations.supabaseCheck ?? "Unavailable"}</span></div>
           </div>
         </article>

--- a/features/ops/server/get-release-health.ts
+++ b/features/ops/server/get-release-health.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
+import { agentTeamRequest } from "@/features/agent/server/teamClient";
 import { requireOpsOperatorPageAccess } from "@/features/ops/server/operator-access";
-import { resolveAgentApiSecrets } from "@/features/shared/lib/server/agent-api-secrets";
 
 const GITHUB_REPOSITORY = "EdwardLakin/ProFixIQ";
 const GITHUB_API = `https://api.github.com/repos/${GITHUB_REPOSITORY}`;
@@ -127,7 +127,7 @@ export type OpsReleaseHealthSnapshot = {
     requiredForRelease: boolean | null;
     releaseMigrationCount: number;
     repoCount: number;
-    appliedCount: number;
+    appliedCount: number | null;
     pending: string[];
     drift: string[];
     latestRepoVersion: string | null;
@@ -255,46 +255,22 @@ async function agentReleaseEvidence(since: string): Promise<AgentReleaseEvidence
     };
   }
 
-  const secret = resolveAgentApiSecrets().primary;
-  if (!secret) {
-    return {
-      agent: await publicAgentRuntime(baseUrl),
-      database: { state: "degraded", data: null },
-    };
-  }
-
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 18_000);
   try {
-    const response = await fetch(
-      `${baseUrl}/ops/release-evidence?since=${encodeURIComponent(since)}`,
+    const payload = await agentTeamRequest<AgentReleaseEvidencePayload>(
+      `/ops/release-evidence?since=${encodeURIComponent(since)}`,
       {
         method: "GET",
-        cache: "no-store",
         signal: controller.signal,
-        headers: {
-          accept: "application/json",
-          "x-agent-api-secret": secret,
-        },
+        headers: { accept: "application/json" },
       },
     );
-    const raw = await response.text();
-    let payload: AgentReleaseEvidencePayload | null = null;
-    try {
-      const parsed = JSON.parse(raw) as unknown;
-      payload = isRecord(parsed) ? parsed as AgentReleaseEvidencePayload : null;
-    } catch {
-      payload = null;
-    }
 
-    if (!payload) {
-      return {
-        agent: await publicAgentRuntime(baseUrl),
-        database: { state: "degraded", data: null },
-      };
-    }
-
-    const agent = normalizeAgentRuntime(payload.runtime);
+    const privilegedAgent = normalizeAgentRuntime(payload.runtime);
+    const agent = privilegedAgent.generationVerified
+      ? privilegedAgent
+      : await publicAgentRuntime(baseUrl);
     const database = payload.database;
     const databaseError = text(database?.error);
     const migrations = Array.isArray(database?.migrations)
@@ -304,8 +280,7 @@ async function agentReleaseEvidence(since: string): Promise<AgentReleaseEvidence
           return version && name ? [{ version, name }] : [];
         })
       : [];
-    const databaseHealthy = response.ok
-      && payload.status === "ok"
+    const databaseHealthy = payload.status === "ok"
       && database?.configured === true
       && !databaseError;
 
@@ -421,11 +396,19 @@ export async function getOpsReleaseHealth(): Promise<OpsReleaseHealthSnapshot> {
     const version = migrationVersion(item.name);
     return version ? [version] : [];
   });
-  const appliedVersions = infrastructure.database.data?.migrations.map((migration) => migration.version) ?? [];
+  const databaseEvidenceAvailable = infrastructure.database.state === "healthy"
+    && infrastructure.database.data !== null;
+  const appliedVersions = databaseEvidenceAvailable
+    ? infrastructure.database.data.migrations.map((migration) => migration.version)
+    : [];
   const repoSet = new Set(repoVersions);
   const appliedSet = new Set(appliedVersions);
-  const pending = repoVersions.filter((version) => !appliedSet.has(version)).sort();
-  const drift = appliedVersions.filter((version) => !repoSet.has(version)).sort();
+  const pending = databaseEvidenceAvailable
+    ? repoVersions.filter((version) => !appliedSet.has(version)).sort()
+    : [];
+  const drift = databaseEvidenceAvailable
+    ? appliedVersions.filter((version) => !repoSet.has(version)).sort()
+    : [];
   const migrationsRequired = parentSha ? releaseMigrationFiles.length > 0 : null;
 
   let migrationStatus: OpsReleaseHealthSnapshot["migrations"]["status"] = "unknown";
@@ -530,11 +513,11 @@ export async function getOpsReleaseHealth(): Promise<OpsReleaseHealthSnapshot> {
       requiredForRelease: migrationsRequired,
       releaseMigrationCount: releaseMigrationFiles.length,
       repoCount: repoVersions.length,
-      appliedCount: appliedVersions.length,
+      appliedCount: databaseEvidenceAvailable ? appliedVersions.length : null,
       pending,
       drift,
       latestRepoVersion: latest(repoVersions),
-      latestAppliedVersion: latest(appliedVersions),
+      latestAppliedVersion: databaseEvidenceAvailable ? latest(appliedVersions) : null,
       supabaseCheck: supabaseCheck?.conclusion ?? null,
     },
     pullRequests: {

--- a/features/ops/server/get-release-health.ts
+++ b/features/ops/server/get-release-health.ts
@@ -398,9 +398,7 @@ export async function getOpsReleaseHealth(): Promise<OpsReleaseHealthSnapshot> {
   });
   const databaseEvidenceAvailable = infrastructure.database.state === "healthy"
     && infrastructure.database.data !== null;
-  const appliedVersions = databaseEvidenceAvailable
-    ? infrastructure.database.data.migrations.map((migration) => migration.version)
-    : [];
+  const appliedVersions = infrastructure.database.data?.migrations.map((migration) => migration.version) ?? [];
   const repoSet = new Set(repoVersions);
   const appliedSet = new Set(appliedVersions);
   const pending = databaseEvidenceAvailable

--- a/tests/ops-release-health.test.ts
+++ b/tests/ops-release-health.test.ts
@@ -28,12 +28,14 @@ describe("Ops deployments and release health", () => {
     expect(server).toContain("vercelCheck");
   });
 
-  it("keeps privileged production database inspection behind the authenticated Agent boundary", () => {
+  it("reuses the canonical Agent bridge client for privileged release evidence", () => {
     const server = source("features/ops/server/get-release-health.ts");
-    expect(server).toContain("resolveAgentApiSecrets");
+    expect(server).toContain('import { agentTeamRequest } from "@/features/agent/server/teamClient"');
+    expect(server).toContain("agentTeamRequest<AgentReleaseEvidencePayload>");
     expect(server).toContain("/ops/release-evidence?since=");
-    expect(server).toContain('"x-agent-api-secret": secret');
     expect(server).toContain("publicAgentRuntime");
+    expect(server).not.toContain("resolveAgentApiSecrets");
+    expect(server).not.toContain('"x-agent-api-secret": secret');
     expect(server).not.toContain("ops_release_database_snapshot");
     expect(server).not.toContain("SUPABASE_SERVICE_ROLE_KEY");
     expect(server).not.toContain("PROFIXIQ_SUPABASE_MANAGEMENT_TOKEN");
@@ -41,12 +43,20 @@ describe("Ops deployments and release health", () => {
     expect(server).not.toContain("createClient(");
   });
 
-  it("reports migration parity and release failures from sanitized Agent evidence", () => {
+  it("never turns unavailable database evidence into false migration drift", () => {
     const server = source("features/ops/server/get-release-health.ts");
-    expect(server).toContain("pending = repoVersions.filter");
-    expect(server).toContain("drift = appliedVersions.filter");
+    const component = source("features/ops/components/OpsReleaseHealth.tsx");
+    expect(server).toContain('const databaseEvidenceAvailable = infrastructure.database.state === "healthy"');
+    expect(server).toContain("const pending = databaseEvidenceAvailable");
+    expect(server).toContain("const drift = databaseEvidenceAvailable");
+    expect(server).toContain("appliedCount: databaseEvidenceAvailable ? appliedVersions.length : null");
     expect(server).toContain('migrationStatus = "pending"');
     expect(server).toContain('migrationStatus = "drift"');
+    expect(component).toContain('snapshot.migrations.appliedCount ?? "Unavailable"');
+  });
+
+  it("reports release failures from sanitized Agent evidence", () => {
+    const server = source("features/ops/server/get-release-health.ts");
     expect(server).toContain("failuresSince");
     expect(server).toContain("unresolvedFailures");
     expect(server).toContain("latestFailureAt");


### PR DESCRIPTION
## Outcome

Repairs the production `/ops/deployments` evidence path exposed after #1420 without changing database state or Agent credentials.

## Production diagnosis

The live page showed:
- ProFixIQ production SHA/main parity healthy
- release CI healthy
- Agent runtime unavailable
- migration evidence unavailable
- all 299 repository migrations incorrectly rendered as pending

Production verification showed the Agent itself is healthy and deployed on merge SHA `f532427e...`, while the ProFixIQ request to `/ops/release-evidence` receives HTTP 403.

The durable ProFixIQ ↔ Agent bridge was checked without exposing plaintext secrets: the ProFixIQ integration is enabled, the Agent bridge credential is active, and their SHA-256 digests match. The defect is that #1420 bypassed the canonical bridge client and sent only an environment-secret alias.

## Repair

- routes privileged release evidence through existing `agentTeamRequest`, which already sends the canonical `x-profixiq-bridge-secret` plus supported environment fallbacks
- falls back to public Agent `/health` when privileged release evidence cannot be read, so runtime health is not falsely reported as down
- only calculates migration pending/drift when sanitized production database evidence is actually healthy and present
- unavailable ledger evidence now yields `Unknown` with no fabricated reconciliation list
- renders production migration count as `Unavailable` rather than `0` when evidence is absent

## Production truth verified during diagnosis

- production migration ledger: **299 applied**
- latest applied migration: `20260812140518`
- operational capture failures since #1420 release: **0**
- unresolved failures in that release window: **0**

Expected live state after this repair deploys is therefore approximately **299 / 299**, no migration reconciliation panel, verified Agent runtime, and zero captured failures unless production changes again before refresh.

## Safety

- ProFixIQ-only repair
- no Agent changes
- no migration
- no credential rotation
- no Vercel environment mutation
- no production data mutation
- existing owner-only Ops boundary remains unchanged

## Regression contract

Updates `tests/ops-release-health.test.ts` to prove:
- release evidence reuses the canonical Agent bridge client
- the direct env-secret-only path cannot return
- unavailable database evidence cannot become false migration pending/drift
- unavailable applied-count evidence is displayed explicitly

## Final validation

Final head: `cb9041d58ace57ba8eeb4ef1bb9a6598d01875ae`.

`Agent PR Checks / checks` passed on the fresh run, including:
- full-app regression inventory
- TypeScript type-check
- changed-file ESLint
- complete Vitest suite
- production Next.js build

GitGuardian passed. Supabase preview correctly skipped because there are no `supabase/` changes. Specialized scheduler/mobile validations were skipped by scope.

While validation was running, #1421 merged into `main` at `cc562346...`. Its seven changed files are Field Service/mobile truck inventory only and do not overlap this PR's three Ops files. GitHub's current merge ref is `e061d110...` (`cb9041d...` into `cc562346...`), and the fresh pull-request workflow used the default PR merge checkout, so typecheck/tests/build were exercised against the updated base rather than requiring another redundant rebase run.

There are no review threads.

The branch has two commits because the first CI pass found one strict-null TypeScript error and the second commit corrected that one-line narrowing issue. It is intentionally not force-squashed after green validation to avoid triggering a third redundant full CI run; merge strategy can squash at merge time if desired.