### PR TITLE
Repair owner role governance

### DIFF
--- a/features/admin/components/UsersList.tsx
+++ b/features/admin/components/UsersList.tsx
@@ -34,8 +34,16 @@ const ROLE_OPTIONS: Array<{ value: UserRole; label: string }> = [
   { value: "owner", label: "Owner" },
   { value: "admin", label: "Admin" },
   { value: "manager", label: "Manager" },
+  { value: "foreman", label: "Foreman" },
+  { value: "lead_hand", label: "Lead Hand" },
   { value: "advisor", label: "Advisor" },
-  { value: "mechanic", label: "Mechanic" },
+  { value: "service", label: "Service" },
+  { value: "parts", label: "Parts" },
+  { value: "mechanic", label: "Mechanic / Technician" },
+  { value: "dispatcher", label: "Dispatcher" },
+  { value: "driver", label: "Driver" },
+  { value: "fleet_manager", label: "Fleet Manager" },
+  { value: "customer", label: "Customer" },
 ];
 
 function safeMsg(e: unknown, fallback: string): string {

--- a/tests/owner-settings-experience.test.ts
+++ b/tests/owner-settings-experience.test.ts
@@ -70,6 +70,27 @@ describe("owner settings experience", () => {
     expect(resendInviteRoute).toContain("tempPassword: null");
   });
 
+  it("keeps every creatable operational role filterable and editable", () => {
+    for (const role of [
+      "owner",
+      "admin",
+      "manager",
+      "foreman",
+      "lead_hand",
+      "advisor",
+      "service",
+      "parts",
+      "mechanic",
+      "dispatcher",
+      "driver",
+      "fleet_manager",
+    ]) {
+      expect(usersList).toContain(`value: "${role}"`);
+    }
+
+    expect(usersList).toContain('{ value: "customer", label: "Customer" }');
+  });
+
   it("shows the actual actor and protects unsaved changes", () => {
     expect(header).toContain("roleLabel");
     expect(header).toContain("shopName");


### PR DESCRIPTION
## What changed

- Expand the owner Team directory role selector used by filtering and editing to include every operational role available during account creation.
- Add a regression source-contract test covering the creatable operational roles and the customer role.

## Why

A production smoke test reproduced a role-governance mismatch: owners could create service, parts, dispatcher, driver, fleet manager, foreman, and lead-hand users, but the directory filter and edit dialog only exposed the legacy owner/admin/manager/advisor/mechanic set.

## Impact

Owners can now find and intentionally edit users across the complete operational role model. The mechanic label is clarified as “Mechanic / Technician.”

## Root cause

`UsersList.tsx` maintained a stale local `ROLE_OPTIONS` list that was not updated when newer roles were added to account creation.

## Validation

- Live production smoke test reproduced the defect with newly created service and driver fixtures.
- Remote comparison: one commit, two files, 30 additions, 1 deletion.
- `git diff --check`: passed.
- Source-contract regression test added.
- Agent PR Checks run #299: passed.
  - Regression inventory: passed.
  - Typecheck: passed.
  - Changed-file lint: passed.
  - Complete test suite: passed.
  - Production build: passed.
- Production release posture during smoke test: healthy; main/deploy SHA matched, CI successful, migrations 299/299, operational capture failures 0.

## Production retest plan

After merge and deployment, verify the Team role filter and edit dialog expose all operational roles and preserve existing service/driver assignments.