### PR TITLE
Restore secure owner shop bootstrap

### DIFF
--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -47,6 +47,13 @@ function invalidLength(value: string, maximum: number): boolean {
   return value.length === 0 || value.length > maximum;
 }
 
+function readBootstrapShopId(value: unknown): string | null {
+  if (!Array.isArray(value)) return null;
+  const first: unknown = value[0];
+  if (!first || typeof first !== "object" || !("shop_id" in first)) return null;
+  return typeof first.shop_id === "string" ? first.shop_id : null;
+}
+
 export async function POST(request: Request) {
   const supabase = createServerSupabaseRoute();
 
@@ -169,7 +176,7 @@ export async function POST(request: Request) {
         p_owner_pin_hash: ownerPinHash,
       },
     );
-    const shopId = rows?.[0]?.shop_id ?? null;
+    const shopId = readBootstrapShopId(rows);
 
     if (bootstrapError || !shopId) {
       console.error("owner onboarding bootstrap failed", {

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -1,0 +1,204 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+
+import {
+  OWNER_PIN_PURPOSES,
+  setOwnerPinVerifiedCookie,
+} from "@/features/shared/lib/server/owner-pin";
+import {
+  hashOwnerPin,
+  isValidOwnerPin,
+  normalizeOwnerPin,
+} from "@/features/shared/lib/server/owner-pin-crypto";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+const COUNTRIES = new Set(["US", "CA"]);
+const TIMEZONES = new Set([
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Edmonton",
+  "America/Phoenix",
+  "America/Los_Angeles",
+  "America/Vancouver",
+  "America/Toronto",
+  "America/Halifax",
+]);
+
+type Body = {
+  businessName?: unknown;
+  shopName?: unknown;
+  street?: unknown;
+  city?: unknown;
+  province?: unknown;
+  postalCode?: unknown;
+  country?: unknown;
+  timezone?: unknown;
+  pin?: unknown;
+};
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function invalidLength(value: string, maximum: number): boolean {
+  return value.length === 0 || value.length > maximum;
+}
+
+export async function POST(request: Request) {
+  const supabase = createServerSupabaseRoute();
+
+  try {
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return NextResponse.json(
+        { ok: false, error: "Sign in to create your shop." },
+        { status: 401 },
+      );
+    }
+
+    const body = (await request.json().catch(() => null)) as Body | null;
+    if (!body) {
+      return NextResponse.json(
+        { ok: false, error: "Enter your shop details and try again." },
+        { status: 400 },
+      );
+    }
+
+    const businessName = clean(body.businessName);
+    const shopName = clean(body.shopName) || businessName;
+    const street = clean(body.street);
+    const city = clean(body.city);
+    const province = clean(body.province);
+    const postalCode = clean(body.postalCode);
+    const country = clean(body.country).toUpperCase();
+    const timezone = clean(body.timezone);
+    const pin = normalizeOwnerPin(clean(body.pin));
+
+    if (
+      invalidLength(businessName, 120) ||
+      invalidLength(shopName, 120) ||
+      invalidLength(street, 200) ||
+      invalidLength(city, 100) ||
+      invalidLength(province, 80) ||
+      invalidLength(postalCode, 16)
+    ) {
+      return NextResponse.json(
+        { ok: false, error: "Complete every required shop field." },
+        { status: 400 },
+      );
+    }
+
+    if (!COUNTRIES.has(country) || !TIMEZONES.has(timezone)) {
+      return NextResponse.json(
+        { ok: false, error: "Choose a supported country and timezone." },
+        { status: 400 },
+      );
+    }
+
+    if (!isValidOwnerPin(pin)) {
+      return NextResponse.json(
+        { ok: false, error: "Owner PIN must be 4 to 8 digits." },
+        { status: 400 },
+      );
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select(
+        "shop_id, role, completed_onboarding, stripe_checkout_complete, stripe_customer_id, stripe_subscription_id",
+      )
+      .eq("id", user.id)
+      .maybeSingle();
+
+    if (profileError || !profile) {
+      return NextResponse.json(
+        { ok: false, error: "Your owner profile is not ready. Sign out and sign in again." },
+        { status: 409 },
+      );
+    }
+
+    if (
+      profile.shop_id &&
+      profile.role === "owner" &&
+      profile.completed_onboarding
+    ) {
+      return NextResponse.json({
+        ok: true,
+        destination: "/dashboard/onboarding-v2",
+        replayed: true,
+      });
+    }
+
+    if (profile.shop_id || profile.role || profile.completed_onboarding) {
+      return NextResponse.json(
+        { ok: false, error: "This account is not eligible to create a new shop." },
+        { status: 403 },
+      );
+    }
+
+    if (
+      !profile.stripe_checkout_complete ||
+      !profile.stripe_customer_id ||
+      !profile.stripe_subscription_id
+    ) {
+      return NextResponse.json(
+        { ok: false, error: "Complete trial setup before creating your shop." },
+        { status: 403 },
+      );
+    }
+
+    const ownerPinHash = await hashOwnerPin(pin);
+    const { data: rows, error: bootstrapError } = await supabase.rpc(
+      "bootstrap_owner_atomic",
+      {
+        p_business_name: businessName,
+        p_shop_name: shopName,
+        p_street: street,
+        p_city: city,
+        p_province: province,
+        p_postal_code: postalCode,
+        p_country: country,
+        p_timezone: timezone,
+        p_owner_pin_hash: ownerPinHash,
+      },
+    );
+    const shopId = rows?.[0]?.shop_id ?? null;
+
+    if (bootstrapError || !shopId) {
+      console.error("owner onboarding bootstrap failed", {
+        userId: user.id,
+        code: bootstrapError?.code ?? null,
+      });
+      return NextResponse.json(
+        { ok: false, error: "We could not create your shop. Please try again." },
+        { status: 500 },
+      );
+    }
+
+    const response = NextResponse.json({
+      ok: true,
+      shopId,
+      destination: "/dashboard/onboarding-v2",
+    });
+    return setOwnerPinVerifiedCookie(response, {
+      userId: user.id,
+      shopId,
+      purpose: OWNER_PIN_PURPOSES.PRIVILEGED,
+    });
+  } catch (error) {
+    console.error("owner onboarding bootstrap unexpected failure", {
+      name: error instanceof Error ? error.name : "UnknownError",
+    });
+    return NextResponse.json(
+      { ok: false, error: "We could not create your shop. Please try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/onboarding/OwnerOnboardingForm.tsx
+++ b/app/onboarding/OwnerOnboardingForm.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const COUNTRIES = [
+  { value: "US", label: "United States" },
+  { value: "CA", label: "Canada" },
+] as const;
+
+const TIMEZONES = [
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Edmonton",
+  "America/Phoenix",
+  "America/Los_Angeles",
+  "America/Vancouver",
+  "America/Toronto",
+  "America/Halifax",
+] as const;
+
+type BootstrapResponse = {
+  ok?: boolean;
+  error?: string;
+  destination?: string;
+};
+
+export default function OwnerOnboardingForm() {
+  const [country, setCountry] = useState<"US" | "CA">("US");
+  const [timezone, setTimezone] = useState<string>("America/Denver");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if ((TIMEZONES as readonly string[]).includes(detected)) {
+      setTimezone(detected);
+    }
+  }, []);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    const form = new FormData(event.currentTarget);
+    const pin = String(form.get("pin") ?? "").trim();
+    const pinConfirmation = String(form.get("pinConfirmation") ?? "").trim();
+
+    if (!/^\d{4,8}$/.test(pin)) {
+      setError("Owner PIN must be 4 to 8 digits.");
+      return;
+    }
+    if (pin !== pinConfirmation) {
+      setError("Owner PINs do not match.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await fetch("/api/onboarding/bootstrap-owner", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          businessName: String(form.get("businessName") ?? ""),
+          shopName: String(form.get("shopName") ?? ""),
+          street: String(form.get("street") ?? ""),
+          city: String(form.get("city") ?? ""),
+          province: String(form.get("province") ?? ""),
+          postalCode: String(form.get("postalCode") ?? ""),
+          country,
+          timezone,
+          pin,
+        }),
+      });
+      const payload = (await response.json().catch(() => ({}))) as BootstrapResponse;
+
+      if (!response.ok || !payload.ok) {
+        setError(payload.error || "We could not create your shop. Please try again.");
+        return;
+      }
+
+      window.location.assign(payload.destination || "/dashboard/onboarding-v2");
+    } catch {
+      setError("We could not create your shop. Check your connection and try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const fieldClassName =
+    "w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2.5 text-sm text-[color:var(--theme-text-primary)] outline-none transition focus:border-[var(--accent-copper)] focus:ring-2 focus:ring-[color:var(--accent-copper)]/20";
+
+  return (
+    <main className="min-h-screen bg-[color:var(--theme-surface-page)] px-4 py-8 text-[color:var(--theme-text-primary)] sm:px-6">
+      <div className="mx-auto max-w-3xl">
+        <header className="mb-6">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+            ProFixIQ shop setup
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold">Create your shop workspace</h1>
+          <p className="mt-2 max-w-2xl text-sm text-[color:var(--theme-text-secondary)]">
+            Add the shop details your team and customers will see. You can change these settings later.
+          </p>
+        </header>
+
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-6 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 shadow-[var(--theme-shadow-medium)] sm:p-7"
+        >
+          <section aria-labelledby="shop-details-heading">
+            <h2 id="shop-details-heading" className="text-lg font-semibold">
+              Shop details
+            </h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className="space-y-1.5 text-sm font-medium">
+                <span>Business name</span>
+                <input
+                  name="businessName"
+                  type="text"
+                  autoComplete="organization"
+                  required
+                  maxLength={120}
+                  className={fieldClassName}
+                />
+              </label>
+              <label className="space-y-1.5 text-sm font-medium">
+                <span>Shop name</span>
+                <input
+                  name="shopName"
+                  type="text"
+                  maxLength={120}
+                  placeholder="Defaults to business name"
+                  className={fieldClassName}
+                />
+              </label>
+            </div>
+          </section>
+
+          <section aria-labelledby="location-heading">
+            <h2 id="location-heading" className="text-lg font-semibold">
+              Primary location
+            </h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className="space-y-1.5 text-sm font-medium sm:col-span-2">
+                <span>Street address</span>
+                <input
+                  name="street"
+                  type="text"
+                  autoComplete="street-address"
+                  required
+                  maxLength={200}
+                  className={fieldClassName}
+                />
+              </label>
+              <label className="space-y-1.5 text-sm font-medium">
+                <span>City</span>
+                <input
+                  name="city"
+                  type="text"
+                  autoComplete="address-level2"
+                  required
+                  maxLength={100}
+                  className={fieldClassName}
+                />
+              </label>
+              <label className="space-y-1.5 text-sm font-medium">
+                <span>{country === "CA" ? "Province" : "State"}</span>
+                <input
+                  name="province"
+                  type="text"
+                  autoComplete="address-level1"
+                  required
+                  maxLength={80}
+                  className={fieldClassName}
+                />
+              </label>
+              <label className="space-y-1.5 text-sm font-medium">
+                <span>{country === "CA" ? "Postal code" : "ZIP code"}</span>
+                <input
+                  name="postalCode"
+                  type="text"
+                  autoComplete="postal-code"
+                  required
+                  maxLength={16}
+                  className={fieldClassName}
+                />
+              </label>
+              <label className="space-y-1.5 text-sm font-medium">
+                <span>Country</span>
+                <select
+                  value={country}
+                  onChange={(event) => setCountry(event.target.value as "US" | "CA")}
+                  className={fieldClassName}
+                >
+                  {COUNTRIES.map((item) => (
+                    <option key={item.value} value={item.value}>
+                      {item.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="space-y-1.5 text-sm font-medium sm:col-span-2">
+                <span>Timezone</span>
+                <select
+                  value={timezone}
+                  onChange={(event) => setTimezone(event.target.value)}
+                  className={fieldClassName}
+                >
+                  {TIMEZONES.map((item) => (
+                    <option key={item} value={item}>
+                      {item.replace("America/", "").replaceAll("_", " ")}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </section>
+
+          <section aria-labelledby="owner-pin-heading">
+            <h2 id="owner-pin-heading" className="text-lg font-semibold">
+              Owner PIN
+            </h2>
+            <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+              Use 4 to 8 digits. This protects sensitive owner actions inside the shop.
+            </p>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className="space-y-1.5 text-sm font-medium">
+                <span>Owner PIN</span>
+                <input
+                  name="pin"
+                  type="password"
+                  inputMode="numeric"
+                  autoComplete="new-password"
+                  pattern="[0-9]{4,8}"
+                  required
+                  className={fieldClassName}
+                />
+              </label>
+              <label className="space-y-1.5 text-sm font-medium">
+                <span>Confirm owner PIN</span>
+                <input
+                  name="pinConfirmation"
+                  type="password"
+                  inputMode="numeric"
+                  autoComplete="new-password"
+                  pattern="[0-9]{4,8}"
+                  required
+                  className={fieldClassName}
+                />
+              </label>
+            </div>
+          </section>
+
+          {error ? (
+            <p
+              role="alert"
+              className="rounded-xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-200"
+            >
+              {error}
+            </p>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex min-h-11 w-full items-center justify-center rounded-xl bg-[var(--accent-copper)] px-5 py-3 text-sm font-semibold text-[color:var(--theme-text-on-accent)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+          >
+            {submitting ? "Creating shop…" : "Create shop and continue"}
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,27 @@
+import { redirect } from "next/navigation";
+
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import OwnerOnboardingForm from "./OwnerOnboardingForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function OwnerOnboardingPage() {
+  const supabase = createServerSupabaseRSC();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/sign-in");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("shop_id, completed_onboarding")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profile?.shop_id || profile?.completed_onboarding) {
+    redirect("/dashboard");
+  }
+
+  return <OwnerOnboardingForm />;
+}

--- a/features/shared/lib/routes/shellBoundaries.ts
+++ b/features/shared/lib/routes/shellBoundaries.ts
@@ -4,6 +4,7 @@ const STANDALONE_PUBLIC_PREFIXES = [
   "/signup",
   "/sign-up",
   "/sign-in",
+  "/onboarding",
   "/forgot-password",
   "/auth/reset",
   "/auth/set-password",

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -27023,6 +27023,23 @@ export type Database = {
         }
         Returns: Json
       }
+      bootstrap_owner_atomic: {
+        Args: {
+          p_business_name: string
+          p_city: string
+          p_country: string
+          p_owner_pin_hash: string
+          p_postal_code: string
+          p_province: string
+          p_shop_name: string
+          p_street: string
+          p_timezone: string
+        }
+        Returns: {
+          created_shop: boolean
+          shop_id: string
+        }[]
+      }
       can_access_conversation: {
         Args: { actor_user_id?: string; target_conversation_id: string }
         Returns: boolean

--- a/supabase/migrations/20260814041000_restore_secure_owner_bootstrap.sql
+++ b/supabase/migrations/20260814041000_restore_secure_owner_bootstrap.sql
@@ -1,0 +1,262 @@
+-- Restore the first-shop owner bootstrap contract after the legacy onboarding
+-- surfaces were removed. The authenticated role cannot update profiles.role or
+-- profiles.shop_id directly, so this bounded transition is security-definer and
+-- authorizes from the authenticated caller's locked profile. No tenant/shop
+-- identifier is accepted from the caller.
+
+create or replace function public.bootstrap_owner_atomic(
+  p_business_name text,
+  p_shop_name text,
+  p_street text,
+  p_city text,
+  p_province text,
+  p_postal_code text,
+  p_country text,
+  p_timezone text,
+  p_owner_pin_hash text
+)
+returns table (
+  shop_id uuid,
+  created_shop boolean
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid;
+  v_profile public.profiles%rowtype;
+  v_target_shop_id uuid;
+  v_created boolean := false;
+begin
+  v_uid := auth.uid();
+  if v_uid is null then
+    raise exception 'Unauthorized';
+  end if;
+
+  if nullif(trim(coalesce(p_business_name, '')), '') is null
+    or nullif(trim(coalesce(p_shop_name, '')), '') is null
+    or nullif(trim(coalesce(p_street, '')), '') is null
+    or nullif(trim(coalesce(p_city, '')), '') is null
+    or nullif(trim(coalesce(p_province, '')), '') is null
+    or nullif(trim(coalesce(p_postal_code, '')), '') is null
+    or nullif(trim(coalesce(p_country, '')), '') is null
+    or nullif(trim(coalesce(p_timezone, '')), '') is null
+    or nullif(trim(coalesce(p_owner_pin_hash, '')), '') is null
+  then
+    raise exception 'Missing required fields';
+  end if;
+
+  if upper(trim(p_country)) not in ('US', 'CA') then
+    raise exception 'Unsupported country';
+  end if;
+
+  if trim(p_timezone) not in (
+    'America/New_York',
+    'America/Chicago',
+    'America/Denver',
+    'America/Edmonton',
+    'America/Phoenix',
+    'America/Los_Angeles',
+    'America/Vancouver',
+    'America/Toronto',
+    'America/Halifax'
+  ) then
+    raise exception 'Unsupported timezone';
+  end if;
+
+  select p.*
+    into v_profile
+  from public.profiles as p
+  where p.id = v_uid
+  for update;
+
+  if not found then
+    raise exception 'Profile not found';
+  end if;
+
+  -- A completed owner retry is read-only and idempotent. Any other assigned
+  -- account must use normal shop membership/admin flows and cannot self-promote.
+  if v_profile.shop_id is not null then
+    if v_profile.role = 'owner'
+      and coalesce(v_profile.completed_onboarding, false)
+      and exists (
+        select 1
+        from public.shops as existing_shop
+        where existing_shop.id = v_profile.shop_id
+          and existing_shop.owner_id = v_uid
+      )
+    then
+      return query select v_profile.shop_id, false;
+      return;
+    end if;
+
+    raise exception 'Owner bootstrap not allowed';
+  end if;
+
+  if v_profile.role is not null
+    or coalesce(v_profile.completed_onboarding, false)
+  then
+    raise exception 'Owner bootstrap not allowed';
+  end if;
+
+  if not coalesce(v_profile.stripe_checkout_complete, false)
+    or v_profile.stripe_customer_id is null
+    or v_profile.stripe_subscription_id is null
+  then
+    raise exception 'Completed trial claim required';
+  end if;
+
+  if exists (
+    select 1
+    from public.shop_members as existing_membership
+    where existing_membership.user_id = v_uid
+  ) then
+    raise exception 'Owner bootstrap not allowed';
+  end if;
+
+  -- Recover a historical owner-created shop if one exists; otherwise create
+  -- exactly one while the profile row lock serializes browser retries.
+  select s.id
+    into v_target_shop_id
+  from public.shops as s
+  where s.owner_id = v_uid
+  order by s.created_at desc nulls last
+  limit 1
+  for update;
+
+  if v_target_shop_id is null then
+    insert into public.shops (
+      owner_id,
+      created_by,
+      business_name,
+      shop_name,
+      name,
+      street,
+      address,
+      city,
+      province,
+      postal_code,
+      country,
+      timezone,
+      owner_pin_hash,
+      owner_pin,
+      pin
+    )
+    values (
+      v_uid,
+      v_uid,
+      trim(p_business_name),
+      trim(p_shop_name),
+      trim(p_shop_name),
+      trim(p_street),
+      trim(p_street),
+      trim(p_city),
+      trim(p_province),
+      trim(p_postal_code),
+      upper(trim(p_country)),
+      trim(p_timezone),
+      p_owner_pin_hash,
+      null,
+      null
+    )
+    returning id into v_target_shop_id;
+
+    v_created := true;
+  end if;
+
+  -- Assign the caller before RLS-dependent shop profile/member writes. Every
+  -- statement remains in this transaction and rolls back together on failure.
+  update public.profiles as p
+    set role = 'owner',
+        shop_id = v_target_shop_id,
+        completed_onboarding = true
+  where p.id = v_uid
+    and p.shop_id is null
+    and p.role is null
+    and not coalesce(p.completed_onboarding, false);
+
+  if not found then
+    raise exception 'Owner bootstrap not allowed';
+  end if;
+
+  update public.shops as s
+    set business_name = trim(p_business_name),
+        shop_name = trim(p_shop_name),
+        name = trim(p_shop_name),
+        street = trim(p_street),
+        address = trim(p_street),
+        city = trim(p_city),
+        province = trim(p_province),
+        postal_code = trim(p_postal_code),
+        country = upper(trim(p_country)),
+        timezone = trim(p_timezone),
+        owner_pin_hash = p_owner_pin_hash,
+        owner_pin = null,
+        pin = null,
+        owner_id = v_uid,
+        created_by = coalesce(s.created_by, v_uid)
+  where s.id = v_target_shop_id
+    and s.owner_id = v_uid;
+
+  if not found then
+    raise exception 'Owner shop not found';
+  end if;
+
+  insert into public.shop_profiles (
+    shop_id,
+    address_line1,
+    city,
+    province,
+    postal_code,
+    country
+  )
+  values (
+    v_target_shop_id,
+    trim(p_street),
+    trim(p_city),
+    trim(p_province),
+    trim(p_postal_code),
+    upper(trim(p_country))
+  )
+  on conflict on constraint shop_profiles_pkey do update
+    set address_line1 = excluded.address_line1,
+        city = excluded.city,
+        province = excluded.province,
+        postal_code = excluded.postal_code,
+        country = excluded.country;
+
+  insert into public.shop_members (shop_id, user_id, role, created_by)
+  values (v_target_shop_id, v_uid, 'owner', v_uid)
+  on conflict (shop_id, user_id) do update
+    set role = 'owner',
+        created_by = coalesce(shop_members.created_by, excluded.created_by);
+
+  return query
+  select v_target_shop_id, v_created;
+end;
+$$;
+
+revoke all on function public.bootstrap_owner_atomic(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text
+) from public, anon;
+
+grant execute on function public.bootstrap_owner_atomic(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text
+) to authenticated;

--- a/tests/owner-onboarding-bootstrap.test.ts
+++ b/tests/owner-onboarding-bootstrap.test.ts
@@ -1,0 +1,201 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getUser: vi.fn(),
+  maybeSingle: vi.fn(),
+  rpc: vi.fn(),
+  hashOwnerPin: vi.fn(),
+  setOwnerPinVerifiedCookie: vi.fn((response: Response) => response),
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createServerSupabaseRoute: () => ({
+    auth: { getUser: mocks.getUser },
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: mocks.maybeSingle })),
+      })),
+    })),
+    rpc: mocks.rpc,
+  }),
+}));
+
+vi.mock("@/features/shared/lib/server/owner-pin-crypto", () => ({
+  normalizeOwnerPin: (pin: string) => pin.trim(),
+  isValidOwnerPin: (pin: string) => /^\d{4,8}$/.test(pin),
+  hashOwnerPin: mocks.hashOwnerPin,
+}));
+
+vi.mock("@/features/shared/lib/server/owner-pin", () => ({
+  OWNER_PIN_PURPOSES: { PRIVILEGED: "owner_pin:privileged" },
+  setOwnerPinVerifiedCookie: mocks.setOwnerPinVerifiedCookie,
+}));
+
+function request(overrides: Record<string, unknown> = {}) {
+  return new Request("https://profixiq.test/api/onboarding/bootstrap-owner", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      businessName: "High Plains Auto & Fleet",
+      shopName: "High Plains Auto & Fleet",
+      street: "4250 Trade Center Drive",
+      city: "Denver",
+      province: "CO",
+      postalCode: "80216",
+      country: "us",
+      timezone: "America/Denver",
+      pin: "4826",
+      ...overrides,
+    }),
+  });
+}
+
+describe("owner onboarding bootstrap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.getUser.mockResolvedValue({
+      data: { user: { id: "owner-user-1" } },
+      error: null,
+    });
+    mocks.maybeSingle.mockResolvedValue({
+      data: {
+        shop_id: null,
+        role: null,
+        completed_onboarding: false,
+        stripe_checkout_complete: true,
+        stripe_customer_id: "cus_trial_owner",
+        stripe_subscription_id: "sub_trial_owner",
+      },
+      error: null,
+    });
+    mocks.hashOwnerPin.mockResolvedValue("hashed-owner-pin");
+    mocks.rpc.mockResolvedValue({
+      data: [{ shop_id: "11111111-1111-4111-8111-111111111111", created_shop: true }],
+      error: null,
+    });
+  });
+
+  it("restores a real /onboarding page instead of the production 404", () => {
+    const page = readFileSync("app/onboarding/page.tsx", "utf8");
+    const form = readFileSync("app/onboarding/OwnerOnboardingForm.tsx", "utf8");
+
+    expect(page).toContain("<OwnerOnboardingForm />");
+    expect(form).toContain('fetch("/api/onboarding/bootstrap-owner"');
+    expect(form).toContain("Create shop and continue");
+  });
+
+  it("requires an authenticated caller", async () => {
+    mocks.getUser.mockResolvedValue({ data: { user: null }, error: null });
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(401);
+    expect(mocks.rpc).not.toHaveBeenCalled();
+  });
+
+  it("rejects assigned staff before the privileged RPC", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: {
+        shop_id: "22222222-2222-4222-8222-222222222222",
+        role: "mechanic",
+        completed_onboarding: true,
+      },
+      error: null,
+    });
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(403);
+    expect(mocks.hashOwnerPin).not.toHaveBeenCalled();
+    expect(mocks.rpc).not.toHaveBeenCalled();
+  });
+
+  it("validates the PIN and supported region before hashing", async () => {
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const invalidPin = await POST(request({ pin: "12ab" }));
+    const invalidTimezone = await POST(request({ timezone: "Etc/Unknown" }));
+
+    expect(invalidPin.status).toBe(400);
+    expect(invalidTimezone.status).toBe(400);
+    expect(mocks.hashOwnerPin).not.toHaveBeenCalled();
+    expect(mocks.rpc).not.toHaveBeenCalled();
+  });
+
+  it("requires a completed Stripe trial claim before shop creation", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: {
+        shop_id: null,
+        role: null,
+        completed_onboarding: false,
+        stripe_checkout_complete: false,
+        stripe_customer_id: null,
+        stripe_subscription_id: null,
+      },
+      error: null,
+    });
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(403);
+    expect(mocks.hashOwnerPin).not.toHaveBeenCalled();
+    expect(mocks.rpc).not.toHaveBeenCalled();
+  });
+
+  it("derives owner scope from auth and calls the atomic bootstrap without a client shop id", async () => {
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual(expect.objectContaining({
+      ok: true,
+      destination: "/dashboard/onboarding-v2",
+    }));
+    expect(mocks.hashOwnerPin).toHaveBeenCalledWith("4826");
+    expect(mocks.rpc).toHaveBeenCalledWith("bootstrap_owner_atomic", {
+      p_business_name: "High Plains Auto & Fleet",
+      p_shop_name: "High Plains Auto & Fleet",
+      p_street: "4250 Trade Center Drive",
+      p_city: "Denver",
+      p_province: "CO",
+      p_postal_code: "80216",
+      p_country: "US",
+      p_timezone: "America/Denver",
+      p_owner_pin_hash: "hashed-owner-pin",
+    });
+    expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalledWith(
+      expect.any(Response),
+      {
+        userId: "owner-user-1",
+        shopId: "11111111-1111-4111-8111-111111111111",
+        purpose: "owner_pin:privileged",
+      },
+    );
+  });
+
+  it("keeps the database contract RLS-compatible and blocks self-promotion", () => {
+    const migration = readFileSync(
+      "supabase/migrations/20260814041000_restore_secure_owner_bootstrap.sql",
+      "utf8",
+    );
+    const profileAssignment = migration.indexOf("update public.profiles as p");
+    const shopProfileWrite = migration.indexOf("insert into public.shop_profiles");
+
+    expect(profileAssignment).toBeGreaterThan(-1);
+    expect(profileAssignment).toBeLessThan(shopProfileWrite);
+    expect(migration).toContain("security definer");
+    expect(migration).toContain("set search_path = public");
+    expect(migration).toContain("raise exception 'Owner bootstrap not allowed'");
+    expect(migration).toContain("Completed trial claim required");
+    expect(migration).toContain("from public.shop_members as existing_membership");
+    expect(migration).toContain("from public, anon");
+    expect(migration).toContain("to authenticated");
+  });
+});


### PR DESCRIPTION
## What changed

- restores the authenticated `/onboarding` page that first-time trial owners are already redirected to
- adds a server-validated owner shop form and the canonical `/api/onboarding/bootstrap-owner` transition
- sends a completed owner into the existing guided setup workspace
- renders onboarding outside the desktop app shell
- restores the owner bootstrap function in ordered migrations and generated types
- adds focused regression coverage for the route, trial gate, tenant derivation, and database authorization contract

## Root cause

PR #847 removed the legacy onboarding UI, including the initial owner shop page and bootstrap API, while later auth/middleware work again made `/onboarding` the required destination for a clean signed-in acquisition owner. Production therefore authenticated successfully and then rendered a 404.

Read-only production inspection also found that the surviving RPC was both unusable with current RLS/column grants and unsafe: its assigned-shop branch could change `owner_id`, `profiles.role`, and `shop_members.role` for an authenticated caller.

## Security and data integrity

The forward migration keeps the sensitive role/shop columns non-writable from browser clients and exposes one bounded security-definer transition with a fixed `search_path`. It:

- derives identity exclusively from `auth.uid()`
- locks the caller's profile
- accepts no shop or tenant ID from the request
- requires a clean no-shop/no-role/incomplete profile with a completed Stripe trial claim
- rejects existing shop memberships
- makes an exact completed-owner retry read-only
- creates or recovers only a shop owned by that caller
- commits the profile, shop profile, membership, and PIN hash atomically
- revokes execute from `PUBLIC` and `anon`; only `authenticated` can invoke it

Supabase's advisor reports the intentional authenticated `SECURITY DEFINER` exposure ([lint 0029](https://supabase.com/docs/guides/database/database-linter?lint=0029_authenticated_security_definer_function_executable)). This function requires elevated rights because normal authenticated column grants deliberately exclude `profiles.role` and `profiles.shop_id`; its internal trial, clean-profile, ownership, and membership checks are covered by the exact-head replay/privilege suite.

## User impact

A new shop owner can complete the 14-day-trial acquisition flow, create the first shop, receive the owner role, and continue into guided setup instead of landing on a 404.

## Validation

Exact PR head: `06341ede3bededa39cb674902464e4775f7ba8ae`

- Agent PR Checks #351 — passed
  - type-check
  - changed-file lint
  - complete test suite
  - production application build
- Supabase Clean Replay Validation #685 — passed
  - unique migration version
  - deterministic generated baseline
  - clean first install
  - generated types match
  - full reset/replay
  - RPC privilege and production-signature integrations
  - schema reconciliation and bootstrap/existing-database checks
- P0-006 Stripe Identity Validation #318 — passed
- local/remote tree match: `9e1752ba3fd9dd27654273c2ec5206af2c921603`
- `git diff --check` — passed

## Database/deployment

Repository migration: `20260814041000_restore_secure_owner_bootstrap.sql`

Applied to canonical ProFixIQ production through the Supabase migration API as `20260814045808_restore_secure_owner_bootstrap` after the exact-head gates passed.

Post-apply verification:

- `SECURITY DEFINER`: true
- fixed `search_path=public`
- `anon` execute: false
- `authenticated` execute: true
- trial, clean-profile, and existing-membership guards present
- no task-created performance advisor finding