### PR TITLE
harden technician CoPilot assignment boundary and text runtime

### DIFF
--- a/app/api/copilot/technician/session/route.ts
+++ b/app/api/copilot/technician/session/route.ts
@@ -40,7 +40,11 @@ async function snapshot(
     action: "session.read",
     args: { sessionId },
   });
-  const candidates = await listTechnicianWorkCandidates(access.supabase);
+  const candidates = await listTechnicianWorkCandidates({
+    supabase: access.supabase,
+    shopId: access.shopId,
+    technicianIds: [access.authUserId, access.profileId],
+  });
   const workOrder = envelope.session
     ? candidates.find(
         (candidate) => candidate.id === envelope.session?.workOrderId,

--- a/features/copilot/technician/server/assignedWork.ts
+++ b/features/copilot/technician/server/assignedWork.ts
@@ -14,9 +14,19 @@ export type TechnicianWorkCandidate = {
   vehicleModel: string | null;
   vehicleVin: string | null;
   vehicleUnitNumber: string | null;
+  /** Only line IDs canonically assigned to this technician. */
   lineIds: string[];
+  /** Readable complaints on the assigned work order for conversational context. */
   lineComplaints: string[];
 };
+
+export type TechnicianWorkScope = {
+  supabase: SupabaseClient<Database>;
+  shopId: string;
+  technicianIds: string[];
+};
+
+type AssignedLine = { id: string; work_order_id: string };
 
 function object(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -27,6 +37,19 @@ function object(value: unknown): Record<string, unknown> | null {
 function text(value: unknown): string | null {
   const normalized = typeof value === "string" ? value.trim() : "";
   return normalized || null;
+}
+
+function uniqueIds(values: readonly string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+function directAssignmentFilter(technicianIds: readonly string[]): string {
+  return technicianIds
+    .flatMap((technicianId) => [
+      `assigned_tech_id.eq.${technicianId}`,
+      `assigned_to.eq.${technicianId}`,
+    ])
+    .join(",");
 }
 
 export function readCanonicalWorkOrderConcern(intakeJson: unknown): string | null {
@@ -42,51 +65,114 @@ export function readCanonicalWorkOrderConcern(intakeJson: unknown): string | nul
 }
 
 export async function listTechnicianWorkCandidates(
-  supabase: SupabaseClient<Database>,
+  input: TechnicianWorkScope,
 ): Promise<TechnicianWorkCandidate[]> {
-  const workOrders = await supabase
+  const technicianIds = uniqueIds(input.technicianIds);
+  if (!input.shopId || technicianIds.length === 0) return [];
+
+  // Discover assignment identity first. This intentionally mirrors the
+  // canonical technician work surfaces instead of asking for the newest shop
+  // work orders and assuming RLS alone defines the candidate list.
+  const [directResult, sharedResult] = await Promise.all([
+    input.supabase
+      .from("work_order_lines")
+      .select("id,work_order_id")
+      .eq("shop_id", input.shopId)
+      .eq("line_type", "job")
+      .or(directAssignmentFilter(technicianIds)),
+    input.supabase
+      .from("work_order_line_technicians")
+      .select("work_order_line_id")
+      .in("technician_id", technicianIds),
+  ]);
+
+  if (directResult.error) throw new Error(directResult.error.message);
+  if (sharedResult.error) throw new Error(sharedResult.error.message);
+
+  const sharedLineIds = uniqueIds(
+    (sharedResult.data ?? []).map((row) => row.work_order_line_id),
+  );
+
+  let sharedLines: AssignedLine[] = [];
+  if (sharedLineIds.length > 0) {
+    const sharedLinesResult = await input.supabase
+      .from("work_order_lines")
+      .select("id,work_order_id")
+      .eq("shop_id", input.shopId)
+      .eq("line_type", "job")
+      .in("id", sharedLineIds);
+    if (sharedLinesResult.error) throw new Error(sharedLinesResult.error.message);
+    sharedLines = sharedLinesResult.data ?? [];
+  }
+
+  const assignedById = new Map<string, AssignedLine>();
+  for (const row of [...(directResult.data ?? []), ...sharedLines]) {
+    assignedById.set(row.id, row);
+  }
+  const assignedLines = [...assignedById.values()];
+  if (assignedLines.length === 0) return [];
+
+  const workOrderIds = uniqueIds(
+    assignedLines.map((line) => line.work_order_id),
+  );
+  const workOrders = await input.supabase
     .from("work_orders")
     .select(
       "id,custom_id,status,notes,intake_json,vehicle_year,vehicle_make,vehicle_model,vehicle_vin,vehicle_unit_number,updated_at",
     )
+    .eq("shop_id", input.shopId)
+    .in("id", workOrderIds)
+    .or("type.neq.historical_import,type.is.null")
     .order("updated_at", { ascending: false })
     .limit(30);
   if (workOrders.error) throw new Error(workOrders.error.message);
   const rows = workOrders.data ?? [];
   if (!rows.length) return [];
 
-  const lines = await supabase
+  const visibleWorkOrderIds = rows.map((row) => row.id);
+  const lines = await input.supabase
     .from("work_order_lines")
     .select("id,work_order_id,complaint")
-    .in(
-      "work_order_id",
-      rows.map((row) => row.id),
-    );
+    .eq("shop_id", input.shopId)
+    .eq("line_type", "job")
+    .in("work_order_id", visibleWorkOrderIds);
   if (lines.error) throw new Error(lines.error.message);
 
-  const byWorkOrder = new Map<string, { ids: string[]; complaints: string[] }>();
+  const assignedLineIds = new Set(assignedLines.map((line) => line.id));
+  const byWorkOrder = new Map<
+    string,
+    { assignedIds: string[]; complaints: string[] }
+  >();
   for (const line of lines.data ?? []) {
-    const value = byWorkOrder.get(line.work_order_id) ?? { ids: [], complaints: [] };
-    value.ids.push(line.id);
+    const value = byWorkOrder.get(line.work_order_id) ?? {
+      assignedIds: [],
+      complaints: [],
+    };
+    if (assignedLineIds.has(line.id)) value.assignedIds.push(line.id);
     if (line.complaint?.trim()) value.complaints.push(line.complaint.trim());
     byWorkOrder.set(line.work_order_id, value);
   }
 
-  return rows.map((row) => {
-    const linesForOrder = byWorkOrder.get(row.id) ?? { ids: [], complaints: [] };
-    return {
-      id: row.id,
-      customId: row.custom_id,
-      status: row.status,
-      concern: readCanonicalWorkOrderConcern(row.intake_json),
-      description: text(row.notes),
-      vehicleYear: row.vehicle_year,
-      vehicleMake: row.vehicle_make,
-      vehicleModel: row.vehicle_model,
-      vehicleVin: row.vehicle_vin,
-      vehicleUnitNumber: row.vehicle_unit_number,
-      lineIds: linesForOrder.ids,
-      lineComplaints: linesForOrder.complaints,
-    };
-  });
+  return rows
+    .map((row) => {
+      const linesForOrder = byWorkOrder.get(row.id) ?? {
+        assignedIds: [],
+        complaints: [],
+      };
+      return {
+        id: row.id,
+        customId: row.custom_id,
+        status: row.status,
+        concern: readCanonicalWorkOrderConcern(row.intake_json),
+        description: text(row.notes),
+        vehicleYear: row.vehicle_year,
+        vehicleMake: row.vehicle_make,
+        vehicleModel: row.vehicle_model,
+        vehicleVin: row.vehicle_vin,
+        vehicleUnitNumber: row.vehicle_unit_number,
+        lineIds: linesForOrder.assignedIds,
+        lineComplaints: [...new Set(linesForOrder.complaints)],
+      } satisfies TechnicianWorkCandidate;
+    })
+    .filter((candidate) => candidate.lineIds.length > 0);
 }

--- a/features/copilot/technician/server/auth.ts
+++ b/features/copilot/technician/server/auth.ts
@@ -58,9 +58,10 @@ export async function requireTechnicianCopilotAccess() {
     );
   }
 
-  // The work-order RLS contract is shop-scoped. Establish the same security
-  // context used by the canonical technician offline/runtime surfaces before
-  // any CoPilot capability or assigned-work query is allowed to run.
+  // current_shop_id() resolves from the authenticated profile directly. This
+  // compatibility RPC is still useful as an explicit ownership assertion: it
+  // rejects a profile/shop mismatch before CoPilot capability or assigned-work
+  // reads begin, without relying on its transaction-local setting afterward.
   const { error: shopContextError } = await supabase.rpc(
     "set_current_shop_id",
     { p_shop_id: profile.shop_id },

--- a/features/copilot/technician/server/auth.ts
+++ b/features/copilot/technician/server/auth.ts
@@ -58,6 +58,21 @@ export async function requireTechnicianCopilotAccess() {
     );
   }
 
+  // The work-order RLS contract is shop-scoped. Establish the same security
+  // context used by the canonical technician offline/runtime surfaces before
+  // any CoPilot capability or assigned-work query is allowed to run.
+  const { error: shopContextError } = await supabase.rpc(
+    "set_current_shop_id",
+    { p_shop_id: profile.shop_id },
+  );
+  if (shopContextError) {
+    throw new TechnicianCopilotAccessError(
+      500,
+      "shop_security_context_failed",
+      "Shop security context could not be initialized.",
+    );
+  }
+
   const capabilities = await getTechnicianCopilotCapabilities(
     supabase,
     profile.shop_id,

--- a/features/copilot/technician/server/chat.ts
+++ b/features/copilot/technician/server/chat.ts
@@ -13,6 +13,7 @@ import { projectTechnicianContext } from "../session/projectTechnicianContext";
 import {
   listTechnicianWorkCandidates,
   type TechnicianWorkCandidate,
+  type TechnicianWorkScope,
 } from "./assignedWork";
 import { extractTechnicianDocumentationTurn } from "./documentation";
 import { decideTechnicianCopilotTurn } from "./model";
@@ -24,7 +25,7 @@ export type CopilotIdentity = {
   profileId: string;
   shopId: string;
   documentationEnabled: boolean;
-  supabase: Parameters<typeof listTechnicianWorkCandidates>[0];
+  supabase: TechnicianWorkScope["supabase"];
 };
 
 type Session = {
@@ -178,9 +179,11 @@ export async function runTechnicianCopilotTurn(input: {
   const capabilities = {
     documentation: input.identity.documentationEnabled,
   };
-  const candidates = await listTechnicianWorkCandidates(
-    input.identity.supabase,
-  );
+  const candidates = await listTechnicianWorkCandidates({
+    supabase: input.identity.supabase,
+    shopId: input.identity.shopId,
+    technicianIds: [input.identity.authUserId, input.identity.profileId],
+  });
   let envelope = await read(input.identity, input.sessionId);
   let context = envelope.session
     ? projectTechnicianContext({

--- a/tests/technician-copilot-assigned-work.test.ts
+++ b/tests/technician-copilot-assigned-work.test.ts
@@ -35,4 +35,32 @@ describe("Technician CoPilot assigned-work context", () => {
     );
     expect(assignedWorkSource).not.toContain("customer_concern");
   });
+
+  it("derives candidates from canonical technician assignment paths before loading work orders", () => {
+    const directAssignmentIndex = assignedWorkSource.indexOf(
+      '.from("work_order_lines")',
+    );
+    const sharedAssignmentIndex = assignedWorkSource.indexOf(
+      '.from("work_order_line_technicians")',
+    );
+    const workOrderIndex = assignedWorkSource.indexOf('.from("work_orders")');
+
+    expect(directAssignmentIndex).toBeGreaterThanOrEqual(0);
+    expect(sharedAssignmentIndex).toBeGreaterThanOrEqual(0);
+    expect(workOrderIndex).toBeGreaterThan(directAssignmentIndex);
+    expect(workOrderIndex).toBeGreaterThan(sharedAssignmentIndex);
+    expect(assignedWorkSource).toContain("assigned_tech_id.eq.");
+    expect(assignedWorkSource).toContain("assigned_to.eq.");
+    expect(assignedWorkSource).toContain('.eq("shop_id", input.shopId)');
+    expect(assignedWorkSource).toContain('.eq("line_type", "job")');
+  });
+
+  it("exposes only assigned line IDs as startable CoPilot lines", () => {
+    expect(assignedWorkSource).toContain(
+      "if (assignedLineIds.has(line.id)) value.assignedIds.push(line.id);",
+    );
+    expect(assignedWorkSource).toContain(
+      ".filter((candidate) => candidate.lineIds.length > 0)",
+    );
+  });
 });

--- a/tests/technician-copilot-assignment-recheck.test.ts
+++ b/tests/technician-copilot-assignment-recheck.test.ts
@@ -5,19 +5,30 @@ const runtimeSql = readFileSync(
   "supabase/migrations/20260813223510_technician_copilot_private_runtime.sql",
   "utf8",
 );
+const documentationSql = readFileSync(
+  "supabase/migrations/20260814030000_technician_copilot_atomic_documentation_turns.sql",
+  "utf8",
+);
 
-function functionSection(start: string, next?: string): string {
-  const startIndex = runtimeSql.indexOf(start);
+function functionSection(
+  sql: string,
+  start: string,
+  next?: string,
+): string {
+  const startIndex = sql.indexOf(start);
   if (startIndex < 0) throw new Error(`Missing SQL function marker: ${start}`);
-  const endIndex = next ? runtimeSql.indexOf(next, startIndex + start.length) : -1;
-  return runtimeSql.slice(startIndex, endIndex >= 0 ? endIndex : undefined);
+  const endIndex = next ? sql.indexOf(next, startIndex + start.length) : -1;
+  return sql.slice(startIndex, endIndex >= 0 ? endIndex : undefined);
 }
 
 describe("Technician CoPilot assignment recheck", () => {
-  it("rechecks canonical assignment whenever an existing session is read", () => {
+  it("rechecks canonical assignment in the effective current session-read implementation", () => {
+    // Phase 3 replaces the Phase-2 read helper to include documentation-turn
+    // receipts, so this assertion intentionally targets the latest definition.
     const section = functionSection(
+      documentationSql,
       "create or replace function copilot.technician_session_read_internal",
-      "create or replace function copilot.technician_session_start_internal",
+      "create or replace function copilot.technician_documentation_append_internal",
     );
     expect(section).toContain("copilot.technician_is_assigned(");
     expect(section).toContain("copilot_work_order_assignment_required");
@@ -25,6 +36,7 @@ describe("Technician CoPilot assignment recheck", () => {
 
   it("rechecks canonical assignment before a session can start or resume", () => {
     const section = functionSection(
+      runtimeSql,
       "create or replace function copilot.technician_session_start_internal",
       "create or replace function copilot.technician_event_append_internal",
     );
@@ -33,13 +45,26 @@ describe("Technician CoPilot assignment recheck", () => {
     expect(section).toContain("copilot_work_order_assignment_required");
   });
 
-  it("rechecks canonical assignment before any event can be appended to an existing session", () => {
+  it("rechecks canonical assignment before any regular event can be appended", () => {
     const section = functionSection(
+      runtimeSql,
       "create or replace function copilot.technician_event_append_internal",
     );
     expect(section).toContain("copilot.technician_is_assigned(");
     expect(section).toContain("v_work_order_id");
     expect(section).toContain("copilot_work_order_assignment_required");
     expect(section).toContain("rs.status<>'closed'");
+  });
+
+  it("rechecks canonical assignment before silent documentation can append repair facts", () => {
+    const section = functionSection(
+      documentationSql,
+      "create or replace function copilot.technician_documentation_append_internal",
+      "comment on table copilot.repair_session_documentation_turns",
+    );
+    expect(section).toContain("copilot.technician_is_assigned(");
+    expect(section).toContain("v_work_order_id");
+    expect(section).toContain("copilot_work_order_assignment_required");
+    expect(section).toContain("rs.status <> 'closed'");
   });
 });

--- a/tests/technician-copilot-assignment-recheck.test.ts
+++ b/tests/technician-copilot-assignment-recheck.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const runtimeSql = readFileSync(
+  "supabase/migrations/20260813223510_technician_copilot_private_runtime.sql",
+  "utf8",
+);
+
+function functionSection(start: string, next?: string): string {
+  const startIndex = runtimeSql.indexOf(start);
+  if (startIndex < 0) throw new Error(`Missing SQL function marker: ${start}`);
+  const endIndex = next ? runtimeSql.indexOf(next, startIndex + start.length) : -1;
+  return runtimeSql.slice(startIndex, endIndex >= 0 ? endIndex : undefined);
+}
+
+describe("Technician CoPilot assignment recheck", () => {
+  it("rechecks canonical assignment whenever an existing session is read", () => {
+    const section = functionSection(
+      "create or replace function copilot.technician_session_read_internal",
+      "create or replace function copilot.technician_session_start_internal",
+    );
+    expect(section).toContain("copilot.technician_is_assigned(");
+    expect(section).toContain("copilot_work_order_assignment_required");
+  });
+
+  it("rechecks canonical assignment before a session can start or resume", () => {
+    const section = functionSection(
+      "create or replace function copilot.technician_session_start_internal",
+      "create or replace function copilot.technician_event_append_internal",
+    );
+    expect(section).toContain("copilot.technician_is_assigned(");
+    expect(section).toContain("p_work_order_line_id");
+    expect(section).toContain("copilot_work_order_assignment_required");
+  });
+
+  it("rechecks canonical assignment before any event can be appended to an existing session", () => {
+    const section = functionSection(
+      "create or replace function copilot.technician_event_append_internal",
+    );
+    expect(section).toContain("copilot.technician_is_assigned(");
+    expect(section).toContain("v_work_order_id");
+    expect(section).toContain("copilot_work_order_assignment_required");
+    expect(section).toContain("rs.status<>'closed'");
+  });
+});

--- a/tests/technician-copilot-auth-boundary.test.ts
+++ b/tests/technician-copilot-auth-boundary.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const authSource = readFileSync(
+  "features/copilot/technician/server/auth.ts",
+  "utf8",
+);
+
+describe("Technician CoPilot auth boundary", () => {
+  it("establishes canonical shop security context before capability and assigned-work reads", () => {
+    const shopContextIndex = authSource.indexOf('"set_current_shop_id"');
+    const capabilityIndex = authSource.indexOf(
+      "getTechnicianCopilotCapabilities(\n    supabase,",
+    );
+
+    expect(shopContextIndex).toBeGreaterThanOrEqual(0);
+    expect(capabilityIndex).toBeGreaterThan(shopContextIndex);
+    expect(authSource).toContain("shop_security_context_failed");
+    expect(authSource).toContain("p_shop_id: profile.shop_id");
+  });
+
+  it("continues to require an authenticated technician role before the runtime is exposed", () => {
+    expect(authSource).toContain('"technician_role_required"');
+    expect(authSource).toContain('role !== "mechanic"');
+    expect(authSource).toContain('role !== "technician"');
+    expect(authSource).toContain('role !== "tech"');
+    expect(authSource).toContain('"technician_copilot_disabled"');
+  });
+});

--- a/tests/technician-copilot-text-runtime.test.ts
+++ b/tests/technician-copilot-text-runtime.test.ts
@@ -1,0 +1,363 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RepairSessionEvent } from "@/features/copilot/technician/session/types";
+
+const mocks = vi.hoisted(() => ({
+  listTechnicianWorkCandidates: vi.fn(),
+  decideTechnicianCopilotTurn: vi.fn(),
+  extractTechnicianDocumentationTurn: vi.fn(),
+  sendCopilotServerCommand: vi.fn(),
+}));
+
+vi.mock("@/features/copilot/technician/server/assignedWork", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/copilot/technician/server/assignedWork")
+  >("@/features/copilot/technician/server/assignedWork");
+  return {
+    ...actual,
+    listTechnicianWorkCandidates: mocks.listTechnicianWorkCandidates,
+  };
+});
+
+vi.mock("@/features/copilot/technician/server/model", () => ({
+  decideTechnicianCopilotTurn: mocks.decideTechnicianCopilotTurn,
+}));
+
+vi.mock("@/features/copilot/technician/server/documentation", () => ({
+  extractTechnicianDocumentationTurn:
+    mocks.extractTechnicianDocumentationTurn,
+}));
+
+vi.mock("@/features/copilot/technician/server/transport", () => ({
+  sendCopilotServerCommand: mocks.sendCopilotServerCommand,
+}));
+
+import { runTechnicianCopilotTurn } from "@/features/copilot/technician/server/chat";
+
+const candidate = {
+  id: "wo-ford",
+  customId: "WO-FORD",
+  status: "in_progress",
+  concern: "Vibration at highway speed",
+  description: null,
+  vehicleYear: 2021,
+  vehicleMake: "Ford",
+  vehicleModel: "F-350",
+  vehicleVin: null,
+  vehicleUnitNumber: "214",
+  lineIds: ["line-driveline"],
+  lineComplaints: ["Driveline vibration at 80 km/h"],
+};
+
+type RuntimeSession = {
+  id: string;
+  workOrderId: string;
+  activeWorkOrderLineId: string | null;
+  mode: "shop";
+  status: "active";
+};
+
+describe("Technician CoPilot persistent text runtime", () => {
+  let session: RuntimeSession | null;
+  let events: RepairSessionEvent[];
+  let documentationTurns: string[];
+  let eventCounter: number;
+  let finalReasoningContext: Record<string, unknown> | null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    session = null;
+    events = [];
+    documentationTurns = [];
+    eventCounter = 0;
+    finalReasoningContext = null;
+
+    mocks.listTechnicianWorkCandidates.mockResolvedValue([candidate]);
+
+    mocks.decideTechnicianCopilotTurn.mockImplementation(
+      async (input: Record<string, unknown>) => {
+        const message = String(input.message ?? "");
+        const activeSession = input.activeSession as Record<string, unknown> | null;
+
+        if (message === "Start the Ford." && !activeSession) {
+          return {
+            mode: "start",
+            workOrderId: candidate.id,
+            workOrderLineId: "line-driveline",
+            reply: "Starting the Ford.",
+          };
+        }
+
+        if (message === "What have we figured out so far?") {
+          finalReasoningContext = input.repairContext as Record<string, unknown>;
+          const context = input.repairContext as {
+            currentTask: string | null;
+            observations: Array<{
+              text: string;
+              assessment: string | null;
+            }>;
+          };
+          const uJoint = context.observations.find((item) =>
+            item.text.includes("U-joint"),
+          );
+          const carrier = context.observations.find((item) =>
+            item.text.includes("Carrier bearing"),
+          );
+          return {
+            mode: "reply",
+            workOrderId: null,
+            workOrderLineId: null,
+            reply: `We're on the ${context.currentTask}. The rear U-joint is ${uJoint?.assessment}; the carrier bearing is ${carrier?.assessment}.`,
+          };
+        }
+
+        const replies: Record<string, string> = {
+          "Start the Ford.": "Ford session is active.",
+          "Read me the complaint.":
+            "Complaint is a driveline vibration at highway speed.",
+          "I'm checking the driveline.": "Okay, I'm with you on the driveline.",
+          "Rear U-joint has play.": "Rear U-joint play noted.",
+          "Carrier bearing looks okay.": "Carrier bearing looks normal.",
+        };
+
+        return {
+          mode: "reply",
+          workOrderId: null,
+          workOrderLineId: null,
+          reply: replies[message] ?? "I'm with you.",
+        };
+      },
+    );
+
+    mocks.extractTechnicianDocumentationTurn.mockImplementation(
+      async (input: { message: string }) => {
+        const byMessage: Record<
+          string,
+          Array<{ type: string; details: Record<string, unknown> }>
+        > = {
+          "I'm checking the driveline.": [
+            { type: "task.changed", details: { task: "driveline" } },
+          ],
+          "Rear U-joint has play.": [
+            {
+              type: "observation.recorded",
+              details: {
+                text: "Rear U-joint has play",
+                assessment: "abnormal",
+                component: "U-joint",
+                location: "rear",
+              },
+            },
+          ],
+          "Carrier bearing looks okay.": [
+            {
+              type: "observation.recorded",
+              details: {
+                text: "Carrier bearing looks okay",
+                assessment: "normal",
+                component: "carrier bearing",
+              },
+            },
+          ],
+        };
+        return {
+          events: byMessage[input.message] ?? [],
+          model: "test-model",
+          providerMode: "ai" as const,
+          promptVersion: "technician_copilot_documentation_v1" as const,
+        };
+      },
+    );
+
+    const appendEvent = (
+      eventType: string,
+      source: RepairSessionEvent["source"],
+      payload: Record<string, unknown>,
+      occurredAt?: string,
+    ) => {
+      if (!session) throw new Error("Test session is not active");
+      eventCounter += 1;
+      events.push({
+        id: `event-${eventCounter}`,
+        repairSessionId: session.id,
+        eventSeq: eventCounter,
+        eventType,
+        source,
+        payload,
+        occurredAt:
+          occurredAt ?? `2026-08-14T14:${String(eventCounter).padStart(2, "0")}:00Z`,
+      });
+      return {
+        eventId: `event-${eventCounter}`,
+        eventSeq: eventCounter,
+        replayed: false,
+      };
+    };
+
+    mocks.sendCopilotServerCommand.mockImplementation(
+      async (input: {
+        action: string;
+        args: Record<string, unknown>;
+      }) => {
+        if (input.action === "session.read") {
+          return {
+            session,
+            events: [...events],
+            documentationTurns: [...documentationTurns],
+          };
+        }
+
+        if (input.action === "session.start") {
+          if (!session) {
+            session = {
+              id: "session-ford",
+              workOrderId: String(input.args.workOrderId),
+              activeWorkOrderLineId:
+                typeof input.args.workOrderLineId === "string"
+                  ? input.args.workOrderLineId
+                  : null,
+              mode: "shop",
+              status: "active",
+            };
+            appendEvent("session.started", "system", {
+              workOrderId: session.workOrderId,
+              workOrderLineId: session.activeWorkOrderLineId,
+            });
+          }
+          return { sessionId: session.id, replayed: false };
+        }
+
+        if (input.action === "event.append") {
+          return appendEvent(
+            String(input.args.eventType),
+            String(input.args.origin) as RepairSessionEvent["source"],
+            (input.args.details ?? {}) as Record<string, unknown>,
+            typeof input.args.occurredAt === "string"
+              ? input.args.occurredAt
+              : undefined,
+          );
+        }
+
+        if (input.action === "documentation.append") {
+          const sourceTurnId = String(input.args.sourceTurnId);
+          if (documentationTurns.includes(sourceTurnId)) {
+            return {
+              turnId: sourceTurnId,
+              sourceTurnId,
+              eventCount: 0,
+              replayed: true,
+            };
+          }
+          const documentationEvents = (input.args.events ?? []) as Array<{
+            type: string;
+            details: Record<string, unknown>;
+          }>;
+          for (const event of documentationEvents) {
+            appendEvent(event.type, "copilot", event.details);
+          }
+          documentationTurns.push(sourceTurnId);
+          return {
+            turnId: sourceTurnId,
+            sourceTurnId,
+            eventCount: documentationEvents.length,
+            replayed: false,
+          };
+        }
+
+        throw new Error(`Unexpected command: ${input.action}`);
+      },
+    );
+  });
+
+  it("keeps the same assigned Ford repair context across the six-turn acceptance conversation", async () => {
+    const messages = [
+      "Start the Ford.",
+      "Read me the complaint.",
+      "I'm checking the driveline.",
+      "Rear U-joint has play.",
+      "Carrier bearing looks okay.",
+      "What have we figured out so far?",
+    ];
+
+    let sessionId: string | null = null;
+    let finalResult: Awaited<ReturnType<typeof runTechnicianCopilotTurn>> | null =
+      null;
+
+    for (const [index, message] of messages.entries()) {
+      const result = await runTechnicianCopilotTurn({
+        identity: {
+          authUserId: "auth-tech",
+          profileId: "profile-tech",
+          shopId: "shop-1",
+          documentationEnabled: true,
+          supabase: {} as never,
+        },
+        message,
+        turnId: `turn-${index + 1}`,
+        sessionId,
+      });
+      sessionId = result.sessionId;
+      finalResult = result;
+      expect(result.sessionId).toBe("session-ford");
+    }
+
+    expect(finalResult).not.toBeNull();
+    expect(finalResult?.workOrder?.id).toBe("wo-ford");
+    expect(finalResult?.context?.currentTask).toBe("driveline");
+    expect(finalResult?.context?.conversation).toHaveLength(12);
+
+    expect(finalResult?.context?.observations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: "Rear U-joint has play",
+          assessment: "abnormal",
+          component: "U-joint",
+          location: "rear",
+        }),
+        expect.objectContaining({
+          text: "Carrier bearing looks okay",
+          assessment: "normal",
+          component: "carrier bearing",
+        }),
+      ]),
+    );
+    expect(finalResult?.context?.complaint).toContain(
+      "Vibration at highway speed",
+    );
+    expect(finalResult?.reply).toContain("rear U-joint is abnormal");
+    expect(finalResult?.reply).toContain("carrier bearing is normal");
+
+    expect(finalReasoningContext).toMatchObject({
+      repairSessionId: "session-ford",
+      currentTask: "driveline",
+    });
+    expect(
+      (finalReasoningContext?.observations as Array<{ text: string }>).map(
+        (item) => item.text,
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        "Rear U-joint has play",
+        "Carrier bearing looks okay",
+      ]),
+    );
+
+    expect(mocks.listTechnicianWorkCandidates).toHaveBeenCalledWith({
+      supabase: expect.anything(),
+      shopId: "shop-1",
+      technicianIds: ["auth-tech", "profile-tech"],
+    });
+
+    const actions = mocks.sendCopilotServerCommand.mock.calls.map(
+      ([call]) => call.action,
+    );
+    expect(new Set(actions)).toEqual(
+      new Set([
+        "session.read",
+        "session.start",
+        "event.append",
+        "documentation.append",
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Technician CoPilot — text runtime hardening gate

Phase 2 (#1427) and silent documentation (#1428) are already merged. This PR does not rebuild either slice. It closes the remaining security and acceptance-test gaps before Realtime voice is attached.

### What changed
- Validates the authenticated technician's profile/shop ownership through the canonical `set_current_shop_id` compatibility boundary before CoPilot capability and assigned-work reads.
- Changes pre-session work discovery from a broad recent-WO query to assignment-first discovery.
- Resolves direct assignments through `assigned_tech_id` / `assigned_to` and shared assignments through `work_order_line_technicians` using the authenticated client.
- Loads work orders only after assigned work-order IDs are known; canonical RLS remains the final authorization boundary.
- Exposes only canonically assigned job-line IDs as startable CoPilot lines.
- Keeps readable complaint context for the assigned work order without broadening mutation authority.
- Passes explicit shop + auth/profile technician identity into both chat and session snapshot candidate discovery.

### Acceptance proof
Adds a six-turn in-memory runtime test through the real session projection:

1. `Start the Ford.`
2. `Read me the complaint.`
3. `I'm checking the driveline.`
4. `Rear U-joint has play.`
5. `Carrier bearing looks okay.`
6. `What have we figured out so far?`

The final turn must retain the same session/work order, `driveline` task, abnormal U-joint observation, normal carrier-bearing observation, complaint context, and all 12 persisted conversation events. The final reasoning call must receive that reconstructed context rather than rely on transient chat memory.

### Assignment revocation safety
Adds a database-contract regression test proving canonical assignment is rechecked on:
- session read
- session start/resume
- event append

If a technician is removed from a work order mid-session, the next private CoPilot operation therefore fails closed with `copilot_work_order_assignment_required`.

### Safety / rollback
- No new database migrations.
- No canonical work-order, line, labor, parts, inspection, approval, billing, or customer mutation changes.
- No existing voice path is redirected.
- Existing text/documentation feature flags remain default closed.
- Disabling `technician_copilot_text` still removes access to the runtime.

### Validation
CI is the authoritative validation boundary for this connector-backed change. This PR should pass typecheck, lint, complete tests, production build, regression inventory, and the repository's applicable runtime gates before merge.
