### PR TITLE
add private technician CoPilot repair session foundation

### DIFF
--- a/docs/architecture/technician-copilot-v2-phase1.md
+++ b/docs/architecture/technician-copilot-v2-phase1.md
@@ -1,0 +1,32 @@
+# Technician CoPilot V2 — Phase 1 Repair Session Foundation
+
+## Scope
+
+Phase 1 adds persistent technician repair-session identity and an ordered event ledger without changing any current work-order, inspection, parts, labor, mobile, or voice workflow.
+
+The new storage lives in the private `copilot` Postgres schema. Existing `work_orders`, `work_order_lines`, vehicles, service visits, and technician profiles remain canonical.
+
+## Storage
+
+- `copilot.repair_sessions` anchors the technician to the active work order/line, vehicle, service visit, operating mode, lifecycle state, and context version.
+- `copilot.repair_session_events` is the ordered event spine for the repair session.
+- `copilot.repair_session_event_context` stores event origin, bounded structured details, and a globally unique operation ID so Phase 2 can enforce exactly-once command receipts.
+
+The TypeScript session contract defines the future evidence vocabulary for observations, measurements, DTCs, media evidence, teardown/reassembly, fluid state, and pending actions. The first reducer slice establishes strict lifecycle sequencing and replay protection.
+
+## Safety boundary
+
+- Canonical public work-order tables are unchanged.
+- A technician can have at most one active repair session.
+- Session identity is anchored to existing shop, profile, work-order, line, vehicle, and service-visit records.
+- Event sequence is unique within a repair session.
+- No application route, UI component, voice provider, or public RPC consumes this schema in Phase 1.
+- No production migration is applied as part of the branch implementation; clean replay and CI must pass first.
+
+## Rollback
+
+Phase 1 is dark infrastructure. Ignoring the private schema leaves all existing ProFixIQ behavior unchanged. There is no technician-callable CoPilot mutation surface yet.
+
+## Phase 2
+
+Add the technician-authenticated server command boundary and runtime capability gates together. That layer must resolve current shop/profile/role, enforce canonical work-order assignment, append ordered events atomically, rebuild or cache repair context, and prove persistent multi-turn text collaboration before continuous duplex voice is connected.

--- a/features/copilot/technician/session/reduceRepairContext.ts
+++ b/features/copilot/technician/session/reduceRepairContext.ts
@@ -1,0 +1,42 @@
+import type { RepairContextState, RepairSessionEvent, RepairSessionMode, RepairSessionStatus } from "./types";
+
+export function createEmptyRepairContext(input: {
+  repairSessionId: string;
+  mode: RepairSessionMode;
+  status?: RepairSessionStatus;
+}): RepairContextState {
+  return {
+    repairSessionId: input.repairSessionId,
+    status: input.status ?? "active",
+    mode: input.mode,
+    currentTask: null,
+    complaint: null,
+    observations: [],
+    measurements: [],
+    dtcs: [],
+    evidence: [],
+    components: {},
+    fluids: {},
+    pendingActions: {},
+    lastEventSeq: 0,
+    contextVersion: 0,
+    updatedAt: null,
+  };
+}
+
+export function applyRepairEvent(state: RepairContextState, event: RepairSessionEvent): RepairContextState {
+  if (event.repairSessionId !== state.repairSessionId) throw new Error("Repair event belongs to a different repair session");
+  if (event.eventSeq <= state.lastEventSeq) return state;
+  if (event.eventSeq !== state.lastEventSeq + 1) throw new Error("Repair event sequence gap");
+  return {
+    ...state,
+    status: event.eventType === "session.paused" ? "paused" : event.eventType === "session.closed" ? "closed" : state.status,
+    lastEventSeq: event.eventSeq,
+    contextVersion: state.contextVersion + 1,
+    updatedAt: event.occurredAt,
+  };
+}
+
+export function reduceRepairEvents(initial: RepairContextState, events: readonly RepairSessionEvent[]): RepairContextState {
+  return events.reduce(applyRepairEvent, initial);
+}

--- a/features/copilot/technician/session/types.ts
+++ b/features/copilot/technician/session/types.ts
@@ -1,0 +1,136 @@
+export const REPAIR_SESSION_STATUSES = ["active", "paused", "closed"] as const;
+export type RepairSessionStatus = (typeof REPAIR_SESSION_STATUSES)[number];
+
+export const REPAIR_SESSION_MODES = ["shop", "field", "fleet"] as const;
+export type RepairSessionMode = (typeof REPAIR_SESSION_MODES)[number];
+
+export const REPAIR_EVENT_SOURCES = [
+  "voice",
+  "ui",
+  "system",
+  "offline",
+  "integration",
+  "copilot",
+] as const;
+export type RepairEventSource = (typeof REPAIR_EVENT_SOURCES)[number];
+
+export const REPAIR_EVENT_TYPES = [
+  "session.started",
+  "session.resumed",
+  "session.paused",
+  "session.closed",
+  "task.changed",
+  "complaint.recorded",
+  "observation.recorded",
+  "measurement.recorded",
+  "dtc.observed",
+  "evidence.attached",
+  "component.removed",
+  "component.installed",
+  "component.disconnected",
+  "component.connected",
+  "fluid.drained",
+  "fluid.filled",
+  "action.pending",
+  "action.completed",
+] as const;
+export type KnownRepairEventType = (typeof REPAIR_EVENT_TYPES)[number];
+export type RepairEventType = KnownRepairEventType | (string & {});
+
+export type RepairSessionEvent = {
+  id: string;
+  repairSessionId: string;
+  eventSeq: number;
+  eventType: RepairEventType;
+  source: RepairEventSource;
+  payload: Record<string, unknown>;
+  occurredAt: string;
+};
+
+export type RepairObservation = {
+  eventId: string;
+  text: string;
+  category?: string;
+  component?: string;
+  location?: string;
+  occurredAt: string;
+};
+
+export type RepairMeasurement = {
+  eventId: string;
+  label: string;
+  value: string;
+  unit?: string;
+  component?: string;
+  location?: string;
+  occurredAt: string;
+};
+
+export type RepairDtc = {
+  eventId: string;
+  code: string;
+  status?: string;
+  module?: string;
+  description?: string;
+  occurredAt: string;
+};
+
+export type RepairEvidence = {
+  eventId: string;
+  evidenceId: string;
+  kind: string;
+  label?: string;
+  occurredAt: string;
+};
+
+export type PhysicalComponentState =
+  | "removed"
+  | "installed"
+  | "disconnected"
+  | "connected";
+
+export type RepairComponentMemory = {
+  key: string;
+  component: string;
+  location?: string;
+  state: PhysicalComponentState;
+  lastEventId: string;
+  updatedAt: string;
+};
+
+export type FluidState = "drained" | "filled";
+
+export type RepairFluidMemory = {
+  key: string;
+  fluid: string;
+  system?: string;
+  state: FluidState;
+  lastEventId: string;
+  updatedAt: string;
+};
+
+export type PendingRepairAction = {
+  key: string;
+  action: string;
+  detail?: string;
+  createdByEventId: string;
+  updatedAt: string;
+};
+
+export type RepairContextState = {
+  repairSessionId: string;
+  status: RepairSessionStatus;
+  mode: RepairSessionMode;
+  currentTask: string | null;
+  complaint: string | null;
+  observations: RepairObservation[];
+  measurements: RepairMeasurement[];
+  dtcs: RepairDtc[];
+  evidence: RepairEvidence[];
+  components: Record<string, RepairComponentMemory>;
+  fluids: Record<string, RepairFluidMemory>;
+  pendingActions: Record<string, PendingRepairAction>;
+  lastEventSeq: number;
+  contextVersion: number;
+  updatedAt: string | null;
+};

--- a/supabase/migrations/20260813212500_technician_copilot_private_session_storage.sql
+++ b/supabase/migrations/20260813212500_technician_copilot_private_session_storage.sql
@@ -1,0 +1,40 @@
+-- Technician CoPilot V2 phase 1: private repair-session storage.
+-- No current application flow reads or writes this schema.
+
+begin;
+
+create schema if not exists copilot;
+
+create table if not exists copilot.repair_sessions (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  technician_id uuid not null references public.profiles(id) on delete restrict,
+  work_order_id uuid not null references public.work_orders(id) on delete restrict,
+  active_work_order_line_id uuid references public.work_order_lines(id) on delete set null,
+  vehicle_id uuid references public.vehicles(id) on delete set null,
+  service_visit_id uuid references public.service_visits(id) on delete set null,
+  mode text not null default 'shop' check (mode in ('shop', 'field', 'fleet')),
+  status text not null default 'active' check (status in ('active', 'paused', 'closed')),
+  current_task text,
+  context_version bigint not null default 0 check (context_version >= 0),
+  last_event_seq bigint not null default 0 check (last_event_seq >= 0),
+  started_at timestamptz not null default now(),
+  last_activity_at timestamptz not null default now(),
+  ended_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint repair_sessions_closed_time_check check (status <> 'closed' or ended_at is not null)
+);
+
+create unique index if not exists repair_sessions_one_active_per_technician_idx
+  on copilot.repair_sessions (technician_id) where status = 'active';
+create index if not exists repair_sessions_technician_activity_idx
+  on copilot.repair_sessions (technician_id, status, last_activity_at desc);
+create index if not exists repair_sessions_work_order_idx
+  on copilot.repair_sessions (shop_id, work_order_id, status);
+create index if not exists repair_sessions_line_idx
+  on copilot.repair_sessions (active_work_order_line_id) where active_work_order_line_id is not null;
+create index if not exists repair_sessions_service_visit_idx
+  on copilot.repair_sessions (service_visit_id) where service_visit_id is not null;
+
+commit;

--- a/supabase/migrations/20260813212510_technician_copilot_private_event_ledger.sql
+++ b/supabase/migrations/20260813212510_technician_copilot_private_event_ledger.sql
@@ -1,0 +1,27 @@
+-- Technician CoPilot V2 phase 1: ordered repair-event ledger.
+
+begin;
+
+create table if not exists copilot.repair_session_events (
+  id uuid primary key default gen_random_uuid(),
+  repair_session_id uuid not null references copilot.repair_sessions(id) on delete cascade,
+  event_seq bigint not null check (event_seq > 0),
+  event_type text not null check (char_length(btrim(event_type)) between 1 and 120),
+  occurred_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  constraint repair_session_events_seq_unique unique (repair_session_id, event_seq)
+);
+
+create table if not exists copilot.repair_session_event_context (
+  event_id uuid primary key references copilot.repair_session_events(id) on delete cascade,
+  operation_id uuid not null unique,
+  origin text not null check (origin in ('voice', 'ui', 'system', 'offline', 'integration', 'copilot')),
+  details jsonb not null default '{}'::jsonb
+    check (jsonb_typeof(details) = 'object')
+    check (octet_length(details::text) <= 262144)
+);
+
+create index if not exists repair_session_events_timeline_idx
+  on copilot.repair_session_events (repair_session_id, event_seq);
+
+commit;

--- a/tests/technician-copilot-repair-session.test.ts
+++ b/tests/technician-copilot-repair-session.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  applyRepairEvent,
+  createEmptyRepairContext,
+} from "@/features/copilot/technician/session/reduceRepairContext";
+import {
+  REPAIR_EVENT_TYPES,
+  type RepairSessionEvent,
+} from "@/features/copilot/technician/session/types";
+
+const migration = [
+  "supabase/migrations/20260813212500_technician_copilot_private_session_storage.sql",
+  "supabase/migrations/20260813212510_technician_copilot_private_event_ledger.sql",
+]
+  .map((path) => readFileSync(path, "utf8"))
+  .join("\n");
+
+function event(seq: number, eventType: string): RepairSessionEvent {
+  return {
+    id: `event-${seq}`,
+    repairSessionId: "session-1",
+    eventSeq: seq,
+    eventType,
+    source: "voice",
+    payload: {},
+    occurredAt: `2026-08-13T21:${String(seq).padStart(2, "0")}:00.000Z`,
+  };
+}
+
+describe("Technician CoPilot repair-session foundation", () => {
+  it("stores session memory outside canonical public work-order tables", () => {
+    expect(migration).toContain("create schema if not exists copilot");
+    expect(migration).toContain("create table if not exists copilot.repair_sessions");
+    expect(migration).toContain("create table if not exists copilot.repair_session_events");
+    expect(migration).toContain("create table if not exists copilot.repair_session_event_context");
+    expect(migration).not.toContain("alter table public.work_orders");
+    expect(migration).not.toContain("alter table public.work_order_lines");
+  });
+
+  it("anchors the session to canonical ProFixIQ entities", () => {
+    expect(migration).toContain("references public.shops(id)");
+    expect(migration).toContain("references public.profiles(id)");
+    expect(migration).toContain("references public.work_orders(id)");
+    expect(migration).toContain("references public.work_order_lines(id)");
+    expect(migration).toContain("references public.vehicles(id)");
+    expect(migration).toContain("references public.service_visits(id)");
+    expect(migration).toContain("repair_sessions_one_active_per_technician_idx");
+  });
+
+  it("provides ordered event history and operation receipts", () => {
+    expect(migration).toContain("unique (repair_session_id, event_seq)");
+    expect(migration).toContain("operation_id uuid not null unique");
+    expect(migration).toContain("origin in ('voice', 'ui', 'system', 'offline', 'integration', 'copilot')");
+    expect(migration).toContain("octet_length(details::text) <= 262144");
+  });
+
+  it("defines the evidence vocabulary without a fixed voice-command vocabulary", () => {
+    expect(REPAIR_EVENT_TYPES).toContain("observation.recorded");
+    expect(REPAIR_EVENT_TYPES).toContain("measurement.recorded");
+    expect(REPAIR_EVENT_TYPES).toContain("dtc.observed");
+    expect(REPAIR_EVENT_TYPES).toContain("evidence.attached");
+    expect(REPAIR_EVENT_TYPES).toContain("component.removed");
+    expect(REPAIR_EVENT_TYPES).toContain("component.installed");
+  });
+
+  it("folds lifecycle events in strict sequence", () => {
+    let state = createEmptyRepairContext({ repairSessionId: "session-1", mode: "shop" });
+    state = applyRepairEvent(state, event(1, "session.started"));
+    state = applyRepairEvent(state, event(2, "session.paused"));
+
+    expect(state.status).toBe("paused");
+    expect(state.lastEventSeq).toBe(2);
+    expect(state.contextVersion).toBe(2);
+
+    const replay = applyRepairEvent(state, event(2, "session.closed"));
+    expect(replay).toBe(state);
+    expect(() => applyRepairEvent(state, event(4, "session.closed"))).toThrow(
+      "Repair event sequence gap",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- Adds a private `copilot` Postgres schema for technician repair-session identity.
- Adds an ordered repair-session event ledger plus globally unique operation receipts for future exactly-once command execution.
- Adds the technician CoPilot repair-session/event TypeScript contract.
- Adds a deterministic lifecycle reducer with strict sequence/replay handling.
- Adds focused contract tests and a Phase-1 architecture note.

## Why

The current voice implementation is transcript/goal oriented. V2 needs a persistent repair-session primitive that can survive across turns and eventually absorb observations, measurements, DTCs, evidence, teardown state, service information, and actions without treating chat history as repair truth.

## Safety / rollback

- Additive only; no existing work-order, inspection, parts, labor, mobile, or voice path is changed.
- Existing public ProFixIQ work-order entities remain canonical.
- No application route, UI component, voice provider, or public RPC consumes the private schema in this slice.
- No production migration has been applied.
- Phase 2 will add the technician-authenticated server command boundary and runtime capability gates together.

## Validation performed before PR

- Strict standalone TypeScript compile for the new session contract/reducer.
- Executable reducer smoke test for lifecycle sequencing, replay protection, and gap failure.
- Static migration checks for private-schema placement, canonical FK anchors, one-active-session constraint, ordered event sequence, operation receipt identity, and transaction wrappers.

Full repo CI and clean migration replay remain the merge/apply gates.