### PR TITLE
Fix observability cron auth and Supabase maintenance CI

### DIFF
--- a/.github/workflows/dump-supabase-schema.yml
+++ b/.github/workflows/dump-supabase-schema.yml
@@ -2,11 +2,12 @@ name: Dump Supabase Schema + Types
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "17 4 * * *"   # nightly 04:17 UTC
+    - cron: "17 4 * * *"   # retained for history; scheduled job is skipped below
 permissions:
   contents: write
 jobs:
   dump:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,46 +1,25 @@
-name: Dump Supabase Schema
+name: Nightly Supabase Schema Contract
 
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: "0 7 * * *"  # Runs daily at 07:00 UTC
+    - cron: "0 7 * * *"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  dump:
+  verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install PostgreSQL client (pg_dump)
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - uses: supabase/setup-cli@v2
+        with:
+          version: 2.101.0
+          github-token: ${{ github.token }}
 
-      - name: Dump schema.sql from Supabase
-        env:
-          DB_URL: ${{ secrets.SUPABASE_DB_URL }}
-        run: |
-          set -euo pipefail
-          if [ -z "${DB_URL:-}" ]; then
-            echo "❌ Missing SUPABASE_DB_URL secret" && exit 1
-          fi
-          mkdir -p supabase
-          pg_dump "$DB_URL" \
-            --schema-only \
-            --no-owner \
-            --no-privileges \
-            --quote-all-identifiers \
-            > supabase/schema.sql
-
-      - name: Commit and push if changed
-        run: |
-          if ! git diff --quiet; then
-            git config user.name "schema-bot"
-            git config user.email "schema-bot@example.com"
-            git add supabase/schema.sql
-            git commit -m "chore(schema): update schema.sql via pg_dump"
-            git push
-          else
-            echo "No schema changes."
-          fi
+      - name: Replay migrations and verify generated types
+        shell: bash
+        run: bash scripts/check-supabase-schema-contract.sh --check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,15 @@ jobs:
           version: 2.101.0
           github-token: ${{ github.token }}
 
+      - name: Initialize ephemeral Supabase configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f supabase/config.toml ]]; then
+            supabase init
+          fi
+          supabase --version
+
       - name: Replay migrations and verify generated types
         shell: bash
         run: bash scripts/check-supabase-schema-contract.sh --check

--- a/app/api/internal/observability/health/route.ts
+++ b/app/api/internal/observability/health/route.ts
@@ -18,29 +18,16 @@ type ProjectionWarning = {
   message: string;
 };
 
-function parseBearerSecret(request: Request): string | null {
-  const authorization = request.headers.get("authorization")?.trim();
-  if (!authorization) return null;
-  const [scheme, token] = authorization.split(/\s+/, 2);
-  return scheme?.toLowerCase() === "bearer" && token ? token : null;
-}
-
 function authorizeInternalRequest(
   request: Request,
 ): { ok: true } | { ok: false; response: NextResponse } {
-  const internalGate = requireInternalApiSecret({
+  return requireInternalApiSecret({
     request,
     envSecretName: "INTERNAL_CRON_SECRET",
     headerName: "x-internal-cron-secret",
     routeLabel: "internal/observability/health",
+    bearerEnvSecretName: "CRON_SECRET",
   });
-
-  const configuredSecret = process.env.INTERNAL_CRON_SECRET;
-  const bearerAuthorized =
-    !!configuredSecret && parseBearerSecret(request) === configuredSecret;
-
-  if (internalGate.ok || bearerAuthorized) return { ok: true };
-  return { ok: false, response: internalGate.response };
 }
 
 function projectionUnavailable(error: unknown): boolean {

--- a/features/shared/lib/server/api-route-guard.ts
+++ b/features/shared/lib/server/api-route-guard.ts
@@ -27,9 +27,19 @@ export function requireInternalApiSecret(options: {
   envSecretName: string;
   headerName: string;
   routeLabel: string;
+  bearerEnvSecretName?: string;
 }):
   | { ok: true }
   | { ok: false; response: NextResponse } {
+  const bearerSecret = options.bearerEnvSecretName
+    ? process.env[options.bearerEnvSecretName]
+    : undefined;
+  const authorization = options.request.headers.get("authorization");
+
+  if (bearerSecret && authorization === `Bearer ${bearerSecret}`) {
+    return { ok: true };
+  }
+
   const configuredSecret = process.env[options.envSecretName];
 
   if (!configuredSecret) {

--- a/features/shared/lib/server/api-route-guard.ts
+++ b/features/shared/lib/server/api-route-guard.ts
@@ -34,15 +34,19 @@ export function requireInternalApiSecret(options: {
   const bearerSecret = options.bearerEnvSecretName
     ? process.env[options.bearerEnvSecretName]
     : undefined;
+  const configuredSecret = process.env[options.envSecretName];
   const authorization = options.request.headers.get("authorization");
+  const providedSecret = options.request.headers.get(options.headerName);
 
   if (bearerSecret && authorization === `Bearer ${bearerSecret}`) {
     return { ok: true };
   }
 
-  const configuredSecret = process.env[options.envSecretName];
+  if (configuredSecret && providedSecret === configuredSecret) {
+    return { ok: true };
+  }
 
-  if (!configuredSecret) {
+  if (!bearerSecret && !configuredSecret) {
     return {
       ok: false,
       response: NextResponse.json(
@@ -52,14 +56,8 @@ export function requireInternalApiSecret(options: {
     };
   }
 
-  const providedSecret = options.request.headers.get(options.headerName);
-
-  if (!providedSecret || providedSecret !== configuredSecret) {
-    return {
-      ok: false,
-      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
-    };
-  }
-
-  return { ok: true };
+  return {
+    ok: false,
+    response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+  };
 }

--- a/tests/api-route-guard.test.ts
+++ b/tests/api-route-guard.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const options = {
+  envSecretName: "INTERNAL_CRON_SECRET",
+  headerName: "x-internal-cron-secret",
+  routeLabel: "internal/test",
+} as const;
+
+describe("requireInternalApiSecret", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.INTERNAL_CRON_SECRET;
+    delete process.env.CRON_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.INTERNAL_CRON_SECRET;
+    delete process.env.CRON_SECRET;
+  });
+
+  it("accepts an explicitly configured bearer secret when the header secret is absent", async () => {
+    process.env.CRON_SECRET = "vercel-cron-secret";
+    const { requireInternalApiSecret } = await import(
+      "../features/shared/lib/server/api-route-guard"
+    );
+
+    const result = requireInternalApiSecret({
+      ...options,
+      bearerEnvSecretName: "CRON_SECRET",
+      request: new Request("https://example.test/api/internal/test", {
+        headers: { authorization: "Bearer vercel-cron-secret" },
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("remains fail-closed when neither configured credential can authorize the request", async () => {
+    process.env.CRON_SECRET = "vercel-cron-secret";
+    const { requireInternalApiSecret } = await import(
+      "../features/shared/lib/server/api-route-guard"
+    );
+
+    const result = requireInternalApiSecret({
+      ...options,
+      bearerEnvSecretName: "CRON_SECRET",
+      request: new Request("https://example.test/api/internal/test", {
+        headers: { authorization: "Bearer wrong-secret" },
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(500);
+  });
+
+  it("preserves the existing internal header credential path", async () => {
+    process.env.INTERNAL_CRON_SECRET = "internal-secret";
+    const { requireInternalApiSecret } = await import(
+      "../features/shared/lib/server/api-route-guard"
+    );
+
+    const result = requireInternalApiSecret({
+      ...options,
+      bearerEnvSecretName: "CRON_SECRET",
+      request: new Request("https://example.test/api/internal/test", {
+        headers: { "x-internal-cron-secret": "internal-secret" },
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tests/api-route-guard.test.ts
+++ b/tests/api-route-guard.test.ts
@@ -22,10 +22,10 @@ describe("requireInternalApiSecret", () => {
 
   it("accepts an explicitly configured bearer secret when the header secret is absent", async () => {
     process.env.CRON_SECRET = "vercel-cron-secret";
+
     const { requireInternalApiSecret } = await import(
       "../features/shared/lib/server/api-route-guard"
     );
-
     const result = requireInternalApiSecret({
       ...options,
       bearerEnvSecretName: "CRON_SECRET",
@@ -37,12 +37,12 @@ describe("requireInternalApiSecret", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("remains fail-closed when neither configured credential can authorize the request", async () => {
+  it("returns unauthorized when the configured bearer credential does not match", async () => {
     process.env.CRON_SECRET = "vercel-cron-secret";
+
     const { requireInternalApiSecret } = await import(
       "../features/shared/lib/server/api-route-guard"
     );
-
     const result = requireInternalApiSecret({
       ...options,
       bearerEnvSecretName: "CRON_SECRET",
@@ -52,20 +52,59 @@ describe("requireInternalApiSecret", () => {
     });
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.response.status).toBe(500);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  it("returns not configured when neither credential exists", async () => {
+    const { requireInternalApiSecret } = await import(
+      "../features/shared/lib/server/api-route-guard"
+    );
+    const result = requireInternalApiSecret({
+      ...options,
+      bearerEnvSecretName: "CRON_SECRET",
+      request: new Request("https://example.test/api/internal/test"),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(500);
+    }
   });
 
   it("preserves the existing internal header credential path", async () => {
     process.env.INTERNAL_CRON_SECRET = "internal-secret";
+
     const { requireInternalApiSecret } = await import(
       "../features/shared/lib/server/api-route-guard"
     );
-
     const result = requireInternalApiSecret({
       ...options,
       bearerEnvSecretName: "CRON_SECRET",
       request: new Request("https://example.test/api/internal/test", {
         headers: { "x-internal-cron-secret": "internal-secret" },
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a valid header credential when both credential types are configured", async () => {
+    process.env.INTERNAL_CRON_SECRET = "internal-secret";
+    process.env.CRON_SECRET = "vercel-cron-secret";
+
+    const { requireInternalApiSecret } = await import(
+      "../features/shared/lib/server/api-route-guard"
+    );
+    const result = requireInternalApiSecret({
+      ...options,
+      bearerEnvSecretName: "CRON_SECRET",
+      request: new Request("https://example.test/api/internal/test", {
+        headers: {
+          authorization: "Bearer wrong-secret",
+          "x-internal-cron-secret": "internal-secret",
+        },
       }),
     });
 

--- a/tests/internal-operational-observability-health-route.test.ts
+++ b/tests/internal-operational-observability-health-route.test.ts
@@ -72,6 +72,28 @@ describe("GET /api/internal/observability/health", () => {
     });
   });
 
+  it("uses the shared guard with Vercel cron bearer authorization enabled", async () => {
+    createAdminSupabaseMock.mockReturnValue(
+      createSupabase({ projectionError: null }),
+    );
+
+    const { GET } = await import(
+      "../app/api/internal/observability/health/route"
+    );
+    const response = await GET(
+      new Request("https://example.test/api/internal/observability/health"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(requireInternalApiSecretMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envSecretName: "INTERNAL_CRON_SECRET",
+        headerName: "x-internal-cron-secret",
+        bearerEnvSecretName: "CRON_SECRET",
+      }),
+    );
+  });
+
   it("rejects requests that fail the internal secret guard", async () => {
     requireInternalApiSecretMock.mockReturnValue({
       ok: false,


### PR DESCRIPTION
## Summary

- fixes `/api/internal/observability/health` so Vercel Cron can authenticate with the already-configured `CRON_SECRET` bearer credential while preserving the existing `INTERNAL_CRON_SECRET` header path
- adds an optional bearer-secret capability to the shared internal API guard without changing existing callers
- adds regression coverage for bearer authorization, fail-closed behavior, and the observability route contract
- replaces the primary scheduled production schema dump with a secret-free local Supabase migration replay + generated-types contract check
- prevents the obsolete credential-dependent `Dump Supabase Schema + Types` workflow from running on schedule; it remains manual-only for historical compatibility

## Production evidence

The current production deployment has four consecutive hourly 500s on `/api/internal/observability/health`. Other cron routes using `CRON_SECRET` succeed. The observability route only opted into `INTERNAL_CRON_SECRET`, whose missing configuration causes the shared guard to return 500.

The scheduled `Dump Supabase Schema` workflow fails because its stored pooler URL is invalid for Supabase (`ENOIDENTIFIER: no tenant identifier provided`). The second legacy scheduled workflow also fails because its project ref/database password inputs are blank. This PR removes both scheduled failure modes without requiring production database credentials.

## Verification

- dedicated shared-guard tests added
- observability route regression test added
- full PR CI: typecheck, changed-file lint, complete test suite, production build, regression inventory
- no database migration required

## Operational posture

Production database logs show no new Postgres errors after the previously-fixed planner notification incident; the remaining live 500 is isolated to the observability cron until this PR deploys.