### PR TITLE
allow cardless 14-day trials

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -251,12 +251,21 @@ function buildCheckoutParams(input: {
     success_url: input.successUrl,
     cancel_url: input.cancelUrl,
     allow_promotion_codes: true,
+    payment_method_collection:
+      input.trialDays > 0 ? "if_required" : "always",
     ...(input.clientReferenceId
       ? { client_reference_id: input.clientReferenceId }
       : {}),
     ...(automaticTaxEnabled() ? { automatic_tax: { enabled: true } } : {}),
     subscription_data: {
-      ...(input.trialDays > 0 ? { trial_period_days: input.trialDays } : {}),
+      ...(input.trialDays > 0
+        ? {
+            trial_period_days: input.trialDays,
+            trial_settings: {
+              end_behavior: { missing_payment_method: "cancel" },
+            },
+          }
+        : {}),
       metadata: input.metadata,
     },
     metadata: input.metadata,

--- a/tests/product-package-billing-contract.test.ts
+++ b/tests/product-package-billing-contract.test.ts
@@ -169,6 +169,10 @@ describe("ProFixIQ product package billing contract", () => {
     expect(checkout).toContain("packageKey: z.enum(PRODUCT_PACKAGE_KEYS)");
     expect(checkout).toContain("package_key: selection.packageKey");
     expect(checkout).not.toContain("payment_method_types");
+    expect(checkout).toContain("payment_method_collection");
+    expect(checkout).toContain('"if_required"');
+    expect(checkout).toContain("missing_payment_method");
+    expect(checkout).toContain('"cancel"');
     expect(migration).toContain("profixiq_shop_has_product_access");
     expect(migration).toContain("profixiq_fleet_has_product_access");
     expect(migration).toContain("mobile_profile_has_field_service_access");


### PR DESCRIPTION
## What changed

- Set Stripe Checkout `payment_method_collection` to `if_required` whenever a trial is active.
- Preserve `always` collection for non-trial subscription checkouts.
- Cancel a trial automatically at the end of the trial if no payment method was added.
- Add static contract assertions for the cardless-trial behavior.

## Why

The public 14-day trial Checkout Session was created with `payment_method_collection: "always"`, forcing a credit card even though the amount due today is zero. Stripe requires `if_required` on each newly created subscription Checkout Session to support a free trial without payment details.

## Impact

New 14-day trial sessions can be completed with email only. Existing open Checkout Sessions are immutable and must be replaced by starting a fresh trial after deployment. Trials without a payment method cancel at the end of day 14, preventing unintended unpaid continuation.

## Validation

- Verified the live session currently reports `payment_method_collection: "always"`.
- Verified the branch is one commit ahead of `main`.
- Verified the Checkout route contains the conditional collection setting and missing-payment cancellation behavior.
- Added contract coverage in `tests/product-package-billing-contract.test.ts`.
