### PR TITLE
build technician CoPilot text collaborator runtime

### DIFF
--- a/app/api/copilot/technician/chat/route.ts
+++ b/app/api/copilot/technician/chat/route.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  requireTechnicianCopilotAccess,
+  TechnicianCopilotAccessError,
+} from "@/features/copilot/technician/server/auth";
+import { runTechnicianCopilotTurn } from "@/features/copilot/technician/server/chat";
+
+export const runtime = "nodejs";
+
+export async function POST(request: NextRequest) {
+  try {
+    const access = await requireTechnicianCopilotAccess();
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const message = typeof body.message === "string" ? body.message.trim() : "";
+    if (!message || message.length > 4000) {
+      return NextResponse.json(
+        { error: "Message is required and must be 4000 characters or less." },
+        { status: 400 },
+      );
+    }
+
+    const turnId = typeof body.turnId === "string" && body.turnId.trim()
+      ? body.turnId.trim().slice(0, 128)
+      : randomUUID();
+    const sessionId = typeof body.sessionId === "string" ? body.sessionId : null;
+
+    const result = await runTechnicianCopilotTurn({
+      identity: {
+        authUserId: access.authUserId,
+        profileId: access.profileId,
+        shopId: access.shopId,
+        supabase: access.supabase,
+      },
+      message,
+      turnId,
+      sessionId,
+    });
+
+    return NextResponse.json({ ...result, turnId });
+  } catch (error) {
+    if (error instanceof TechnicianCopilotAccessError) {
+      return NextResponse.json({ error: error.message, code: error.code }, { status: error.status });
+    }
+    console.error("[technician-copilot] chat failed", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Technician CoPilot failed." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/copilot/technician/session/route.ts
+++ b/app/api/copilot/technician/session/route.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+import type { RepairSessionEvent, RepairSessionMode, RepairSessionStatus } from "@/features/copilot/technician/session/types";
+import { projectTechnicianContext } from "@/features/copilot/technician/session/projectTechnicianContext";
+import { listTechnicianWorkCandidates } from "@/features/copilot/technician/server/assignedWork";
+import { requireTechnicianCopilotAccess, TechnicianCopilotAccessError } from "@/features/copilot/technician/server/auth";
+import { sendCopilotServerCommand } from "@/features/copilot/technician/server/transport";
+
+export const runtime = "nodejs";
+
+type Envelope = {
+  session: null | {
+    id: string;
+    workOrderId: string;
+    mode: RepairSessionMode;
+    status: RepairSessionStatus;
+  };
+  events: RepairSessionEvent[];
+};
+
+async function snapshot(request: NextRequest, explicitSessionId?: string | null) {
+  const access = await requireTechnicianCopilotAccess();
+  const sessionId = explicitSessionId ?? request.nextUrl.searchParams.get("sessionId");
+  const envelope = await sendCopilotServerCommand<Envelope>({
+    authUserId: access.authUserId,
+    profileId: access.profileId,
+    shopId: access.shopId,
+    action: "session.read",
+    args: { sessionId },
+  });
+  const candidates = await listTechnicianWorkCandidates(access.supabase);
+  const workOrder = envelope.session
+    ? candidates.find((candidate) => candidate.id === envelope.session?.workOrderId) ?? null
+    : null;
+  const context = envelope.session
+    ? projectTechnicianContext({
+        repairSessionId: envelope.session.id,
+        mode: envelope.session.mode,
+        status: envelope.session.status,
+        events: envelope.events,
+      })
+    : null;
+  return { envelope, context, workOrder, access };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const result = await snapshot(request);
+    return NextResponse.json({ session: result.envelope.session, context: result.context, workOrder: result.workOrder });
+  } catch (error) {
+    if (error instanceof TechnicianCopilotAccessError) {
+      return NextResponse.json({ error: error.message, code: error.code }, { status: error.status });
+    }
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Unable to read CoPilot session." }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const access = await requireTechnicianCopilotAccess();
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const workOrderId = typeof body.workOrderId === "string" ? body.workOrderId : "";
+    if (!workOrderId) return NextResponse.json({ error: "workOrderId is required." }, { status: 400 });
+
+    const mode: RepairSessionMode = body.mode === "field" || body.mode === "fleet" ? body.mode : "shop";
+    const started = await sendCopilotServerCommand<{ sessionId: string }>({
+      authUserId: access.authUserId,
+      profileId: access.profileId,
+      shopId: access.shopId,
+      action: "session.start",
+      args: {
+        workOrderId,
+        workOrderLineId: typeof body.workOrderLineId === "string" ? body.workOrderLineId : null,
+        mode,
+        operationId: randomUUID(),
+      },
+    });
+
+    const url = new URL(request.url);
+    url.searchParams.set("sessionId", started.sessionId);
+    const result = await snapshot(new NextRequest(url), started.sessionId);
+    return NextResponse.json({ session: result.envelope.session, context: result.context, workOrder: result.workOrder });
+  } catch (error) {
+    if (error instanceof TechnicianCopilotAccessError) {
+      return NextResponse.json({ error: error.message, code: error.code }, { status: error.status });
+    }
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Unable to start CoPilot session." }, { status: 500 });
+  }
+}

--- a/app/copilot/technician/page.tsx
+++ b/app/copilot/technician/page.tsx
@@ -1,0 +1,5 @@
+import { TechnicianTextCopilot } from "@/features/copilot/technician/components/TechnicianTextCopilot";
+
+export default function TechnicianCopilotPage() {
+  return <TechnicianTextCopilot />;
+}

--- a/docs/architecture/technician-copilot-v2-phase2.md
+++ b/docs/architecture/technician-copilot-v2-phase2.md
@@ -1,0 +1,80 @@
+# Technician CoPilot V2 — Phase 2
+
+## Scope
+
+Phase 2 proves a persistent technician collaborator in text before realtime voice is attached.
+
+The runtime path is:
+
+```text
+Technician
+  -> authenticated CoPilot API
+  -> resolve canonical profile / shop / technician role
+  -> tenant or technician capability gate
+  -> canonical assigned-work reads under existing RLS
+  -> private Repair Session runtime
+  -> ordered event ledger
+  -> deterministic repair-context projection
+  -> structured Text CoPilot
+```
+
+## Security boundary
+
+The `copilot` Postgres schema remains private. Browser roles do not receive direct access to repair-session tables or functions.
+
+The Next.js server uses the existing `ai_action_events` service-role write path as an internal command envelope. Rows use `source = technician_copilot_command`. A private trigger validates technician identity and shop ownership, then delegates to private session handlers. The normal shop SELECT policy explicitly excludes these internal command rows.
+
+Private handlers re-check canonical technician assignment on every session read, session start/resume, and event append. The AI therefore cannot use the service credential to escape the technician's authority.
+
+## Rollout
+
+The runtime defaults closed. Access requires an enabled row in `ai_automation_capability_settings` for either:
+
+- `technician_copilot_text`
+- `technician_copilot_text:<profile-id>`
+
+This provides a shop kill switch plus technician-scoped beta rollout without changing existing voice or technician workflows.
+
+## Phase-2 action boundary
+
+The model may write repair-session memory only:
+
+- conversation turns
+- current task
+- complaint snapshot
+- observations
+- measurements
+- DTCs
+- evidence references
+- teardown / reassembly state
+- fluid state
+- pending context markers
+
+It does **not** execute canonical work-order, labor, parts, approvals, invoicing, customer communication, or financial mutations in this phase.
+
+## Conversation behavior
+
+The CoPilot is prompted as an experienced technician collaborator, not a command parser. It should document routine facts silently and ask a follow-up only when missing information materially changes the repair or the next useful step.
+
+The model receives only assigned work-order candidates before a session begins. Any selected work-order ID is validated against those RLS-scoped candidates before a session can start.
+
+Once a session is active, every technician and assistant turn is persisted into the ordered repair ledger. Structured findings are projected from that ledger each turn instead of relying on LLM chat memory.
+
+## Acceptance path
+
+The target manual/automated smoke sequence is:
+
+1. `Start the Ford.`
+2. `Read me the complaint.`
+3. `I'm checking the driveline.`
+4. `Rear U-joint has play.`
+5. `Carrier bearing looks okay.`
+6. `What have we figured out so far?`
+
+At the final turn the CoPilot must still resolve the same repair session and work order, identify the driveline as the active task, retain both findings, and answer from the structured repair context.
+
+## Rollback
+
+No existing voice provider, work-order screen, inspection workflow, parts workflow, time tracking, mobile shell, or canonical work-order table is redirected to this runtime. Disabling the capability row makes the preview API unavailable and returns technicians to the existing application with no repair-data dependency on the CoPilot.
+
+Realtime audio is intentionally out of scope until this text acceptance path is reliable.

--- a/features/copilot/technician/components/TechnicianTextCopilot.tsx
+++ b/features/copilot/technician/components/TechnicianTextCopilot.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+type Turn = { eventId: string; role: "user" | "assistant"; text: string; turnId: string | null };
+type Context = {
+  currentTask: string | null;
+  complaint: string | null;
+  conversation: Turn[];
+  observations: Array<{ eventId: string; text: string }>;
+  measurements: Array<{ eventId: string; label: string; value: string; unit: string | null }>;
+  dtcs: string[];
+};
+type WorkOrder = {
+  customId: string | null;
+  vehicleYear: number | null;
+  vehicleMake: string | null;
+  vehicleModel: string | null;
+  vehicleUnitNumber: string | null;
+};
+
+type Snapshot = {
+  sessionId?: string | null;
+  session?: { id: string } | null;
+  context: Context | null;
+  workOrder: WorkOrder | null;
+  reply?: string;
+  error?: string;
+};
+
+export function TechnicianTextCopilot() {
+  const [snapshot, setSnapshot] = useState<Snapshot>({ context: null, workOrder: null });
+  const [message, setMessage] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/copilot/technician/session", { cache: "no-store" })
+      .then(async (response) => {
+        const body = (await response.json()) as Snapshot;
+        if (!response.ok) throw new Error(body.error || "Unable to load CoPilot.");
+        if (!cancelled) setSnapshot(body);
+      })
+      .catch((reason) => {
+        if (!cancelled) setError(reason instanceof Error ? reason.message : "Unable to load CoPilot.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const sessionId = snapshot.session?.id ?? snapshot.sessionId ?? null;
+  const vehicleLabel = useMemo(() => {
+    const workOrder = snapshot.workOrder;
+    if (!workOrder) return null;
+    const vehicle = [workOrder.vehicleYear, workOrder.vehicleMake, workOrder.vehicleModel]
+      .filter(Boolean)
+      .join(" ");
+    const unit = workOrder.vehicleUnitNumber ? `Unit ${workOrder.vehicleUnitNumber}` : "";
+    return [workOrder.customId, vehicle, unit].filter(Boolean).join(" · ");
+  }, [snapshot.workOrder]);
+
+  async function send(event: FormEvent) {
+    event.preventDefault();
+    const text = message.trim();
+    if (!text || busy) return;
+    setBusy(true);
+    setError(null);
+    setMessage("");
+    try {
+      const response = await fetch("/api/copilot/technician/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: text, sessionId, turnId: crypto.randomUUID() }),
+      });
+      const body = (await response.json()) as Snapshot;
+      if (!response.ok) throw new Error(body.error || "CoPilot could not process that turn.");
+      setSnapshot((current) => ({
+        ...current,
+        ...body,
+        session: body.session ?? (body.sessionId ? { id: body.sessionId } : current.session),
+      }));
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "CoPilot could not process that turn.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (loading) {
+    return <main className="mx-auto max-w-3xl p-4 text-sm text-muted-foreground">Loading Technician CoPilot…</main>;
+  }
+
+  return (
+    <main className="mx-auto flex min-h-[100dvh] max-w-3xl flex-col gap-4 p-4 pb-28">
+      <header className="rounded-2xl border bg-card p-4 shadow-sm">
+        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Phase 2 Preview · Text only</div>
+        <h1 className="mt-1 text-2xl font-semibold">Technician CoPilot</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Continuous repair conversation and memory. Voice remains disconnected until this flow is proven.
+        </p>
+        {vehicleLabel ? <div className="mt-3 rounded-xl bg-muted px-3 py-2 text-sm font-medium">{vehicleLabel}</div> : null}
+      </header>
+
+      {error ? <div className="rounded-xl border border-destructive/40 bg-destructive/10 p-3 text-sm">{error}</div> : null}
+
+      <section className="flex min-h-[45vh] flex-col gap-3 rounded-2xl border bg-card p-4">
+        {!snapshot.context?.conversation.length ? (
+          <div className="my-auto text-center text-sm text-muted-foreground">
+            Start naturally: “What do I have?” or “Start the Ford.”
+          </div>
+        ) : (
+          snapshot.context.conversation.map((turn) => (
+            <div
+              key={turn.eventId}
+              className={`max-w-[88%] rounded-2xl px-4 py-3 text-sm ${
+                turn.role === "user" ? "ml-auto bg-primary text-primary-foreground" : "mr-auto bg-muted"
+              }`}
+            >
+              {turn.text}
+            </div>
+          ))
+        )}
+      </section>
+
+      {snapshot.context ? (
+        <section className="grid gap-3 sm:grid-cols-2">
+          <div className="rounded-2xl border bg-card p-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Current repair memory</div>
+            <div className="mt-2 text-sm"><span className="font-medium">Task:</span> {snapshot.context.currentTask ?? "Not established"}</div>
+            <div className="mt-1 text-sm"><span className="font-medium">Complaint:</span> {snapshot.context.complaint ?? "None captured"}</div>
+          </div>
+          <div className="rounded-2xl border bg-card p-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Evidence captured</div>
+            <div className="mt-2 text-sm">{snapshot.context.observations.length} observations · {snapshot.context.measurements.length} measurements · {snapshot.context.dtcs.length} DTCs</div>
+            {snapshot.context.observations.slice(-3).map((item) => (
+              <div key={item.eventId} className="mt-1 text-xs text-muted-foreground">• {item.text}</div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <form onSubmit={send} className="fixed inset-x-0 bottom-0 z-20 border-t bg-background/95 p-3 backdrop-blur">
+        <div className="mx-auto flex max-w-3xl gap-2">
+          <input
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            placeholder={sessionId ? "Talk to your CoPilot…" : "Start a job naturally…"}
+            className="min-w-0 flex-1 rounded-xl border bg-background px-4 py-3 text-base outline-none focus:ring-2 focus:ring-ring"
+            disabled={busy}
+          />
+          <button type="submit" disabled={busy || !message.trim()} className="rounded-xl bg-primary px-5 py-3 font-medium text-primary-foreground disabled:opacity-50">
+            {busy ? "…" : "Send"}
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/features/copilot/technician/server/assignedWork.ts
+++ b/features/copilot/technician/server/assignedWork.ts
@@ -18,17 +18,50 @@ export type TechnicianWorkCandidate = {
   lineComplaints: string[];
 };
 
-export async function listTechnicianWorkCandidates(supabase: SupabaseClient<Database>): Promise<TechnicianWorkCandidate[]> {
+function object(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function text(value: unknown): string | null {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized || null;
+}
+
+export function readCanonicalWorkOrderConcern(intakeJson: unknown): string | null {
+  const intake = object(intakeJson);
+  const concern = object(intake?.concern);
+  if (!concern) return null;
+
+  const values = [text(concern.primary_text), text(concern.additional_text)].filter(
+    (value): value is string => Boolean(value),
+  );
+
+  return values.length ? [...new Set(values)].join(" | ") : null;
+}
+
+export async function listTechnicianWorkCandidates(
+  supabase: SupabaseClient<Database>,
+): Promise<TechnicianWorkCandidate[]> {
   const workOrders = await supabase
     .from("work_orders")
-    .select("id,custom_id,status,customer_concern,description,vehicle_year,vehicle_make,vehicle_model,vehicle_vin,vehicle_unit_number,updated_at")
+    .select(
+      "id,custom_id,status,notes,intake_json,vehicle_year,vehicle_make,vehicle_model,vehicle_vin,vehicle_unit_number,updated_at",
+    )
     .order("updated_at", { ascending: false })
     .limit(30);
   if (workOrders.error) throw new Error(workOrders.error.message);
   const rows = workOrders.data ?? [];
   if (!rows.length) return [];
 
-  const lines = await supabase.from("work_order_lines").select("id,work_order_id,complaint").in("work_order_id", rows.map((row) => row.id));
+  const lines = await supabase
+    .from("work_order_lines")
+    .select("id,work_order_id,complaint")
+    .in(
+      "work_order_id",
+      rows.map((row) => row.id),
+    );
   if (lines.error) throw new Error(lines.error.message);
 
   const byWorkOrder = new Map<string, { ids: string[]; complaints: string[] }>();
@@ -45,8 +78,8 @@ export async function listTechnicianWorkCandidates(supabase: SupabaseClient<Data
       id: row.id,
       customId: row.custom_id,
       status: row.status,
-      concern: row.customer_concern,
-      description: row.description,
+      concern: readCanonicalWorkOrderConcern(row.intake_json),
+      description: text(row.notes),
       vehicleYear: row.vehicle_year,
       vehicleMake: row.vehicle_make,
       vehicleModel: row.vehicle_model,

--- a/features/copilot/technician/server/assignedWork.ts
+++ b/features/copilot/technician/server/assignedWork.ts
@@ -1,0 +1,59 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/features/shared/types/types/supabase";
+
+export type TechnicianWorkCandidate = {
+  id: string;
+  customId: string | null;
+  status: string | null;
+  concern: string | null;
+  description: string | null;
+  vehicleYear: number | null;
+  vehicleMake: string | null;
+  vehicleModel: string | null;
+  vehicleVin: string | null;
+  vehicleUnitNumber: string | null;
+  lineIds: string[];
+  lineComplaints: string[];
+};
+
+export async function listTechnicianWorkCandidates(supabase: SupabaseClient<Database>): Promise<TechnicianWorkCandidate[]> {
+  const workOrders = await supabase
+    .from("work_orders")
+    .select("id,custom_id,status,customer_concern,description,vehicle_year,vehicle_make,vehicle_model,vehicle_vin,vehicle_unit_number,updated_at")
+    .order("updated_at", { ascending: false })
+    .limit(30);
+  if (workOrders.error) throw new Error(workOrders.error.message);
+  const rows = workOrders.data ?? [];
+  if (!rows.length) return [];
+
+  const lines = await supabase.from("work_order_lines").select("id,work_order_id,complaint").in("work_order_id", rows.map((row) => row.id));
+  if (lines.error) throw new Error(lines.error.message);
+
+  const byWorkOrder = new Map<string, { ids: string[]; complaints: string[] }>();
+  for (const line of lines.data ?? []) {
+    const value = byWorkOrder.get(line.work_order_id) ?? { ids: [], complaints: [] };
+    value.ids.push(line.id);
+    if (line.complaint?.trim()) value.complaints.push(line.complaint.trim());
+    byWorkOrder.set(line.work_order_id, value);
+  }
+
+  return rows.map((row) => {
+    const linesForOrder = byWorkOrder.get(row.id) ?? { ids: [], complaints: [] };
+    return {
+      id: row.id,
+      customId: row.custom_id,
+      status: row.status,
+      concern: row.customer_concern,
+      description: row.description,
+      vehicleYear: row.vehicle_year,
+      vehicleMake: row.vehicle_make,
+      vehicleModel: row.vehicle_model,
+      vehicleVin: row.vehicle_vin,
+      vehicleUnitNumber: row.vehicle_unit_number,
+      lineIds: linesForOrder.ids,
+      lineComplaints: linesForOrder.complaints,
+    };
+  });
+}

--- a/features/copilot/technician/server/auth.ts
+++ b/features/copilot/technician/server/auth.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { hasTechnicianCopilotTextCapability } from "./capability";
+
+export class TechnicianCopilotAccessError extends Error {
+  constructor(public status: number, public code: string, message: string) {
+    super(message);
+  }
+}
+
+export async function requireTechnicianCopilotAccess() {
+  const supabase = await createServerSupabaseRoute();
+  const auth = await supabase.auth.getUser();
+  const user = auth.data.user;
+  if (auth.error || !user) throw new TechnicianCopilotAccessError(401, "unauthorized", "Authentication required.");
+
+  let profileResult = await supabase.from("profiles").select("id,user_id,shop_id,role").eq("user_id", user.id).maybeSingle();
+  if (!profileResult.data && !profileResult.error) {
+    profileResult = await supabase.from("profiles").select("id,user_id,shop_id,role").eq("id", user.id).maybeSingle();
+  }
+  if (profileResult.error) throw new TechnicianCopilotAccessError(500, "profile_lookup_failed", profileResult.error.message);
+
+  const profile = profileResult.data;
+  if (!profile?.id || !profile.shop_id) throw new TechnicianCopilotAccessError(403, "technician_profile_required", "Technician profile required.");
+  const role = String(profile.role ?? "").toLowerCase();
+  if (role !== "mechanic" && role !== "technician" && role !== "tech") {
+    throw new TechnicianCopilotAccessError(403, "technician_role_required", "Technician role required.");
+  }
+
+  const enabled = await hasTechnicianCopilotTextCapability(supabase, profile.shop_id, profile.id);
+  if (!enabled) throw new TechnicianCopilotAccessError(404, "technician_copilot_disabled", "Technician CoPilot is not enabled.");
+
+  return { supabase, user, authUserId: user.id, profileId: profile.id, shopId: profile.shop_id, role };
+}

--- a/features/copilot/technician/server/capability.ts
+++ b/features/copilot/technician/server/capability.ts
@@ -1,0 +1,18 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/features/shared/types/types/supabase";
+
+export async function hasTechnicianCopilotTextCapability(
+  supabase: SupabaseClient<Database>,
+  shopId: string,
+  technicianId: string,
+): Promise<boolean> {
+  const names = ["technician_copilot_text", `technician_copilot_text:${technicianId}`];
+  const result = await supabase
+    .from("ai_automation_capability_settings")
+    .select("enabled")
+    .eq("shop_id", shopId)
+    .in("capability", names);
+  return !result.error && (result.data ?? []).some((row) => row.enabled === true);
+}

--- a/features/copilot/technician/server/chat.ts
+++ b/features/copilot/technician/server/chat.ts
@@ -1,0 +1,203 @@
+import "server-only";
+
+import type { RepairSessionEvent, RepairSessionMode, RepairSessionStatus } from "../session/types";
+import { projectTechnicianContext } from "../session/projectTechnicianContext";
+import { listTechnicianWorkCandidates, type TechnicianWorkCandidate } from "./assignedWork";
+import { decideTechnicianCopilotTurn } from "./model";
+import { deriveCopilotOperationId } from "./operationId";
+import { sendCopilotServerCommand } from "./transport";
+
+export type CopilotIdentity = {
+  authUserId: string;
+  profileId: string;
+  shopId: string;
+  supabase: Parameters<typeof listTechnicianWorkCandidates>[0];
+};
+
+type Session = {
+  id: string;
+  workOrderId: string;
+  activeWorkOrderLineId: string | null;
+  mode: RepairSessionMode;
+  status: RepairSessionStatus;
+};
+
+type Envelope = { session: Session | null; events: RepairSessionEvent[] };
+
+function command<T>(identity: CopilotIdentity, action: "session.read" | "session.start" | "event.append", args: Record<string, unknown>) {
+  return sendCopilotServerCommand<T>({
+    authUserId: identity.authUserId,
+    profileId: identity.profileId,
+    shopId: identity.shopId,
+    action,
+    args,
+  });
+}
+
+function read(identity: CopilotIdentity, sessionId?: string | null) {
+  return command<Envelope>(identity, "session.read", { sessionId: sessionId ?? null });
+}
+
+function candidateFor(candidates: TechnicianWorkCandidate[], id: string | null | undefined) {
+  return id ? candidates.find((candidate) => candidate.id === id) ?? null : null;
+}
+
+function complaintFor(candidate: TechnicianWorkCandidate | null): string | null {
+  if (!candidate) return null;
+  const values = [candidate.concern, ...candidate.lineComplaints].map((value) => value?.trim()).filter(Boolean) as string[];
+  return values.length ? [...new Set(values)].join(" | ") : null;
+}
+
+async function append(identity: CopilotIdentity, input: {
+  sessionId: string;
+  eventType: string;
+  turnId: string;
+  suffix: string;
+  origin: "ui" | "copilot" | "system";
+  details: Record<string, unknown>;
+}) {
+  return command(identity, "event.append", {
+    sessionId: input.sessionId,
+    eventType: input.eventType,
+    origin: input.origin,
+    operationId: deriveCopilotOperationId(input.turnId, input.suffix),
+    details: input.details,
+    occurredAt: new Date().toISOString(),
+  });
+}
+
+export async function runTechnicianCopilotTurn(input: {
+  identity: CopilotIdentity;
+  message: string;
+  turnId: string;
+  sessionId?: string | null;
+}) {
+  const candidates = await listTechnicianWorkCandidates(input.identity.supabase);
+  let envelope = await read(input.identity, input.sessionId);
+  let context = envelope.session
+    ? projectTechnicianContext({
+        repairSessionId: envelope.session.id,
+        mode: envelope.session.mode,
+        status: envelope.session.status,
+        events: envelope.events,
+      })
+    : null;
+
+  const existingAssistant = context?.conversation.find(
+    (turn) => turn.turnId === input.turnId && turn.role === "assistant",
+  );
+  if (existingAssistant && envelope.session) {
+    return {
+      sessionId: envelope.session.id,
+      reply: existingAssistant.text,
+      context,
+      workOrder: candidateFor(candidates, envelope.session.workOrderId),
+      replayed: true,
+    };
+  }
+
+  if (!envelope.session) {
+    const decision = await decideTechnicianCopilotTurn({
+      message: input.message,
+      activeSession: null,
+      assignedWork: candidates,
+    });
+    const selected = decision.mode === "start" ? candidateFor(candidates, decision.workOrderId) : null;
+    if (!selected) {
+      return { sessionId: null, reply: decision.reply, context: null, workOrder: null, replayed: false };
+    }
+
+    const lineId = decision.workOrderLineId && selected.lineIds.includes(decision.workOrderLineId)
+      ? decision.workOrderLineId
+      : selected.lineIds.length === 1 ? selected.lineIds[0] : null;
+    const started = await command<{ sessionId: string }>(input.identity, "session.start", {
+      workOrderId: selected.id,
+      workOrderLineId: lineId,
+      mode: "shop",
+      operationId: deriveCopilotOperationId(input.turnId, "session-start"),
+    });
+    envelope = await read(input.identity, started.sessionId);
+  }
+
+  const session = envelope.session;
+  if (!session) throw new Error("Technician CoPilot could not establish a repair session.");
+
+  const userAlreadyStored = envelope.events.some(
+    (event) => event.eventType === "conversation.user" && event.payload?.turnId === input.turnId,
+  );
+  if (!userAlreadyStored) {
+    await append(input.identity, {
+      sessionId: session.id,
+      eventType: "conversation.user",
+      turnId: input.turnId,
+      suffix: "user",
+      origin: "ui",
+      details: { text: input.message, turnId: input.turnId },
+    });
+  }
+
+  const activeWorkOrder = candidateFor(candidates, session.workOrderId);
+  const existingComplaint = complaintFor(activeWorkOrder);
+  if (existingComplaint && !envelope.events.some((event) => event.eventType === "complaint.recorded")) {
+    await append(input.identity, {
+      sessionId: session.id,
+      eventType: "complaint.recorded",
+      turnId: input.turnId,
+      suffix: "canonical-complaint",
+      origin: "system",
+      details: { text: existingComplaint, source: "work_order" },
+    });
+  }
+
+  envelope = await read(input.identity, session.id);
+  context = projectTechnicianContext({
+    repairSessionId: session.id,
+    mode: session.mode,
+    status: session.status,
+    events: envelope.events,
+  });
+
+  const decision = await decideTechnicianCopilotTurn({
+    message: input.message,
+    activeSession: { id: session.id, workOrderId: session.workOrderId },
+    workOrder: activeWorkOrder,
+    repairContext: context,
+  });
+
+  for (let index = 0; index < decision.events.length; index += 1) {
+    const event = decision.events[index];
+    await append(input.identity, {
+      sessionId: session.id,
+      eventType: event.type,
+      turnId: input.turnId,
+      suffix: `memory-${index}-${event.type}`,
+      origin: "copilot",
+      details: event.details,
+    });
+  }
+
+  await append(input.identity, {
+    sessionId: session.id,
+    eventType: "conversation.assistant",
+    turnId: input.turnId,
+    suffix: "assistant",
+    origin: "copilot",
+    details: { text: decision.reply, turnId: input.turnId },
+  });
+
+  const finalEnvelope = await read(input.identity, session.id);
+  const finalContext = projectTechnicianContext({
+    repairSessionId: session.id,
+    mode: session.mode,
+    status: session.status,
+    events: finalEnvelope.events,
+  });
+
+  return {
+    sessionId: session.id,
+    reply: decision.reply,
+    context: finalContext,
+    workOrder: activeWorkOrder,
+    replayed: false,
+  };
+}

--- a/features/copilot/technician/server/model.ts
+++ b/features/copilot/technician/server/model.ts
@@ -1,0 +1,95 @@
+import "server-only";
+
+import { runOpenAIStructuredJson } from "@/features/shared/lib/server/openai-structured";
+
+const SAFE_EVENTS = new Set([
+  "task.changed",
+  "complaint.recorded",
+  "observation.recorded",
+  "measurement.recorded",
+  "dtc.observed",
+  "evidence.attached",
+  "component.removed",
+  "component.installed",
+  "component.disconnected",
+  "component.connected",
+  "fluid.drained",
+  "fluid.filled",
+  "action.pending",
+  "action.completed",
+]);
+
+export type CopilotModelEvent = { type: string; details: Record<string, unknown> };
+export type CopilotModelDecision = {
+  mode: "start" | "reply";
+  workOrderId: string | null;
+  workOrderLineId: string | null;
+  reply: string;
+  events: CopilotModelEvent[];
+};
+
+function object(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function validateDecision(candidate: unknown): CopilotModelDecision {
+  const value = object(candidate);
+  if (!value) throw new Error("CoPilot returned an invalid decision.");
+
+  const mode = value.mode === "start" ? "start" : "reply";
+  const reply = typeof value.reply === "string" ? value.reply.trim().slice(0, 2000) : "";
+  if (!reply) throw new Error("CoPilot returned an empty reply.");
+
+  const events: CopilotModelEvent[] = [];
+  if (Array.isArray(value.events)) {
+    for (const raw of value.events.slice(0, 12)) {
+      const event = object(raw);
+      const type = typeof event?.type === "string" ? event.type : "";
+      const details = object(event?.details);
+      if (SAFE_EVENTS.has(type) && details) events.push({ type, details });
+    }
+  }
+
+  return {
+    mode,
+    workOrderId: typeof value.workOrderId === "string" ? value.workOrderId : null,
+    workOrderLineId: typeof value.workOrderLineId === "string" ? value.workOrderLineId : null,
+    reply,
+    events,
+  };
+}
+
+const SYSTEM = `You are the ProFixIQ Technician CoPilot, an experienced technician working beside the user.
+You are an active collaborator, not a voice-command parser. Maintain continuity from the supplied repair session and evidence.
+Ask a follow-up only when the missing information materially changes diagnosis, documentation, or what should happen next.
+Routine repair-session documentation should happen silently through structured events; do not ask permission to save notes.
+Never invent a work order, vehicle fact, measurement, DTC, diagnosis, service specification, procedure, approval, part status, or completed action.
+In this Phase-2 build you may update repair-session memory only. You cannot execute canonical work-order, parts, labor, billing, approval, or customer-facing actions.
+If no repair session is active and the technician clearly selects one assigned job, return mode=start and its exact workOrderId from assignedWork. If ambiguous, ask the smallest useful question and return mode=reply.
+If a session is active, return mode=reply and extract only evidence actually stated by the technician.
+Use task.changed when the technician says what they are checking or working on. Use observation.recorded for factual findings. Measurements and DTCs require explicit stated values/codes. Teardown events require explicit physical actions.
+Return JSON only: {mode,workOrderId,workOrderLineId,reply,events:[{type,details}]}.`;
+
+export async function decideTechnicianCopilotTurn(input: unknown) {
+  const result = await runOpenAIStructuredJson<CopilotModelDecision>({
+    purpose: "reasoning",
+    feature: "technician_copilot_text",
+    system: SYSTEM,
+    user: input,
+    schemaName: "technician_copilot_turn",
+    validate: (candidate) => validateDecision(candidate),
+    fallback: () => ({
+      mode: "reply",
+      workOrderId: null,
+      workOrderLineId: null,
+      reply: "I couldn't process that turn reliably. Say that again with the job or finding you want me to work from.",
+      events: [],
+    }),
+    requireAI: true,
+    maxOutputTokens: 1000,
+    temperature: 0.1,
+  });
+  return result.output;
+}

--- a/features/copilot/technician/server/operationId.ts
+++ b/features/copilot/technician/server/operationId.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+function hash32(input: string, seed: number): number {
+  let value = seed >>> 0;
+  for (let index = 0; index < input.length; index += 1) {
+    value ^= input.charCodeAt(index);
+    value = Math.imul(value, 16777619) >>> 0;
+  }
+  return value >>> 0;
+}
+
+export function deriveCopilotOperationId(turnId: string, suffix: string): string {
+  const input = `${turnId}:${suffix}`;
+  const a = hash32(input, 2166136261);
+  const b = hash32(input, 2246822519);
+  const c = hash32(input, 3266489917);
+  const d = hash32(input, 668265263);
+  const hex = [a, b, c, d].map((value) => value.toString(16).padStart(8, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(13, 16)}-a${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
+}

--- a/features/copilot/technician/server/transport.ts
+++ b/features/copilot/technician/server/transport.ts
@@ -1,0 +1,39 @@
+import "server-only";
+
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import type { Json } from "@/features/shared/types/types/supabase";
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export async function sendCopilotServerCommand<T>(input: {
+  authUserId: string;
+  profileId: string;
+  shopId: string;
+  action: "session.read" | "session.start" | "event.append";
+  args: Record<string, unknown>;
+}): Promise<T> {
+  const admin = createAdminSupabase();
+  const response = await admin
+    .from("ai_action_events")
+    .insert({
+      shop_id: input.shopId,
+      event_type: "technician_copilot_command",
+      actor_id: input.profileId,
+      actor_role: "mechanic",
+      source: "technician_copilot_command",
+      payload: { authUserId: input.authUserId, action: input.action, ...input.args } as Json,
+      metadata: {} as Json,
+    })
+    .select("metadata")
+    .single();
+
+  if (response.error) throw new Error(response.error.message);
+  const metadata = asObject(response.data.metadata);
+  const commandError = asObject(metadata.copilotCommandError);
+  if (commandError.message) throw new Error(String(commandError.message));
+  return metadata.copilotCommandResult as T;
+}

--- a/features/copilot/technician/server/transport.ts
+++ b/features/copilot/technician/server/transport.ts
@@ -28,12 +28,17 @@ export async function sendCopilotServerCommand<T>(input: {
       payload: { authUserId: input.authUserId, action: input.action, ...input.args } as Json,
       metadata: {} as Json,
     })
-    .select("metadata")
+    .select("id,metadata")
     .single();
 
   if (response.error) throw new Error(response.error.message);
   const metadata = asObject(response.data.metadata);
   const commandError = asObject(metadata.copilotCommandError);
+  const result = metadata.copilotCommandResult as T;
+
+  void admin.from("ai_action_events").delete().eq("id", response.data.id);
+
   if (commandError.message) throw new Error(String(commandError.message));
-  return metadata.copilotCommandResult as T;
+  if (result == null) throw new Error("Technician CoPilot command returned no result.");
+  return result;
 }

--- a/features/copilot/technician/session/projectTechnicianContext.ts
+++ b/features/copilot/technician/session/projectTechnicianContext.ts
@@ -1,0 +1,138 @@
+import type { RepairSessionEvent, RepairSessionMode, RepairSessionStatus } from "./types";
+
+export type TechnicianConversationTurn = {
+  eventId: string;
+  role: "user" | "assistant";
+  text: string;
+  turnId: string | null;
+  occurredAt: string;
+};
+
+export type TechnicianObservation = {
+  eventId: string;
+  text: string;
+  component: string | null;
+  location: string | null;
+  occurredAt: string;
+};
+
+export type TechnicianMeasurement = {
+  eventId: string;
+  label: string;
+  value: string;
+  unit: string | null;
+  occurredAt: string;
+};
+
+export type TechnicianContext = {
+  repairSessionId: string;
+  mode: RepairSessionMode;
+  status: RepairSessionStatus;
+  currentTask: string | null;
+  complaint: string | null;
+  conversation: TechnicianConversationTurn[];
+  observations: TechnicianObservation[];
+  measurements: TechnicianMeasurement[];
+  dtcs: string[];
+  componentStates: Record<string, "removed" | "installed" | "disconnected" | "connected">;
+  pendingActions: Record<string, string>;
+  lastEventSeq: number;
+  contextVersion: number;
+};
+
+function clean(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  return text || null;
+}
+
+export function projectTechnicianContext(input: {
+  repairSessionId: string;
+  mode: RepairSessionMode;
+  status: RepairSessionStatus;
+  events: readonly RepairSessionEvent[];
+}): TechnicianContext {
+  const state: TechnicianContext = {
+    repairSessionId: input.repairSessionId,
+    mode: input.mode,
+    status: input.status,
+    currentTask: null,
+    complaint: null,
+    conversation: [],
+    observations: [],
+    measurements: [],
+    dtcs: [],
+    componentStates: {},
+    pendingActions: {},
+    lastEventSeq: 0,
+    contextVersion: 0,
+  };
+
+  for (const event of input.events) {
+    if (event.repairSessionId !== input.repairSessionId) {
+      throw new Error("Repair event belongs to a different repair session");
+    }
+    if (event.eventSeq <= state.lastEventSeq) continue;
+    if (event.eventSeq !== state.lastEventSeq + 1) throw new Error("Repair event sequence gap");
+
+    state.lastEventSeq = event.eventSeq;
+    state.contextVersion += 1;
+    if (event.eventType === "session.paused") state.status = "paused";
+    if (event.eventType === "session.closed") state.status = "closed";
+    if (event.eventType === "session.started" || event.eventType === "session.resumed") state.status = "active";
+
+    const payload = event.payload ?? {};
+    if (event.eventType === "conversation.user" || event.eventType === "conversation.assistant") {
+      const text = clean(payload.text);
+      if (text) state.conversation.push({
+        eventId: event.id,
+        role: event.eventType === "conversation.user" ? "user" : "assistant",
+        text,
+        turnId: clean(payload.turnId),
+        occurredAt: event.occurredAt,
+      });
+    } else if (event.eventType === "task.changed") {
+      state.currentTask = clean(payload.task);
+    } else if (event.eventType === "complaint.recorded") {
+      state.complaint = clean(payload.text) ?? state.complaint;
+    } else if (event.eventType === "observation.recorded") {
+      const text = clean(payload.text);
+      if (text) state.observations.push({
+        eventId: event.id,
+        text,
+        component: clean(payload.component),
+        location: clean(payload.location),
+        occurredAt: event.occurredAt,
+      });
+    } else if (event.eventType === "measurement.recorded") {
+      const label = clean(payload.label);
+      const value = clean(payload.value);
+      if (label && value) state.measurements.push({
+        eventId: event.id,
+        label,
+        value,
+        unit: clean(payload.unit),
+        occurredAt: event.occurredAt,
+      });
+    } else if (event.eventType === "dtc.observed") {
+      const code = clean(payload.code);
+      if (code) state.dtcs.push(code);
+    } else if (["component.removed","component.installed","component.disconnected","component.connected"].includes(event.eventType)) {
+      const component = clean(payload.component);
+      if (component) {
+        const location = clean(payload.location);
+        const key = `${location ?? ""}:${component}`.toLowerCase();
+        state.componentStates[key] = event.eventType.split(".")[1] as "removed" | "installed" | "disconnected" | "connected";
+      }
+    } else if (event.eventType === "action.pending") {
+      const action = clean(payload.action);
+      if (action) state.pendingActions[clean(payload.key) ?? action.toLowerCase()] = action;
+    } else if (event.eventType === "action.completed") {
+      const action = clean(payload.action);
+      const key = clean(payload.key) ?? action?.toLowerCase();
+      if (key) delete state.pendingActions[key];
+    }
+  }
+
+  return state;
+}

--- a/supabase/migrations/20260813223500_technician_copilot_runtime_helpers.sql
+++ b/supabase/migrations/20260813223500_technician_copilot_runtime_helpers.sql
@@ -1,0 +1,87 @@
+-- Technician CoPilot V2 phase 2: private runtime helpers.
+
+begin;
+
+create or replace function copilot.technician_profile_id(p_auth_user_id uuid)
+returns uuid
+language plpgsql
+stable
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_profile public.profiles%rowtype;
+begin
+  select p.* into v_profile
+  from public.profiles p
+  where p.id = p_auth_user_id or p.user_id = p_auth_user_id
+  order by (p.id = p_auth_user_id) desc
+  limit 1;
+
+  if not found then raise exception 'copilot_profile_not_found' using errcode = 'P0001'; end if;
+  if lower(coalesce(v_profile.role::text, '')) not in ('mechanic', 'technician', 'tech') then
+    raise exception 'copilot_technician_role_required' using errcode = '42501';
+  end if;
+  if v_profile.shop_id is null then raise exception 'copilot_shop_required' using errcode = '42501'; end if;
+  return v_profile.id;
+end;
+$$;
+
+create or replace function copilot.technician_is_assigned(p_auth_user_id uuid,p_profile_id uuid,p_shop_id uuid,p_work_order_id uuid,p_work_order_line_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+  select exists (
+    select 1 from public.work_order_lines wol
+    where wol.shop_id = p_shop_id
+      and wol.work_order_id = p_work_order_id
+      and (p_work_order_line_id is null or wol.id = p_work_order_line_id)
+      and (
+        wol.assigned_tech_id in (p_auth_user_id, p_profile_id)
+        or wol.assigned_to in (p_auth_user_id, p_profile_id)
+        or exists (
+          select 1 from public.work_order_line_technicians wolt
+          where wolt.work_order_line_id = wol.id
+            and wolt.technician_id in (p_auth_user_id, p_profile_id)
+        )
+      )
+  )
+$$;
+
+create or replace function copilot.append_repair_event_internal(p_session_id uuid,p_shop_id uuid,p_technician_id uuid,p_event_type text,p_origin text,p_operation_id uuid,p_details jsonb,p_occurred_at timestamptz)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_existing_event_id uuid; v_existing_session_id uuid; v_existing_seq bigint;
+  v_event_id uuid; v_next_seq bigint;
+begin
+  select e.id,e.session_id,e.event_seq into v_existing_event_id,v_existing_session_id,v_existing_seq
+  from copilot.repair_session_event_context c
+  join copilot.repair_session_events e on e.id=c.event_id
+  where c.operation_id=p_operation_id;
+  if found then
+    if v_existing_session_id <> p_session_id then raise exception 'copilot_operation_id_conflict' using errcode='23505'; end if;
+    return jsonb_build_object('eventId',v_existing_event_id,'eventSeq',v_existing_seq,'replayed',true);
+  end if;
+
+  select rs.last_event_seq+1 into v_next_seq from copilot.repair_sessions rs
+  where rs.id=p_session_id and rs.shop_id=p_shop_id and rs.technician_id=p_technician_id for update;
+  if not found then raise exception 'copilot_session_not_found' using errcode='P0001'; end if;
+
+  insert into copilot.repair_session_events(session_id,shop_id,technician_id,event_seq,event_type,occurred_at)
+  values(p_session_id,p_shop_id,p_technician_id,v_next_seq,p_event_type,p_occurred_at) returning id into v_event_id;
+  insert into copilot.repair_session_event_context(event_id,shop_id,technician_id,operation_id,origin,details,occurred_at)
+  values(v_event_id,p_shop_id,p_technician_id,p_operation_id,p_origin,p_details,p_occurred_at);
+  update copilot.repair_sessions set last_event_seq=v_next_seq,context_version=context_version+1,last_activity_at=greatest(last_activity_at,p_occurred_at),updated_at=now()
+  where id=p_session_id;
+  return jsonb_build_object('eventId',v_event_id,'eventSeq',v_next_seq,'replayed',false);
+end;
+$$;
+
+commit;

--- a/supabase/migrations/20260813223510_technician_copilot_private_runtime.sql
+++ b/supabase/migrations/20260813223510_technician_copilot_private_runtime.sql
@@ -1,0 +1,120 @@
+-- Technician CoPilot V2 phase 2: private read/start/event handlers.
+
+begin;
+
+create or replace function copilot.technician_session_read_internal(p_auth_user_id uuid,p_session_id uuid)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare v_profile_id uuid; v_session copilot.repair_sessions%rowtype; v_events jsonb;
+begin
+  v_profile_id := copilot.technician_profile_id(p_auth_user_id);
+  if p_session_id is null then
+    select rs.* into v_session from copilot.repair_sessions rs
+    where rs.technician_id=v_profile_id and rs.status='active'
+    order by rs.last_activity_at desc limit 1;
+  else
+    select rs.* into v_session from copilot.repair_sessions rs
+    where rs.id=p_session_id and rs.technician_id=v_profile_id;
+  end if;
+  if not found then return jsonb_build_object('session',null,'events','[]'::jsonb); end if;
+  if not copilot.technician_is_assigned(p_auth_user_id,v_profile_id,v_session.shop_id,v_session.work_order_id,null) then
+    raise exception 'copilot_work_order_assignment_required' using errcode='42501';
+  end if;
+  select coalesce(jsonb_agg(jsonb_build_object(
+    'id',e.id,'repairSessionId',e.session_id,'eventSeq',e.event_seq,'eventType',e.event_type,
+    'source',c.origin,'payload',c.details,'operationId',c.operation_id,'occurredAt',e.occurred_at
+  ) order by e.event_seq),'[]'::jsonb) into v_events
+  from copilot.repair_session_events e join copilot.repair_session_event_context c on c.event_id=e.id
+  where e.session_id=v_session.id;
+  return jsonb_build_object('session',jsonb_build_object(
+    'id',v_session.id,'shopId',v_session.shop_id,'technicianId',v_session.technician_id,
+    'workOrderId',v_session.work_order_id,'activeWorkOrderLineId',v_session.active_work_order_line_id,
+    'vehicleId',v_session.vehicle_id,'serviceVisitId',v_session.service_visit_id,'mode',v_session.mode,
+    'status',v_session.status,'currentTask',v_session.current_task,'contextVersion',v_session.context_version,
+    'lastEventSeq',v_session.last_event_seq,'startedAt',v_session.started_at,'lastActivityAt',v_session.last_activity_at,
+    'endedAt',v_session.ended_at),'events',v_events);
+end;
+$$;
+
+create or replace function copilot.technician_session_start_internal(p_auth_user_id uuid,p_work_order_id uuid,p_work_order_line_id uuid,p_mode text,p_operation_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_profile_id uuid; v_shop_id uuid; v_vehicle_id uuid; v_existing_session_id uuid;
+  v_active_session_id uuid; v_target_session_id uuid; v_event jsonb;
+begin
+  if p_mode not in ('shop','field','fleet') then raise exception 'copilot_invalid_session_mode' using errcode='22023'; end if;
+  v_profile_id := copilot.technician_profile_id(p_auth_user_id);
+  select p.shop_id into v_shop_id from public.profiles p where p.id=v_profile_id;
+  select wo.vehicle_id into v_vehicle_id from public.work_orders wo where wo.id=p_work_order_id and wo.shop_id=v_shop_id;
+  if not found then raise exception 'copilot_work_order_not_found' using errcode='P0001'; end if;
+  if not copilot.technician_is_assigned(p_auth_user_id,v_profile_id,v_shop_id,p_work_order_id,p_work_order_line_id) then
+    raise exception 'copilot_work_order_assignment_required' using errcode='42501';
+  end if;
+  select e.session_id into v_existing_session_id
+  from copilot.repair_session_event_context c join copilot.repair_session_events e on e.id=c.event_id
+  where c.operation_id=p_operation_id and e.technician_id=v_profile_id;
+  if found then return jsonb_build_object('sessionId',v_existing_session_id,'replayed',true); end if;
+
+  select rs.id into v_active_session_id from copilot.repair_sessions rs
+  where rs.technician_id=v_profile_id and rs.status='active' for update;
+  if found and exists(select 1 from copilot.repair_sessions rs where rs.id=v_active_session_id and rs.work_order_id=p_work_order_id) then
+    update copilot.repair_sessions set active_work_order_line_id=coalesce(p_work_order_line_id,active_work_order_line_id),last_activity_at=now(),updated_at=now()
+    where id=v_active_session_id;
+    return jsonb_build_object('sessionId',v_active_session_id,'replayed',false,'alreadyActive',true);
+  end if;
+  if v_active_session_id is not null then
+    v_event := copilot.append_repair_event_internal(v_active_session_id,v_shop_id,v_profile_id,'session.paused','system',md5(p_operation_id::text||':auto-pause')::uuid,jsonb_build_object('reason','switched_work_order'),now());
+    update copilot.repair_sessions set status='paused',updated_at=now() where id=v_active_session_id;
+  end if;
+
+  select rs.id into v_target_session_id from copilot.repair_sessions rs
+  where rs.technician_id=v_profile_id and rs.work_order_id=p_work_order_id and rs.status='paused'
+  order by rs.last_activity_at desc limit 1 for update;
+  if found then
+    update copilot.repair_sessions set status='active',active_work_order_line_id=coalesce(p_work_order_line_id,active_work_order_line_id),ended_at=null,last_activity_at=now(),updated_at=now()
+    where id=v_target_session_id;
+    v_event := copilot.append_repair_event_internal(v_target_session_id,v_shop_id,v_profile_id,'session.resumed','system',p_operation_id,jsonb_build_object('workOrderId',p_work_order_id,'workOrderLineId',p_work_order_line_id),now());
+  else
+    insert into copilot.repair_sessions(shop_id,technician_id,work_order_id,active_work_order_line_id,vehicle_id,mode,status)
+    values(v_shop_id,v_profile_id,p_work_order_id,p_work_order_line_id,v_vehicle_id,p_mode,'active') returning id into v_target_session_id;
+    v_event := copilot.append_repair_event_internal(v_target_session_id,v_shop_id,v_profile_id,'session.started','system',p_operation_id,jsonb_build_object('workOrderId',p_work_order_id,'workOrderLineId',p_work_order_line_id,'mode',p_mode),now());
+  end if;
+  return jsonb_build_object('sessionId',v_target_session_id,'replayed',coalesce((v_event->>'replayed')::boolean,false));
+end;
+$$;
+
+create or replace function copilot.technician_event_append_internal(p_auth_user_id uuid,p_session_id uuid,p_event_type text,p_origin text,p_operation_id uuid,p_details jsonb,p_occurred_at timestamptz)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare v_profile_id uuid; v_shop_id uuid; v_work_order_id uuid; v_result jsonb;
+begin
+  if p_event_type not in ('conversation.user','conversation.assistant','task.changed','complaint.recorded','observation.recorded','measurement.recorded','dtc.observed','evidence.attached','component.removed','component.installed','component.disconnected','component.connected','fluid.drained','fluid.filled','action.pending','action.completed') then
+    raise exception 'copilot_event_type_not_allowed' using errcode='22023';
+  end if;
+  if p_origin not in ('voice','ui','system','offline','integration','copilot') then raise exception 'copilot_event_origin_not_allowed' using errcode='22023'; end if;
+  if p_details is null or jsonb_typeof(p_details)<>'object' or octet_length(p_details::text)>262144 then raise exception 'copilot_event_details_invalid' using errcode='22023'; end if;
+  v_profile_id := copilot.technician_profile_id(p_auth_user_id);
+  select rs.shop_id,rs.work_order_id into v_shop_id,v_work_order_id from copilot.repair_sessions rs
+  where rs.id=p_session_id and rs.technician_id=v_profile_id and rs.status<>'closed';
+  if not found then raise exception 'copilot_session_not_found' using errcode='P0001'; end if;
+  if not copilot.technician_is_assigned(p_auth_user_id,v_profile_id,v_shop_id,v_work_order_id,null) then raise exception 'copilot_work_order_assignment_required' using errcode='42501'; end if;
+  v_result := copilot.append_repair_event_internal(p_session_id,v_shop_id,v_profile_id,p_event_type,p_origin,p_operation_id,p_details,p_occurred_at);
+  if coalesce((v_result->>'replayed')::boolean,false)=false and p_event_type='task.changed' then
+    update copilot.repair_sessions set current_task=nullif(trim(p_details->>'task'),''),updated_at=now() where id=p_session_id;
+  end if;
+  return v_result;
+end;
+$$;
+
+commit;

--- a/supabase/migrations/20260813223520_technician_copilot_ai_command_bridge.sql
+++ b/supabase/migrations/20260813223520_technician_copilot_ai_command_bridge.sql
@@ -1,0 +1,92 @@
+-- Technician CoPilot V2 phase 2: service-only command transport over the
+-- existing AI action event relation. CoPilot command rows are hidden from
+-- normal shop SELECT access and are removed by the API after consumption.
+
+begin;
+
+create or replace function copilot.process_ai_action_command()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_auth_user_id uuid;
+  v_profile_id uuid;
+  v_profile_shop_id uuid;
+  v_action text;
+  v_result jsonb;
+begin
+  v_auth_user_id := (new.payload ->> 'authUserId')::uuid;
+  v_profile_id := copilot.technician_profile_id(v_auth_user_id);
+  select p.shop_id into v_profile_shop_id from public.profiles p where p.id=v_profile_id;
+
+  if new.shop_id <> v_profile_shop_id or new.actor_id is distinct from v_profile_id then
+    raise exception 'copilot_command_identity_mismatch' using errcode='42501';
+  end if;
+
+  v_action := new.payload ->> 'action';
+  begin
+    case v_action
+      when 'session.read' then
+        v_result := copilot.technician_session_read_internal(
+          v_auth_user_id,
+          nullif(new.payload ->> 'sessionId','')::uuid
+        );
+      when 'session.start' then
+        v_result := copilot.technician_session_start_internal(
+          v_auth_user_id,
+          (new.payload ->> 'workOrderId')::uuid,
+          nullif(new.payload ->> 'workOrderLineId','')::uuid,
+          coalesce(nullif(new.payload ->> 'mode',''),'shop'),
+          (new.payload ->> 'operationId')::uuid
+        );
+      when 'event.append' then
+        v_result := copilot.technician_event_append_internal(
+          v_auth_user_id,
+          (new.payload ->> 'sessionId')::uuid,
+          new.payload ->> 'eventType',
+          coalesce(nullif(new.payload ->> 'origin',''),'ui'),
+          (new.payload ->> 'operationId')::uuid,
+          coalesce(new.payload -> 'details','{}'::jsonb),
+          coalesce(nullif(new.payload ->> 'occurredAt','')::timestamptz,now())
+        );
+      else
+        raise exception 'copilot_command_not_allowed' using errcode='22023';
+    end case;
+
+    new.metadata := coalesce(new.metadata,'{}'::jsonb) || jsonb_build_object(
+      'copilotCommandResult',v_result,
+      'copilotCommandError',null
+    );
+  exception when others then
+    new.metadata := coalesce(new.metadata,'{}'::jsonb) || jsonb_build_object(
+      'copilotCommandResult',null,
+      'copilotCommandError',jsonb_build_object('code',sqlstate,'message',sqlerrm)
+    );
+  end;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists technician_copilot_ai_action_command on public.ai_action_events;
+create trigger technician_copilot_ai_action_command
+before insert on public.ai_action_events
+for each row
+when (new.source = 'technician_copilot_command')
+execute function copilot.process_ai_action_command();
+
+drop policy if exists ai_action_events_shop_select on public.ai_action_events;
+create policy ai_action_events_shop_select on public.ai_action_events
+for select to authenticated
+using (
+  source <> 'technician_copilot_command'
+  and exists (
+    select 1 from public.profiles p
+    where (p.id = auth.uid() or p.user_id = auth.uid())
+      and p.shop_id = ai_action_events.shop_id
+  )
+);
+
+commit;

--- a/tests/technician-copilot-assigned-work.test.ts
+++ b/tests/technician-copilot-assigned-work.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { readCanonicalWorkOrderConcern } from "@/features/copilot/technician/server/assignedWork";
+
+const assignedWorkSource = readFileSync(
+  "features/copilot/technician/server/assignedWork.ts",
+  "utf8",
+);
+
+describe("Technician CoPilot assigned-work context", () => {
+  it("reads the canonical structured intake concern", () => {
+    expect(
+      readCanonicalWorkOrderConcern({
+        concern: {
+          primary_text: " Rear driveline vibration ",
+          additional_text: "Customer hears a clunk on takeoff",
+        },
+      }),
+    ).toBe("Rear driveline vibration | Customer hears a clunk on takeoff");
+  });
+
+  it("returns no concern for missing or empty intake data", () => {
+    expect(readCanonicalWorkOrderConcern(null)).toBeNull();
+    expect(
+      readCanonicalWorkOrderConcern({
+        concern: { primary_text: "  ", additional_text: null },
+      }),
+    ).toBeNull();
+  });
+
+  it("queries only canonical work-order columns", () => {
+    expect(assignedWorkSource).toContain(
+      "id,custom_id,status,notes,intake_json,vehicle_year,vehicle_make,vehicle_model,vehicle_vin,vehicle_unit_number,updated_at",
+    );
+    expect(assignedWorkSource).not.toContain("customer_concern");
+  });
+});

--- a/tests/technician-copilot-projection.test.ts
+++ b/tests/technician-copilot-projection.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from "vitest";
+import { projectTechnicianContext } from "@/features/copilot/technician/session/projectTechnicianContext";
+import type { RepairSessionEvent } from "@/features/copilot/technician/session/types";
+
+it("projects persisted technician context", () => {
+  const events: RepairSessionEvent[] = [
+    { id: "1", repairSessionId: "s", eventSeq: 1, eventType: "session.started", source: "system", payload: {}, occurredAt: "2026-08-13T00:00:00Z" },
+    { id: "2", repairSessionId: "s", eventSeq: 2, eventType: "task.changed", source: "copilot", payload: { task: "driveline" }, occurredAt: "2026-08-13T00:01:00Z" },
+    { id: "3", repairSessionId: "s", eventSeq: 3, eventType: "observation.recorded", source: "copilot", payload: { text: "joint has play" }, occurredAt: "2026-08-13T00:02:00Z" },
+  ];
+  const context = projectTechnicianContext({ repairSessionId: "s", mode: "shop", status: "active", events });
+  expect(context.currentTask).toBe("driveline");
+  expect(context.observations[0]?.text).toBe("joint has play");
+  expect(context.lastEventSeq).toBe(3);
+});


### PR DESCRIPTION
## Phase 2 — Technician Session Runtime + Text CoPilot

This slice builds the collaborator before attaching realtime voice.

### What changed
- Adds technician-only authenticated CoPilot API routes for session state and chat.
- Uses existing `ai_automation_capability_settings` as a default-closed shop / technician rollout gate.
- Loads assigned work through the authenticated Supabase client so canonical work-order RLS remains in force.
- Adds private `copilot` runtime helpers for technician identity, assignment verification, session start/resume, ordered event append, and session reads.
- Uses the existing `ai_action_events` service-role path as an internal command envelope; normal shop SELECT access explicitly excludes CoPilot command rows.
- Adds a deterministic Phase-2 repair-context projection for conversation, task, complaint, findings, measurements, DTCs, teardown state and pending context.
- Adds a structured AI collaborator that may write repair-session memory only. It cannot mutate canonical WO/parts/labor/billing/approval state in this phase.
- Adds a text-only preview at `/copilot/technician`.

### Target acceptance conversation
`Start the Ford.` → `Read me the complaint.` → `I'm checking the driveline.` → `Rear U-joint has play.` → `Carrier bearing looks okay.` → `What have we figured out so far?`

The final turn must still resolve the same work order/session and answer from the persisted structured repair context.

### Regression-gate repair
- Replaced invalid `work_orders.customer_concern` and `work_orders.description` reads with canonical `intake_json.concern` and `work_orders.notes` sources.
- Added focused tests for canonical concern extraction and the assigned-work select contract.
- Full-app regression inventory now reports **0 new errors**, **0 resolved-baseline mismatches**, and **0 expired entries**.

### Safety / rollback
- Additive only; no existing voice provider or technician workflow is redirected.
- `copilot` tables remain private.
- Every private session read/start/event append re-checks technician role and canonical assignment.
- The rollout gate defaults off unless `technician_copilot_text` or `technician_copilot_text:<profile-id>` is enabled for the shop.
- No production migration has been applied from this branch.
- Realtime audio is intentionally out of scope.

### Validation — passed
- Supabase clean migration replay and generated-type reconciliation
- Typecheck and changed-file lint
- Complete Vitest suite
- Production Next.js build
- Full-app regression inventory gate
- P0 financial outbox validation
- Mobile Dispatch runtime validation
- Universal Scheduler runtime validation

Ready to merge.