### PR TITLE
Fix acquisition owner authentication handoff

### DIFF
--- a/app/api/auth/sign-in/route.ts
+++ b/app/api/auth/sign-in/route.ts
@@ -193,7 +193,14 @@ export async function POST(req: Request) {
     .eq("id", signedInUser.id)
     .maybeSingle();
 
-  if (!profile?.shop_id) return deny();
+  if (!profile) return deny();
+
+  if (!profile.shop_id) {
+    if (surface === "shop" && !profile.role) {
+      return NextResponse.json({ ok: true, destination: "/onboarding" });
+    }
+    return deny();
+  }
 
   if (surface === "mobile") {
     const capabilities = getActorCapabilities({ role: profile.role });

--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
+import { resolvePostAuthDestination } from "@/features/auth/lib/postAuthRouting";
 import { activatePasswordProfile } from "@/features/auth/lib/passwordActivation";
+import { claimStripeAcquisitionAfterAuth } from "@/features/stripe/lib/client/claim-acquisition";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/input";
 
@@ -82,17 +83,28 @@ export default function SetPasswordPage() {
       return false;
     }
 
+    const claim = await claimStripeAcquisitionAfterAuth(searchParams);
+    if (!claim.linked) {
+      setStatusTone("error");
+      setStatusMessage(
+        "Your password was updated, but the trial could not be linked. Retry account activation from the checkout confirmation link.",
+      );
+      return false;
+    }
+
     setStatusTone("success");
     setStatusMessage(
       isPortalActivation
         ? "Portal password created. Opening your portal..."
-        : "Password updated. Redirecting...",
+        : claim.required
+          ? "Password updated. Opening shop setup..."
+          : "Password updated. Redirecting...",
     );
-    const redirect = safeInternalRedirect(
-      searchParams.get("redirect"),
-      getReturnPath(role),
-      ["/dashboard", "/onboarding", "/portal", "/fleet", "/mobile"],
-    );
+    const redirect = await resolvePostAuthDestination({
+      supabase,
+      searchParams,
+      defaultDashboardHref: claim.required ? "/onboarding" : getReturnPath(role),
+    });
     window.setTimeout(() => window.location.replace(redirect), 700);
     return true;
   }

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -12,22 +12,54 @@ type ResetResponse = {
   details?: string;
 };
 
+type SearchParamsReader = {
+  get(name: string): string | null;
+};
+
+const CONTINUATION_KEYS = [
+  "redirect",
+  "session_id",
+  "flow",
+  "demoId",
+  "intakeId",
+  "activationContext",
+] as const;
+
+function buildContinuationParams(
+  searchParams: SearchParamsReader,
+  email: string,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  for (const key of CONTINUATION_KEYS) {
+    const value = searchParams.get(key)?.trim();
+    if (value) params.set(key, value);
+  }
+
+  const normalizedEmail = email.trim().toLowerCase();
+  if (normalizedEmail.includes("@")) params.set("email", normalizedEmail);
+  return params;
+}
+
 export default function ForgotPasswordPage() {
   const router = useRouter();
   const sp = useSearchParams();
 
-  const [email, setEmail] = useState("");
+  const [email, setEmail] = useState(
+    () => sp.get("email")?.trim().toLowerCase() ?? "",
+  );
   const [status, setStatus] = useState<Status>("idle");
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
 
   const goBack = () => {
-    const redirect = sp.get("redirect");
-    const tail = redirect ? `?redirect=${encodeURIComponent(redirect)}` : "";
+    const params = buildContinuationParams(sp, email);
+    const redirect = params.get("redirect");
     const signInPath = redirect?.startsWith("/mobile")
       ? "/mobile/sign-in"
       : "/sign-in";
-    router.push(`${signInPath}${tail}`);
+    router.push(
+      `${signInPath}${params.size ? `?${params.toString()}` : ""}`,
+    );
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -45,7 +77,10 @@ export default function ForgotPasswordPage() {
     }
 
     try {
-      const res = await fetch("/api/auth/send-reset", {
+      const continuation = buildContinuationParams(sp, trimmed);
+      const setPasswordRedirect = `/auth/set-password${continuation.size ? `?${continuation.toString()}` : ""}`;
+      const resetEndpoint = `/api/auth/send-reset?redirect=${encodeURIComponent(setPasswordRedirect)}`;
+      const res = await fetch(resetEndpoint, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -62,6 +62,27 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
     return `${origin}/auth/callback${params.size ? `?${params.toString()}` : ""}`;
   }, [origin, searchParams]);
 
+  const forgotPasswordHref = useMemo(() => {
+    const params = new URLSearchParams();
+    const email = identifier.trim().toLowerCase();
+    const redirect = safeInternalRedirect(searchParams.get("redirect"), "");
+    const sessionId = searchParams.get("session_id")?.trim();
+    const flow = searchParams.get("flow")?.trim();
+    const demoId = searchParams.get("demoId")?.trim();
+    const intakeId = searchParams.get("intakeId")?.trim();
+    const activationContext = searchParams.get("activationContext")?.trim();
+
+    if (email.includes("@")) params.set("email", email);
+    if (redirect) params.set("redirect", redirect);
+    if (sessionId) params.set("session_id", sessionId);
+    if (flow) params.set("flow", flow);
+    if (demoId) params.set("demoId", demoId);
+    if (intakeId) params.set("intakeId", intakeId);
+    if (activationContext) params.set("activationContext", activationContext);
+
+    return `/forgot-password${params.size ? `?${params.toString()}` : ""}`;
+  }, [identifier, searchParams]);
+
   const isOpsSignIn = useMemo(
     () => safeInternalRedirect(searchParams.get("redirect"), "") === "/ops",
     [searchParams],
@@ -138,7 +159,10 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         return;
       }
       if (!data.session) {
-        setNotice("Check your email to verify the account, then continue into shop setup.");
+        setPassword("");
+        setNotice(
+          "If this is a new account, check its inbox for the verification link. If you already have an account, choose Sign in—another confirmation email will not be sent.",
+        );
         return;
       }
       const claim = await claimStripeAcquisitionAfterAuth(searchParams);
@@ -262,7 +286,7 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
               Password
             </label>
             {isSignIn ? (
-              <Link href="/forgot-password" className="text-xs font-semibold text-[var(--accent-copper)] hover:underline">
+              <Link href={forgotPasswordHref} className="text-xs font-semibold text-[var(--accent-copper)] hover:underline">
                 Forgot password?
               </Link>
             ) : null}

--- a/tests/acquisition-auth-handoff.test.ts
+++ b/tests/acquisition-auth-handoff.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("acquisition auth handoff", () => {
+  it("lets only a canonical unassigned shop owner continue to onboarding", () => {
+    const route = read("app/api/auth/sign-in/route.ts");
+
+    expect(route).toContain("if (!profile) return deny();");
+    expect(route).toContain('if (surface === "shop" && !profile.role)');
+    expect(route).toContain(
+      'return NextResponse.json({ ok: true, destination: "/onboarding" });',
+    );
+    expect(route).not.toContain("if (!profile?.shop_id) return deny();");
+  });
+
+  it("preserves acquisition context through forgot-password and recovery", () => {
+    const signIn = read("features/auth/components/SignIn.tsx");
+    const forgotPassword = read("app/forgot-password/page.tsx");
+
+    for (const key of [
+      "session_id",
+      "flow",
+      "demoId",
+      "intakeId",
+      "activationContext",
+    ]) {
+      expect(signIn).toContain(`searchParams.get("${key}")`);
+      expect(forgotPassword).toContain(`"${key}"`);
+    }
+
+    expect(signIn).toContain("forgotPasswordHref");
+    expect(signIn).toContain("href={forgotPasswordHref}");
+    expect(forgotPassword).toContain('sp.get("email")');
+    expect(forgotPassword).toContain("buildContinuationParams(sp, trimmed)");
+    expect(forgotPassword).toContain("setPasswordRedirect");
+    expect(forgotPassword).toContain(
+      "/api/auth/send-reset?redirect=",
+    );
+  });
+
+  it("does not promise a confirmation email for a repeated signup", () => {
+    const signIn = read("features/auth/components/SignIn.tsx");
+
+    expect(signIn).toContain(
+      "If this is a new account, check its inbox for the verification link.",
+    );
+    expect(signIn).toContain(
+      "If you already have an account, choose Sign in—another confirmation email will not be sent.",
+    );
+    expect(signIn).toContain('setPassword("");');
+    expect(signIn).not.toContain(
+      "Check your email to verify the account, then continue into shop setup.",
+    );
+  });
+
+  it("claims a completed acquisition before leaving password recovery", () => {
+    const setPassword = read("app/auth/set-password/page.tsx");
+
+    expect(setPassword).toContain("claimStripeAcquisitionAfterAuth");
+    expect(setPassword).toContain("if (!claim.linked)");
+    expect(setPassword).toContain("resolvePostAuthDestination");
+    expect(setPassword).toContain(
+      'defaultDashboardHref: claim.required ? "/onboarding" : getReturnPath(role)',
+    );
+    expect(setPassword).toContain("window.location.replace(redirect)");
+  });
+});


### PR DESCRIPTION
## What changed

- allow a canonical shop account with no role or shop assignment to authenticate into onboarding, while still denying dangling staff/mobile identities
- preserve `session_id`, `flow`, email, redirect, and activation context through forgot-password and recovery
- claim the completed Stripe acquisition immediately after a recovery password is saved, before navigating to onboarding
- replace the repeated-signup confirmation promise with enumeration-safe guidance for new versus existing accounts
- add focused acquisition-auth regression coverage

## Root cause

The server sign-in exchange successfully authenticated a new owner, then called `deny()` and signed the user out because `profile.shop_id` was null. A null shop is the expected pre-onboarding state for a fresh acquisition. Password recovery compounded the issue by dropping the checkout query parameters, while Supabase intentionally returned HTTP 200 for repeated signup and the UI incorrectly promised another confirmation email.

## User impact

A trial owner can reset a password, keep the checkout identity attached, sign in as an unassigned owner, link the trial, and continue into shop setup without creating another account or repeating checkout.

## Validation

- added `tests/acquisition-auth-handoff.test.ts`
- reviewed the branch diff against `main` (5 files, no unrelated changes)
- CI checks requested on this draft PR; production browser verification will follow deployment