### PR TITLE
Fix portal identity conversion during shop acquisition

### DIFF
--- a/app/api/auth/sign-in/route.ts
+++ b/app/api/auth/sign-in/route.ts
@@ -17,7 +17,12 @@ import {
 } from "@/features/users/lib/username";
 
 type AccessSurface = "shop" | "mobile" | "customer" | "fleet";
-type Body = { identifier?: string; password?: string; surface?: AccessSurface };
+type Body = {
+  identifier?: string;
+  password?: string;
+  surface?: AccessSurface;
+  acquisitionSessionId?: string;
+};
 
 type RateLimitResult = ReturnType<typeof enforceAuthRateLimit>;
 
@@ -97,6 +102,9 @@ export async function POST(req: Request) {
     body?.surface === "fleet"
       ? body.surface
       : "shop";
+  const acquisitionSessionId = String(body?.acquisitionSessionId ?? "").trim();
+  const hasAcquisitionContext =
+    surface === "shop" && /^cs_[A-Za-z0-9_]+$/.test(acquisitionSessionId);
 
   if (!identifier || !password) {
     return NextResponse.json(
@@ -151,7 +159,8 @@ export async function POST(req: Request) {
 
   if (
     (surface === "shop" || surface === "mobile") &&
-    signedInUser.app_metadata?.profixiq_portal_only === true
+    signedInUser.app_metadata?.profixiq_portal_only === true &&
+    !hasAcquisitionContext
   ) {
     return deny();
   }

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -119,10 +119,15 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
 
     try {
       if (mode === "sign-in") {
+        const acquisitionSessionId =
+          searchParams.get("flow")?.trim() === "acquisition"
+            ? searchParams.get("session_id")?.trim() || undefined
+            : undefined;
         const result = await signInWithIdentifier({
           identifier,
           password,
           surface: "shop",
+          acquisitionSessionId,
         });
         if (!result.ok) {
           setError(result.error);

--- a/features/auth/lib/signInClient.ts
+++ b/features/auth/lib/signInClient.ts
@@ -4,6 +4,7 @@ export async function signInWithIdentifier(input: {
   identifier: string;
   password: string;
   surface: SignInSurface;
+  acquisitionSessionId?: string;
 }): Promise<{ ok: true; destination: string } | { ok: false; error: string }> {
   const response = await fetch("/api/auth/sign-in", {
     method: "POST",

--- a/features/stripe/api/stripe/checkout/link-user/route.ts
+++ b/features/stripe/api/stripe/checkout/link-user/route.ts
@@ -113,7 +113,7 @@ export async function handleStripeCheckoutLinkUser(req: Request) {
       if (identityUpgradeError) {
         console.error("stripe_acquisition_identity_upgrade_failed", {
           userId: user.id,
-          code: identityUpgradeError.code,
+          message: identityUpgradeError.message,
         });
         return noStoreJson({ error: "Account upgrade unavailable" }, 503);
       }

--- a/features/stripe/api/stripe/checkout/link-user/route.ts
+++ b/features/stripe/api/stripe/checkout/link-user/route.ts
@@ -102,6 +102,23 @@ export async function handleStripeCheckoutLinkUser(req: Request) {
       );
     }
 
+    if (user.app_metadata?.profixiq_portal_only === true) {
+      const { error: identityUpgradeError } =
+        await admin.auth.admin.updateUserById(user.id, {
+          app_metadata: {
+            ...user.app_metadata,
+            profixiq_portal_only: false,
+          },
+        });
+      if (identityUpgradeError) {
+        console.error("stripe_acquisition_identity_upgrade_failed", {
+          userId: user.id,
+          code: identityUpgradeError.code,
+        });
+        return noStoreJson({ error: "Account upgrade unavailable" }, 503);
+      }
+    }
+
     const identityMetadata = {
       acquisition_intent_id: metadata.intentId,
       shop_id: claim.shopId ?? "",

--- a/tests/acquisition-auth-handoff.test.ts
+++ b/tests/acquisition-auth-handoff.test.ts
@@ -15,6 +15,31 @@ describe("acquisition auth handoff", () => {
     expect(route).not.toContain("if (!profile?.shop_id) return deny();");
   });
 
+  it("upgrades a portal identity only through the acquisition claim path", () => {
+    const route = read("app/api/auth/sign-in/route.ts");
+    const signIn = read("features/auth/components/SignIn.tsx");
+    const signInClient = read("features/auth/lib/signInClient.ts");
+    const linkUser = read(
+      "features/stripe/api/stripe/checkout/link-user/route.ts",
+    );
+
+    expect(route).toContain("acquisitionSessionId?: string");
+    expect(route).toContain(
+      'surface === "shop" && /^cs_[A-Za-z0-9_]+$/.test(acquisitionSessionId)',
+    );
+    expect(route).toContain("!hasAcquisitionContext");
+    expect(signIn).toContain(
+      'searchParams.get("flow")?.trim() === "acquisition"',
+    );
+    expect(signIn).toContain("acquisitionSessionId,");
+    expect(signInClient).toContain("acquisitionSessionId?: string");
+    expect(linkUser).toContain("admin.auth.admin.updateUserById");
+    expect(linkUser).toContain("profixiq_portal_only: false");
+    expect(linkUser.indexOf("if (!claim.claimed)")).toBeLessThan(
+      linkUser.indexOf("profixiq_portal_only: false"),
+    );
+  });
+
   it("preserves acquisition context through forgot-password and recovery", () => {
     const signIn = read("features/auth/components/SignIn.tsx");
     const forgotPassword = read("app/forgot-password/page.tsx");


### PR DESCRIPTION
## What changed

- carry the acquisition Checkout Session through the shop sign-in request
- permit a portal-only identity to complete shop authentication only when that acquisition context is present
- clear the stale `profixiq_portal_only` marker only after Stripe successfully verifies and claims the checkout
- add regression coverage for the conversion sequence and ordering

## Root cause

The password login succeeded, but the canonical auth user still had `profixiq_portal_only=true` from an earlier portal identity. The shop sign-in route rejected and logged out that user before reading the legitimate pre-onboarding owner profile. Repeating owner signup could not fix the state because Supabase intentionally returns an obfuscated successful response for an existing confirmed account and sends no new confirmation email.

## User impact

An existing customer/portal identity can become a shop owner through a verified ProFixIQ acquisition without deleting the identity, repeating checkout, or weakening normal portal-only sign-in isolation.

## Evidence

- production Supabase auth log: password login HTTP 200 followed immediately by logout HTTP 204
- canonical profile: confirmed, `shop_id=null`, `role=null`, onboarding incomplete
- auth app metadata: `profixiq_portal_only=true`
- branch diff is limited to five acquisition/auth files and one focused regression suite

## Validation

- added acquisition handoff contract coverage
- CI requested on this draft PR
- production browser verification will follow deployment