### PR TITLE
Fix acknowledged notification sync 500 loop

### DIFF
--- a/features/agent/server/syncAssistantNotifications.ts
+++ b/features/agent/server/syncAssistantNotifications.ts
@@ -186,7 +186,7 @@ export async function syncAssistantNotifications(params: {
 
   let existingQuery = supabase
     .from("assistant_notifications")
-    .select("id, fingerprint, first_seen_at, status")
+    .select("id, fingerprint, first_seen_at, status, acknowledged_at, acknowledged_by")
     .eq("shop_id", shopId)
     .eq("source", source);
 
@@ -202,7 +202,13 @@ export async function syncAssistantNotifications(params: {
 
   const existingByFingerprint = new Map<
     string,
-    { id: string; first_seen_at: string; status: AssistantNotificationStatus }
+    {
+      id: string;
+      first_seen_at: string;
+      status: AssistantNotificationStatus;
+      acknowledged_at: string | null;
+      acknowledged_by: string | null;
+    }
   >();
 
   for (const row of existingRows ?? []) {
@@ -210,6 +216,8 @@ export async function syncAssistantNotifications(params: {
       id: row.id,
       first_seen_at: row.first_seen_at,
       status: normalizeAssistantNotificationStatus(row.status),
+      acknowledged_at: row.acknowledged_at ?? null,
+      acknowledged_by: row.acknowledged_by ?? null,
     });
   }
 
@@ -248,6 +256,14 @@ export async function syncAssistantNotifications(params: {
       },
       first_seen_at: existing?.first_seen_at ?? now,
       last_seen_at: now,
+      acknowledged_at:
+        existing?.status === "acknowledged"
+          ? existing.acknowledged_at
+          : null,
+      acknowledged_by:
+        existing?.status === "acknowledged"
+          ? existing.acknowledged_by
+          : null,
       resolved_at: null,
       updated_at: now,
     };

--- a/tests/assistant-notification-acknowledgement.test.ts
+++ b/tests/assistant-notification-acknowledgement.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-const getServerSupabaseMock = vi.fn();
-const getOpsNotificationsMock = vi.fn();
+const { getServerSupabaseMock, getOpsNotificationsMock } = vi.hoisted(() => ({
+  getServerSupabaseMock: vi.fn(),
+  getOpsNotificationsMock: vi.fn(),
+}));
 
 vi.mock("@/features/agent/server/supabase", () => ({
   getServerSupabase: getServerSupabaseMock,

--- a/tests/assistant-notification-acknowledgement.test.ts
+++ b/tests/assistant-notification-acknowledgement.test.ts
@@ -1,7 +1,93 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const getServerSupabaseMock = vi.fn();
+const getOpsNotificationsMock = vi.fn();
+
+vi.mock("@/features/agent/server/supabase", () => ({
+  getServerSupabase: getServerSupabaseMock,
+}));
+
+vi.mock("@/features/agent/server/getOpsNotifications", () => ({
+  getOpsNotifications: getOpsNotificationsMock,
+}));
+
+import { syncAssistantNotifications } from "@/features/agent/server/syncAssistantNotifications";
+
+function queryResult(data: unknown[]) {
+  const builder: Record<string, unknown> = {};
+  const chain = () => builder;
+
+  builder.select = vi.fn(chain);
+  builder.eq = vi.fn(chain);
+  builder.in = vi.fn(chain);
+  builder.order = vi.fn(chain);
+  builder.then = (
+    resolve: (value: { data: unknown[]; error: null }) => unknown,
+    reject?: (reason: unknown) => unknown,
+  ) => Promise.resolve({ data, error: null }).then(resolve, reject);
+
+  return builder;
+}
 
 describe("assistant notification acknowledgement persistence", () => {
-  it("keeps the acknowledged status contract covered", () => {
-    expect(true).toBe(true);
+  it("preserves acknowledgement audit fields when an acknowledged notification is recomputed", async () => {
+    const acknowledgedAt = "2026-08-12T22:00:00.000Z";
+    const acknowledgedBy = "11111111-1111-4111-8111-111111111111";
+    const upsertMock = vi.fn().mockResolvedValue({ error: null });
+    let assistantNotificationsAccessCount = 0;
+
+    getOpsNotificationsMock.mockResolvedValue([
+      {
+        code: "parts_waiting_too_long",
+        level: "warning",
+        title: "Parts waiting too long",
+        message: "One parts request needs attention.",
+      },
+    ]);
+
+    getServerSupabaseMock.mockReturnValue({
+      from: vi.fn((table: string) => {
+        expect(table).toBe("assistant_notifications");
+        assistantNotificationsAccessCount += 1;
+
+        if (assistantNotificationsAccessCount === 1) {
+          return queryResult([
+            {
+              id: "notification-1",
+              fingerprint: "shop::parts_waiting_too_long::na::na::na",
+              first_seen_at: "2026-08-12T20:00:00.000Z",
+              status: "acknowledged",
+              acknowledged_at: acknowledgedAt,
+              acknowledged_by: acknowledgedBy,
+            },
+          ]);
+        }
+
+        if (assistantNotificationsAccessCount === 2) {
+          return { upsert: upsertMock };
+        }
+
+        if (assistantNotificationsAccessCount === 3) {
+          return queryResult([]);
+        }
+
+        throw new Error(`Unexpected assistant_notifications access #${assistantNotificationsAccessCount}`);
+      }),
+    });
+
+    await syncAssistantNotifications({
+      shopId: "shop-1",
+      role: "owner",
+    });
+
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    const upsertRows = upsertMock.mock.calls[0]?.[0] as Array<Record<string, unknown>>;
+    expect(upsertRows).toHaveLength(1);
+    expect(upsertRows[0]).toMatchObject({
+      fingerprint: "shop::parts_waiting_too_long::na::na::na",
+      status: "acknowledged",
+      acknowledged_at: acknowledgedAt,
+      acknowledged_by: acknowledgedBy,
+    });
   });
 });

--- a/tests/assistant-notification-acknowledgement.test.ts
+++ b/tests/assistant-notification-acknowledgement.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "vitest";
+
+describe("assistant notification acknowledgement persistence", () => {
+  it("keeps the acknowledged status contract covered", () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Preserves acknowledgement audit fields during assistant notification upserts and adds regression coverage. No migration or production data change. Validation will run on the draft PR head.