### PR TITLE
harden owner onboarding after Codex review

### DIFF
--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -22,6 +22,7 @@ import {
   type ShopCountryCode,
 } from "@/features/shared/lib/timezones/shopTimezones";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
+import { isStripeSubscriptionAccessBearing } from "@/features/stripe/lib/stripe/subscriptionStatus";
 import { reconcileShopBillingFromUser } from "@/features/stripe/lib/server/canonical-shop-billing";
 
 const COUNTRIES = new Set<ShopCountryCode>(["US", "CA"]);
@@ -68,19 +69,16 @@ async function verifyExistingOwnerPin(args: {
     .eq("id", args.shopId)
     .maybeSingle();
 
-  if (
-    error ||
-    !shop ||
-    shop.owner_id !== args.userId ||
-    !shop.owner_pin_hash
-  ) {
+  if (error || !shop || shop.owner_id !== args.userId || !shop.owner_pin_hash) {
     return false;
   }
 
   return verifyOwnerPin(args.pin, shop.owner_pin_hash);
 }
 
-async function inspectOwnedShopRecovery(userId: string): Promise<
+async function inspectOwnedShopRecovery(
+  userId: string,
+): Promise<
   | { ok: true }
   | { ok: false; reason: "lookup_failed" | "ambiguous_owner_shop_recovery" }
 > {
@@ -119,7 +117,9 @@ async function reconcileAcquiredBilling(args: {
     return {
       ok: false,
       reason:
-        error instanceof Error ? error.message : "billing_reconciliation_failed",
+        error instanceof Error
+          ? error.message
+          : "billing_reconciliation_failed",
     };
   }
 }
@@ -143,7 +143,7 @@ async function finalizeOwnerOnboarding(args: {
   if (
     shop.owner_id !== args.userId ||
     !shop.stripe_subscription_id ||
-    !shop.stripe_subscription_status ||
+    !isStripeSubscriptionAccessBearing(shop.stripe_subscription_status) ||
     !shop.stripe_pricing_model ||
     !shop.plan
   ) {
@@ -365,7 +365,10 @@ export async function POST(request: Request) {
 
     if (profile.shop_id || profile.role || profile.completed_onboarding) {
       return NextResponse.json(
-        { ok: false, error: "This account is not eligible to create a new shop." },
+        {
+          ok: false,
+          error: "This account is not eligible to create a new shop.",
+        },
         { status: 403 },
       );
     }
@@ -476,7 +479,10 @@ export async function POST(request: Request) {
         code: bootstrapError?.code ?? null,
       });
       return NextResponse.json(
-        { ok: false, error: "We could not create your shop. Please try again." },
+        {
+          ok: false,
+          error: "We could not create your shop. Please try again.",
+        },
         { status: 500 },
       );
     }

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -12,20 +12,18 @@ import {
   isValidOwnerPin,
   normalizeOwnerPin,
 } from "@/features/shared/lib/server/owner-pin-crypto";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
+import {
+  isSupportedShopTimezone,
+  type ShopCountryCode,
+} from "@/features/shared/lib/timezones/shopTimezones";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
+import { reconcileShopBillingFromUser } from "@/features/stripe/lib/server/canonical-shop-billing";
 
-const COUNTRIES = new Set(["US", "CA"]);
-const TIMEZONES = new Set([
-  "America/New_York",
-  "America/Chicago",
-  "America/Denver",
-  "America/Edmonton",
-  "America/Phoenix",
-  "America/Los_Angeles",
-  "America/Vancouver",
-  "America/Toronto",
-  "America/Halifax",
-]);
+const COUNTRIES = new Set<ShopCountryCode>(["US", "CA"]);
 
 type Body = {
   businessName?: unknown;
@@ -52,6 +50,43 @@ function readBootstrapShopId(value: unknown): string | null {
   const first: unknown = value[0];
   if (!first || typeof first !== "object" || !("shop_id" in first)) return null;
   return typeof first.shop_id === "string" ? first.shop_id : null;
+}
+
+async function reconcileAcquiredBilling(args: {
+  userId: string;
+  shopId: string;
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const secretKey = String(process.env.STRIPE_SECRET_KEY ?? "").trim();
+  if (!secretKey) return { ok: false, reason: "stripe_not_configured" };
+
+  try {
+    const result = await reconcileShopBillingFromUser({
+      stripe: createStripeClient(secretKey),
+      supabase: createAdminSupabase(),
+      userId: args.userId,
+      shopId: args.shopId,
+    });
+    return result.linked
+      ? { ok: true }
+      : { ok: false, reason: result.reason ?? "billing_not_linked" };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : "billing_reconciliation_failed",
+    };
+  }
+}
+
+function billingUnavailable(reason: string) {
+  console.error("owner onboarding billing reconciliation failed", { reason });
+  return NextResponse.json(
+    {
+      ok: false,
+      error:
+        "Your shop was created, but billing access could not be finalized. Try again before continuing.",
+    },
+    { status: 503 },
+  );
 }
 
 export async function POST(request: Request) {
@@ -102,9 +137,15 @@ export async function POST(request: Request) {
       );
     }
 
-    if (!COUNTRIES.has(country) || !TIMEZONES.has(timezone)) {
+    if (!COUNTRIES.has(country as ShopCountryCode)) {
       return NextResponse.json(
-        { ok: false, error: "Choose a supported country and timezone." },
+        { ok: false, error: "Choose a supported country." },
+        { status: 400 },
+      );
+    }
+    if (!isSupportedShopTimezone(country as ShopCountryCode, timezone)) {
+      return NextResponse.json(
+        { ok: false, error: "Choose a supported timezone for this country." },
         { status: 400 },
       );
     }
@@ -136,8 +177,15 @@ export async function POST(request: Request) {
       profile.role === "owner" &&
       profile.completed_onboarding
     ) {
+      const billing = await reconcileAcquiredBilling({
+        userId: user.id,
+        shopId: profile.shop_id,
+      });
+      if (!billing.ok) return billingUnavailable(billing.reason);
+
       return NextResponse.json({
         ok: true,
+        shopId: profile.shop_id,
         destination: "/dashboard/onboarding-v2",
         replayed: true,
       });
@@ -188,6 +236,13 @@ export async function POST(request: Request) {
         { status: 500 },
       );
     }
+
+    // Checkout/account claiming can occur before the first shop exists. Now
+    // that the canonical shop has been created, immediately hydrate its package,
+    // pricing model, subscription status, plan and Stripe identity. Do not let a
+    // Complete/Field/Fleet purchaser enter the app with legacy/null access.
+    const billing = await reconcileAcquiredBilling({ userId: user.id, shopId });
+    if (!billing.ok) return billingUnavailable(billing.reason);
 
     const response = NextResponse.json({
       ok: true,

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -39,6 +39,33 @@ type Body = {
   pin?: unknown;
 };
 
+type BootstrapRpcArgs = {
+  p_business_name: string;
+  p_shop_name: string;
+  p_street: string;
+  p_city: string;
+  p_province: string;
+  p_postal_code: string;
+  p_country: string;
+  p_timezone: string;
+  p_owner_pin_hash: string;
+};
+
+type BootstrapRpcRow = {
+  shop_id: string;
+  created_shop: boolean;
+};
+
+type BootstrapRpcError = {
+  code?: string | null;
+  message?: string | null;
+};
+
+type BootstrapRpcResult = {
+  data: BootstrapRpcRow[] | null;
+  error: BootstrapRpcError | null;
+};
+
 function clean(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
@@ -190,10 +217,9 @@ function bootstrapUpgradeUnavailable() {
   );
 }
 
-function isPendingBootstrapRpcUnavailable(error: {
-  code?: string | null;
-  message?: string | null;
-} | null): boolean {
+function isPendingBootstrapRpcUnavailable(
+  error: BootstrapRpcError | null,
+): boolean {
   if (!error) return false;
   if (error.code === "PGRST202") return true;
   return String(error.message ?? "").includes(PENDING_BOOTSTRAP_RPC);
@@ -377,20 +403,28 @@ export async function POST(request: Request) {
     }
 
     const ownerPinHash = await hashOwnerPin(pin);
-    const { data: rows, error: bootstrapError } = await supabase.rpc(
-      PENDING_BOOTSTRAP_RPC,
-      {
-        p_business_name: businessName,
-        p_shop_name: shopName,
-        p_street: street,
-        p_city: city,
-        p_province: province,
-        p_postal_code: postalCode,
-        p_country: country,
-        p_timezone: timezone,
-        p_owner_pin_hash: ownerPinHash,
-      },
-    );
+    const rpcPayload: BootstrapRpcArgs = {
+      p_business_name: businessName,
+      p_shop_name: shopName,
+      p_street: street,
+      p_city: city,
+      p_province: province,
+      p_postal_code: postalCode,
+      p_country: country,
+      p_timezone: timezone,
+      p_owner_pin_hash: ownerPinHash,
+    };
+    // The expand migration intentionally introduces this RPC before generated
+    // Supabase types know about it. Keep the untyped seam narrow and explicit,
+    // matching the repository's compatibility pattern for forward RPCs.
+    const { data: rows, error: bootstrapError } = await (
+      supabase as never as {
+        rpc: (
+          fn: typeof PENDING_BOOTSTRAP_RPC,
+          args: BootstrapRpcArgs,
+        ) => Promise<BootstrapRpcResult>;
+      }
+    ).rpc(PENDING_BOOTSTRAP_RPC, rpcPayload);
     const shopId = readBootstrapShopId(rows);
 
     if (bootstrapError || !shopId) {
@@ -407,10 +441,6 @@ export async function POST(request: Request) {
       );
     }
 
-    // The v2 RPC may have created/recovered the shop for this request or
-    // returned an already-owned shop after another concurrent request won the
-    // profile row lock. Every path must prove the submitted PIN matches the
-    // persisted owner_pin_hash before billing/finalization/privilege issuance.
     const persistedPinVerified = await verifyExistingOwnerPin({
       userId: user.id,
       shopId,

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -77,16 +77,93 @@ async function reconcileAcquiredBilling(args: {
   }
 }
 
+async function finalizeOwnerOnboarding(args: {
+  userId: string;
+  shopId: string;
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const admin = createAdminSupabase();
+
+  // Re-read the shop after canonical Stripe reconciliation. Completion is a
+  // separate durable transition and is allowed only after the shop has the
+  // canonical billing identity/status/pricing/plan written by that reconciler.
+  const { data: shop, error: shopError } = await admin
+    .from("shops")
+    .select(
+      "id,owner_id,stripe_subscription_id,stripe_subscription_status,stripe_pricing_model,plan",
+    )
+    .eq("id", args.shopId)
+    .maybeSingle();
+  if (shopError || !shop) {
+    return { ok: false, reason: shopError?.message ?? "shop_not_found" };
+  }
+  if (
+    shop.owner_id !== args.userId ||
+    !shop.stripe_subscription_id ||
+    !shop.stripe_subscription_status ||
+    !shop.stripe_pricing_model ||
+    !shop.plan
+  ) {
+    return { ok: false, reason: "canonical_billing_not_ready" };
+  }
+
+  const { data: profile, error: profileError } = await admin
+    .from("profiles")
+    .update({ completed_onboarding: true })
+    .eq("id", args.userId)
+    .eq("shop_id", args.shopId)
+    .eq("role", "owner")
+    .select("id,completed_onboarding")
+    .maybeSingle();
+  if (profileError || !profile?.completed_onboarding) {
+    return {
+      ok: false,
+      reason: profileError?.message ?? "owner_completion_not_persisted",
+    };
+  }
+
+  return { ok: true };
+}
+
 function billingUnavailable(reason: string) {
   console.error("owner onboarding billing reconciliation failed", { reason });
   return NextResponse.json(
     {
       ok: false,
       error:
-        "Your shop was created, but billing access could not be finalized. Try again before continuing.",
+        "Your shop is saved, but billing access is not ready yet. Try again before continuing.",
     },
     { status: 503 },
   );
+}
+
+function completionUnavailable(reason: string) {
+  console.error("owner onboarding completion failed", { reason });
+  return NextResponse.json(
+    {
+      ok: false,
+      error:
+        "Your shop and billing are saved, but setup could not be finalized. Try again.",
+    },
+    { status: 503 },
+  );
+}
+
+function successfulBootstrapResponse(args: {
+  userId: string;
+  shopId: string;
+  replayed?: boolean;
+}) {
+  const response = NextResponse.json({
+    ok: true,
+    shopId: args.shopId,
+    destination: "/dashboard/onboarding-v2",
+    ...(args.replayed ? { replayed: true } : {}),
+  });
+  return setOwnerPinVerifiedCookie(response, {
+    userId: args.userId,
+    shopId: args.shopId,
+    purpose: OWNER_PIN_PURPOSES.PRIVILEGED,
+  });
 }
 
 export async function POST(request: Request) {
@@ -113,6 +190,94 @@ export async function POST(request: Request) {
       );
     }
 
+    const pin = normalizeOwnerPin(clean(body.pin));
+    if (!isValidOwnerPin(pin)) {
+      return NextResponse.json(
+        { ok: false, error: "Owner PIN must be 4 to 8 digits." },
+        { status: 400 },
+      );
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from("profiles")
+      .select(
+        "shop_id, role, completed_onboarding, stripe_checkout_complete, stripe_customer_id, stripe_subscription_id",
+      )
+      .eq("id", user.id)
+      .maybeSingle();
+
+    if (profileError || !profile) {
+      return NextResponse.json(
+        { ok: false, error: "Your owner profile is not ready. Sign out and sign in again." },
+        { status: 409 },
+      );
+    }
+
+    // Completed-owner retries repair canonical billing if necessary and refresh
+    // the privileged PIN session just like the first successful bootstrap.
+    if (
+      profile.shop_id &&
+      profile.role === "owner" &&
+      profile.completed_onboarding
+    ) {
+      const billing = await reconcileAcquiredBilling({
+        userId: user.id,
+        shopId: profile.shop_id,
+      });
+      if (!billing.ok) return billingUnavailable(billing.reason);
+      return successfulBootstrapResponse({
+        userId: user.id,
+        shopId: profile.shop_id,
+        replayed: true,
+      });
+    }
+
+    // A Stripe/finalization failure after the shop transaction leaves an
+    // explicit pending owner state: owner + shop + completed_onboarding=false.
+    // Retry billing/finalization directly instead of trying to create or recover
+    // the shop again.
+    if (
+      profile.shop_id &&
+      profile.role === "owner" &&
+      !profile.completed_onboarding
+    ) {
+      const billing = await reconcileAcquiredBilling({
+        userId: user.id,
+        shopId: profile.shop_id,
+      });
+      if (!billing.ok) return billingUnavailable(billing.reason);
+
+      const finalized = await finalizeOwnerOnboarding({
+        userId: user.id,
+        shopId: profile.shop_id,
+      });
+      if (!finalized.ok) return completionUnavailable(finalized.reason);
+
+      return successfulBootstrapResponse({
+        userId: user.id,
+        shopId: profile.shop_id,
+        replayed: true,
+      });
+    }
+
+    if (profile.shop_id || profile.role || profile.completed_onboarding) {
+      return NextResponse.json(
+        { ok: false, error: "This account is not eligible to create a new shop." },
+        { status: 403 },
+      );
+    }
+
+    if (
+      !profile.stripe_checkout_complete ||
+      !profile.stripe_customer_id ||
+      !profile.stripe_subscription_id
+    ) {
+      return NextResponse.json(
+        { ok: false, error: "Complete trial setup before creating your shop." },
+        { status: 403 },
+      );
+    }
+
     const businessName = clean(body.businessName);
     const shopName = clean(body.shopName) || businessName;
     const street = clean(body.street);
@@ -121,7 +286,6 @@ export async function POST(request: Request) {
     const postalCode = clean(body.postalCode);
     const country = clean(body.country).toUpperCase();
     const timezone = clean(body.timezone);
-    const pin = normalizeOwnerPin(clean(body.pin));
 
     if (
       invalidLength(businessName, 120) ||
@@ -147,65 +311,6 @@ export async function POST(request: Request) {
       return NextResponse.json(
         { ok: false, error: "Choose a supported timezone for this country." },
         { status: 400 },
-      );
-    }
-
-    if (!isValidOwnerPin(pin)) {
-      return NextResponse.json(
-        { ok: false, error: "Owner PIN must be 4 to 8 digits." },
-        { status: 400 },
-      );
-    }
-
-    const { data: profile, error: profileError } = await supabase
-      .from("profiles")
-      .select(
-        "shop_id, role, completed_onboarding, stripe_checkout_complete, stripe_customer_id, stripe_subscription_id",
-      )
-      .eq("id", user.id)
-      .maybeSingle();
-
-    if (profileError || !profile) {
-      return NextResponse.json(
-        { ok: false, error: "Your owner profile is not ready. Sign out and sign in again." },
-        { status: 409 },
-      );
-    }
-
-    if (
-      profile.shop_id &&
-      profile.role === "owner" &&
-      profile.completed_onboarding
-    ) {
-      const billing = await reconcileAcquiredBilling({
-        userId: user.id,
-        shopId: profile.shop_id,
-      });
-      if (!billing.ok) return billingUnavailable(billing.reason);
-
-      return NextResponse.json({
-        ok: true,
-        shopId: profile.shop_id,
-        destination: "/dashboard/onboarding-v2",
-        replayed: true,
-      });
-    }
-
-    if (profile.shop_id || profile.role || profile.completed_onboarding) {
-      return NextResponse.json(
-        { ok: false, error: "This account is not eligible to create a new shop." },
-        { status: 403 },
-      );
-    }
-
-    if (
-      !profile.stripe_checkout_complete ||
-      !profile.stripe_customer_id ||
-      !profile.stripe_subscription_id
-    ) {
-      return NextResponse.json(
-        { ok: false, error: "Complete trial setup before creating your shop." },
-        { status: 403 },
       );
     }
 
@@ -237,23 +342,20 @@ export async function POST(request: Request) {
       );
     }
 
-    // Checkout/account claiming can occur before the first shop exists. Now
-    // that the canonical shop has been created, immediately hydrate its package,
-    // pricing model, subscription status, plan and Stripe identity. Do not let a
-    // Complete/Field/Fleet purchaser enter the app with legacy/null access.
+    // The DB transaction intentionally leaves completed_onboarding=false. First
+    // hydrate canonical billing, then finalize the owner profile as a separate
+    // durable step. Any failure remains recoverable through the pending-owner
+    // branch above and middleware keeps that owner inside onboarding.
     const billing = await reconcileAcquiredBilling({ userId: user.id, shopId });
     if (!billing.ok) return billingUnavailable(billing.reason);
 
-    const response = NextResponse.json({
-      ok: true,
-      shopId,
-      destination: "/dashboard/onboarding-v2",
-    });
-    return setOwnerPinVerifiedCookie(response, {
+    const finalized = await finalizeOwnerOnboarding({
       userId: user.id,
       shopId,
-      purpose: OWNER_PIN_PURPOSES.PRIVILEGED,
     });
+    if (!finalized.ok) return completionUnavailable(finalized.reason);
+
+    return successfulBootstrapResponse({ userId: user.id, shopId });
   } catch (error) {
     console.error("owner onboarding bootstrap unexpected failure", {
       name: error instanceof Error ? error.name : "UnknownError",

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -98,29 +98,6 @@ async function inspectOwnedShopRecovery(userId: string): Promise<
   return { ok: true };
 }
 
-async function markOwnerBootstrapPending(args: {
-  userId: string;
-  shopId: string;
-}): Promise<{ ok: true } | { ok: false; reason: string }> {
-  const admin = createAdminSupabase();
-  const { data: profile, error } = await admin
-    .from("profiles")
-    .update({ completed_onboarding: false })
-    .eq("id", args.userId)
-    .eq("shop_id", args.shopId)
-    .eq("role", "owner")
-    .select("id,completed_onboarding")
-    .maybeSingle();
-
-  if (error || !profile || profile.completed_onboarding !== false) {
-    return {
-      ok: false,
-      reason: error?.message ?? "owner_pending_state_not_persisted",
-    };
-  }
-  return { ok: true };
-}
-
 async function reconcileAcquiredBilling(args: {
   userId: string;
   shopId: string;
@@ -504,20 +481,17 @@ export async function POST(request: Request) {
       );
     }
 
-    // The hardened DB stores only the real PIN hash and leaves the owner pending
-    // atomically. A concurrent retry still has to prove its submitted PIN before
-    // this request may touch billing or privileged state.
+    // The hardened DB stores only the real PIN hash and owns the atomic pending
+    // transition. A concurrent read-only retry still has to prove its submitted
+    // PIN before this request may touch billing or privileged state. Do not write
+    // completed_onboarding=false again here: a duplicate request must never
+    // reopen an owner another request has already finalized successfully.
     const persistedPinVerified = await verifyExistingOwnerPin({
       userId: user.id,
       shopId,
       pin,
     });
     if (!persistedPinVerified) return invalidExistingOwnerPin();
-
-    // Reassert the pending state through the server boundary. This is idempotent
-    // with the hardened RPC and fails closed if profile ownership drifted.
-    const pending = await markOwnerBootstrapPending({ userId: user.id, shopId });
-    if (!pending.ok) return pendingStateUnavailable(pending.reason);
 
     const billing = await reconcileAcquiredBilling({ userId: user.id, shopId });
     if (!billing.ok) return billingUnavailable(billing.reason);

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -25,6 +25,9 @@ import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import { reconcileShopBillingFromUser } from "@/features/stripe/lib/server/canonical-shop-billing";
 
 const COUNTRIES = new Set<ShopCountryCode>(["US", "CA"]);
+const OWNER_BOOTSTRAP_CONTRACT_PROBE_SHOP_ID =
+  "00000000-0000-4000-8000-000000000002";
+const OWNER_BOOTSTRAP_PENDING_MARKER = "profixiq-owner-bootstrap-pending-v2:";
 
 type Body = {
   businessName?: unknown;
@@ -219,6 +222,17 @@ function pendingStateUnavailable(reason: string) {
       ok: false,
       error:
         "Your shop is saved, but setup could not be secured for billing. Try again.",
+    },
+    { status: 503 },
+  );
+}
+
+function bootstrapUpgradeUnavailable() {
+  return NextResponse.json(
+    {
+      ok: false,
+      error:
+        "Shop setup is being upgraded. Try again in a moment before continuing.",
     },
     { status: 503 },
   );
@@ -426,10 +440,34 @@ export async function POST(request: Request) {
       );
     }
 
-    // App-first deployments can briefly run against the previous RPC body,
-    // which recovered the newest historical owner shop. Fail closed before the
-    // RPC if the caller has more than one owned shop so no old database version
-    // can make that ambiguous selection.
+    // App-first deployment must never call the previous bootstrap body. The
+    // hardened same-signature function recognizes this harmless sentinel; the
+    // previous function rejects its country before any mutation. A failed probe
+    // therefore means "wait for the DB expand step" and fails closed.
+    const { data: probeRows, error: probeError } = await supabase.rpc(
+      "bootstrap_owner_atomic",
+      {
+        p_business_name: "__profixiq_owner_bootstrap_v2_probe__",
+        p_shop_name: "__probe__",
+        p_street: "__probe__",
+        p_city: "__probe__",
+        p_province: "__probe__",
+        p_postal_code: "__probe__",
+        p_country: "__PROBE__",
+        p_timezone: "Etc/UTC",
+        p_owner_pin_hash: "__probe__",
+      },
+    );
+    if (
+      probeError ||
+      readBootstrapShopId(probeRows) !== OWNER_BOOTSTRAP_CONTRACT_PROBE_SHOP_ID
+    ) {
+      return bootstrapUpgradeUnavailable();
+    }
+
+    // Even after the readiness probe, explicitly reject ambiguous historical
+    // recovery in the application so a rollback to the previous DB body cannot
+    // ever select "newest shop wins" for this request.
     const recovery = await inspectOwnedShopRecovery(user.id);
     if (!recovery.ok) {
       if (recovery.reason === "ambiguous_owner_shop_recovery") {
@@ -450,7 +488,7 @@ export async function POST(request: Request) {
         p_postal_code: postalCode,
         p_country: country,
         p_timezone: timezone,
-        p_owner_pin_hash: ownerPinHash,
+        p_owner_pin_hash: `${OWNER_BOOTSTRAP_PENDING_MARKER}${ownerPinHash}`,
       },
     );
     const shopId = readBootstrapShopId(rows);
@@ -466,10 +504,9 @@ export async function POST(request: Request) {
       );
     }
 
-    // A concurrent request or an app-first deployment can receive a shop from
-    // the legacy-compatible RPC after it has set completed_onboarding=true.
-    // Never mutate billing/state for this request until the submitted PIN proves
-    // it owns the persisted shop chosen by the atomic transition.
+    // The hardened DB stores only the real PIN hash and leaves the owner pending
+    // atomically. A concurrent retry still has to prove its submitted PIN before
+    // this request may touch billing or privileged state.
     const persistedPinVerified = await verifyExistingOwnerPin({
       userId: user.id,
       shopId,
@@ -477,6 +514,8 @@ export async function POST(request: Request) {
     });
     if (!persistedPinVerified) return invalidExistingOwnerPin();
 
+    // Reassert the pending state through the server boundary. This is idempotent
+    // with the hardened RPC and fails closed if profile ownership drifted.
     const pending = await markOwnerBootstrapPending({ userId: user.id, shopId });
     if (!pending.ok) return pendingStateUnavailable(pending.reason);
 

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -25,7 +25,6 @@ import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import { reconcileShopBillingFromUser } from "@/features/stripe/lib/server/canonical-shop-billing";
 
 const COUNTRIES = new Set<ShopCountryCode>(["US", "CA"]);
-const PENDING_BOOTSTRAP_RPC = "bootstrap_owner_pending_v2" as const;
 
 type Body = {
   businessName?: unknown;
@@ -37,33 +36,6 @@ type Body = {
   country?: unknown;
   timezone?: unknown;
   pin?: unknown;
-};
-
-type BootstrapRpcArgs = {
-  p_business_name: string;
-  p_shop_name: string;
-  p_street: string;
-  p_city: string;
-  p_province: string;
-  p_postal_code: string;
-  p_country: string;
-  p_timezone: string;
-  p_owner_pin_hash: string;
-};
-
-type BootstrapRpcRow = {
-  shop_id: string;
-  created_shop: boolean;
-};
-
-type BootstrapRpcError = {
-  code?: string | null;
-  message?: string | null;
-};
-
-type BootstrapRpcResult = {
-  data: BootstrapRpcRow[] | null;
-  error: BootstrapRpcError | null;
 };
 
 function clean(value: unknown): string {
@@ -103,6 +75,47 @@ async function verifyExistingOwnerPin(args: {
   }
 
   return verifyOwnerPin(args.pin, shop.owner_pin_hash);
+}
+
+async function inspectOwnedShopRecovery(userId: string): Promise<
+  | { ok: true }
+  | { ok: false; reason: "lookup_failed" | "ambiguous_owner_shop_recovery" }
+> {
+  const admin = createAdminSupabase();
+  const { data, error } = await admin
+    .from("shops")
+    .select("id")
+    .eq("owner_id", userId)
+    .limit(2);
+
+  if (error) return { ok: false, reason: "lookup_failed" };
+  if ((data?.length ?? 0) > 1) {
+    return { ok: false, reason: "ambiguous_owner_shop_recovery" };
+  }
+  return { ok: true };
+}
+
+async function markOwnerBootstrapPending(args: {
+  userId: string;
+  shopId: string;
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const admin = createAdminSupabase();
+  const { data: profile, error } = await admin
+    .from("profiles")
+    .update({ completed_onboarding: false })
+    .eq("id", args.userId)
+    .eq("shop_id", args.shopId)
+    .eq("role", "owner")
+    .select("id,completed_onboarding")
+    .maybeSingle();
+
+  if (error || !profile || profile.completed_onboarding !== false) {
+    return {
+      ok: false,
+      reason: error?.message ?? "owner_pending_state_not_persisted",
+    };
+  }
+  return { ok: true };
 }
 
 async function reconcileAcquiredBilling(args: {
@@ -199,6 +212,18 @@ function completionUnavailable(reason: string) {
   );
 }
 
+function pendingStateUnavailable(reason: string) {
+  console.error("owner onboarding pending transition failed", { reason });
+  return NextResponse.json(
+    {
+      ok: false,
+      error:
+        "Your shop is saved, but setup could not be secured for billing. Try again.",
+    },
+    { status: 503 },
+  );
+}
+
 function invalidExistingOwnerPin() {
   return NextResponse.json(
     { ok: false, error: "Owner PIN is incorrect." },
@@ -206,23 +231,15 @@ function invalidExistingOwnerPin() {
   );
 }
 
-function bootstrapUpgradeUnavailable() {
+function ambiguousOwnerRecovery() {
   return NextResponse.json(
     {
       ok: false,
       error:
-        "Shop setup is being upgraded. Try again in a moment before continuing.",
+        "More than one historical shop is linked to this owner. Resolve the shop identity before continuing setup.",
     },
-    { status: 503 },
+    { status: 409 },
   );
-}
-
-function isPendingBootstrapRpcUnavailable(
-  error: BootstrapRpcError | null,
-): boolean {
-  if (!error) return false;
-  if (error.code === "PGRST202") return true;
-  return String(error.message ?? "").includes(PENDING_BOOTSTRAP_RPC);
 }
 
 function successfulBootstrapResponse(args: {
@@ -310,6 +327,13 @@ export async function POST(request: Request) {
         shopId: profile.shop_id,
       });
       if (!billing.ok) return billingUnavailable(billing.reason);
+
+      const finalized = await finalizeOwnerOnboarding({
+        userId: user.id,
+        shopId: profile.shop_id,
+      });
+      if (!finalized.ok) return completionUnavailable(finalized.reason);
+
       return successfulBootstrapResponse({
         userId: user.id,
         shopId: profile.shop_id,
@@ -402,35 +426,36 @@ export async function POST(request: Request) {
       );
     }
 
-    const ownerPinHash = await hashOwnerPin(pin);
-    const rpcPayload: BootstrapRpcArgs = {
-      p_business_name: businessName,
-      p_shop_name: shopName,
-      p_street: street,
-      p_city: city,
-      p_province: province,
-      p_postal_code: postalCode,
-      p_country: country,
-      p_timezone: timezone,
-      p_owner_pin_hash: ownerPinHash,
-    };
-    // The expand migration intentionally introduces this RPC before generated
-    // Supabase types know about it. Keep the untyped seam narrow and explicit,
-    // matching the repository's compatibility pattern for forward RPCs.
-    const { data: rows, error: bootstrapError } = await (
-      supabase as never as {
-        rpc: (
-          fn: typeof PENDING_BOOTSTRAP_RPC,
-          args: BootstrapRpcArgs,
-        ) => Promise<BootstrapRpcResult>;
+    // App-first deployments can briefly run against the previous RPC body,
+    // which recovered the newest historical owner shop. Fail closed before the
+    // RPC if the caller has more than one owned shop so no old database version
+    // can make that ambiguous selection.
+    const recovery = await inspectOwnedShopRecovery(user.id);
+    if (!recovery.ok) {
+      if (recovery.reason === "ambiguous_owner_shop_recovery") {
+        return ambiguousOwnerRecovery();
       }
-    ).rpc(PENDING_BOOTSTRAP_RPC, rpcPayload);
+      return pendingStateUnavailable(recovery.reason);
+    }
+
+    const ownerPinHash = await hashOwnerPin(pin);
+    const { data: rows, error: bootstrapError } = await supabase.rpc(
+      "bootstrap_owner_atomic",
+      {
+        p_business_name: businessName,
+        p_shop_name: shopName,
+        p_street: street,
+        p_city: city,
+        p_province: province,
+        p_postal_code: postalCode,
+        p_country: country,
+        p_timezone: timezone,
+        p_owner_pin_hash: ownerPinHash,
+      },
+    );
     const shopId = readBootstrapShopId(rows);
 
     if (bootstrapError || !shopId) {
-      if (isPendingBootstrapRpcUnavailable(bootstrapError)) {
-        return bootstrapUpgradeUnavailable();
-      }
       console.error("owner onboarding bootstrap failed", {
         userId: user.id,
         code: bootstrapError?.code ?? null,
@@ -441,12 +466,19 @@ export async function POST(request: Request) {
       );
     }
 
+    // A concurrent request or an app-first deployment can receive a shop from
+    // the legacy-compatible RPC after it has set completed_onboarding=true.
+    // Never mutate billing/state for this request until the submitted PIN proves
+    // it owns the persisted shop chosen by the atomic transition.
     const persistedPinVerified = await verifyExistingOwnerPin({
       userId: user.id,
       shopId,
       pin,
     });
     if (!persistedPinVerified) return invalidExistingOwnerPin();
+
+    const pending = await markOwnerBootstrapPending({ userId: user.id, shopId });
+    if (!pending.ok) return pendingStateUnavailable(pending.reason);
 
     const billing = await reconcileAcquiredBilling({ userId: user.id, shopId });
     if (!billing.ok) return billingUnavailable(billing.reason);

--- a/app/api/onboarding/bootstrap-owner/route.ts
+++ b/app/api/onboarding/bootstrap-owner/route.ts
@@ -11,6 +11,7 @@ import {
   hashOwnerPin,
   isValidOwnerPin,
   normalizeOwnerPin,
+  verifyOwnerPin,
 } from "@/features/shared/lib/server/owner-pin-crypto";
 import {
   createAdminSupabase,
@@ -24,6 +25,7 @@ import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import { reconcileShopBillingFromUser } from "@/features/stripe/lib/server/canonical-shop-billing";
 
 const COUNTRIES = new Set<ShopCountryCode>(["US", "CA"]);
+const PENDING_BOOTSTRAP_RPC = "bootstrap_owner_pending_v2" as const;
 
 type Body = {
   businessName?: unknown;
@@ -52,6 +54,30 @@ function readBootstrapShopId(value: unknown): string | null {
   return typeof first.shop_id === "string" ? first.shop_id : null;
 }
 
+async function verifyExistingOwnerPin(args: {
+  userId: string;
+  shopId: string;
+  pin: string;
+}): Promise<boolean> {
+  const admin = createAdminSupabase();
+  const { data: shop, error } = await admin
+    .from("shops")
+    .select("owner_id,owner_pin_hash")
+    .eq("id", args.shopId)
+    .maybeSingle();
+
+  if (
+    error ||
+    !shop ||
+    shop.owner_id !== args.userId ||
+    !shop.owner_pin_hash
+  ) {
+    return false;
+  }
+
+  return verifyOwnerPin(args.pin, shop.owner_pin_hash);
+}
+
 async function reconcileAcquiredBilling(args: {
   userId: string;
   shopId: string;
@@ -72,7 +98,8 @@ async function reconcileAcquiredBilling(args: {
   } catch (error) {
     return {
       ok: false,
-      reason: error instanceof Error ? error.message : "billing_reconciliation_failed",
+      reason:
+        error instanceof Error ? error.message : "billing_reconciliation_failed",
     };
   }
 }
@@ -83,9 +110,6 @@ async function finalizeOwnerOnboarding(args: {
 }): Promise<{ ok: true } | { ok: false; reason: string }> {
   const admin = createAdminSupabase();
 
-  // Re-read the shop after canonical Stripe reconciliation. Completion is a
-  // separate durable transition and is allowed only after the shop has the
-  // canonical billing identity/status/pricing/plan written by that reconciler.
   const { data: shop, error: shopError } = await admin
     .from("shops")
     .select(
@@ -148,6 +172,33 @@ function completionUnavailable(reason: string) {
   );
 }
 
+function invalidExistingOwnerPin() {
+  return NextResponse.json(
+    { ok: false, error: "Owner PIN is incorrect." },
+    { status: 401 },
+  );
+}
+
+function bootstrapUpgradeUnavailable() {
+  return NextResponse.json(
+    {
+      ok: false,
+      error:
+        "Shop setup is being upgraded. Try again in a moment before continuing.",
+    },
+    { status: 503 },
+  );
+}
+
+function isPendingBootstrapRpcUnavailable(error: {
+  code?: string | null;
+  message?: string | null;
+} | null): boolean {
+  if (!error) return false;
+  if (error.code === "PGRST202") return true;
+  return String(error.message ?? "").includes(PENDING_BOOTSTRAP_RPC);
+}
+
 function successfulBootstrapResponse(args: {
   userId: string;
   shopId: string;
@@ -208,18 +259,26 @@ export async function POST(request: Request) {
 
     if (profileError || !profile) {
       return NextResponse.json(
-        { ok: false, error: "Your owner profile is not ready. Sign out and sign in again." },
+        {
+          ok: false,
+          error: "Your owner profile is not ready. Sign out and sign in again.",
+        },
         { status: 409 },
       );
     }
 
-    // Completed-owner retries repair canonical billing if necessary and refresh
-    // the privileged PIN session just like the first successful bootstrap.
     if (
       profile.shop_id &&
       profile.role === "owner" &&
       profile.completed_onboarding
     ) {
+      const pinVerified = await verifyExistingOwnerPin({
+        userId: user.id,
+        shopId: profile.shop_id,
+        pin,
+      });
+      if (!pinVerified) return invalidExistingOwnerPin();
+
       const billing = await reconcileAcquiredBilling({
         userId: user.id,
         shopId: profile.shop_id,
@@ -232,15 +291,18 @@ export async function POST(request: Request) {
       });
     }
 
-    // A Stripe/finalization failure after the shop transaction leaves an
-    // explicit pending owner state: owner + shop + completed_onboarding=false.
-    // Retry billing/finalization directly instead of trying to create or recover
-    // the shop again.
     if (
       profile.shop_id &&
       profile.role === "owner" &&
       !profile.completed_onboarding
     ) {
+      const pinVerified = await verifyExistingOwnerPin({
+        userId: user.id,
+        shopId: profile.shop_id,
+        pin,
+      });
+      if (!pinVerified) return invalidExistingOwnerPin();
+
       const billing = await reconcileAcquiredBilling({
         userId: user.id,
         shopId: profile.shop_id,
@@ -316,7 +378,7 @@ export async function POST(request: Request) {
 
     const ownerPinHash = await hashOwnerPin(pin);
     const { data: rows, error: bootstrapError } = await supabase.rpc(
-      "bootstrap_owner_atomic",
+      PENDING_BOOTSTRAP_RPC,
       {
         p_business_name: businessName,
         p_shop_name: shopName,
@@ -332,6 +394,9 @@ export async function POST(request: Request) {
     const shopId = readBootstrapShopId(rows);
 
     if (bootstrapError || !shopId) {
+      if (isPendingBootstrapRpcUnavailable(bootstrapError)) {
+        return bootstrapUpgradeUnavailable();
+      }
       console.error("owner onboarding bootstrap failed", {
         userId: user.id,
         code: bootstrapError?.code ?? null,
@@ -342,10 +407,17 @@ export async function POST(request: Request) {
       );
     }
 
-    // The DB transaction intentionally leaves completed_onboarding=false. First
-    // hydrate canonical billing, then finalize the owner profile as a separate
-    // durable step. Any failure remains recoverable through the pending-owner
-    // branch above and middleware keeps that owner inside onboarding.
+    // The v2 RPC may have created/recovered the shop for this request or
+    // returned an already-owned shop after another concurrent request won the
+    // profile row lock. Every path must prove the submitted PIN matches the
+    // persisted owner_pin_hash before billing/finalization/privilege issuance.
+    const persistedPinVerified = await verifyExistingOwnerPin({
+      userId: user.id,
+      shopId,
+      pin,
+    });
+    if (!persistedPinVerified) return invalidExistingOwnerPin();
+
     const billing = await reconcileAcquiredBilling({ userId: user.id, shopId });
     if (!billing.ok) return billingUnavailable(billing.reason);
 

--- a/app/api/shop/owner-pin/verify/route.ts
+++ b/app/api/shop/owner-pin/verify/route.ts
@@ -1,13 +1,17 @@
 import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import {
+  getOwnerPinCookieFromRequest,
   OWNER_PIN_PURPOSES,
   type OwnerPinPurpose,
   setOwnerPinVerifiedCookie,
+  verifyOwnerPinToken,
 } from "@/features/shared/lib/server/owner-pin";
-import { normalizeOwnerPin, verifyOwnerPin } from "@/features/shared/lib/server/owner-pin-crypto";
+import {
+  normalizeOwnerPin,
+  verifyOwnerPin,
+} from "@/features/shared/lib/server/owner-pin-crypto";
 import { resolveAuthenticatedStaffProfile } from "@/features/shared/lib/server/admin-access";
-
 
 type Body = {
   shopId?: string;
@@ -15,7 +19,86 @@ type Body = {
   purpose?: string;
 };
 
-const OWNER_PIN_PURPOSE_VALUES = new Set<OwnerPinPurpose>(Object.values(OWNER_PIN_PURPOSES));
+const OWNER_PIN_PURPOSE_VALUES = new Set<OwnerPinPurpose>(
+  Object.values(OWNER_PIN_PURPOSES),
+);
+const SETTINGS_PURPOSES = new Set<OwnerPinPurpose>([
+  OWNER_PIN_PURPOSES.SETTINGS,
+  OWNER_PIN_PURPOSES.PRIVILEGED,
+]);
+
+function noStoreJson(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: { "Cache-Control": "private, no-store" },
+  });
+}
+
+async function loadOwnerAdminProfile(
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
+  userId: string,
+) {
+  const { profile: resolvedProfile } =
+    await resolveAuthenticatedStaffProfile(supabase, userId);
+  if (!resolvedProfile) return null;
+
+  const { data: completion } = await supabase
+    .from("profiles")
+    .select("completed_onboarding")
+    .eq("id", resolvedProfile.id)
+    .maybeSingle();
+
+  const profile = { ...resolvedProfile, ...completion };
+  const role = String(profile.role ?? "").trim().toLowerCase();
+  if (role !== "owner" && role !== "admin") return null;
+  return profile;
+}
+
+export async function GET(req: Request) {
+  try {
+    const supabase = createServerSupabaseRoute();
+    const {
+      data: { user },
+      error: userErr,
+    } = await supabase.auth.getUser();
+
+    if (userErr || !user) {
+      return noStoreJson({ error: "Unauthorized" }, 401);
+    }
+
+    const profile = await loadOwnerAdminProfile(supabase, user.id);
+    if (!profile?.shop_id) {
+      return noStoreJson({ ok: true, verified: false });
+    }
+
+    const token = getOwnerPinCookieFromRequest(req);
+    if (!token) return noStoreJson({ ok: true, verified: false });
+
+    const verification = verifyOwnerPinToken(token);
+    if (!verification.ok) {
+      return noStoreJson({ ok: true, verified: false });
+    }
+
+    const claims = verification.claims;
+    if (
+      claims.sub !== user.id ||
+      claims.shop_id !== profile.shop_id ||
+      !SETTINGS_PURPOSES.has(claims.purpose)
+    ) {
+      return noStoreJson({ ok: true, verified: false });
+    }
+
+    return noStoreJson({
+      ok: true,
+      verified: true,
+      shopId: profile.shop_id,
+      expiresAt: new Date(claims.exp * 1000).toISOString(),
+    });
+  } catch (err) {
+    console.error("owner-pin.verify status error", err);
+    return noStoreJson({ ok: true, verified: false });
+  }
+}
 
 export async function POST(req: Request) {
   try {
@@ -34,37 +117,39 @@ export async function POST(req: Request) {
     const shopId = body.shopId?.trim() ?? "";
     const pin = normalizeOwnerPin(body.pin ?? "");
     const requestedPurpose = (body.purpose ?? "").trim();
-    const purpose = OWNER_PIN_PURPOSE_VALUES.has(requestedPurpose as OwnerPinPurpose)
+    const purpose = OWNER_PIN_PURPOSE_VALUES.has(
+      requestedPurpose as OwnerPinPurpose,
+    )
       ? (requestedPurpose as OwnerPinPurpose)
       : OWNER_PIN_PURPOSES.PRIVILEGED;
 
     if (!shopId || !pin) {
-      return NextResponse.json({ error: "shopId and pin required" }, { status: 400 });
+      return NextResponse.json(
+        { error: "shopId and pin required" },
+        { status: 400 },
+      );
     }
 
-    const { profile: resolvedProfile } =
-      await resolveAuthenticatedStaffProfile(supabase, user.id);
-    if (!resolvedProfile) {
-      return NextResponse.json({ error: "Profile not found" }, { status: 404 });
+    const profile = await loadOwnerAdminProfile(supabase, user.id);
+    if (!profile) {
+      return NextResponse.json(
+        { error: "Only owner/admin can unlock owner settings" },
+        { status: 403 },
+      );
     }
-    const { data: completion } = await supabase
-      .from("profiles")
-      .select("completed_onboarding")
-      .eq("id", resolvedProfile.id)
-      .maybeSingle();
-    const profile = { ...resolvedProfile, ...completion };
 
     if (!profile.shop_id) {
-      return NextResponse.json({ error: "No shop linked to your account" }, { status: 409 });
-    }
-
-    const role = String(profile.role ?? "").toLowerCase();
-    if (role !== "owner" && role !== "admin") {
-      return NextResponse.json({ error: "Only owner/admin can unlock owner settings" }, { status: 403 });
+      return NextResponse.json(
+        { error: "No shop linked to your account" },
+        { status: 409 },
+      );
     }
 
     if (!profile.completed_onboarding) {
-      return NextResponse.json({ error: "Complete profile setup before unlocking owner settings" }, { status: 409 });
+      return NextResponse.json(
+        { error: "Complete profile setup before unlocking owner settings" },
+        { status: 409 },
+      );
     }
 
     if (profile.shop_id !== shopId) {
@@ -84,12 +169,18 @@ export async function POST(req: Request) {
     const pinConfigured = Boolean(shop.owner_pin_hash);
 
     if (!pinConfigured) {
-      return NextResponse.json({ error: "Owner PIN not set", pinConfigured: false }, { status: 400 });
+      return NextResponse.json(
+        { error: "Owner PIN not set", pinConfigured: false },
+        { status: 400 },
+      );
     }
 
     const ok = await verifyOwnerPin(pin, shop.owner_pin_hash);
     if (!ok) {
-      return NextResponse.json({ error: "Invalid PIN", pinConfigured: true }, { status: 401 });
+      return NextResponse.json(
+        { error: "Invalid PIN", pinConfigured: true },
+        { status: 401 },
+      );
     }
 
     const res = NextResponse.json({ ok: true, pinConfigured: true });
@@ -100,7 +191,8 @@ export async function POST(req: Request) {
     });
   } catch (err) {
     console.error("owner-pin.verify error", err);
-    const message = err instanceof Error ? err.message : "Unexpected server error";
+    const message =
+      err instanceof Error ? err.message : "Unexpected server error";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/stripe/checkout/acquisition-context/route.ts
+++ b/app/api/stripe/checkout/acquisition-context/route.ts
@@ -1,0 +1,8 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { handleStripeAcquisitionContext } from "@/features/stripe/api/stripe/checkout/acquisition-context/route";
+
+export async function GET(req: Request) {
+  return handleStripeAcquisitionContext(req);
+}

--- a/app/onboarding/OwnerOnboardingForm.tsx
+++ b/app/onboarding/OwnerOnboardingForm.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { readPersistedActivationContext } from "@/features/integrations/shopBoost/activationContext";
+import {
+  appendActivationContextToHref,
+  readActivationContextFromSearchParams,
+} from "@/features/integrations/shopBoost/activationContext";
 import {
   defaultShopTimezone,
   getSupportedShopTimezones,
@@ -87,17 +90,21 @@ export default function OwnerOnboardingForm() {
         return;
       }
 
-      // Shop Boost is an explicit acquisition handoff, not something middleware
-      // should infer from a missing intake row. Only a browser that actually
-      // carries a valid persisted analysis context enters the activation path.
-      const activationContext = readPersistedActivationContext(
+      // Only provenance carried by this acquisition URL may select Shop Boost.
+      // Do not consult the unscoped localStorage fallback here: an old analysis
+      // from another signup/browser session must never redirect an ordinary
+      // owner into activation. The current context is forwarded explicitly so
+      // the Shop Boost page receives the same analysis identity.
+      const activationContext = readActivationContextFromSearchParams(
         new URLSearchParams(window.location.search),
       );
-      window.location.assign(
-        activationContext
-          ? "/onboarding/shop-boost"
-          : payload.destination || "/dashboard/onboarding-v2",
-      );
+      const destination = activationContext
+        ? appendActivationContextToHref(
+            "/onboarding/shop-boost",
+            activationContext,
+          )
+        : payload.destination || "/dashboard/onboarding-v2";
+      window.location.assign(destination);
     } catch {
       setError("We could not create your shop. Check your connection and try again.");
     } finally {
@@ -132,100 +139,43 @@ export default function OwnerOnboardingForm() {
             <div className="mt-4 grid gap-4 sm:grid-cols-2">
               <label className="space-y-1.5 text-sm font-medium">
                 <span>Business name</span>
-                <input
-                  name="businessName"
-                  type="text"
-                  autoComplete="organization"
-                  required
-                  maxLength={120}
-                  className={fieldClassName}
-                />
+                <input name="businessName" type="text" autoComplete="organization" required maxLength={120} className={fieldClassName} />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>Shop name</span>
-                <input
-                  name="shopName"
-                  type="text"
-                  maxLength={120}
-                  placeholder="Defaults to business name"
-                  className={fieldClassName}
-                />
+                <input name="shopName" type="text" maxLength={120} placeholder="Defaults to business name" className={fieldClassName} />
               </label>
             </div>
           </section>
 
           <section aria-labelledby="location-heading">
-            <h2 id="location-heading" className="text-lg font-semibold">
-              Primary location
-            </h2>
+            <h2 id="location-heading" className="text-lg font-semibold">Primary location</h2>
             <div className="mt-4 grid gap-4 sm:grid-cols-2">
               <label className="space-y-1.5 text-sm font-medium sm:col-span-2">
                 <span>Street address</span>
-                <input
-                  name="street"
-                  type="text"
-                  autoComplete="street-address"
-                  required
-                  maxLength={200}
-                  className={fieldClassName}
-                />
+                <input name="street" type="text" autoComplete="street-address" required maxLength={200} className={fieldClassName} />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>City</span>
-                <input
-                  name="city"
-                  type="text"
-                  autoComplete="address-level2"
-                  required
-                  maxLength={100}
-                  className={fieldClassName}
-                />
+                <input name="city" type="text" autoComplete="address-level2" required maxLength={100} className={fieldClassName} />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>{country === "CA" ? "Province" : "State"}</span>
-                <input
-                  name="province"
-                  type="text"
-                  autoComplete="address-level1"
-                  required
-                  maxLength={80}
-                  className={fieldClassName}
-                />
+                <input name="province" type="text" autoComplete="address-level1" required maxLength={80} className={fieldClassName} />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>{country === "CA" ? "Postal code" : "ZIP code"}</span>
-                <input
-                  name="postalCode"
-                  type="text"
-                  autoComplete="postal-code"
-                  required
-                  maxLength={16}
-                  className={fieldClassName}
-                />
+                <input name="postalCode" type="text" autoComplete="postal-code" required maxLength={16} className={fieldClassName} />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>Country</span>
-                <select
-                  value={country}
-                  onChange={(event) =>
-                    changeCountry(event.target.value as ShopCountryCode)
-                  }
-                  className={fieldClassName}
-                >
-                  {COUNTRIES.map((item) => (
-                    <option key={item.value} value={item.value}>
-                      {item.label}
-                    </option>
-                  ))}
+                <select value={country} onChange={(event) => changeCountry(event.target.value as ShopCountryCode)} className={fieldClassName}>
+                  {COUNTRIES.map((item) => <option key={item.value} value={item.value}>{item.label}</option>)}
                 </select>
               </label>
               <label className="space-y-1.5 text-sm font-medium sm:col-span-2">
                 <span>Timezone</span>
-                <select
-                  value={timezone}
-                  onChange={(event) => setTimezone(event.target.value)}
-                  className={fieldClassName}
-                >
+                <select value={timezone} onChange={(event) => setTimezone(event.target.value)} className={fieldClassName}>
                   {timezoneOptions.map((item) => (
                     <option key={item} value={item}>
                       {item.replace("America/", "").replace("Pacific/", "").replaceAll("_", " ")}
@@ -237,54 +187,23 @@ export default function OwnerOnboardingForm() {
           </section>
 
           <section aria-labelledby="owner-pin-heading">
-            <h2 id="owner-pin-heading" className="text-lg font-semibold">
-              Owner PIN
-            </h2>
-            <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
-              Use 4 to 8 digits. This protects sensitive owner actions inside the shop.
-            </p>
+            <h2 id="owner-pin-heading" className="text-lg font-semibold">Owner PIN</h2>
+            <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">Use 4 to 8 digits. This protects sensitive owner actions inside the shop.</p>
             <div className="mt-4 grid gap-4 sm:grid-cols-2">
               <label className="space-y-1.5 text-sm font-medium">
                 <span>Owner PIN</span>
-                <input
-                  name="pin"
-                  type="password"
-                  inputMode="numeric"
-                  autoComplete="new-password"
-                  pattern="[0-9]{4,8}"
-                  required
-                  className={fieldClassName}
-                />
+                <input name="pin" type="password" inputMode="numeric" autoComplete="new-password" pattern="[0-9]{4,8}" required className={fieldClassName} />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>Confirm owner PIN</span>
-                <input
-                  name="pinConfirmation"
-                  type="password"
-                  inputMode="numeric"
-                  autoComplete="new-password"
-                  pattern="[0-9]{4,8}"
-                  required
-                  className={fieldClassName}
-                />
+                <input name="pinConfirmation" type="password" inputMode="numeric" autoComplete="new-password" pattern="[0-9]{4,8}" required className={fieldClassName} />
               </label>
             </div>
           </section>
 
-          {error ? (
-            <p
-              role="alert"
-              className="rounded-xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-200"
-            >
-              {error}
-            </p>
-          ) : null}
+          {error ? <p role="alert" className="rounded-xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</p> : null}
 
-          <button
-            type="submit"
-            disabled={submitting}
-            className="inline-flex min-h-11 w-full items-center justify-center rounded-xl bg-[var(--accent-copper)] px-5 py-3 text-sm font-semibold text-[color:var(--theme-text-on-accent)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
-          >
+          <button type="submit" disabled={submitting} className="inline-flex min-h-11 w-full items-center justify-center rounded-xl bg-[var(--accent-copper)] px-5 py-3 text-sm font-semibold text-[color:var(--theme-text-on-accent)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto">
             {submitting ? "Creating shop…" : "Create shop and continue"}
           </button>
         </form>

--- a/app/onboarding/OwnerOnboardingForm.tsx
+++ b/app/onboarding/OwnerOnboardingForm.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   appendActivationContextToHref,
-  readActivationContextFromSearchParams,
+  parseActivationContextFromSearchParams,
 } from "@/features/integrations/shopBoost/activationContext";
 import {
   defaultShopTimezone,
@@ -95,7 +95,7 @@ export default function OwnerOnboardingForm() {
       // from another signup/browser session must never redirect an ordinary
       // owner into activation. The current context is forwarded explicitly so
       // the Shop Boost page receives the same analysis identity.
-      const activationContext = readActivationContextFromSearchParams(
+      const activationContext = parseActivationContextFromSearchParams(
         new URLSearchParams(window.location.search),
       );
       const destination = activationContext

--- a/app/onboarding/OwnerOnboardingForm.tsx
+++ b/app/onboarding/OwnerOnboardingForm.tsx
@@ -1,22 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { readPersistedActivationContext } from "@/features/integrations/shopBoost/activationContext";
+import {
+  defaultShopTimezone,
+  getSupportedShopTimezones,
+  isSupportedShopTimezone,
+  shopCountryForTimezone,
+  type ShopCountryCode,
+} from "@/features/shared/lib/timezones/shopTimezones";
 
 const COUNTRIES = [
   { value: "US", label: "United States" },
   { value: "CA", label: "Canada" },
-] as const;
-
-const TIMEZONES = [
-  "America/New_York",
-  "America/Chicago",
-  "America/Denver",
-  "America/Edmonton",
-  "America/Phoenix",
-  "America/Los_Angeles",
-  "America/Vancouver",
-  "America/Toronto",
-  "America/Halifax",
 ] as const;
 
 type BootstrapResponse = {
@@ -26,17 +22,29 @@ type BootstrapResponse = {
 };
 
 export default function OwnerOnboardingForm() {
-  const [country, setCountry] = useState<"US" | "CA">("US");
-  const [timezone, setTimezone] = useState<string>("America/Denver");
+  const [country, setCountry] = useState<ShopCountryCode>("US");
+  const [timezone, setTimezone] = useState<string>(defaultShopTimezone("US"));
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const timezoneOptions = useMemo(
+    () => getSupportedShopTimezones(country),
+    [country],
+  );
 
   useEffect(() => {
     const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    if ((TIMEZONES as readonly string[]).includes(detected)) {
-      setTimezone(detected);
-    }
+    const detectedCountry = shopCountryForTimezone(detected);
+    if (!detectedCountry) return;
+    setCountry(detectedCountry);
+    setTimezone(detected);
   }, []);
+
+  function changeCountry(nextCountry: ShopCountryCode) {
+    setCountry(nextCountry);
+    if (!isSupportedShopTimezone(nextCountry, timezone)) {
+      setTimezone(defaultShopTimezone(nextCountry));
+    }
+  }
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -79,7 +87,17 @@ export default function OwnerOnboardingForm() {
         return;
       }
 
-      window.location.assign(payload.destination || "/dashboard/onboarding-v2");
+      // Shop Boost is an explicit acquisition handoff, not something middleware
+      // should infer from a missing intake row. Only a browser that actually
+      // carries a valid persisted analysis context enters the activation path.
+      const activationContext = readPersistedActivationContext(
+        new URLSearchParams(window.location.search),
+      );
+      window.location.assign(
+        activationContext
+          ? "/onboarding/shop-boost"
+          : payload.destination || "/dashboard/onboarding-v2",
+      );
     } catch {
       setError("We could not create your shop. Check your connection and try again.");
     } finally {
@@ -189,7 +207,9 @@ export default function OwnerOnboardingForm() {
                 <span>Country</span>
                 <select
                   value={country}
-                  onChange={(event) => setCountry(event.target.value as "US" | "CA")}
+                  onChange={(event) =>
+                    changeCountry(event.target.value as ShopCountryCode)
+                  }
                   className={fieldClassName}
                 >
                   {COUNTRIES.map((item) => (
@@ -206,9 +226,9 @@ export default function OwnerOnboardingForm() {
                   onChange={(event) => setTimezone(event.target.value)}
                   className={fieldClassName}
                 >
-                  {TIMEZONES.map((item) => (
+                  {timezoneOptions.map((item) => (
                     <option key={item} value={item}>
-                      {item.replace("America/", "").replaceAll("_", " ")}
+                      {item.replace("America/", "").replace("Pacific/", "").replaceAll("_", " ")}
                     </option>
                   ))}
                 </select>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -15,11 +15,14 @@ export default async function OwnerOnboardingPage() {
 
   const { data: profile } = await supabase
     .from("profiles")
-    .select("shop_id, completed_onboarding")
+    .select("shop_id, role, completed_onboarding")
     .eq("id", user.id)
     .maybeSingle();
 
-  if (profile?.shop_id || profile?.completed_onboarding) {
+  // A shop_id can exist while first-shop billing reconciliation is still
+  // pending. Only the explicit completion marker may release an owner from the
+  // setup surface; the bootstrap API's pending-owner branch handles retries.
+  if (profile?.completed_onboarding) {
     redirect("/dashboard");
   }
 

--- a/app/onboarding/shop-boost/page.tsx
+++ b/app/onboarding/shop-boost/page.tsx
@@ -2,22 +2,30 @@
 
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { readPersistedActivationContext } from "@/features/integrations/shopBoost/activationContext";
+import { useSearchParams } from "next/navigation";
+import { parseActivationContextFromSearchParams } from "@/features/integrations/shopBoost/activationContext";
 
 type ActivationResponse =
   | { ok: true; redirectTo: string; guidedSessionId: string; intakeId: string; status: string }
   | { ok: false; error: string };
 
 export default function ShopBoostOnboardingHandoffPage() {
+  const searchParams = useSearchParams();
   const [message, setMessage] = useState("Preparing your analyzed shop…");
   const [error, setError] = useState<string | null>(null);
   const [attempt, setAttempt] = useState(0);
 
   const activate = useCallback(async () => {
     setError(null);
-    const context = readPersistedActivationContext();
+
+    // The owner onboarding handoff forwards the exact acquisition context in
+    // the URL. Treat that URL as the authoritative handoff evidence instead of
+    // falling back to unrelated/stale browser storage from another analysis.
+    const context = parseActivationContextFromSearchParams(searchParams);
     if (!context) {
-      setError("Your saved analysis context could not be found. Return to Instant Shop Analysis to resume it.");
+      setError(
+        "Your analysis handoff could not be verified. Return to Instant Shop Analysis to resume it.",
+      );
       return;
     }
 
@@ -29,10 +37,16 @@ export default function ShopBoostOnboardingHandoffPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ demoId: context.demoId, intakeId: context.intakeId }),
       });
-      const payload = (await response.json().catch(() => null)) as ActivationResponse | null;
+      const payload = (await response.json().catch(() => null)) as
+        | ActivationResponse
+        | null;
 
       if (!response.ok || !payload?.ok) {
-        setError(payload && !payload.ok ? payload.error : "We could not activate this analysis.");
+        setError(
+          payload && !payload.ok
+            ? payload.error
+            : "We could not activate this analysis.",
+        );
         return;
       }
 
@@ -45,7 +59,7 @@ export default function ShopBoostOnboardingHandoffPage() {
           : "We could not activate this analysis.",
       );
     }
-  }, []);
+  }, [searchParams]);
 
   useEffect(() => {
     void activate();
@@ -57,13 +71,18 @@ export default function ShopBoostOnboardingHandoffPage() {
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
           Instant Shop Analysis
         </p>
-        <h1 className="mt-3 text-2xl font-semibold">Building your real ProFixIQ workspace</h1>
+        <h1 className="mt-3 text-2xl font-semibold">
+          Building your real ProFixIQ workspace
+        </h1>
         {!error ? (
           <>
             <div className="mx-auto mt-6 h-12 w-12 animate-spin rounded-full border-4 border-[color:var(--theme-border-soft)] border-t-[var(--accent-copper)]" />
-            <p className="mt-5 text-sm text-[color:var(--theme-text-secondary)]">{message}</p>
+            <p className="mt-5 text-sm text-[color:var(--theme-text-secondary)]">
+              {message}
+            </p>
             <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
-              Customers, vehicles, history, invoices, and parts are being connected to guided onboarding.
+              Customers, vehicles, history, invoices, and parts are being
+              connected to guided onboarding.
             </p>
           </>
         ) : (

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -13,6 +13,7 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { claimStripeAcquisitionAfterAuth } from "@/features/stripe/lib/client/claim-acquisition";
 
 type Mode = "sign-in" | "sign-up";
+type AcquisitionContextStatus = "idle" | "loading" | "ready" | "error";
 
 type AuthPageProps = {
   initialMode?: Mode;
@@ -25,25 +26,23 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const supabase = useMemo(() => createBrowserSupabase(), []);
-  const [mode, setMode] = useState<Mode>(initialMode);
+  const isAcquisitionFlow = searchParams.get("flow")?.trim() === "acquisition";
+  const acquisitionSessionId = useMemo(() => {
+    const value = searchParams.get("session_id")?.trim() ?? "";
+    return isAcquisitionFlow && /^cs_[A-Za-z0-9_]+$/.test(value) ? value : null;
+  }, [isAcquisitionFlow, searchParams]);
+  const [mode, setMode] = useState<Mode>(() => (isAcquisitionFlow ? "sign-up" : initialMode));
   const [identifier, setIdentifier] = useState(() => searchParams.get("email")?.trim().toLowerCase() ?? "");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
-  const [error, setError] = useState(() =>
-    searchParams.get("billing_link_error") === "1"
-      ? "We couldn't securely link that checkout. Retry from the same checkout confirmation link."
-      : "",
-  );
+  const [error, setError] = useState(() => (searchParams.get("billing_link_error") === "1" ? "We couldn't securely link that checkout. Retry from the same checkout confirmation link." : ""));
   const [notice, setNotice] = useState("");
   const [loading, setLoading] = useState(false);
+  const [resendLoading, setResendLoading] = useState(false);
+  const [pendingConfirmationEmail, setPendingConfirmationEmail] = useState<string | null>(null);
+  const [acquisitionContextStatus, setAcquisitionContextStatus] = useState<AcquisitionContextStatus>(isAcquisitionFlow ? "loading" : "idle");
 
-  const origin = useMemo(
-    () =>
-      typeof window !== "undefined"
-        ? window.location.origin
-        : process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") || "https://profixiq.com",
-    [],
-  );
+  const origin = useMemo(() => (typeof window !== "undefined" ? window.location.origin : process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") || "https://profixiq.com"), []);
 
   const emailRedirectTo = useMemo(() => {
     const params = new URLSearchParams();
@@ -83,10 +82,45 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
     return `/forgot-password${params.size ? `?${params.toString()}` : ""}`;
   }, [identifier, searchParams]);
 
-  const isOpsSignIn = useMemo(
-    () => safeInternalRedirect(searchParams.get("redirect"), "") === "/ops",
-    [searchParams],
-  );
+  const isOpsSignIn = useMemo(() => safeInternalRedirect(searchParams.get("redirect"), "") === "/ops", [searchParams]);
+
+  useEffect(() => {
+    if (!isAcquisitionFlow) return;
+    if (!acquisitionSessionId) {
+      setAcquisitionContextStatus("error");
+      setError("This trial checkout link is invalid. Return to pricing and start a new trial.");
+      return;
+    }
+
+    const controller = new AbortController();
+    setAcquisitionContextStatus("loading");
+    void fetch(`/api/stripe/checkout/acquisition-context?session_id=${encodeURIComponent(acquisitionSessionId)}`, {
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        const body = (await response.json().catch(() => null)) as {
+          email?: unknown;
+        } | null;
+        const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : "";
+        if (!response.ok || !email.includes("@")) {
+          throw new Error("checkout_not_eligible");
+        }
+        setIdentifier(email);
+        setAcquisitionContextStatus("ready");
+      })
+      .catch((fetchError: unknown) => {
+        if (controller.signal.aborted) return;
+        console.warn("stripe acquisition context unavailable", {
+          name: fetchError instanceof Error ? fetchError.name : "UnknownError",
+        });
+        setAcquisitionContextStatus("error");
+        setError("We couldn't verify this trial checkout. Return to the checkout confirmation page and try again.");
+      });
+
+    return () => controller.abort();
+  }, [acquisitionSessionId, isAcquisitionFlow]);
 
   useEffect(() => {
     let cancelled = false;
@@ -118,16 +152,17 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
     setNotice("");
 
     try {
+      if (isAcquisitionFlow && acquisitionContextStatus !== "ready") {
+        setError("Wait for us to verify your trial checkout before continuing.");
+        return;
+      }
+
       if (mode === "sign-in") {
-        const acquisitionSessionId =
-          searchParams.get("flow")?.trim() === "acquisition"
-            ? searchParams.get("session_id")?.trim() || undefined
-            : undefined;
         const result = await signInWithIdentifier({
           identifier,
           password,
           surface: "shop",
-          acquisitionSessionId,
+          acquisitionSessionId: acquisitionSessionId ?? undefined,
         });
         if (!result.ok) {
           setError(result.error);
@@ -165,9 +200,8 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
       }
       if (!data.session) {
         setPassword("");
-        setNotice(
-          "If this is a new account, check its inbox for the verification link. If you already have an account, choose Sign in—another confirmation email will not be sent.",
-        );
+        setPendingConfirmationEmail(email);
+        setNotice("Check your inbox for the verification link. If it doesn't arrive, resend it below or choose Sign in if this account already exists.");
         return;
       }
       const claim = await claimStripeAcquisitionAfterAuth(searchParams);
@@ -186,6 +220,28 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
     }
   }
 
+  async function handleResendConfirmation() {
+    if (!pendingConfirmationEmail || resendLoading) return;
+    setResendLoading(true);
+    setError("");
+    setNotice("");
+
+    try {
+      const { error: resendError } = await supabase.auth.resend({
+        type: "signup",
+        email: pendingConfirmationEmail,
+        options: { emailRedirectTo },
+      });
+      if (resendError) {
+        setError("We couldn't resend the verification email. Wait a minute and try again, or choose Sign in if this account is already verified.");
+        return;
+      }
+      setNotice("Verification email resent. Check your inbox and spam folder for the newest link.");
+    } finally {
+      setResendLoading(false);
+    }
+  }
+
   async function handleOpsOAuthSignIn() {
     if (loading) return;
     setLoading(true);
@@ -198,9 +254,7 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         options: { redirectTo: emailRedirectTo },
       });
       if (oauthError) {
-        setError(
-          "Google sign-in is not available yet. Use email and password for now.",
-        );
+        setError("Google sign-in is not available yet. Use email and password for now.");
       }
     } finally {
       setLoading(false);
@@ -217,16 +271,10 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
       highlights={["Role-aware access", "Live work visibility", "Secure approvals"]}
     >
       <div className="mb-6">
-        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
-          Shop dashboard
-        </div>
-        <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em] text-[color:var(--theme-text-primary)] sm:text-4xl">
-          {isSignIn ? "Welcome back" : "Create your shop account"}
-        </h1>
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">Shop dashboard</div>
+        <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em] text-[color:var(--theme-text-primary)] sm:text-4xl">{isSignIn ? "Welcome back" : "Create your shop account"}</h1>
         <p className="mt-2 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
-          {isSignIn
-            ? "Use your shop username or account email."
-            : "Start with the owner account; invite the rest of your team after setup."}
+          {isSignIn ? "Use your shop username or account email." : "Start with the owner account; invite the rest of your team after setup."}
         </p>
       </div>
 
@@ -281,8 +329,19 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
             placeholder={isSignIn ? "name@shop.com or username" : "owner@shop.com"}
             value={identifier}
             onChange={(event) => setIdentifier(event.target.value)}
+            readOnly={isAcquisitionFlow && acquisitionContextStatus === "ready"}
+            aria-describedby={isAcquisitionFlow ? "acquisition-email-help" : undefined}
             required
           />
+          {isAcquisitionFlow ? (
+            <p id="acquisition-email-help" className="mt-1.5 text-xs text-[color:var(--theme-text-muted)]">
+              {acquisitionContextStatus === "loading"
+                ? "Verifying the email used for your trial checkout…"
+                : acquisitionContextStatus === "ready"
+                  ? "This email is locked to the completed trial checkout."
+                  : "The completed trial checkout must be verified before account setup."}
+            </p>
+          ) : null}
         </div>
 
         <div>
@@ -321,7 +380,7 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
 
         <button
           type="submit"
-          disabled={loading}
+          disabled={loading || (isAcquisitionFlow && acquisitionContextStatus !== "ready")}
           className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--accent-copper)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-on-accent)] shadow-[0_14px_32px_color-mix(in_srgb,var(--accent-copper)_25%,transparent)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
@@ -329,14 +388,35 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         </button>
       </form>
 
+      {!isSignIn && pendingConfirmationEmail ? (
+        <button
+          type="button"
+          disabled={resendLoading}
+          onClick={handleResendConfirmation}
+          className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {resendLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          {resendLoading ? "Resending…" : "Resend verification email"}
+        </button>
+      ) : null}
+
       <div className="mt-6 grid gap-2 border-t border-[color:var(--theme-border-soft)] pt-5 sm:grid-cols-3">
-        <Link href="/mobile/sign-in" className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2.5 text-center text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[var(--accent-copper)] hover:text-[color:var(--theme-text-primary)]">
+        <Link
+          href="/mobile/sign-in"
+          className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2.5 text-center text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[var(--accent-copper)] hover:text-[color:var(--theme-text-primary)]"
+        >
           Mobile companion
         </Link>
-        <Link href="/portal/auth/sign-in" className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2.5 text-center text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[var(--accent-copper)] hover:text-[color:var(--theme-text-primary)]">
+        <Link
+          href="/portal/auth/sign-in"
+          className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2.5 text-center text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[var(--accent-copper)] hover:text-[color:var(--theme-text-primary)]"
+        >
           Customer portal
         </Link>
-        <Link href="/portal/auth/fleet-sign-in" className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2.5 text-center text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[var(--accent-copper)] hover:text-[color:var(--theme-text-primary)]">
+        <Link
+          href="/portal/auth/fleet-sign-in"
+          className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2.5 text-center text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[var(--accent-copper)] hover:text-[color:var(--theme-text-primary)]"
+        >
           Fleet portal
         </Link>
       </div>

--- a/features/onboarding-v2/components/ShopSettingsSetupModal.tsx
+++ b/features/onboarding-v2/components/ShopSettingsSetupModal.tsx
@@ -89,6 +89,7 @@ export default function ShopSettingsSetupModal({
 }: Props) {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [loading, setLoading] = useState(false);
+  const [settingsReady, setSettingsReady] = useState(false);
   const [saving, setSaving] = useState(false);
   const [shopId, setShopId] = useState<string | null>(null);
   const [pinModalOpen, setPinModalOpen] = useState(false);
@@ -108,23 +109,24 @@ export default function ShopSettingsSetupModal({
   const [diagnosticFee, setDiagnosticFee] = useState("");
   const [taxRate, setTaxRate] = useState("");
   const [shopSuppliesEnabled, setShopSuppliesEnabled] = useState(false);
-  const [shopSuppliesType, setShopSuppliesType] =
-    useState<SuppliesType>("percentage");
+  const [shopSuppliesType, setShopSuppliesType] = useState<SuppliesType>("percentage");
   const [shopSuppliesPercent, setShopSuppliesPercent] = useState("");
   const [shopSuppliesFlatAmount, setShopSuppliesFlatAmount] = useState("");
   const [shopSuppliesCapAmount, setShopSuppliesCapAmount] = useState("");
-  const [hours, setHours] = useState<OnboardingHourRow[]>(
-    DEFAULT_ONBOARDING_HOURS,
-  );
+  const [hours, setHours] = useState<OnboardingHourRow[]>(DEFAULT_ONBOARDING_HOURS);
   const [requireCauseCorrection, setRequireCauseCorrection] = useState(false);
   const [requireAuthorization, setRequireAuthorization] = useState(false);
   const [autoGeneratePdf, setAutoGeneratePdf] = useState(false);
   const [autoSendQuoteEmail, setAutoSendQuoteEmail] = useState(false);
 
-  const timezoneOptions = useMemo(
-    () => getSupportedShopTimezones(country),
-    [country],
-  );
+  const timezoneOptions = useMemo(() => {
+    const supported = [...getSupportedShopTimezones(country)];
+    // Preserve an existing historical country/timezone pair until the owner
+    // explicitly changes it. Dropping the current value from the select would
+    // silently coerce it to the first supported option on the next save.
+    if (timezone && !supported.includes(timezone)) supported.push(timezone);
+    return supported;
+  }, [country, timezone]);
   const isUnlocked = useMemo(
     () => Boolean(pinExpiresAt && new Date(pinExpiresAt).getTime() > now),
     [pinExpiresAt, now],
@@ -138,13 +140,13 @@ export default function ShopSettingsSetupModal({
   const loadSettings = useCallback(async () => {
     if (!open) return;
     setLoading(true);
+    setSettingsReady(false);
+    setPinExpiresAt(undefined);
     try {
       const {
         data: { user },
       } = await supabase.auth.getUser();
-      if (!user?.id) {
-        throw new Error("Sign in is required to load shop settings.");
-      }
+      if (!user?.id) throw new Error("Sign in is required to load shop settings.");
 
       const { data: profile, error: profileError } = await supabase
         .from("profiles")
@@ -152,9 +154,7 @@ export default function ShopSettingsSetupModal({
         .eq("id", user.id)
         .maybeSingle<{ shop_id: string | null }>();
       if (profileError) throw profileError;
-      if (!profile?.shop_id) {
-        throw new Error("No shop is associated with this profile.");
-      }
+      if (!profile?.shop_id) throw new Error("No shop is associated with this profile.");
       setShopId(profile.shop_id);
 
       const { data: shop, error: shopError } = await supabase
@@ -163,111 +163,96 @@ export default function ShopSettingsSetupModal({
         .eq("id", profile.shop_id)
         .maybeSingle<Record<string, unknown>>();
       if (shopError) throw shopError;
-      if (shop) {
-        const shopCountry: ShopCountryCode = shop.country === "CA" ? "CA" : "US";
-        const storedTimezone = String(shop.timezone ?? "").trim();
-        setShopName(String(shop.shop_name ?? shop.name ?? shop.business_name ?? ""));
-        setCountry(shopCountry);
-        setTimezone(
-          isSupportedShopTimezone(shopCountry, storedTimezone)
-            ? storedTimezone
-            : defaultShopTimezone(shopCountry),
-        );
-        setPhone(String(shop.phone_number ?? ""));
-        setEmail(String(shop.email ?? ""));
-        setAddress(String(shop.street ?? shop.address ?? ""));
-        setCity(String(shop.city ?? ""));
-        setProvince(String(shop.province ?? ""));
-        setPostalCode(String(shop.postal_code ?? ""));
-        setLaborRate(
-          typeof shop.labor_rate === "number" ? String(shop.labor_rate) : "",
-        );
-        setDiagnosticFee(
-          typeof shop.diagnostic_fee === "number"
-            ? String(shop.diagnostic_fee)
+      if (!shop) throw new Error("Shop settings could not be loaded.");
+
+      const shopCountry: ShopCountryCode = shop.country === "CA" ? "CA" : "US";
+      const storedTimezone = String(shop.timezone ?? "").trim();
+      setShopName(String(shop.shop_name ?? shop.name ?? shop.business_name ?? ""));
+      setCountry(shopCountry);
+      setTimezone(storedTimezone || defaultShopTimezone(shopCountry));
+      setPhone(String(shop.phone_number ?? ""));
+      setEmail(String(shop.email ?? ""));
+      setAddress(String(shop.street ?? shop.address ?? ""));
+      setCity(String(shop.city ?? ""));
+      setProvince(String(shop.province ?? ""));
+      setPostalCode(String(shop.postal_code ?? ""));
+      setLaborRate(typeof shop.labor_rate === "number" ? String(shop.labor_rate) : "");
+      setDiagnosticFee(typeof shop.diagnostic_fee === "number" ? String(shop.diagnostic_fee) : "");
+      setTaxRate(typeof shop.tax_rate === "number" ? String(shop.tax_rate) : "");
+      setShopSuppliesEnabled(
+        Boolean(
+          shop.shop_supplies_enabled ??
+            (typeof shop.supplies_percent === "number" && shop.supplies_percent > 0),
+        ),
+      );
+      setShopSuppliesType(shop.shop_supplies_type === "flat" ? "flat" : "percentage");
+      setShopSuppliesPercent(
+        typeof shop.shop_supplies_percent === "number"
+          ? String(shop.shop_supplies_percent)
+          : typeof shop.supplies_percent === "number"
+            ? String(shop.supplies_percent)
             : "",
+      );
+      setShopSuppliesFlatAmount(
+        typeof shop.shop_supplies_flat_amount === "number"
+          ? String(shop.shop_supplies_flat_amount)
+          : "",
+      );
+      setShopSuppliesCapAmount(
+        typeof shop.shop_supplies_cap_amount === "number"
+          ? String(shop.shop_supplies_cap_amount)
+          : "",
+      );
+      setRequireCauseCorrection(Boolean(shop.require_cause_correction));
+      setRequireAuthorization(Boolean(shop.require_authorization));
+      setAutoGeneratePdf(Boolean(shop.auto_generate_pdf));
+      setAutoSendQuoteEmail(Boolean(shop.auto_send_quote_email));
+
+      // Hours are part of the editable settings contract, so failing to load
+      // them must keep Save disabled. Never substitute defaults after a network
+      // failure and risk overwriting a shop's real schedule.
+      const hoursResponse = await fetch("/api/settings/hours", { cache: "no-store" });
+      if (!hoursResponse.ok) {
+        throw new Error(await readJsonError(hoursResponse, "Unable to load shop hours."));
+      }
+      const payload = (await hoursResponse.json()) as { hours?: OnboardingHourRow[] };
+      if (Array.isArray(payload.hours) && payload.hours.length > 0) {
+        const byDay = new Map(payload.hours.map((row) => [row.weekday, row]));
+        setHours(
+          DEFAULT_ONBOARDING_HOURS.map((fallback) => ({
+            ...fallback,
+            ...(byDay.get(fallback.weekday) ?? {}),
+          })),
         );
-        setTaxRate(
-          typeof shop.tax_rate === "number" ? String(shop.tax_rate) : "",
-        );
-        setShopSuppliesEnabled(
-          Boolean(
-            shop.shop_supplies_enabled ??
-              (typeof shop.supplies_percent === "number" &&
-                shop.supplies_percent > 0),
-          ),
-        );
-        setShopSuppliesType(
-          shop.shop_supplies_type === "flat" ? "flat" : "percentage",
-        );
-        setShopSuppliesPercent(
-          typeof shop.shop_supplies_percent === "number"
-            ? String(shop.shop_supplies_percent)
-            : typeof shop.supplies_percent === "number"
-              ? String(shop.supplies_percent)
-              : "",
-        );
-        setShopSuppliesFlatAmount(
-          typeof shop.shop_supplies_flat_amount === "number"
-            ? String(shop.shop_supplies_flat_amount)
-            : "",
-        );
-        setShopSuppliesCapAmount(
-          typeof shop.shop_supplies_cap_amount === "number"
-            ? String(shop.shop_supplies_cap_amount)
-            : "",
-        );
-        setRequireCauseCorrection(Boolean(shop.require_cause_correction));
-        setRequireAuthorization(Boolean(shop.require_authorization));
-        setAutoGeneratePdf(Boolean(shop.auto_generate_pdf));
-        setAutoSendQuoteEmail(Boolean(shop.auto_send_quote_email));
+      } else {
+        setHours(DEFAULT_ONBOARDING_HOURS);
       }
 
-      // bootstrap-owner just established a privileged 30-minute PIN cookie.
-      // Read only its verified/expiry state; the HTTP-only token itself never
-      // crosses into client JavaScript.
-      const pinStatusResponse = await fetch("/api/shop/owner-pin/verify", {
-        method: "GET",
-        cache: "no-store",
-      });
-      if (pinStatusResponse.ok) {
-        const pinStatus = (await pinStatusResponse.json()) as OwnerPinStatus;
-        if (
-          pinStatus.verified &&
-          pinStatus.shopId === profile.shop_id &&
-          pinStatus.expiresAt
-        ) {
-          setPinExpiresAt(pinStatus.expiresAt);
-        } else {
-          setPinExpiresAt(undefined);
-        }
-      }
+      setSettingsReady(true);
 
-      const hoursResponse = await fetch("/api/settings/hours", {
-        cache: "no-store",
-      });
-      if (hoursResponse.ok) {
-        const payload = (await hoursResponse.json()) as {
-          hours?: OnboardingHourRow[];
-        };
-        if (Array.isArray(payload.hours) && payload.hours.length > 0) {
-          const byDay = new Map(
-            payload.hours.map((row) => [row.weekday, row]),
-          );
-          setHours(
-            DEFAULT_ONBOARDING_HOURS.map((fallback) => ({
-              ...fallback,
-              ...(byDay.get(fallback.weekday) ?? {}),
-            })),
-          );
-        } else {
-          setHours(DEFAULT_ONBOARDING_HOURS);
+      // PIN status is optional convenience only. A failure here must not poison
+      // the mandatory settings/hours load; the owner can still unlock manually.
+      try {
+        const pinStatusResponse = await fetch("/api/shop/owner-pin/verify", {
+          method: "GET",
+          cache: "no-store",
+        });
+        if (pinStatusResponse.ok) {
+          const pinStatus = (await pinStatusResponse.json()) as OwnerPinStatus;
+          if (
+            pinStatus.verified &&
+            pinStatus.shopId === profile.shop_id &&
+            pinStatus.expiresAt
+          ) {
+            setPinExpiresAt(pinStatus.expiresAt);
+          }
         }
+      } catch {
+        setPinExpiresAt(undefined);
       }
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Unable to load shop settings.",
-      );
+      setSettingsReady(false);
+      toast.error(error instanceof Error ? error.message : "Unable to load shop settings.");
     } finally {
       setLoading(false);
     }
@@ -279,13 +264,18 @@ export default function ShopSettingsSetupModal({
 
   function changeCountry(nextCountry: ShopCountryCode) {
     setCountry(nextCountry);
+    // Once the owner explicitly changes country, move an incompatible legacy
+    // timezone onto that country's supported default rather than preserving it.
     if (!isSupportedShopTimezone(nextCountry, timezone)) {
       setTimezone(defaultShopTimezone(nextCountry));
     }
   }
 
   async function save() {
-    if (!shopId) return;
+    if (!shopId || !settingsReady) {
+      toast.warning("Load the current shop settings before saving.");
+      return;
+    }
     if (!isUnlocked) {
       toast.warning("Unlock with Owner PIN first.");
       setPinModalOpen(true);
@@ -311,10 +301,7 @@ export default function ShopSettingsSetupModal({
             phone_number: phone,
             email,
             labor_rate: asNumber(laborRate),
-            supplies_percent:
-              shopSuppliesType === "percentage"
-                ? asNumber(shopSuppliesPercent)
-                : null,
+            supplies_percent: shopSuppliesType === "percentage" ? asNumber(shopSuppliesPercent) : null,
             shop_supplies_enabled: shopSuppliesEnabled,
             shop_supplies_type: shopSuppliesType,
             shop_supplies_percent: asNumber(shopSuppliesPercent),
@@ -330,9 +317,7 @@ export default function ShopSettingsSetupModal({
         }),
       });
       if (!updateResponse.ok) {
-        throw new Error(
-          await readJsonError(updateResponse, "Failed to save shop settings."),
-        );
+        throw new Error(await readJsonError(updateResponse, "Failed to save shop settings."));
       }
 
       const openDays = hours.filter((hour) => !hour.closed);
@@ -342,9 +327,7 @@ export default function ShopSettingsSetupModal({
         body: JSON.stringify({ shopId, hours: openDays }),
       });
       if (!hoursResponse.ok) {
-        throw new Error(
-          await readJsonError(hoursResponse, "Failed to save shop hours."),
-        );
+        throw new Error(await readJsonError(hoursResponse, "Failed to save shop hours."));
       }
 
       const detail = await completeStep(sessionId, "complete");
@@ -352,9 +335,7 @@ export default function ShopSettingsSetupModal({
       onClose();
       toast.success("Shop Settings saved and onboarding updated.");
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Unable to save Shop Settings.",
-      );
+      toast.error(error instanceof Error ? error.message : "Unable to save Shop Settings.");
     } finally {
       setSaving(false);
     }
@@ -368,9 +349,7 @@ export default function ShopSettingsSetupModal({
       onClose();
       toast.success("Shop Settings skipped for now.");
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Unable to skip Shop Settings.",
-      );
+      toast.error(error instanceof Error ? error.message : "Unable to skip Shop Settings.");
     } finally {
       setSaving(false);
     }
@@ -389,238 +368,69 @@ export default function ShopSettingsSetupModal({
       <section className="mx-auto my-6 max-w-5xl rounded-[2rem] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-5 text-[color:var(--theme-text-primary)] shadow-2xl">
         <div className="flex flex-col gap-3 border-b border-[color:var(--theme-border-soft)] pb-4 md:flex-row md:items-start md:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">
-              Guided onboarding · Shop Settings
-            </p>
-            <h2 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
-              Confirm setup-critical shop defaults
-            </h2>
-            <p className="mt-2 max-w-3xl text-sm text-[color:var(--theme-text-secondary)]">
-              These focused settings keep quotes, invoices, approvals, and booking
-              hours ready without leaving guided onboarding.
-            </p>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">Guided onboarding · Shop Settings</p>
+            <h2 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">Confirm setup-critical shop defaults</h2>
+            <p className="mt-2 max-w-3xl text-sm text-[color:var(--theme-text-secondary)]">These focused settings keep quotes, invoices, approvals, and booking hours ready without leaving guided onboarding.</p>
           </div>
           <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={onClose}
-              disabled={saving}
-            >
-              Close
-            </Button>
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={skip}
-              disabled={saving}
-            >
-              Skip for now
-            </Button>
-            <Button
-              type="button"
-              onClick={save}
-              disabled={saving || loading}
-            >
-              {saving
-                ? "Saving..."
-                : isUnlocked
-                  ? "Save Shop Settings"
-                  : "Unlock & save"}
+            <Button type="button" variant="secondary" onClick={onClose} disabled={saving}>Close</Button>
+            <Button type="button" variant="secondary" onClick={skip} disabled={saving}>Skip for now</Button>
+            <Button type="button" onClick={save} disabled={saving || loading || !settingsReady}>
+              {saving ? "Saving..." : isUnlocked ? "Save Shop Settings" : "Unlock & save"}
             </Button>
           </div>
         </div>
 
         {loading ? (
-          <div className="mt-5 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
-            Loading current shop settings…
-          </div>
+          <div className="mt-5 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">Loading current shop settings…</div>
         ) : null}
 
         <div className="mt-5 grid gap-5 lg:grid-cols-2">
           <Panel title="Business">
             <div className="grid gap-3 md:grid-cols-2">
-              <Input
-                className={inputClass}
-                value={shopName}
-                onChange={(e) => setShopName(e.target.value)}
-                placeholder="Shop name"
-              />
-              <select
-                value={country}
-                onChange={(e) => changeCountry(e.target.value as ShopCountryCode)}
-                className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]"
-              >
-                <option value="US">United States</option>
-                <option value="CA">Canada</option>
+              <Input className={inputClass} value={shopName} onChange={(e) => setShopName(e.target.value)} placeholder="Shop name" />
+              <select value={country} onChange={(e) => changeCountry(e.target.value as ShopCountryCode)} className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]">
+                <option value="US">United States</option><option value="CA">Canada</option>
               </select>
-              <select
-                value={timezone}
-                onChange={(e) => setTimezone(e.target.value)}
-                className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]"
-              >
-                {timezoneOptions.map((tz) => (
-                  <option key={tz} value={tz}>
-                    {tz}
-                  </option>
-                ))}
+              <select value={timezone} onChange={(e) => setTimezone(e.target.value)} className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]">
+                {timezoneOptions.map((tz) => <option key={tz} value={tz}>{tz}</option>)}
               </select>
-              <Input
-                className={inputClass}
-                value={phone}
-                onChange={(e) => setPhone(e.target.value)}
-                placeholder="Phone"
-              />
-              <Input
-                className={inputClass}
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="Email"
-              />
-              <Input
-                className={inputClass}
-                value={address}
-                onChange={(e) => setAddress(e.target.value)}
-                placeholder="Street address"
-              />
-              <Input
-                className={inputClass}
-                value={city}
-                onChange={(e) => setCity(e.target.value)}
-                placeholder="City"
-              />
-              <Input
-                className={inputClass}
-                value={province}
-                onChange={(e) => setProvince(e.target.value)}
-                placeholder={provinceLabel}
-              />
-              <Input
-                className={inputClass}
-                value={postalCode}
-                onChange={(e) => setPostalCode(e.target.value)}
-                placeholder={postalLabel}
-              />
+              <Input className={inputClass} value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="Phone" />
+              <Input className={inputClass} value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
+              <Input className={inputClass} value={address} onChange={(e) => setAddress(e.target.value)} placeholder="Street address" />
+              <Input className={inputClass} value={city} onChange={(e) => setCity(e.target.value)} placeholder="City" />
+              <Input className={inputClass} value={province} onChange={(e) => setProvince(e.target.value)} placeholder={provinceLabel} />
+              <Input className={inputClass} value={postalCode} onChange={(e) => setPostalCode(e.target.value)} placeholder={postalLabel} />
             </div>
           </Panel>
 
           <Panel title="Operations">
             <div className="grid gap-3 md:grid-cols-2">
-              <Input
-                className={inputClass}
-                value={laborRate}
-                onChange={(e) => setLaborRate(e.target.value)}
-                placeholder={`Labor rate (${currency}/hr)`}
-              />
-              <Input
-                className={inputClass}
-                value={diagnosticFee}
-                onChange={(e) => setDiagnosticFee(e.target.value)}
-                placeholder={`Diagnostic fee (${currency})`}
-              />
-              <Input
-                className={inputClass}
-                value={taxRate}
-                onChange={(e) => setTaxRate(e.target.value)}
-                placeholder="Tax rate (%)"
-              />
+              <Input className={inputClass} value={laborRate} onChange={(e) => setLaborRate(e.target.value)} placeholder={`Labor rate (${currency}/hr)`} />
+              <Input className={inputClass} value={diagnosticFee} onChange={(e) => setDiagnosticFee(e.target.value)} placeholder={`Diagnostic fee (${currency})`} />
+              <Input className={inputClass} value={taxRate} onChange={(e) => setTaxRate(e.target.value)} placeholder="Tax rate (%)" />
               <label className="flex items-center gap-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={shopSuppliesEnabled}
-                  onChange={(e) => setShopSuppliesEnabled(e.target.checked)}
-                />{" "}
-                Shop supplies enabled
+                <input type="checkbox" checked={shopSuppliesEnabled} onChange={(e) => setShopSuppliesEnabled(e.target.checked)} /> Shop supplies enabled
               </label>
-              <select
-                value={shopSuppliesType}
-                onChange={(e) =>
-                  setShopSuppliesType(
-                    e.target.value === "flat" ? "flat" : "percentage",
-                  )
-                }
-                className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]"
-              >
-                <option value="percentage">Percentage</option>
-                <option value="flat">Flat amount</option>
+              <select value={shopSuppliesType} onChange={(e) => setShopSuppliesType(e.target.value === "flat" ? "flat" : "percentage")} className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]">
+                <option value="percentage">Percentage</option><option value="flat">Flat amount</option>
               </select>
-              <Input
-                className={inputClass}
-                value={shopSuppliesPercent}
-                onChange={(e) => setShopSuppliesPercent(e.target.value)}
-                placeholder="Shop supplies (%)"
-              />
-              <Input
-                className={inputClass}
-                value={shopSuppliesFlatAmount}
-                onChange={(e) => setShopSuppliesFlatAmount(e.target.value)}
-                placeholder={`Shop supplies flat (${currency})`}
-              />
-              <Input
-                className={inputClass}
-                value={shopSuppliesCapAmount}
-                onChange={(e) => setShopSuppliesCapAmount(e.target.value)}
-                placeholder={`Supplies cap (${currency})`}
-              />
+              <Input className={inputClass} value={shopSuppliesPercent} onChange={(e) => setShopSuppliesPercent(e.target.value)} placeholder="Shop supplies (%)" />
+              <Input className={inputClass} value={shopSuppliesFlatAmount} onChange={(e) => setShopSuppliesFlatAmount(e.target.value)} placeholder={`Shop supplies flat (${currency})`} />
+              <Input className={inputClass} value={shopSuppliesCapAmount} onChange={(e) => setShopSuppliesCapAmount(e.target.value)} placeholder={`Supplies cap (${currency})`} />
             </div>
           </Panel>
 
           <Panel title="Hours">
             <div className="divide-y divide-[color:var(--theme-border-soft)] rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]">
               {hours.map((row, idx) => (
-                <div
-                  key={row.weekday}
-                  className="grid gap-3 p-3 md:grid-cols-[70px_110px_1fr_1fr] md:items-center"
-                >
-                  <div className="text-sm font-semibold">
-                    {WEEKDAYS[row.weekday]}
-                  </div>
+                <div key={row.weekday} className="grid gap-3 p-3 md:grid-cols-[70px_110px_1fr_1fr] md:items-center">
+                  <div className="text-sm font-semibold">{WEEKDAYS[row.weekday]}</div>
                   <label className="flex items-center gap-2 text-sm">
-                    <input
-                      type="checkbox"
-                      checked={!!row.closed}
-                      onChange={(e) =>
-                        setHours((prev) =>
-                          prev.map((hour, i) =>
-                            i === idx
-                              ? { ...hour, closed: e.target.checked }
-                              : hour,
-                          ),
-                        )
-                      }
-                    />{" "}
-                    Closed
+                    <input type="checkbox" checked={!!row.closed} onChange={(e) => setHours((prev) => prev.map((hour, i) => i === idx ? { ...hour, closed: e.target.checked } : hour))} /> Closed
                   </label>
-                  <input
-                    type="time"
-                    className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-sm"
-                    value={row.open_time}
-                    disabled={!!row.closed}
-                    onChange={(e) =>
-                      setHours((prev) =>
-                        prev.map((hour, i) =>
-                          i === idx
-                            ? { ...hour, open_time: e.target.value }
-                            : hour,
-                        ),
-                      )
-                    }
-                  />
-                  <input
-                    type="time"
-                    className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-sm"
-                    value={row.close_time}
-                    disabled={!!row.closed}
-                    onChange={(e) =>
-                      setHours((prev) =>
-                        prev.map((hour, i) =>
-                          i === idx
-                            ? { ...hour, close_time: e.target.value }
-                            : hour,
-                        ),
-                      )
-                    }
-                  />
+                  <input type="time" className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-sm" value={row.open_time} disabled={!!row.closed} onChange={(e) => setHours((prev) => prev.map((hour, i) => i === idx ? { ...hour, open_time: e.target.value } : hour))} />
+                  <input type="time" className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-sm" value={row.close_time} disabled={!!row.closed} onChange={(e) => setHours((prev) => prev.map((hour, i) => i === idx ? { ...hour, close_time: e.target.value } : hour))} />
                 </div>
               ))}
             </div>
@@ -629,59 +439,28 @@ export default function ShopSettingsSetupModal({
           <Panel title="Workflow">
             <div className="space-y-3 text-sm">
               {([
-                [
-                  "Require cause / correction on lines",
-                  requireCauseCorrection,
-                  setRequireCauseCorrection,
-                ],
-                [
-                  "Require customer authorization",
-                  requireAuthorization,
-                  setRequireAuthorization,
-                ],
+                ["Require cause / correction on lines", requireCauseCorrection, setRequireCauseCorrection],
+                ["Require customer authorization", requireAuthorization, setRequireAuthorization],
                 ["Auto-generate quote PDF", autoGeneratePdf, setAutoGeneratePdf],
                 ["Auto-send quote email", autoSendQuoteEmail, setAutoSendQuoteEmail],
-              ] as Array<[string, boolean, (next: boolean) => void]>).map(
-                ([label, value, setter]) => (
-                  <label
-                    key={label}
-                    className="flex items-center gap-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={value}
-                      onChange={(e) => setter(e.target.checked)}
-                    />
-                    {label}
-                  </label>
-                ),
-              )}
+              ] as Array<[string, boolean, (next: boolean) => void]>).map(([label, value, setter]) => (
+                <label key={label} className="flex items-center gap-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2">
+                  <input type="checkbox" checked={value} onChange={(e) => setter(e.target.checked)} />{label}
+                </label>
+              ))}
             </div>
           </Panel>
         </div>
       </section>
-      <OwnerPinModal
-        shopId={shopId}
-        open={pinModalOpen}
-        onClose={() => setPinModalOpen(false)}
-        onVerified={(iso) => setPinExpiresAt(iso)}
-      />
+      <OwnerPinModal shopId={shopId} open={pinModalOpen} onClose={() => setPinModalOpen(false)} onVerified={(iso) => setPinExpiresAt(iso)} />
     </div>
   );
 }
 
-function Panel({
-  title,
-  children,
-}: {
-  title: string;
-  children: React.ReactNode;
-}) {
+function Panel({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4">
-      <h3 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">
-        {title}
-      </h3>
+      <h3 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">{title}</h3>
       {children}
     </section>
   );

--- a/features/onboarding-v2/components/ShopSettingsSetupModal.tsx
+++ b/features/onboarding-v2/components/ShopSettingsSetupModal.tsx
@@ -6,10 +6,22 @@ import { Input } from "@/features/shared/components/ui/input";
 import { Button } from "@/features/shared/components/ui/Button";
 import OwnerPinModal from "@/features/shared/components/OwnerPinModal";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import {
+  defaultShopTimezone,
+  getSupportedShopTimezones,
+  isSupportedShopTimezone,
+  type ShopCountryCode,
+} from "@/features/shared/lib/timezones/shopTimezones";
 import type { GuidedOnboardingSessionDetail } from "@/features/onboarding-v2/guided/types";
 
-type CountryCode = "US" | "CA";
 type SuppliesType = "percentage" | "flat";
+
+type OwnerPinStatus = {
+  ok?: boolean;
+  verified?: boolean;
+  shopId?: string;
+  expiresAt?: string;
+};
 
 export type OnboardingHourRow = {
   weekday: number;
@@ -24,18 +36,6 @@ type Props = {
   onClose: () => void;
   onCompleted: (detail: GuidedOnboardingSessionDetail) => void;
 };
-
-const TIMEZONES = [
-  "America/New_York",
-  "America/Chicago",
-  "America/Denver",
-  "America/Edmonton",
-  "America/Phoenix",
-  "America/Los_Angeles",
-  "America/Vancouver",
-  "America/Toronto",
-  "America/Halifax",
-] as const;
 
 const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -61,16 +61,32 @@ async function readJsonError(response: Response, fallback: string) {
 }
 
 async function completeStep(sessionId: string, action: "complete" | "skip") {
-  const response = await fetch(`/api/onboarding-v2/guided/sessions/${encodeURIComponent(sessionId)}/steps/shop_settings/${action}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(action === "complete" ? { summary: { savedSettings: true } } : { skippedReason: "Shop settings skipped during onboarding." }),
-  });
-  if (!response.ok) throw new Error(await readJsonError(response, "Unable to update Shop Settings onboarding step."));
+  const response = await fetch(
+    `/api/onboarding-v2/guided/sessions/${encodeURIComponent(sessionId)}/steps/shop_settings/${action}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        action === "complete"
+          ? { summary: { savedSettings: true } }
+          : { skippedReason: "Shop settings skipped during onboarding." },
+      ),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      await readJsonError(response, "Unable to update Shop Settings onboarding step."),
+    );
+  }
   return (await response.json()) as GuidedOnboardingSessionDetail;
 }
 
-export default function ShopSettingsSetupModal({ sessionId, open, onClose, onCompleted }: Props) {
+export default function ShopSettingsSetupModal({
+  sessionId,
+  open,
+  onClose,
+  onCompleted,
+}: Props) {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -80,8 +96,8 @@ export default function ShopSettingsSetupModal({ sessionId, open, onClose, onCom
   const [now, setNow] = useState(() => Date.now());
 
   const [shopName, setShopName] = useState("");
-  const [country, setCountry] = useState<CountryCode>("US");
-  const [timezone, setTimezone] = useState("America/New_York");
+  const [country, setCountry] = useState<ShopCountryCode>("US");
+  const [timezone, setTimezone] = useState(defaultShopTimezone("US"));
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
   const [address, setAddress] = useState("");
@@ -92,17 +108,27 @@ export default function ShopSettingsSetupModal({ sessionId, open, onClose, onCom
   const [diagnosticFee, setDiagnosticFee] = useState("");
   const [taxRate, setTaxRate] = useState("");
   const [shopSuppliesEnabled, setShopSuppliesEnabled] = useState(false);
-  const [shopSuppliesType, setShopSuppliesType] = useState<SuppliesType>("percentage");
+  const [shopSuppliesType, setShopSuppliesType] =
+    useState<SuppliesType>("percentage");
   const [shopSuppliesPercent, setShopSuppliesPercent] = useState("");
   const [shopSuppliesFlatAmount, setShopSuppliesFlatAmount] = useState("");
   const [shopSuppliesCapAmount, setShopSuppliesCapAmount] = useState("");
-  const [hours, setHours] = useState<OnboardingHourRow[]>(DEFAULT_ONBOARDING_HOURS);
+  const [hours, setHours] = useState<OnboardingHourRow[]>(
+    DEFAULT_ONBOARDING_HOURS,
+  );
   const [requireCauseCorrection, setRequireCauseCorrection] = useState(false);
   const [requireAuthorization, setRequireAuthorization] = useState(false);
   const [autoGeneratePdf, setAutoGeneratePdf] = useState(false);
   const [autoSendQuoteEmail, setAutoSendQuoteEmail] = useState(false);
 
-  const isUnlocked = useMemo(() => Boolean(pinExpiresAt && new Date(pinExpiresAt).getTime() > now), [pinExpiresAt, now]);
+  const timezoneOptions = useMemo(
+    () => getSupportedShopTimezones(country),
+    [country],
+  );
+  const isUnlocked = useMemo(
+    () => Boolean(pinExpiresAt && new Date(pinExpiresAt).getTime() > now),
+    [pinExpiresAt, now],
+  );
 
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), 1000);
@@ -113,57 +139,150 @@ export default function ShopSettingsSetupModal({ sessionId, open, onClose, onCom
     if (!open) return;
     setLoading(true);
     try {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user?.id) throw new Error("Sign in is required to load shop settings.");
-      const { data: profile, error: profileError } = await supabase.from("profiles").select("shop_id").eq("id", user.id).maybeSingle<{ shop_id: string | null }>();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user?.id) {
+        throw new Error("Sign in is required to load shop settings.");
+      }
+
+      const { data: profile, error: profileError } = await supabase
+        .from("profiles")
+        .select("shop_id")
+        .eq("id", user.id)
+        .maybeSingle<{ shop_id: string | null }>();
       if (profileError) throw profileError;
-      if (!profile?.shop_id) throw new Error("No shop is associated with this profile.");
+      if (!profile?.shop_id) {
+        throw new Error("No shop is associated with this profile.");
+      }
       setShopId(profile.shop_id);
 
-      const { data: shop, error: shopError } = await supabase.from("shops").select("*").eq("id", profile.shop_id).maybeSingle<Record<string, unknown>>();
+      const { data: shop, error: shopError } = await supabase
+        .from("shops")
+        .select("*")
+        .eq("id", profile.shop_id)
+        .maybeSingle<Record<string, unknown>>();
       if (shopError) throw shopError;
       if (shop) {
+        const shopCountry: ShopCountryCode = shop.country === "CA" ? "CA" : "US";
+        const storedTimezone = String(shop.timezone ?? "").trim();
         setShopName(String(shop.shop_name ?? shop.name ?? shop.business_name ?? ""));
-        setCountry(shop.country === "CA" ? "CA" : "US");
-        setTimezone(String(shop.timezone ?? "America/New_York"));
+        setCountry(shopCountry);
+        setTimezone(
+          isSupportedShopTimezone(shopCountry, storedTimezone)
+            ? storedTimezone
+            : defaultShopTimezone(shopCountry),
+        );
         setPhone(String(shop.phone_number ?? ""));
         setEmail(String(shop.email ?? ""));
         setAddress(String(shop.street ?? shop.address ?? ""));
         setCity(String(shop.city ?? ""));
         setProvince(String(shop.province ?? ""));
         setPostalCode(String(shop.postal_code ?? ""));
-        setLaborRate(typeof shop.labor_rate === "number" ? String(shop.labor_rate) : "");
-        setDiagnosticFee(typeof shop.diagnostic_fee === "number" ? String(shop.diagnostic_fee) : "");
-        setTaxRate(typeof shop.tax_rate === "number" ? String(shop.tax_rate) : "");
-        setShopSuppliesEnabled(Boolean(shop.shop_supplies_enabled ?? (typeof shop.supplies_percent === "number" && shop.supplies_percent > 0)));
-        setShopSuppliesType(shop.shop_supplies_type === "flat" ? "flat" : "percentage");
-        setShopSuppliesPercent(typeof shop.shop_supplies_percent === "number" ? String(shop.shop_supplies_percent) : typeof shop.supplies_percent === "number" ? String(shop.supplies_percent) : "");
-        setShopSuppliesFlatAmount(typeof shop.shop_supplies_flat_amount === "number" ? String(shop.shop_supplies_flat_amount) : "");
-        setShopSuppliesCapAmount(typeof shop.shop_supplies_cap_amount === "number" ? String(shop.shop_supplies_cap_amount) : "");
+        setLaborRate(
+          typeof shop.labor_rate === "number" ? String(shop.labor_rate) : "",
+        );
+        setDiagnosticFee(
+          typeof shop.diagnostic_fee === "number"
+            ? String(shop.diagnostic_fee)
+            : "",
+        );
+        setTaxRate(
+          typeof shop.tax_rate === "number" ? String(shop.tax_rate) : "",
+        );
+        setShopSuppliesEnabled(
+          Boolean(
+            shop.shop_supplies_enabled ??
+              (typeof shop.supplies_percent === "number" &&
+                shop.supplies_percent > 0),
+          ),
+        );
+        setShopSuppliesType(
+          shop.shop_supplies_type === "flat" ? "flat" : "percentage",
+        );
+        setShopSuppliesPercent(
+          typeof shop.shop_supplies_percent === "number"
+            ? String(shop.shop_supplies_percent)
+            : typeof shop.supplies_percent === "number"
+              ? String(shop.supplies_percent)
+              : "",
+        );
+        setShopSuppliesFlatAmount(
+          typeof shop.shop_supplies_flat_amount === "number"
+            ? String(shop.shop_supplies_flat_amount)
+            : "",
+        );
+        setShopSuppliesCapAmount(
+          typeof shop.shop_supplies_cap_amount === "number"
+            ? String(shop.shop_supplies_cap_amount)
+            : "",
+        );
         setRequireCauseCorrection(Boolean(shop.require_cause_correction));
         setRequireAuthorization(Boolean(shop.require_authorization));
         setAutoGeneratePdf(Boolean(shop.auto_generate_pdf));
         setAutoSendQuoteEmail(Boolean(shop.auto_send_quote_email));
       }
 
-      const hoursResponse = await fetch("/api/settings/hours", { cache: "no-store" });
+      // bootstrap-owner just established a privileged 30-minute PIN cookie.
+      // Read only its verified/expiry state; the HTTP-only token itself never
+      // crosses into client JavaScript.
+      const pinStatusResponse = await fetch("/api/shop/owner-pin/verify", {
+        method: "GET",
+        cache: "no-store",
+      });
+      if (pinStatusResponse.ok) {
+        const pinStatus = (await pinStatusResponse.json()) as OwnerPinStatus;
+        if (
+          pinStatus.verified &&
+          pinStatus.shopId === profile.shop_id &&
+          pinStatus.expiresAt
+        ) {
+          setPinExpiresAt(pinStatus.expiresAt);
+        } else {
+          setPinExpiresAt(undefined);
+        }
+      }
+
+      const hoursResponse = await fetch("/api/settings/hours", {
+        cache: "no-store",
+      });
       if (hoursResponse.ok) {
-        const payload = (await hoursResponse.json()) as { hours?: OnboardingHourRow[] };
+        const payload = (await hoursResponse.json()) as {
+          hours?: OnboardingHourRow[];
+        };
         if (Array.isArray(payload.hours) && payload.hours.length > 0) {
-          const byDay = new Map(payload.hours.map((row) => [row.weekday, row]));
-          setHours(DEFAULT_ONBOARDING_HOURS.map((fallback) => ({ ...fallback, ...(byDay.get(fallback.weekday) ?? {}) })));
+          const byDay = new Map(
+            payload.hours.map((row) => [row.weekday, row]),
+          );
+          setHours(
+            DEFAULT_ONBOARDING_HOURS.map((fallback) => ({
+              ...fallback,
+              ...(byDay.get(fallback.weekday) ?? {}),
+            })),
+          );
         } else {
           setHours(DEFAULT_ONBOARDING_HOURS);
         }
       }
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Unable to load shop settings.");
+      toast.error(
+        error instanceof Error ? error.message : "Unable to load shop settings.",
+      );
     } finally {
       setLoading(false);
     }
   }, [open, supabase]);
 
-  useEffect(() => { void loadSettings(); }, [loadSettings]);
+  useEffect(() => {
+    void loadSettings();
+  }, [loadSettings]);
+
+  function changeCountry(nextCountry: ShopCountryCode) {
+    setCountry(nextCountry);
+    if (!isSupportedShopTimezone(nextCountry, timezone)) {
+      setTimezone(defaultShopTimezone(nextCountry));
+    }
+  }
 
   async function save() {
     if (!shopId) return;
@@ -192,7 +311,10 @@ export default function ShopSettingsSetupModal({ sessionId, open, onClose, onCom
             phone_number: phone,
             email,
             labor_rate: asNumber(laborRate),
-            supplies_percent: shopSuppliesType === "percentage" ? asNumber(shopSuppliesPercent) : null,
+            supplies_percent:
+              shopSuppliesType === "percentage"
+                ? asNumber(shopSuppliesPercent)
+                : null,
             shop_supplies_enabled: shopSuppliesEnabled,
             shop_supplies_type: shopSuppliesType,
             shop_supplies_percent: asNumber(shopSuppliesPercent),
@@ -207,7 +329,11 @@ export default function ShopSettingsSetupModal({ sessionId, open, onClose, onCom
           },
         }),
       });
-      if (!updateResponse.ok) throw new Error(await readJsonError(updateResponse, "Failed to save shop settings."));
+      if (!updateResponse.ok) {
+        throw new Error(
+          await readJsonError(updateResponse, "Failed to save shop settings."),
+        );
+      }
 
       const openDays = hours.filter((hour) => !hour.closed);
       const hoursResponse = await fetch("/api/settings/hours", {
@@ -215,14 +341,20 @@ export default function ShopSettingsSetupModal({ sessionId, open, onClose, onCom
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ shopId, hours: openDays }),
       });
-      if (!hoursResponse.ok) throw new Error(await readJsonError(hoursResponse, "Failed to save shop hours."));
+      if (!hoursResponse.ok) {
+        throw new Error(
+          await readJsonError(hoursResponse, "Failed to save shop hours."),
+        );
+      }
 
       const detail = await completeStep(sessionId, "complete");
       onCompleted(detail);
       onClose();
       toast.success("Shop Settings saved and onboarding updated.");
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Unable to save Shop Settings.");
+      toast.error(
+        error instanceof Error ? error.message : "Unable to save Shop Settings.",
+      );
     } finally {
       setSaving(false);
     }
@@ -236,7 +368,9 @@ export default function ShopSettingsSetupModal({ sessionId, open, onClose, onCom
       onClose();
       toast.success("Shop Settings skipped for now.");
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Unable to skip Shop Settings.");
+      toast.error(
+        error instanceof Error ? error.message : "Unable to skip Shop Settings.",
+      );
     } finally {
       setSaving(false);
     }
@@ -247,62 +381,246 @@ export default function ShopSettingsSetupModal({ sessionId, open, onClose, onCom
   const provinceLabel = country === "CA" ? "Province" : "State";
   const postalLabel = country === "CA" ? "Postal code" : "ZIP code";
   const currency = country === "CA" ? "CAD" : "USD";
-  const inputClass = "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)]";
+  const inputClass =
+    "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)]";
 
   return (
     <div className="fixed inset-0 z-[90] overflow-y-auto bg-[color:var(--theme-surface-overlay)] p-4 backdrop-blur-sm">
       <section className="mx-auto my-6 max-w-5xl rounded-[2rem] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-5 text-[color:var(--theme-text-primary)] shadow-2xl">
         <div className="flex flex-col gap-3 border-b border-[color:var(--theme-border-soft)] pb-4 md:flex-row md:items-start md:justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">Guided onboarding · Shop Settings</p>
-            <h2 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">Confirm setup-critical shop defaults</h2>
-            <p className="mt-2 max-w-3xl text-sm text-[color:var(--theme-text-secondary)]">These focused settings keep quotes, invoices, approvals, and booking hours ready without leaving guided onboarding.</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-orange-200/85">
+              Guided onboarding · Shop Settings
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+              Confirm setup-critical shop defaults
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm text-[color:var(--theme-text-secondary)]">
+              These focused settings keep quotes, invoices, approvals, and booking
+              hours ready without leaving guided onboarding.
+            </p>
           </div>
           <div className="flex gap-2">
-            <Button type="button" variant="secondary" onClick={onClose} disabled={saving}>Close</Button>
-            <Button type="button" variant="secondary" onClick={skip} disabled={saving}>Skip for now</Button>
-            <Button type="button" onClick={save} disabled={saving || loading}>{saving ? "Saving..." : isUnlocked ? "Save Shop Settings" : "Unlock & save"}</Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Close
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={skip}
+              disabled={saving}
+            >
+              Skip for now
+            </Button>
+            <Button
+              type="button"
+              onClick={save}
+              disabled={saving || loading}
+            >
+              {saving
+                ? "Saving..."
+                : isUnlocked
+                  ? "Save Shop Settings"
+                  : "Unlock & save"}
+            </Button>
           </div>
         </div>
 
-        {loading ? <div className="mt-5 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">Loading current shop settings…</div> : null}
+        {loading ? (
+          <div className="mt-5 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+            Loading current shop settings…
+          </div>
+        ) : null}
 
         <div className="mt-5 grid gap-5 lg:grid-cols-2">
           <Panel title="Business">
             <div className="grid gap-3 md:grid-cols-2">
-              <Input className={inputClass} value={shopName} onChange={(e) => setShopName(e.target.value)} placeholder="Shop name" />
-              <select value={country} onChange={(e) => setCountry(e.target.value as CountryCode)} className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]"><option value="US">United States</option><option value="CA">Canada</option></select>
-              <select value={timezone} onChange={(e) => setTimezone(e.target.value)} className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]">{TIMEZONES.map((tz) => <option key={tz} value={tz}>{tz}</option>)}</select>
-              <Input className={inputClass} value={phone} onChange={(e) => setPhone(e.target.value)} placeholder="Phone" />
-              <Input className={inputClass} value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
-              <Input className={inputClass} value={address} onChange={(e) => setAddress(e.target.value)} placeholder="Street address" />
-              <Input className={inputClass} value={city} onChange={(e) => setCity(e.target.value)} placeholder="City" />
-              <Input className={inputClass} value={province} onChange={(e) => setProvince(e.target.value)} placeholder={provinceLabel} />
-              <Input className={inputClass} value={postalCode} onChange={(e) => setPostalCode(e.target.value)} placeholder={postalLabel} />
+              <Input
+                className={inputClass}
+                value={shopName}
+                onChange={(e) => setShopName(e.target.value)}
+                placeholder="Shop name"
+              />
+              <select
+                value={country}
+                onChange={(e) => changeCountry(e.target.value as ShopCountryCode)}
+                className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]"
+              >
+                <option value="US">United States</option>
+                <option value="CA">Canada</option>
+              </select>
+              <select
+                value={timezone}
+                onChange={(e) => setTimezone(e.target.value)}
+                className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]"
+              >
+                {timezoneOptions.map((tz) => (
+                  <option key={tz} value={tz}>
+                    {tz}
+                  </option>
+                ))}
+              </select>
+              <Input
+                className={inputClass}
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                placeholder="Phone"
+              />
+              <Input
+                className={inputClass}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Email"
+              />
+              <Input
+                className={inputClass}
+                value={address}
+                onChange={(e) => setAddress(e.target.value)}
+                placeholder="Street address"
+              />
+              <Input
+                className={inputClass}
+                value={city}
+                onChange={(e) => setCity(e.target.value)}
+                placeholder="City"
+              />
+              <Input
+                className={inputClass}
+                value={province}
+                onChange={(e) => setProvince(e.target.value)}
+                placeholder={provinceLabel}
+              />
+              <Input
+                className={inputClass}
+                value={postalCode}
+                onChange={(e) => setPostalCode(e.target.value)}
+                placeholder={postalLabel}
+              />
             </div>
           </Panel>
 
           <Panel title="Operations">
             <div className="grid gap-3 md:grid-cols-2">
-              <Input className={inputClass} value={laborRate} onChange={(e) => setLaborRate(e.target.value)} placeholder={`Labor rate (${currency}/hr)`} />
-              <Input className={inputClass} value={diagnosticFee} onChange={(e) => setDiagnosticFee(e.target.value)} placeholder={`Diagnostic fee (${currency})`} />
-              <Input className={inputClass} value={taxRate} onChange={(e) => setTaxRate(e.target.value)} placeholder="Tax rate (%)" />
-              <label className="flex items-center gap-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm"><input type="checkbox" checked={shopSuppliesEnabled} onChange={(e) => setShopSuppliesEnabled(e.target.checked)} /> Shop supplies enabled</label>
-              <select value={shopSuppliesType} onChange={(e) => setShopSuppliesType(e.target.value === "flat" ? "flat" : "percentage")} className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]"><option value="percentage">Percentage</option><option value="flat">Flat amount</option></select>
-              <Input className={inputClass} value={shopSuppliesPercent} onChange={(e) => setShopSuppliesPercent(e.target.value)} placeholder="Shop supplies (%)" />
-              <Input className={inputClass} value={shopSuppliesFlatAmount} onChange={(e) => setShopSuppliesFlatAmount(e.target.value)} placeholder={`Shop supplies flat (${currency})`} />
-              <Input className={inputClass} value={shopSuppliesCapAmount} onChange={(e) => setShopSuppliesCapAmount(e.target.value)} placeholder={`Supplies cap (${currency})`} />
+              <Input
+                className={inputClass}
+                value={laborRate}
+                onChange={(e) => setLaborRate(e.target.value)}
+                placeholder={`Labor rate (${currency}/hr)`}
+              />
+              <Input
+                className={inputClass}
+                value={diagnosticFee}
+                onChange={(e) => setDiagnosticFee(e.target.value)}
+                placeholder={`Diagnostic fee (${currency})`}
+              />
+              <Input
+                className={inputClass}
+                value={taxRate}
+                onChange={(e) => setTaxRate(e.target.value)}
+                placeholder="Tax rate (%)"
+              />
+              <label className="flex items-center gap-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={shopSuppliesEnabled}
+                  onChange={(e) => setShopSuppliesEnabled(e.target.checked)}
+                />{" "}
+                Shop supplies enabled
+              </label>
+              <select
+                value={shopSuppliesType}
+                onChange={(e) =>
+                  setShopSuppliesType(
+                    e.target.value === "flat" ? "flat" : "percentage",
+                  )
+                }
+                className="h-10 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-sm text-[color:var(--theme-text-primary)]"
+              >
+                <option value="percentage">Percentage</option>
+                <option value="flat">Flat amount</option>
+              </select>
+              <Input
+                className={inputClass}
+                value={shopSuppliesPercent}
+                onChange={(e) => setShopSuppliesPercent(e.target.value)}
+                placeholder="Shop supplies (%)"
+              />
+              <Input
+                className={inputClass}
+                value={shopSuppliesFlatAmount}
+                onChange={(e) => setShopSuppliesFlatAmount(e.target.value)}
+                placeholder={`Shop supplies flat (${currency})`}
+              />
+              <Input
+                className={inputClass}
+                value={shopSuppliesCapAmount}
+                onChange={(e) => setShopSuppliesCapAmount(e.target.value)}
+                placeholder={`Supplies cap (${currency})`}
+              />
             </div>
           </Panel>
 
           <Panel title="Hours">
             <div className="divide-y divide-[color:var(--theme-border-soft)] rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]">
               {hours.map((row, idx) => (
-                <div key={row.weekday} className="grid gap-3 p-3 md:grid-cols-[70px_110px_1fr_1fr] md:items-center">
-                  <div className="text-sm font-semibold">{WEEKDAYS[row.weekday]}</div>
-                  <label className="flex items-center gap-2 text-sm"><input type="checkbox" checked={!!row.closed} onChange={(e) => setHours((prev) => prev.map((h, i) => i === idx ? { ...h, closed: e.target.checked } : h))} /> Closed</label>
-                  <input type="time" className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-sm" value={row.open_time} disabled={!!row.closed} onChange={(e) => setHours((prev) => prev.map((h, i) => i === idx ? { ...h, open_time: e.target.value } : h))} />
-                  <input type="time" className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-sm" value={row.close_time} disabled={!!row.closed} onChange={(e) => setHours((prev) => prev.map((h, i) => i === idx ? { ...h, close_time: e.target.value } : h))} />
+                <div
+                  key={row.weekday}
+                  className="grid gap-3 p-3 md:grid-cols-[70px_110px_1fr_1fr] md:items-center"
+                >
+                  <div className="text-sm font-semibold">
+                    {WEEKDAYS[row.weekday]}
+                  </div>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={!!row.closed}
+                      onChange={(e) =>
+                        setHours((prev) =>
+                          prev.map((hour, i) =>
+                            i === idx
+                              ? { ...hour, closed: e.target.checked }
+                              : hour,
+                          ),
+                        )
+                      }
+                    />{" "}
+                    Closed
+                  </label>
+                  <input
+                    type="time"
+                    className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-sm"
+                    value={row.open_time}
+                    disabled={!!row.closed}
+                    onChange={(e) =>
+                      setHours((prev) =>
+                        prev.map((hour, i) =>
+                          i === idx
+                            ? { ...hour, open_time: e.target.value }
+                            : hour,
+                        ),
+                      )
+                    }
+                  />
+                  <input
+                    type="time"
+                    className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-sm"
+                    value={row.close_time}
+                    disabled={!!row.closed}
+                    onChange={(e) =>
+                      setHours((prev) =>
+                        prev.map((hour, i) =>
+                          i === idx
+                            ? { ...hour, close_time: e.target.value }
+                            : hour,
+                        ),
+                      )
+                    }
+                  />
                 </div>
               ))}
             </div>
@@ -311,25 +629,60 @@ export default function ShopSettingsSetupModal({ sessionId, open, onClose, onCom
           <Panel title="Workflow">
             <div className="space-y-3 text-sm">
               {([
-                ["Require cause / correction on lines", requireCauseCorrection, setRequireCauseCorrection],
-                ["Require customer authorization", requireAuthorization, setRequireAuthorization],
+                [
+                  "Require cause / correction on lines",
+                  requireCauseCorrection,
+                  setRequireCauseCorrection,
+                ],
+                [
+                  "Require customer authorization",
+                  requireAuthorization,
+                  setRequireAuthorization,
+                ],
                 ["Auto-generate quote PDF", autoGeneratePdf, setAutoGeneratePdf],
                 ["Auto-send quote email", autoSendQuoteEmail, setAutoSendQuoteEmail],
-              ] as Array<[string, boolean, (next: boolean) => void]>).map(([label, value, setter]) => (
-                <label key={String(label)} className="flex items-center gap-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2">
-                  <input type="checkbox" checked={Boolean(value)} onChange={(e) => setter(e.target.checked)} />
-                  {label}
-                </label>
-              ))}
+              ] as Array<[string, boolean, (next: boolean) => void]>).map(
+                ([label, value, setter]) => (
+                  <label
+                    key={label}
+                    className="flex items-center gap-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={value}
+                      onChange={(e) => setter(e.target.checked)}
+                    />
+                    {label}
+                  </label>
+                ),
+              )}
             </div>
           </Panel>
         </div>
       </section>
-      <OwnerPinModal shopId={shopId} open={pinModalOpen} onClose={() => setPinModalOpen(false)} onVerified={(iso) => setPinExpiresAt(iso)} />
+      <OwnerPinModal
+        shopId={shopId}
+        open={pinModalOpen}
+        onClose={() => setPinModalOpen(false)}
+        onVerified={(iso) => setPinExpiresAt(iso)}
+      />
     </div>
   );
 }
 
-function Panel({ title, children }: { title: string; children: React.ReactNode }) {
-  return <section className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4"><h3 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">{title}</h3>{children}</section>;
+function Panel({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4">
+      <h3 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
 }

--- a/features/shared/lib/timezones/shopTimezones.ts
+++ b/features/shared/lib/timezones/shopTimezones.ts
@@ -84,8 +84,8 @@ export function isSupportedShopTimezone(
 export function shopCountryForTimezone(
   timezone: string,
 ): ShopCountryCode | null {
-  if (CANADA_SHOP_TIMEZONES.includes(timezone)) return "CA";
-  if (US_SHOP_TIMEZONES.includes(timezone)) return "US";
+  if ((CANADA_SHOP_TIMEZONES as readonly string[]).includes(timezone)) return "CA";
+  if ((US_SHOP_TIMEZONES as readonly string[]).includes(timezone)) return "US";
   return null;
 }
 

--- a/features/shared/lib/timezones/shopTimezones.ts
+++ b/features/shared/lib/timezones/shopTimezones.ts
@@ -81,6 +81,14 @@ export function isSupportedShopTimezone(
   return TIMEZONES_BY_COUNTRY[country].includes(timezone);
 }
 
+export function shopCountryForTimezone(
+  timezone: string,
+): ShopCountryCode | null {
+  if (CANADA_SHOP_TIMEZONES.includes(timezone)) return "CA";
+  if (US_SHOP_TIMEZONES.includes(timezone)) return "US";
+  return null;
+}
+
 export function defaultShopTimezone(country: ShopCountryCode): string {
   return country === "CA" ? "America/Edmonton" : "America/Denver";
 }

--- a/features/shared/lib/timezones/shopTimezones.ts
+++ b/features/shared/lib/timezones/shopTimezones.ts
@@ -1,0 +1,86 @@
+export type ShopCountryCode = "US" | "CA";
+
+export const US_SHOP_TIMEZONES = [
+  "America/New_York",
+  "America/Detroit",
+  "America/Kentucky/Louisville",
+  "America/Kentucky/Monticello",
+  "America/Indiana/Indianapolis",
+  "America/Indiana/Vincennes",
+  "America/Indiana/Winamac",
+  "America/Indiana/Marengo",
+  "America/Indiana/Petersburg",
+  "America/Indiana/Vevay",
+  "America/Chicago",
+  "America/Indiana/Knox",
+  "America/Indiana/Tell_City",
+  "America/Menominee",
+  "America/North_Dakota/Center",
+  "America/North_Dakota/New_Salem",
+  "America/North_Dakota/Beulah",
+  "America/Denver",
+  "America/Boise",
+  "America/Phoenix",
+  "America/Los_Angeles",
+  "America/Anchorage",
+  "America/Juneau",
+  "America/Sitka",
+  "America/Metlakatla",
+  "America/Yakutat",
+  "America/Nome",
+  "America/Adak",
+  "Pacific/Honolulu",
+] as const;
+
+export const CANADA_SHOP_TIMEZONES = [
+  "America/St_Johns",
+  "America/Halifax",
+  "America/Moncton",
+  "America/Glace_Bay",
+  "America/Goose_Bay",
+  "America/Blanc-Sablon",
+  "America/Toronto",
+  "America/Nipigon",
+  "America/Thunder_Bay",
+  "America/Iqaluit",
+  "America/Pangnirtung",
+  "America/Winnipeg",
+  "America/Rainy_River",
+  "America/Rankin_Inlet",
+  "America/Resolute",
+  "America/Regina",
+  "America/Swift_Current",
+  "America/Edmonton",
+  "America/Cambridge_Bay",
+  "America/Yellowknife",
+  "America/Inuvik",
+  "America/Creston",
+  "America/Dawson_Creek",
+  "America/Fort_Nelson",
+  "America/Vancouver",
+  "America/Whitehorse",
+  "America/Dawson",
+  "America/Atikokan",
+] as const;
+
+const TIMEZONES_BY_COUNTRY: Record<ShopCountryCode, readonly string[]> = {
+  US: US_SHOP_TIMEZONES,
+  CA: CANADA_SHOP_TIMEZONES,
+};
+
+export function getSupportedShopTimezones(
+  country: ShopCountryCode,
+): readonly string[] {
+  return TIMEZONES_BY_COUNTRY[country];
+}
+
+export function isSupportedShopTimezone(
+  country: ShopCountryCode,
+  timezone: string,
+): boolean {
+  return TIMEZONES_BY_COUNTRY[country].includes(timezone);
+}
+
+export function defaultShopTimezone(country: ShopCountryCode): string {
+  return country === "CA" ? "America/Edmonton" : "America/Denver";
+}

--- a/features/stripe/api/stripe/checkout/acquisition-context/route.ts
+++ b/features/stripe/api/stripe/checkout/acquisition-context/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+
+import { enforceAuthRateLimit } from "@/features/auth/server/authRateLimit";
+import { createStripeClient } from "@/features/stripe/lib/stripe/client";
+import { isStripeSubscriptionAccessBearing } from "@/features/stripe/lib/stripe/subscriptionStatus";
+import {
+  getStripeCheckoutEmail,
+  getStripeCheckoutPriceId,
+  getStripeCheckoutSubscription,
+  isCompletedStripeAcquisitionSession,
+  readStripeAcquisitionMetadata,
+} from "@/features/stripe/lib/server/stripe-acquisition-intent";
+
+const CHECKOUT_SESSION_PATTERN = /^cs_[A-Za-z0-9_]+$/;
+
+function noStoreJson(body: unknown, status = 200, extraHeaders?: HeadersInit) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      "Referrer-Policy": "no-referrer",
+      "X-Content-Type-Options": "nosniff",
+      ...extraHeaders,
+    },
+  });
+}
+
+export async function handleStripeAcquisitionContext(req: Request) {
+  const sessionId =
+    new URL(req.url).searchParams.get("session_id")?.trim() ?? "";
+  if (!CHECKOUT_SESSION_PATTERN.test(sessionId)) {
+    return noStoreJson({ error: "Invalid checkout session" }, 400);
+  }
+
+  const rateLimit = enforceAuthRateLimit(
+    req,
+    "stripe-acquisition-context",
+    sessionId,
+    {
+      max: 10,
+      windowMs: 60_000,
+    },
+  );
+  if (!rateLimit.allowed) {
+    return noStoreJson({ error: "Too many requests" }, 429, {
+      "Retry-After": String(rateLimit.retryAfterSeconds),
+    });
+  }
+
+  try {
+    const secretKey = String(process.env.STRIPE_SECRET_KEY ?? "").trim();
+    if (!secretKey) return noStoreJson({ error: "Billing unavailable" }, 503);
+
+    const stripe = createStripeClient(secretKey);
+    const session = await stripe.checkout.sessions.retrieve(sessionId, {
+      expand: ["subscription", "customer"],
+    });
+    const metadata = readStripeAcquisitionMetadata(session.metadata);
+    if (!metadata || !isCompletedStripeAcquisitionSession(session)) {
+      return noStoreJson(
+        { error: "Checkout is not eligible for account setup" },
+        400,
+      );
+    }
+
+    const [priceId, checkoutEmail, subscription] = await Promise.all([
+      getStripeCheckoutPriceId(stripe, session.id),
+      getStripeCheckoutEmail(stripe, session),
+      getStripeCheckoutSubscription(stripe, session),
+    ]);
+    if (
+      priceId !== metadata.priceId ||
+      !checkoutEmail ||
+      !subscription ||
+      !isStripeSubscriptionAccessBearing(subscription.status)
+    ) {
+      return noStoreJson(
+        { error: "Checkout is not eligible for account setup" },
+        400,
+      );
+    }
+
+    return noStoreJson({ email: checkoutEmail });
+  } catch (error) {
+    console.error("stripe_acquisition_context_failed", {
+      name: error instanceof Error ? error.name : "UnknownError",
+    });
+    return noStoreJson({ error: "Checkout verification unavailable" }, 503);
+  }
+}
+
+export async function GET(req: Request) {
+  return handleStripeAcquisitionContext(req);
+}

--- a/features/stripe/api/stripe/checkout/link-user/route.ts
+++ b/features/stripe/api/stripe/checkout/link-user/route.ts
@@ -7,18 +7,22 @@ import {
   createServerSupabaseRoute,
 } from "@/features/shared/lib/supabase/server";
 import { createStripeClient } from "@/features/stripe/lib/stripe/client";
+import { isStripeSubscriptionAccessBearing } from "@/features/stripe/lib/stripe/subscriptionStatus";
 import { reconcileShopBillingFromUser } from "@/features/stripe/lib/server/canonical-shop-billing";
 import {
   claimStripeAcquisitionIntent,
   getStripeCheckoutEmail,
   getStripeCheckoutPriceId,
+  getStripeCheckoutSubscription,
   isCompletedStripeAcquisitionSession,
   readStripeAcquisitionMetadata,
   toStripeId,
 } from "@/features/stripe/lib/server/stripe-acquisition-intent";
 
 const REQUEST_MAX_BYTES = 2 * 1024;
-const requestSchema = z.object({ sessionId: z.string().regex(/^cs_[A-Za-z0-9_]+$/) }).strict();
+const requestSchema = z
+  .object({ sessionId: z.string().regex(/^cs_[A-Za-z0-9_]+$/) })
+  .strict();
 
 function noStoreJson(body: unknown, status = 200) {
   return NextResponse.json(body, {
@@ -28,8 +32,13 @@ function noStoreJson(body: unknown, status = 200) {
 }
 
 function claimFailureStatus(reason: string): number {
-  if (reason === "email_mismatch" || reason === "billing_role_required") return 403;
-  if (reason.includes("conflict") || reason.includes("linked") || reason === "intent_consumed") {
+  if (reason === "email_mismatch" || reason === "billing_role_required")
+    return 403;
+  if (
+    reason.includes("conflict") ||
+    reason.includes("linked") ||
+    reason === "intent_consumed"
+  ) {
     return 409;
   }
   return 400;
@@ -49,25 +58,38 @@ export async function handleStripeCheckoutLinkUser(req: Request) {
     const bounded = await readBoundedJson(req, REQUEST_MAX_BYTES);
     if (!bounded.ok) {
       return noStoreJson(
-        { error: bounded.reason === "too_large" ? "Request too large" : "Invalid request" },
+        {
+          error:
+            bounded.reason === "too_large"
+              ? "Request too large"
+              : "Invalid request",
+        },
         bounded.reason === "too_large" ? 413 : 400,
       );
     }
     const parsed = requestSchema.safeParse(bounded.value);
-    if (!parsed.success) return noStoreJson({ error: "Invalid checkout session" }, 400);
+    if (!parsed.success)
+      return noStoreJson({ error: "Invalid checkout session" }, 400);
 
     const stripe = createStripeClient(secretKey);
-    const session = await stripe.checkout.sessions.retrieve(parsed.data.sessionId, {
-      expand: ["subscription", "customer"],
-    });
+    const session = await stripe.checkout.sessions.retrieve(
+      parsed.data.sessionId,
+      {
+        expand: ["subscription", "customer"],
+      },
+    );
     const metadata = readStripeAcquisitionMetadata(session.metadata);
     if (!metadata || !isCompletedStripeAcquisitionSession(session)) {
-      return noStoreJson({ error: "Checkout is not eligible for account linking" }, 400);
+      return noStoreJson(
+        { error: "Checkout is not eligible for account linking" },
+        400,
+      );
     }
 
-    const [priceId, checkoutEmail] = await Promise.all([
+    const [priceId, checkoutEmail, subscription] = await Promise.all([
       getStripeCheckoutPriceId(stripe, session.id),
       getStripeCheckoutEmail(stripe, session),
+      getStripeCheckoutSubscription(stripe, session),
     ]);
     const customerId = toStripeId(session.customer, "cus_");
     const subscriptionId = toStripeId(session.subscription, "sub_");
@@ -76,9 +98,14 @@ export async function handleStripeCheckoutLinkUser(req: Request) {
       priceId !== metadata.priceId ||
       !checkoutEmail ||
       !customerId ||
-      !subscriptionId
+      !subscriptionId ||
+      !subscription ||
+      !isStripeSubscriptionAccessBearing(subscription.status)
     ) {
-      return noStoreJson({ error: "Checkout identity could not be verified" }, 400);
+      return noStoreJson(
+        { error: "Checkout identity could not be verified" },
+        400,
+      );
     }
 
     const admin = createAdminSupabase();
@@ -128,17 +155,17 @@ export async function handleStripeCheckoutLinkUser(req: Request) {
     await stripe.customers.update(
       customerId,
       { metadata: identityMetadata },
-      { idempotencyKey: `profixiq:acquisition-customer-link:${metadata.intentId}:${user.id}` },
+      {
+        idempotencyKey: `profixiq:acquisition-customer-link:${metadata.intentId}:${user.id}`,
+      },
     );
 
-    const currentSubscription =
-      typeof session.subscription === "object" && session.subscription
-        ? session.subscription
-        : await stripe.subscriptions.retrieve(subscriptionId);
     await stripe.subscriptions.update(
       subscriptionId,
-      { metadata: { ...(currentSubscription.metadata ?? {}), ...identityMetadata } },
-      { idempotencyKey: `profixiq:acquisition-subscription-link:${metadata.intentId}:${user.id}` },
+      { metadata: { ...(subscription.metadata ?? {}), ...identityMetadata } },
+      {
+        idempotencyKey: `profixiq:acquisition-subscription-link:${metadata.intentId}:${user.id}`,
+      },
     );
 
     if (claim.shopId) {

--- a/features/stripe/lib/server/stripe-acquisition-intent.ts
+++ b/features/stripe/lib/server/stripe-acquisition-intent.ts
@@ -81,11 +81,14 @@ export function readStripeAcquisitionMetadata(
   return { intentId, nonce, planKey, priceId };
 }
 
-export function isCompletedStripeAcquisitionSession(session: Stripe.Checkout.Session): boolean {
+export function isCompletedStripeAcquisitionSession(
+  session: Stripe.Checkout.Session,
+): boolean {
   return (
     session.mode === "subscription" &&
     session.status === "complete" &&
-    (session.payment_status === "paid" || session.payment_status === "no_payment_required") &&
+    (session.payment_status === "paid" ||
+      session.payment_status === "no_payment_required") &&
     Boolean(toStripeId(session.customer, "cus_")) &&
     Boolean(toStripeId(session.subscription, "sub_"))
   );
@@ -95,7 +98,9 @@ export async function getStripeCheckoutPriceId(
   stripe: Stripe,
   sessionId: string,
 ): Promise<string | null> {
-  const items = await stripe.checkout.sessions.listLineItems(sessionId, { limit: 2 });
+  const items = await stripe.checkout.sessions.listLineItems(sessionId, {
+    limit: 2,
+  });
   if (items.data.length !== 1 || items.data[0]?.quantity !== 1) return null;
   return toStripeId(items.data[0]?.price, "price_");
 }
@@ -104,11 +109,19 @@ export async function getStripeCheckoutEmail(
   stripe: Stripe,
   session: Stripe.Checkout.Session,
 ): Promise<string | null> {
-  const checkoutEmail = String(session.customer_details?.email ?? "").trim().toLowerCase();
+  const checkoutEmail = String(session.customer_details?.email ?? "")
+    .trim()
+    .toLowerCase();
   if (checkoutEmail) return checkoutEmail;
 
-  if (session.customer && typeof session.customer === "object" && !("deleted" in session.customer)) {
-    const expandedEmail = String(session.customer.email ?? "").trim().toLowerCase();
+  if (
+    session.customer &&
+    typeof session.customer === "object" &&
+    !("deleted" in session.customer)
+  ) {
+    const expandedEmail = String(session.customer.email ?? "")
+      .trim()
+      .toLowerCase();
     if (expandedEmail) return expandedEmail;
   }
 
@@ -116,7 +129,23 @@ export async function getStripeCheckoutEmail(
   if (!customerId) return null;
   const customer = await stripe.customers.retrieve(customerId);
   if ("deleted" in customer && customer.deleted) return null;
-  return String(customer.email ?? "").trim().toLowerCase() || null;
+  return (
+    String(customer.email ?? "")
+      .trim()
+      .toLowerCase() || null
+  );
+}
+
+export async function getStripeCheckoutSubscription(
+  stripe: Stripe,
+  session: Stripe.Checkout.Session,
+): Promise<Stripe.Subscription | null> {
+  if (session.subscription && typeof session.subscription === "object") {
+    return session.subscription;
+  }
+
+  const subscriptionId = toStripeId(session.subscription, "sub_");
+  return subscriptionId ? stripe.subscriptions.retrieve(subscriptionId) : null;
 }
 
 export async function beginStripeAcquisitionIntent(input: {
@@ -128,17 +157,25 @@ export async function beginStripeAcquisitionIntent(input: {
   trialDays: number;
   foundingDiscountApplied: boolean;
 }): Promise<BegunStripeAcquisitionIntent> {
-  const { data, error } = await input.admin.rpc("begin_stripe_acquisition_intent", {
-    p_founding_discount_applied: input.foundingDiscountApplied,
-    p_nonce: input.nonce,
-    p_plan_key: input.planKey,
-    p_request_key: input.requestKey,
-    p_stripe_price_id: input.priceId,
-    p_trial_days: input.trialDays,
-  });
-  if (error) throw new Error(`acquisition intent unavailable (${error.code ?? "unknown"})`);
+  const { data, error } = await input.admin.rpc(
+    "begin_stripe_acquisition_intent",
+    {
+      p_founding_discount_applied: input.foundingDiscountApplied,
+      p_nonce: input.nonce,
+      p_plan_key: input.planKey,
+      p_request_key: input.requestKey,
+      p_stripe_price_id: input.priceId,
+      p_trial_days: input.trialDays,
+    },
+  );
+  if (error)
+    throw new Error(
+      `acquisition intent unavailable (${error.code ?? "unknown"})`,
+    );
 
-  const row = Array.isArray(data) ? (data[0] as BeginIntentRow | undefined) : undefined;
+  const row = Array.isArray(data)
+    ? (data[0] as BeginIntentRow | undefined)
+    : undefined;
   if (!row?.intent_id || !row.intent_nonce) {
     throw new Error("acquisition intent unavailable (empty_result)");
   }
@@ -156,13 +193,18 @@ export async function attachStripeAcquisitionCheckout(input: {
   nonce: string;
   checkoutSessionId: string;
 }): Promise<void> {
-  const { data, error } = await input.admin.rpc("attach_stripe_acquisition_checkout", {
-    p_checkout_session_id: input.checkoutSessionId,
-    p_intent_id: input.intentId,
-    p_nonce: input.nonce,
-  });
+  const { data, error } = await input.admin.rpc(
+    "attach_stripe_acquisition_checkout",
+    {
+      p_checkout_session_id: input.checkoutSessionId,
+      p_intent_id: input.intentId,
+      p_nonce: input.nonce,
+    },
+  );
   if (error || data !== true) {
-    throw new Error(`acquisition checkout attachment failed (${error?.code ?? "rejected"})`);
+    throw new Error(
+      `acquisition checkout attachment failed (${error?.code ?? "rejected"})`,
+    );
   }
 }
 
@@ -176,18 +218,24 @@ export async function recordStripeAcquisitionCompletion(input: {
   eventId: string;
   eventCreatedAt: string;
 }): Promise<boolean> {
-  const { data, error } = await input.admin.rpc("record_stripe_acquisition_completion", {
-    p_checkout_email: input.checkoutEmail,
-    p_checkout_session_id: input.checkoutSessionId,
-    p_customer_id: input.customerId,
-    p_event_created_at: input.eventCreatedAt,
-    p_event_id: input.eventId,
-    p_intent_id: input.metadata.intentId,
-    p_nonce: input.metadata.nonce,
-    p_stripe_price_id: input.metadata.priceId,
-    p_subscription_id: input.subscriptionId,
-  });
-  if (error) throw new Error(`acquisition completion unavailable (${error.code ?? "unknown"})`);
+  const { data, error } = await input.admin.rpc(
+    "record_stripe_acquisition_completion",
+    {
+      p_checkout_email: input.checkoutEmail,
+      p_checkout_session_id: input.checkoutSessionId,
+      p_customer_id: input.customerId,
+      p_event_created_at: input.eventCreatedAt,
+      p_event_id: input.eventId,
+      p_intent_id: input.metadata.intentId,
+      p_nonce: input.metadata.nonce,
+      p_stripe_price_id: input.metadata.priceId,
+      p_subscription_id: input.subscriptionId,
+    },
+  );
+  if (error)
+    throw new Error(
+      `acquisition completion unavailable (${error.code ?? "unknown"})`,
+    );
   return data === true;
 }
 
@@ -200,19 +248,27 @@ export async function claimStripeAcquisitionIntent(input: {
   checkoutEmail: string;
   userId: string;
 }): Promise<ClaimedStripeAcquisitionIntent> {
-  const { data, error } = await input.admin.rpc("claim_stripe_acquisition_intent", {
-    p_checkout_email: input.checkoutEmail,
-    p_checkout_session_id: input.checkoutSessionId,
-    p_customer_id: input.customerId,
-    p_intent_id: input.metadata.intentId,
-    p_nonce: input.metadata.nonce,
-    p_stripe_price_id: input.metadata.priceId,
-    p_subscription_id: input.subscriptionId,
-    p_user_id: input.userId,
-  });
-  if (error) throw new Error(`acquisition claim unavailable (${error.code ?? "unknown"})`);
+  const { data, error } = await input.admin.rpc(
+    "claim_stripe_acquisition_intent",
+    {
+      p_checkout_email: input.checkoutEmail,
+      p_checkout_session_id: input.checkoutSessionId,
+      p_customer_id: input.customerId,
+      p_intent_id: input.metadata.intentId,
+      p_nonce: input.metadata.nonce,
+      p_stripe_price_id: input.metadata.priceId,
+      p_subscription_id: input.subscriptionId,
+      p_user_id: input.userId,
+    },
+  );
+  if (error)
+    throw new Error(
+      `acquisition claim unavailable (${error.code ?? "unknown"})`,
+    );
 
-  const row = Array.isArray(data) ? (data[0] as ClaimIntentRow | undefined) : undefined;
+  const row = Array.isArray(data)
+    ? (data[0] as ClaimIntentRow | undefined)
+    : undefined;
   if (!row?.claimed) {
     return { claimed: false, reason: row?.denial_reason ?? "claim_rejected" };
   }

--- a/features/stripe/lib/stripe/subscriptionStatus.ts
+++ b/features/stripe/lib/stripe/subscriptionStatus.ts
@@ -9,18 +9,35 @@ export const STRIPE_SUBSCRIPTION_STATUSES = [
   "paused",
 ] as const;
 
-export type StripeSubscriptionStatus = (typeof STRIPE_SUBSCRIPTION_STATUSES)[number];
-export type StripeSubscriptionStatusWithUnknown = StripeSubscriptionStatus | "unknown";
+export type StripeSubscriptionStatus =
+  (typeof STRIPE_SUBSCRIPTION_STATUSES)[number];
+export type StripeSubscriptionStatusWithUnknown =
+  | StripeSubscriptionStatus
+  | "unknown";
 
 const STRIPE_STATUS_SET = new Set<string>(STRIPE_SUBSCRIPTION_STATUSES);
 
-export function parseStripeSubscriptionStatus(v: unknown): StripeSubscriptionStatusWithUnknown {
-  const s = String(v ?? "").trim().toLowerCase();
+export function parseStripeSubscriptionStatus(
+  v: unknown,
+): StripeSubscriptionStatusWithUnknown {
+  const s = String(v ?? "")
+    .trim()
+    .toLowerCase();
   if (!s) return "unknown";
   return STRIPE_STATUS_SET.has(s) ? (s as StripeSubscriptionStatus) : "unknown";
 }
 
 export function isBillingAttentionStatus(v: unknown): boolean {
   const status = parseStripeSubscriptionStatus(v);
-  return status === "trialing" || status === "past_due" || status === "incomplete" || status === "unpaid";
+  return (
+    status === "trialing" ||
+    status === "past_due" ||
+    status === "incomplete" ||
+    status === "unpaid"
+  );
+}
+
+export function isStripeSubscriptionAccessBearing(v: unknown): boolean {
+  const status = parseStripeSubscriptionStatus(v);
+  return status === "trialing" || status === "active";
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -104,13 +104,6 @@ type PortalAccess = {
   fleet: boolean;
 };
 
-function isShopBoostOrchestratedRole(role: string | null | undefined): boolean {
-  const normalized = String(role ?? "")
-    .trim()
-    .toLowerCase();
-  return normalized === "owner" || normalized === "admin";
-}
-
 function createMiddlewareSupabase(req: NextRequest, res: NextResponse) {
   const { supabaseUrl, supabaseAnonKey } = readSupabasePublicEnv("middleware");
   return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
@@ -234,6 +227,9 @@ export async function middleware(req: NextRequest) {
       : null;
 
   const pathname = opsInternalPath ?? fleetInternalPath ?? requestPathname;
+  const isGuidedOnboardingPath =
+    pathname === "/dashboard/onboarding-v2" ||
+    pathname.startsWith("/dashboard/onboarding-v2/");
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set("x-next-pathname", pathname);
   if (fleetProductRequest) {
@@ -333,7 +329,6 @@ export async function middleware(req: NextRequest) {
   }
 
   let completed = false;
-  let needsShopBoostIntake = false;
   let canUseMobile = false;
   const isPortalOnlyAccount = user?.app_metadata?.profixiq_portal_only === true;
 
@@ -350,24 +345,8 @@ export async function middleware(req: NextRequest) {
       const capabilities = getActorCapabilities({ role: profile?.role });
       canUseMobile =
         capabilities.isKnownRole && capabilities.canonicalRole !== "customer";
-
-      if (
-        profile?.completed_onboarding &&
-        profile?.shop_id &&
-        isShopBoostOrchestratedRole(profile.role)
-      ) {
-        const { data: intake } = await supabase
-          .from("shop_boost_intakes")
-          .select("id")
-          .eq("shop_id", profile.shop_id)
-          .order("created_at", { ascending: false })
-          .limit(1)
-          .maybeSingle();
-        needsShopBoostIntake = !intake?.id;
-      }
     } catch {
       completed = false;
-      needsShopBoostIntake = false;
       canUseMobile = false;
     }
   }
@@ -386,11 +365,9 @@ export async function middleware(req: NextRequest) {
       req,
       !completed
         ? "/onboarding"
-        : needsShopBoostIntake
-          ? "/onboarding/shop-boost"
-          : mobileDeviceRequest
-            ? "/mobile"
-            : "/dashboard",
+        : mobileDeviceRequest
+          ? "/mobile"
+          : "/dashboard",
       fleetProductRequest,
     );
     return redirectWithResponseHeaders(target, res);
@@ -420,11 +397,9 @@ export async function middleware(req: NextRequest) {
 
       const defaultAuthenticatedPath = !completed
         ? "/onboarding"
-        : needsShopBoostIntake
-          ? "/onboarding/shop-boost"
-          : isMobileSignIn || mobileDeviceRequest
-            ? "/mobile"
-            : "/dashboard";
+        : isMobileSignIn || mobileDeviceRequest
+          ? "/mobile"
+          : "/dashboard";
       const to = redirectParam ?? defaultAuthenticatedPath;
       const target = productRequestUrl(req, to, fleetProductRequest);
       return redirectWithResponseHeaders(target, res);
@@ -535,8 +510,8 @@ export async function middleware(req: NextRequest) {
   if (
     mobileDeviceRequest &&
     completed &&
-    !needsShopBoostIntake &&
     !isPortal &&
+    !isGuidedOnboardingPath &&
     !pathname.startsWith("/mobile")
   ) {
     const requestedHref = `${pathname}${search}`;

--- a/middleware.ts
+++ b/middleware.ts
@@ -341,7 +341,14 @@ export async function middleware(req: NextRequest) {
         .limit(1)
         .maybeSingle();
 
-      completed = !!profile?.completed_onboarding || !!profile?.shop_id;
+      const normalizedRole = String(profile?.role ?? "").trim().toLowerCase();
+      const pendingOwnerBootstrap =
+        normalizedRole === "owner" &&
+        Boolean(profile?.shop_id) &&
+        !profile?.completed_onboarding;
+      completed = pendingOwnerBootstrap
+        ? false
+        : Boolean(profile?.completed_onboarding || profile?.shop_id);
       const capabilities = getActorCapabilities({ role: profile?.role });
       canUseMobile =
         capabilities.isKnownRole && capabilities.canonicalRole !== "customer";

--- a/supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql
+++ b/supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql
@@ -1,7 +1,8 @@
 -- Harden the already-deployed first-shop bootstrap without rewriting migration
 -- history. The API constrains new shops to supported US/Canada zones; the DB
 -- independently requires the supplied timezone to exist in the installed IANA
--- catalog and refuses to guess when multiple historical owner shops exist.
+-- catalog, refuses ambiguous historical recovery, and deliberately leaves the
+-- owner incomplete until canonical billing reconciliation succeeds server-side.
 
 create or replace function public.bootstrap_owner_atomic(
   p_business_name text,
@@ -69,8 +70,9 @@ begin
     raise exception 'Profile not found';
   end if;
 
-  -- A completed owner retry is read-only and idempotent. Any other assigned
-  -- account must use normal shop membership/admin flows and cannot self-promote.
+  -- A completed owner retry is read-only and idempotent. Pending owners are
+  -- recovered by the server route's billing/finalization path rather than by
+  -- invoking this shop-creation transition again.
   if v_profile.shop_id is not null then
     if v_profile.role = 'owner'
       and coalesce(v_profile.completed_onboarding, false)
@@ -166,12 +168,14 @@ begin
     v_created := true;
   end if;
 
-  -- Assign the caller before RLS-dependent shop profile/member writes. Every
-  -- statement remains in this transaction and rolls back together on failure.
+  -- Assign owner/shop identity atomically, but leave onboarding incomplete.
+  -- The server route reconciles Stripe into the canonical shop first and only
+  -- then flips completed_onboarding=true. A billing failure therefore cannot
+  -- route the owner into the operational application with null/legacy access.
   update public.profiles as p
     set role = 'owner',
         shop_id = v_target_shop_id,
-        completed_onboarding = true
+        completed_onboarding = false
   where p.id = v_uid
     and p.shop_id is null
     and p.role is null

--- a/supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql
+++ b/supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql
@@ -1,10 +1,16 @@
--- Harden the already-deployed first-shop bootstrap without rewriting migration
--- history. The API constrains new shops to supported US/Canada zones; the DB
--- independently requires the supplied timezone to exist in the installed IANA
--- catalog, refuses ambiguous historical recovery, and deliberately leaves the
--- owner incomplete until canonical billing reconciliation succeeds server-side.
+-- Expand phase for first-shop owner bootstrap hardening.
+--
+-- IMPORTANT ROLLING-DEPLOYMENT CONTRACT:
+-- - The already-deployed public.bootstrap_owner_atomic(...) function is left
+--   completely untouched so the currently deployed application remains valid
+--   if this migration lands before the new application.
+-- - The new application calls bootstrap_owner_pending_v2(...), which leaves
+--   completed_onboarding=false until the server has reconciled canonical Stripe
+--   billing and explicitly finalizes the owner profile.
+-- - A later contract migration may retire/repoint bootstrap_owner_atomic only
+--   after every deployed application version has moved to the v2 function.
 
-create or replace function public.bootstrap_owner_atomic(
+create or replace function public.bootstrap_owner_pending_v2(
   p_business_name text,
   p_shop_name text,
   p_street text,
@@ -70,12 +76,12 @@ begin
     raise exception 'Profile not found';
   end if;
 
-  -- A completed owner retry is read-only and idempotent. Pending owners are
-  -- recovered by the server route's billing/finalization path rather than by
-  -- invoking this shop-creation transition again.
+  -- Concurrent or exact retries are read-only once the profile already points
+  -- at a shop owned by the caller. Pending and completed owners are both
+  -- returned. The server route must verify the submitted PIN against the
+  -- persisted owner_pin_hash before billing/finalization/cookie issuance.
   if v_profile.shop_id is not null then
     if v_profile.role = 'owner'
-      and coalesce(v_profile.completed_onboarding, false)
       and exists (
         select 1
         from public.shops as existing_shop
@@ -168,10 +174,9 @@ begin
     v_created := true;
   end if;
 
-  -- Assign owner/shop identity atomically, but leave onboarding incomplete.
-  -- The server route reconciles Stripe into the canonical shop first and only
-  -- then flips completed_onboarding=true. A billing failure therefore cannot
-  -- route the owner into the operational application with null/legacy access.
+  -- Assign owner/shop identity atomically but deliberately leave onboarding
+  -- pending. Canonical billing must be reconciled server-side before the route
+  -- may flip completed_onboarding=true.
   update public.profiles as p
     set role = 'owner',
         shop_id = v_target_shop_id,
@@ -242,7 +247,7 @@ begin
 end;
 $$;
 
-revoke all on function public.bootstrap_owner_atomic(
+revoke all on function public.bootstrap_owner_pending_v2(
   text,
   text,
   text,
@@ -254,7 +259,7 @@ revoke all on function public.bootstrap_owner_atomic(
   text
 ) from public, anon;
 
-grant execute on function public.bootstrap_owner_atomic(
+grant execute on function public.bootstrap_owner_pending_v2(
   text,
   text,
   text,

--- a/supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql
+++ b/supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql
@@ -2,14 +2,15 @@
 -- signature or generated Supabase type shape.
 --
 -- ROLLING-DEPLOYMENT CONTRACT:
--- - Migration first is safe: older application versions continue calling the
---   same bootstrap_owner_atomic(...) signature and retain the historical
+-- - Old app + old DB: existing behavior.
+-- - Old app + new DB: raw PIN hashes retain the historical
 --   completed_onboarding=true success semantic.
--- - Application first is fail-closed: the new route verifies the persisted PIN,
---   immediately marks the acquisition owner pending, reconciles canonical Stripe
---   billing, then sets completed_onboarding=true only after billing is durable.
---   Middleware/onboarding also treats missing canonical shop billing as pending,
---   covering the brief legacy-RPC compatibility window.
+-- - New app + old DB: a harmless contract probe fails before any bootstrap
+--   mutation, so the new app returns 503 instead of calling the old body.
+-- - New app + new DB: the route prefixes the already-string PIN-hash argument
+--   with a private protocol marker. This function strips the marker before
+--   storing the real hash and atomically leaves completed_onboarding=false.
+--   The server then reconciles canonical Stripe billing and explicitly finalizes.
 -- - No second public RPC is introduced, so generated database types do not drift.
 
 create or replace function public.bootstrap_owner_atomic(
@@ -37,10 +38,31 @@ declare
   v_target_shop_id uuid;
   v_created boolean := false;
   v_owned_shop_count bigint := 0;
+  v_pending_protocol boolean := false;
+  v_effective_owner_pin_hash text;
+  v_pending_marker constant text := 'profixiq-owner-bootstrap-pending-v2:';
 begin
   v_uid := auth.uid();
   if v_uid is null then
     raise exception 'Unauthorized';
+  end if;
+
+  -- Harmless readiness probe used by the new application before it sends the
+  -- pending protocol marker. The previously deployed function rejects the
+  -- sentinel country, so app-first deployment fails closed without mutation.
+  if p_business_name = '__profixiq_owner_bootstrap_v2_probe__'
+    and p_shop_name = '__probe__'
+    and p_street = '__probe__'
+    and p_city = '__probe__'
+    and p_province = '__probe__'
+    and p_postal_code = '__probe__'
+    and p_country = '__PROBE__'
+    and p_timezone = 'Etc/UTC'
+    and p_owner_pin_hash = '__probe__'
+  then
+    return query
+    select '00000000-0000-4000-8000-000000000002'::uuid, false;
+    return;
   end if;
 
   if nullif(trim(coalesce(p_business_name, '')), '') is null
@@ -54,6 +76,17 @@ begin
     or nullif(trim(coalesce(p_owner_pin_hash, '')), '') is null
   then
     raise exception 'Missing required fields';
+  end if;
+
+  v_pending_protocol := left(p_owner_pin_hash, length(v_pending_marker)) = v_pending_marker;
+  v_effective_owner_pin_hash := case
+    when v_pending_protocol
+      then substr(p_owner_pin_hash, length(v_pending_marker) + 1)
+    else p_owner_pin_hash
+  end;
+
+  if nullif(trim(coalesce(v_effective_owner_pin_hash, '')), '') is null then
+    raise exception 'Missing owner PIN hash';
   end if;
 
   if upper(trim(p_country)) not in ('US', 'CA') then
@@ -168,7 +201,7 @@ begin
       trim(p_postal_code),
       upper(trim(p_country)),
       trim(p_timezone),
-      p_owner_pin_hash,
+      v_effective_owner_pin_hash,
       null,
       null
     )
@@ -177,14 +210,13 @@ begin
     v_created := true;
   end if;
 
-  -- Preserve the deployed RPC's completion semantic for migration-first rolling
-  -- compatibility. The new application immediately demotes this acquisition
-  -- transition to pending before Stripe reconciliation and only finalizes after
-  -- canonical shop billing is verified.
+  -- Raw hashes preserve the old app's completion contract. The new app sends
+  -- the marker only after the readiness probe proves this function understands
+  -- it, so its first-shop transition is pending atomically.
   update public.profiles as p
     set role = 'owner',
         shop_id = v_target_shop_id,
-        completed_onboarding = true
+        completed_onboarding = not v_pending_protocol
   where p.id = v_uid
     and p.shop_id is null
     and p.role is null
@@ -205,7 +237,7 @@ begin
         postal_code = trim(p_postal_code),
         country = upper(trim(p_country)),
         timezone = trim(p_timezone),
-        owner_pin_hash = p_owner_pin_hash,
+        owner_pin_hash = v_effective_owner_pin_hash,
         owner_pin = null,
         pin = null,
         owner_id = v_uid,

--- a/supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql
+++ b/supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql
@@ -1,16 +1,18 @@
--- Expand phase for first-shop owner bootstrap hardening.
+-- Harden the deployed first-shop owner bootstrap without changing its public
+-- signature or generated Supabase type shape.
 --
--- IMPORTANT ROLLING-DEPLOYMENT CONTRACT:
--- - The already-deployed public.bootstrap_owner_atomic(...) function is left
---   completely untouched so the currently deployed application remains valid
---   if this migration lands before the new application.
--- - The new application calls bootstrap_owner_pending_v2(...), which leaves
---   completed_onboarding=false until the server has reconciled canonical Stripe
---   billing and explicitly finalizes the owner profile.
--- - A later contract migration may retire/repoint bootstrap_owner_atomic only
---   after every deployed application version has moved to the v2 function.
+-- ROLLING-DEPLOYMENT CONTRACT:
+-- - Migration first is safe: older application versions continue calling the
+--   same bootstrap_owner_atomic(...) signature and retain the historical
+--   completed_onboarding=true success semantic.
+-- - Application first is fail-closed: the new route verifies the persisted PIN,
+--   immediately marks the acquisition owner pending, reconciles canonical Stripe
+--   billing, then sets completed_onboarding=true only after billing is durable.
+--   Middleware/onboarding also treats missing canonical shop billing as pending,
+--   covering the brief legacy-RPC compatibility window.
+-- - No second public RPC is introduced, so generated database types do not drift.
 
-create or replace function public.bootstrap_owner_pending_v2(
+create or replace function public.bootstrap_owner_atomic(
   p_business_name text,
   p_shop_name text,
   p_street text,
@@ -76,10 +78,10 @@ begin
     raise exception 'Profile not found';
   end if;
 
-  -- Concurrent or exact retries are read-only once the profile already points
-  -- at a shop owned by the caller. Pending and completed owners are both
-  -- returned. The server route must verify the submitted PIN against the
-  -- persisted owner_pin_hash before billing/finalization/cookie issuance.
+  -- Exact/concurrent retries are read-only once the profile points at a shop
+  -- actually owned by the caller. Both pending and completed owner states are
+  -- accepted. The server verifies the submitted PIN against the persisted shop
+  -- hash before billing, completion, or privileged-cookie issuance.
   if v_profile.shop_id is not null then
     if v_profile.role = 'owner'
       and exists (
@@ -117,8 +119,9 @@ begin
     raise exception 'Owner bootstrap not allowed';
   end if;
 
-  -- Never infer commercial identity from recency. One historical owner-created
-  -- shop can be recovered safely; two or more require explicit resolution.
+  -- Never infer commercial identity from recency. Exactly one historical
+  -- owner-created shop can be recovered; multiple candidates require explicit
+  -- resolution rather than silently mutating whichever row was newest.
   select count(*)
     into v_owned_shop_count
   from public.shops as s
@@ -174,13 +177,14 @@ begin
     v_created := true;
   end if;
 
-  -- Assign owner/shop identity atomically but deliberately leave onboarding
-  -- pending. Canonical billing must be reconciled server-side before the route
-  -- may flip completed_onboarding=true.
+  -- Preserve the deployed RPC's completion semantic for migration-first rolling
+  -- compatibility. The new application immediately demotes this acquisition
+  -- transition to pending before Stripe reconciliation and only finalizes after
+  -- canonical shop billing is verified.
   update public.profiles as p
     set role = 'owner',
         shop_id = v_target_shop_id,
-        completed_onboarding = false
+        completed_onboarding = true
   where p.id = v_uid
     and p.shop_id is null
     and p.role is null
@@ -247,7 +251,7 @@ begin
 end;
 $$;
 
-revoke all on function public.bootstrap_owner_pending_v2(
+revoke all on function public.bootstrap_owner_atomic(
   text,
   text,
   text,
@@ -259,7 +263,7 @@ revoke all on function public.bootstrap_owner_pending_v2(
   text
 ) from public, anon;
 
-grant execute on function public.bootstrap_owner_pending_v2(
+grant execute on function public.bootstrap_owner_atomic(
   text,
   text,
   text,

--- a/supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql
+++ b/supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql
@@ -1,0 +1,263 @@
+-- Harden the already-deployed first-shop bootstrap without rewriting migration
+-- history. The API constrains new shops to supported US/Canada zones; the DB
+-- independently requires the supplied timezone to exist in the installed IANA
+-- catalog and refuses to guess when multiple historical owner shops exist.
+
+create or replace function public.bootstrap_owner_atomic(
+  p_business_name text,
+  p_shop_name text,
+  p_street text,
+  p_city text,
+  p_province text,
+  p_postal_code text,
+  p_country text,
+  p_timezone text,
+  p_owner_pin_hash text
+)
+returns table (
+  shop_id uuid,
+  created_shop boolean
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid;
+  v_profile public.profiles%rowtype;
+  v_target_shop_id uuid;
+  v_created boolean := false;
+  v_owned_shop_count bigint := 0;
+begin
+  v_uid := auth.uid();
+  if v_uid is null then
+    raise exception 'Unauthorized';
+  end if;
+
+  if nullif(trim(coalesce(p_business_name, '')), '') is null
+    or nullif(trim(coalesce(p_shop_name, '')), '') is null
+    or nullif(trim(coalesce(p_street, '')), '') is null
+    or nullif(trim(coalesce(p_city, '')), '') is null
+    or nullif(trim(coalesce(p_province, '')), '') is null
+    or nullif(trim(coalesce(p_postal_code, '')), '') is null
+    or nullif(trim(coalesce(p_country, '')), '') is null
+    or nullif(trim(coalesce(p_timezone, '')), '') is null
+    or nullif(trim(coalesce(p_owner_pin_hash, '')), '') is null
+  then
+    raise exception 'Missing required fields';
+  end if;
+
+  if upper(trim(p_country)) not in ('US', 'CA') then
+    raise exception 'Unsupported country';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_catalog.pg_timezone_names as tz
+    where tz.name = trim(p_timezone)
+  ) then
+    raise exception 'Unsupported timezone';
+  end if;
+
+  select p.*
+    into v_profile
+  from public.profiles as p
+  where p.id = v_uid
+  for update;
+
+  if not found then
+    raise exception 'Profile not found';
+  end if;
+
+  -- A completed owner retry is read-only and idempotent. Any other assigned
+  -- account must use normal shop membership/admin flows and cannot self-promote.
+  if v_profile.shop_id is not null then
+    if v_profile.role = 'owner'
+      and coalesce(v_profile.completed_onboarding, false)
+      and exists (
+        select 1
+        from public.shops as existing_shop
+        where existing_shop.id = v_profile.shop_id
+          and existing_shop.owner_id = v_uid
+      )
+    then
+      return query select v_profile.shop_id, false;
+      return;
+    end if;
+
+    raise exception 'Owner bootstrap not allowed';
+  end if;
+
+  if v_profile.role is not null
+    or coalesce(v_profile.completed_onboarding, false)
+  then
+    raise exception 'Owner bootstrap not allowed';
+  end if;
+
+  if not coalesce(v_profile.stripe_checkout_complete, false)
+    or v_profile.stripe_customer_id is null
+    or v_profile.stripe_subscription_id is null
+  then
+    raise exception 'Completed trial claim required';
+  end if;
+
+  if exists (
+    select 1
+    from public.shop_members as existing_membership
+    where existing_membership.user_id = v_uid
+  ) then
+    raise exception 'Owner bootstrap not allowed';
+  end if;
+
+  -- Never infer commercial identity from recency. One historical owner-created
+  -- shop can be recovered safely; two or more require explicit resolution.
+  select count(*)
+    into v_owned_shop_count
+  from public.shops as s
+  where s.owner_id = v_uid;
+
+  if v_owned_shop_count > 1 then
+    raise exception 'Ambiguous owner shop recovery';
+  end if;
+
+  if v_owned_shop_count = 1 then
+    select s.id
+      into v_target_shop_id
+    from public.shops as s
+    where s.owner_id = v_uid
+    for update;
+  else
+    insert into public.shops (
+      owner_id,
+      created_by,
+      business_name,
+      shop_name,
+      name,
+      street,
+      address,
+      city,
+      province,
+      postal_code,
+      country,
+      timezone,
+      owner_pin_hash,
+      owner_pin,
+      pin
+    )
+    values (
+      v_uid,
+      v_uid,
+      trim(p_business_name),
+      trim(p_shop_name),
+      trim(p_shop_name),
+      trim(p_street),
+      trim(p_street),
+      trim(p_city),
+      trim(p_province),
+      trim(p_postal_code),
+      upper(trim(p_country)),
+      trim(p_timezone),
+      p_owner_pin_hash,
+      null,
+      null
+    )
+    returning id into v_target_shop_id;
+
+    v_created := true;
+  end if;
+
+  -- Assign the caller before RLS-dependent shop profile/member writes. Every
+  -- statement remains in this transaction and rolls back together on failure.
+  update public.profiles as p
+    set role = 'owner',
+        shop_id = v_target_shop_id,
+        completed_onboarding = true
+  where p.id = v_uid
+    and p.shop_id is null
+    and p.role is null
+    and not coalesce(p.completed_onboarding, false);
+
+  if not found then
+    raise exception 'Owner bootstrap not allowed';
+  end if;
+
+  update public.shops as s
+    set business_name = trim(p_business_name),
+        shop_name = trim(p_shop_name),
+        name = trim(p_shop_name),
+        street = trim(p_street),
+        address = trim(p_street),
+        city = trim(p_city),
+        province = trim(p_province),
+        postal_code = trim(p_postal_code),
+        country = upper(trim(p_country)),
+        timezone = trim(p_timezone),
+        owner_pin_hash = p_owner_pin_hash,
+        owner_pin = null,
+        pin = null,
+        owner_id = v_uid,
+        created_by = coalesce(s.created_by, v_uid)
+  where s.id = v_target_shop_id
+    and s.owner_id = v_uid;
+
+  if not found then
+    raise exception 'Owner shop not found';
+  end if;
+
+  insert into public.shop_profiles (
+    shop_id,
+    address_line1,
+    city,
+    province,
+    postal_code,
+    country
+  )
+  values (
+    v_target_shop_id,
+    trim(p_street),
+    trim(p_city),
+    trim(p_province),
+    trim(p_postal_code),
+    upper(trim(p_country))
+  )
+  on conflict on constraint shop_profiles_pkey do update
+    set address_line1 = excluded.address_line1,
+        city = excluded.city,
+        province = excluded.province,
+        postal_code = excluded.postal_code,
+        country = excluded.country;
+
+  insert into public.shop_members (shop_id, user_id, role, created_by)
+  values (v_target_shop_id, v_uid, 'owner', v_uid)
+  on conflict (shop_id, user_id) do update
+    set role = 'owner',
+        created_by = coalesce(shop_members.created_by, excluded.created_by);
+
+  return query
+  select v_target_shop_id, v_created;
+end;
+$$;
+
+revoke all on function public.bootstrap_owner_atomic(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text
+) from public, anon;
+
+grant execute on function public.bootstrap_owner_atomic(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text
+) to authenticated;

--- a/tests/acquisition-auth-handoff.test.ts
+++ b/tests/acquisition-auth-handoff.test.ts
@@ -60,24 +60,35 @@ describe("acquisition auth handoff", () => {
     expect(forgotPassword).toContain('sp.get("email")');
     expect(forgotPassword).toContain("buildContinuationParams(sp, trimmed)");
     expect(forgotPassword).toContain("setPasswordRedirect");
-    expect(forgotPassword).toContain(
-      "/api/auth/send-reset?redirect=",
-    );
+    expect(forgotPassword).toContain("/api/auth/send-reset?redirect=");
   });
 
-  it("does not promise a confirmation email for a repeated signup", () => {
+  it("binds account setup to the completed checkout email", () => {
+    const signIn = read("features/auth/components/SignIn.tsx");
+    const contextRoute = read(
+      "features/stripe/api/stripe/checkout/acquisition-context/route.ts",
+    );
+
+    expect(signIn).toContain('isAcquisitionFlow ? "sign-up" : initialMode');
+    expect(signIn).toContain(
+      "/api/stripe/checkout/acquisition-context?session_id=",
+    );
+    expect(signIn).toContain("setIdentifier(email)");
+    expect(signIn).toContain('acquisitionContextStatus === "ready"');
+    expect(contextRoute).toContain("readStripeAcquisitionMetadata");
+    expect(contextRoute).toContain("isCompletedStripeAcquisitionSession");
+    expect(contextRoute).toContain("isStripeSubscriptionAccessBearing");
+    expect(contextRoute).toContain('"Cache-Control": "no-store"');
+  });
+
+  it("lets an unconfirmed owner resend the verification email", () => {
     const signIn = read("features/auth/components/SignIn.tsx");
 
-    expect(signIn).toContain(
-      "If this is a new account, check its inbox for the verification link.",
-    );
-    expect(signIn).toContain(
-      "If you already have an account, choose Sign in—another confirmation email will not be sent.",
-    );
-    expect(signIn).toContain('setPassword("");');
-    expect(signIn).not.toContain(
-      "Check your email to verify the account, then continue into shop setup.",
-    );
+    expect(signIn).toContain("setPendingConfirmationEmail(email)");
+    expect(signIn).toContain("supabase.auth.resend({");
+    expect(signIn).toContain('type: "signup"');
+    expect(signIn).toContain("options: { emailRedirectTo }");
+    expect(signIn).toContain("Resend verification email");
   });
 
   it("claims a completed acquisition before leaving password recovery", () => {

--- a/tests/instant-shop-analysis-guided-onboarding.test.ts
+++ b/tests/instant-shop-analysis-guided-onboarding.test.ts
@@ -76,7 +76,7 @@ describe("instant shop analysis guided onboarding handoff", () => {
     expect(handoff).not.toContain("importSummary?: ShopBoostImportSummary");
   });
 
-  it("binds activation to the unlocked email and provides a retry-safe handoff page", () => {
+  it("binds activation to the unlocked email and provides a retry-safe url-bound handoff page", () => {
     const activation = read("app/api/demo/shop-boost/activate/route.ts");
     const claim = read("app/api/demo/shop-boost/claim/route.ts");
     const handoffPage = read("app/onboarding/shop-boost/page.tsx");
@@ -92,7 +92,9 @@ describe("instant shop analysis guided onboarding handoff", () => {
     expect(activation).toContain("ensureStorageCopy");
     expect(activation).toContain("demoRow.shop_id !== shopId");
     expect(handoffPage).toContain('fetch("/api/demo/shop-boost/activate"');
-    expect(handoffPage).toContain("readPersistedActivationContext");
+    expect(handoffPage).toContain("parseActivationContextFromSearchParams");
+    expect(handoffPage).toContain("useSearchParams");
+    expect(handoffPage).not.toContain("readPersistedActivationContext");
     expect(signIn).toContain("resolvePostAuthDestination");
     expect(signIn).toContain('searchParams.get("activationContext")');
     expect(signIn).toContain('params.set("activationContext", activationContext)');

--- a/tests/owner-onboarding-bootstrap.test.ts
+++ b/tests/owner-onboarding-bootstrap.test.ts
@@ -167,14 +167,17 @@ describe("owner onboarding bootstrap", () => {
 
     expect(page).toContain("<OwnerOnboardingForm />");
     expect(page).toContain("if (profile?.completed_onboarding)");
-    expect(page).not.toContain("profile?.shop_id || profile?.completed_onboarding");
+    expect(page).not.toContain(
+      "profile?.shop_id || profile?.completed_onboarding",
+    );
     expect(form).toContain('fetch("/api/onboarding/bootstrap-owner"');
     expect(form).toContain("Create shop and continue");
   });
 
   it("requires an authenticated caller", async () => {
     mocks.getUser.mockResolvedValue({ data: { user: null }, error: null });
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
 
@@ -192,7 +195,8 @@ describe("owner onboarding bootstrap", () => {
       },
       error: null,
     });
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
 
@@ -202,7 +206,8 @@ describe("owner onboarding bootstrap", () => {
   });
 
   it("validates the PIN and supported region before a new shop is hashed", async () => {
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const invalidPin = await POST(request({ pin: "12ab" }));
     const invalidTimezone = await POST(request({ timezone: "Etc/Unknown" }));
@@ -219,7 +224,8 @@ describe("owner onboarding bootstrap", () => {
     ["CA", "America/St_Johns"],
     ["CA", "America/Regina"],
   ])("accepts supported regional timezone %s %s", async (country, timezone) => {
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request({ country, timezone }));
 
@@ -238,7 +244,8 @@ describe("owner onboarding bootstrap", () => {
       },
       error: null,
     });
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
 
@@ -249,7 +256,8 @@ describe("owner onboarding bootstrap", () => {
   });
 
   it("probes the hardened contract, bootstraps pending, verifies PIN, hydrates billing, then completes", async () => {
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
     const payload = await response.json();
@@ -282,8 +290,7 @@ describe("owner onboarding bootstrap", () => {
       p_postal_code: "80216",
       p_country: "US",
       p_timezone: "America/Denver",
-      p_owner_pin_hash:
-        "profixiq-owner-bootstrap-pending-v2:hashed-owner-pin",
+      p_owner_pin_hash: "profixiq-owner-bootstrap-pending-v2:hashed-owner-pin",
     });
     expect(mocks.verifyOwnerPin).toHaveBeenCalledWith(
       "4826",
@@ -304,7 +311,8 @@ describe("owner onboarding bootstrap", () => {
       data: null,
       error: { code: "P0001", message: "Unsupported country" },
     });
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
 
@@ -321,7 +329,8 @@ describe("owner onboarding bootstrap", () => {
       data: [{ id: "shop-a" }, { id: "shop-b" }],
       error: null,
     });
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
 
@@ -345,7 +354,8 @@ describe("owner onboarding bootstrap", () => {
               error: null,
             },
     );
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request({ pin: "9999" }));
 
@@ -365,7 +375,8 @@ describe("owner onboarding bootstrap", () => {
       linked: false,
       reason: "no_subscription_found",
     });
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
 
@@ -387,7 +398,31 @@ describe("owner onboarding bootstrap", () => {
       },
       error: null,
     });
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(503);
+    expect(mocks.adminCompleteProfileMaybeSingle).not.toHaveBeenCalled();
+    expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
+  });
+
+  it("does not finalize onboarding for a canceled subscription", async () => {
+    mocks.adminShopMaybeSingle.mockResolvedValue({
+      data: {
+        id: SHOP_ID,
+        owner_id: "owner-user-1",
+        owner_pin_hash: "hashed-existing-owner-pin",
+        stripe_subscription_id: "sub_canceled_owner",
+        stripe_subscription_status: "canceled",
+        stripe_pricing_model: "product_packages_v1",
+        plan: "complete",
+      },
+      error: null,
+    });
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
 
@@ -408,7 +443,8 @@ describe("owner onboarding bootstrap", () => {
       },
       error: null,
     });
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
 
@@ -437,7 +473,8 @@ describe("owner onboarding bootstrap", () => {
       error: null,
     });
     mocks.verifyOwnerPin.mockResolvedValue(false);
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request({ pin: "9999" }));
 
@@ -459,7 +496,8 @@ describe("owner onboarding bootstrap", () => {
       },
       error: null,
     });
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
 
@@ -487,7 +525,8 @@ describe("owner onboarding bootstrap", () => {
       error: null,
     });
     mocks.verifyOwnerPin.mockResolvedValue(false);
-    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+    const { POST } =
+      await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request({ pin: "9999" }));
 
@@ -500,7 +539,7 @@ describe("owner onboarding bootstrap", () => {
     const route = readFileSync(
       "app/api/onboarding/bootstrap-owner/route.ts",
       "utf8",
-    );
+    ).replace(/\r\n/g, "\n");
 
     expect(route).not.toContain("update({ completed_onboarding: false })");
     expect(route).toContain(
@@ -521,7 +560,9 @@ describe("owner onboarding bootstrap", () => {
     expect(migration).toContain("__profixiq_owner_bootstrap_v2_probe__");
     expect(migration).toContain("profixiq-owner-bootstrap-pending-v2:");
     expect(migration).toContain("v_effective_owner_pin_hash");
-    expect(migration).toContain("completed_onboarding = not v_pending_protocol");
+    expect(migration).toContain(
+      "completed_onboarding = not v_pending_protocol",
+    );
     expect(migration).toContain("return query select v_profile.shop_id, false");
     expect(migration).toContain("pg_catalog.pg_timezone_names");
     expect(migration).toContain("Ambiguous owner shop recovery");

--- a/tests/owner-onboarding-bootstrap.test.ts
+++ b/tests/owner-onboarding-bootstrap.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => {
     maybeSingle: vi.fn(),
     rpc: vi.fn(),
     hashOwnerPin: vi.fn(),
+    verifyOwnerPin: vi.fn(),
     setOwnerPinVerifiedCookie: vi.fn((response: Response) => response),
     adminFrom,
     adminShopMaybeSingle: vi.fn(),
@@ -43,6 +44,7 @@ vi.mock("@/features/shared/lib/server/owner-pin-crypto", () => ({
   normalizeOwnerPin: (pin: string) => pin.trim(),
   isValidOwnerPin: (pin: string) => /^\d{4,8}$/.test(pin),
   hashOwnerPin: mocks.hashOwnerPin,
+  verifyOwnerPin: mocks.verifyOwnerPin,
 }));
 
 vi.mock("@/features/shared/lib/server/owner-pin", () => ({
@@ -91,6 +93,7 @@ describe("owner onboarding bootstrap", () => {
       error: null,
     });
     mocks.hashOwnerPin.mockResolvedValue("hashed-owner-pin");
+    mocks.verifyOwnerPin.mockResolvedValue(true);
     mocks.rpc.mockResolvedValue({
       data: [
         {
@@ -105,6 +108,7 @@ describe("owner onboarding bootstrap", () => {
       data: {
         id: "11111111-1111-4111-8111-111111111111",
         owner_id: "owner-user-1",
+        owner_pin_hash: "hashed-existing-owner-pin",
         stripe_subscription_id: "sub_trial_owner",
         stripe_subscription_status: "trialing",
         stripe_pricing_model: "product_packages_v1",
@@ -230,7 +234,7 @@ describe("owner onboarding bootstrap", () => {
     expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
   });
 
-  it("bootstraps, hydrates billing, then durably completes onboarding before success", async () => {
+  it("bootstraps through the pending v2 RPC, verifies persisted PIN, hydrates billing, then completes", async () => {
     const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
@@ -244,7 +248,7 @@ describe("owner onboarding bootstrap", () => {
       }),
     );
     expect(mocks.hashOwnerPin).toHaveBeenCalledWith("4826");
-    expect(mocks.rpc).toHaveBeenCalledWith("bootstrap_owner_atomic", {
+    expect(mocks.rpc).toHaveBeenCalledWith("bootstrap_owner_pending_v2", {
       p_business_name: "High Plains Auto & Fleet",
       p_shop_name: "High Plains Auto & Fleet",
       p_street: "4250 Trade Center Drive",
@@ -255,22 +259,62 @@ describe("owner onboarding bootstrap", () => {
       p_timezone: "America/Denver",
       p_owner_pin_hash: "hashed-owner-pin",
     });
+    expect(mocks.verifyOwnerPin).toHaveBeenCalledWith(
+      "4826",
+      "hashed-existing-owner-pin",
+    );
     expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalledWith({
       stripe: mocks.stripe,
       supabase: mocks.admin,
       userId: "owner-user-1",
       shopId: "11111111-1111-4111-8111-111111111111",
     });
-    expect(mocks.adminShopMaybeSingle).toHaveBeenCalled();
     expect(mocks.adminProfileMaybeSingle).toHaveBeenCalled();
-    expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalledWith(
-      expect.any(Response),
-      {
-        userId: "owner-user-1",
-        shopId: "11111111-1111-4111-8111-111111111111",
-        purpose: "owner_pin:privileged",
+    expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalled();
+  });
+
+  it("fails closed instead of falling back to the legacy RPC if v2 is not deployed yet", async () => {
+    mocks.rpc.mockResolvedValue({
+      data: null,
+      error: {
+        code: "PGRST202",
+        message: "Could not find the function public.bootstrap_owner_pending_v2",
       },
+    });
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(503);
+    expect(mocks.rpc).toHaveBeenCalledTimes(1);
+    expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
+    expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stale concurrent request whose PIN does not match the persisted winner", async () => {
+    mocks.verifyOwnerPin.mockResolvedValue(false);
+    mocks.rpc.mockResolvedValue({
+      data: [
+        {
+          shop_id: "11111111-1111-4111-8111-111111111111",
+          created_shop: false,
+        },
+      ],
+      error: null,
+    });
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request({ pin: "9999" }));
+
+    expect(response.status).toBe(401);
+    expect(mocks.rpc).toHaveBeenCalled();
+    expect(mocks.verifyOwnerPin).toHaveBeenCalledWith(
+      "9999",
+      "hashed-existing-owner-pin",
     );
+    expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
+    expect(mocks.adminProfileMaybeSingle).not.toHaveBeenCalled();
+    expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
   it("fails closed with onboarding still incomplete when billing is unresolved", async () => {
@@ -292,6 +336,7 @@ describe("owner onboarding bootstrap", () => {
       data: {
         id: "11111111-1111-4111-8111-111111111111",
         owner_id: "owner-user-1",
+        owner_pin_hash: "hashed-existing-owner-pin",
         stripe_subscription_id: null,
         stripe_subscription_status: null,
         stripe_pricing_model: null,
@@ -308,7 +353,7 @@ describe("owner onboarding bootstrap", () => {
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
-  it("repairs a pending owner bootstrap without recreating the shop", async () => {
+  it("repairs a pending owner bootstrap only after verifying the stored PIN", async () => {
     mocks.maybeSingle.mockResolvedValue({
       data: {
         shop_id: "11111111-1111-4111-8111-111111111111",
@@ -327,12 +372,39 @@ describe("owner onboarding bootstrap", () => {
     expect(response.status).toBe(200);
     expect(mocks.rpc).not.toHaveBeenCalled();
     expect(mocks.hashOwnerPin).not.toHaveBeenCalled();
+    expect(mocks.verifyOwnerPin).toHaveBeenCalledWith(
+      "4826",
+      "hashed-existing-owner-pin",
+    );
     expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalled();
     expect(mocks.adminProfileMaybeSingle).toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalled();
   });
 
-  it("reconciles billing and refreshes the PIN cookie on an exact completed-owner retry", async () => {
+  it("rejects a wrong PIN on a pending owner before reconciliation", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: {
+        shop_id: "11111111-1111-4111-8111-111111111111",
+        role: "owner",
+        completed_onboarding: false,
+        stripe_checkout_complete: true,
+        stripe_customer_id: "cus_trial_owner",
+        stripe_subscription_id: "sub_trial_owner",
+      },
+      error: null,
+    });
+    mocks.verifyOwnerPin.mockResolvedValue(false);
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request({ pin: "9999" }));
+
+    expect(response.status).toBe(401);
+    expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
+    expect(mocks.adminProfileMaybeSingle).not.toHaveBeenCalled();
+    expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
+  });
+
+  it("reconciles a completed owner retry only after verifying the stored PIN", async () => {
     mocks.maybeSingle.mockResolvedValue({
       data: {
         shop_id: "11111111-1111-4111-8111-111111111111",
@@ -350,54 +422,67 @@ describe("owner onboarding bootstrap", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.rpc).not.toHaveBeenCalled();
-    expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalledWith(
-      expect.objectContaining({
-        userId: "owner-user-1",
-        shopId: "11111111-1111-4111-8111-111111111111",
-      }),
+    expect(mocks.verifyOwnerPin).toHaveBeenCalledWith(
+      "4826",
+      "hashed-existing-owner-pin",
     );
-    expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalledWith(
-      expect.any(Response),
-      expect.objectContaining({
-        userId: "owner-user-1",
-        shopId: "11111111-1111-4111-8111-111111111111",
-      }),
-    );
+    expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalled();
+    expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalled();
   });
 
-  it("keeps the original database contract RLS-compatible and blocks self-promotion", () => {
-    const migration = readFileSync(
-      "supabase/migrations/20260814041000_restore_secure_owner_bootstrap.sql",
-      "utf8",
-    );
-    const profileAssignment = migration.indexOf("update public.profiles as p");
-    const shopProfileWrite = migration.indexOf("insert into public.shop_profiles");
+  it("rejects a wrong PIN on a completed owner before refreshing privileges", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: {
+        shop_id: "11111111-1111-4111-8111-111111111111",
+        role: "owner",
+        completed_onboarding: true,
+        stripe_checkout_complete: true,
+        stripe_customer_id: "cus_trial_owner",
+        stripe_subscription_id: "sub_trial_owner",
+      },
+      error: null,
+    });
+    mocks.verifyOwnerPin.mockResolvedValue(false);
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
 
-    expect(profileAssignment).toBeGreaterThan(-1);
-    expect(profileAssignment).toBeLessThan(shopProfileWrite);
-    expect(migration).toContain("security definer");
-    expect(migration).toContain("set search_path = public");
-    expect(migration).toContain("raise exception 'Owner bootstrap not allowed'");
-    expect(migration).toContain("Completed trial claim required");
-    expect(migration).toContain("from public.shop_members as existing_membership");
-    expect(migration).toContain("from public, anon");
-    expect(migration).toContain("to authenticated");
+    const response = await POST(request({ pin: "9999" }));
+
+    expect(response.status).toBe(401);
+    expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
+    expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
-  it("hardens recovery and leaves new owner onboarding pending until billing succeeds", () => {
+  it("keeps the deployed legacy RPC untouched during the expand phase", () => {
     const migration = readFileSync(
       "supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql",
       "utf8",
     );
 
-    expect(migration).toContain("pg_catalog.pg_timezone_names");
-    expect(migration).toContain("v_owned_shop_count");
-    expect(migration).toContain("if v_owned_shop_count > 1 then");
-    expect(migration).toContain("Ambiguous owner shop recovery");
-    expect(migration).not.toContain("order by s.created_at desc");
+    expect(migration).toContain(
+      "create or replace function public.bootstrap_owner_pending_v2",
+    );
+    expect(migration).not.toContain(
+      "create or replace function public.bootstrap_owner_atomic(",
+    );
     expect(migration).toContain("completed_onboarding = false");
+    expect(migration).toContain("return query select v_profile.shop_id, false");
+    expect(migration).toContain("pg_catalog.pg_timezone_names");
+    expect(migration).toContain("Ambiguous owner shop recovery");
     expect(migration).toContain("security definer");
     expect(migration).toContain("set search_path = public");
     expect(migration).toContain("to authenticated");
+  });
+
+  it("preserves the original deployed RPC contract until a later contract phase", () => {
+    const deployed = readFileSync(
+      "supabase/migrations/20260814041000_restore_secure_owner_bootstrap.sql",
+      "utf8",
+    );
+
+    expect(deployed).toContain(
+      "create or replace function public.bootstrap_owner_atomic",
+    );
+    expect(deployed).toContain("security definer");
+    expect(deployed).toContain("Completed trial claim required");
   });
 });

--- a/tests/owner-onboarding-bootstrap.test.ts
+++ b/tests/owner-onboarding-bootstrap.test.ts
@@ -16,7 +16,6 @@ const mocks = vi.hoisted(() => {
     adminFrom,
     adminShopMaybeSingle: vi.fn(),
     adminShopLookupLimit: vi.fn(),
-    adminPendingProfileMaybeSingle: vi.fn(),
     adminCompleteProfileMaybeSingle: vi.fn(),
     admin: { from: adminFrom },
     stripe: { kind: "stripe" },
@@ -127,10 +126,6 @@ describe("owner onboarding bootstrap", () => {
       },
       error: null,
     });
-    mocks.adminPendingProfileMaybeSingle.mockResolvedValue({
-      data: { id: "owner-user-1", completed_onboarding: false },
-      error: null,
-    });
     mocks.adminCompleteProfileMaybeSingle.mockResolvedValue({
       data: { id: "owner-user-1", completed_onboarding: true },
       error: null,
@@ -149,15 +144,12 @@ describe("owner onboarding bootstrap", () => {
       }
       if (table === "profiles") {
         return {
-          update: vi.fn((patch: { completed_onboarding?: boolean }) => ({
+          update: vi.fn(() => ({
             eq: vi.fn(() => ({
               eq: vi.fn(() => ({
                 eq: vi.fn(() => ({
                   select: vi.fn(() => ({
-                    maybeSingle:
-                      patch.completed_onboarding === false
-                        ? mocks.adminPendingProfileMaybeSingle
-                        : mocks.adminCompleteProfileMaybeSingle,
+                    maybeSingle: mocks.adminCompleteProfileMaybeSingle,
                   })),
                 })),
               })),
@@ -297,7 +289,6 @@ describe("owner onboarding bootstrap", () => {
       "4826",
       "hashed-existing-owner-pin",
     );
-    expect(mocks.adminPendingProfileMaybeSingle).toHaveBeenCalled();
     expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalledWith({
       stripe: mocks.stripe,
       supabase: mocks.admin,
@@ -364,12 +355,12 @@ describe("owner onboarding bootstrap", () => {
       "9999",
       "hashed-existing-owner-pin",
     );
-    expect(mocks.adminPendingProfileMaybeSingle).not.toHaveBeenCalled();
     expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
+    expect(mocks.adminCompleteProfileMaybeSingle).not.toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
-  it("fails closed with onboarding pending when billing is unresolved", async () => {
+  it("fails closed with the database-owned pending state when billing is unresolved", async () => {
     mocks.reconcileShopBillingFromUser.mockResolvedValue({
       linked: false,
       reason: "no_subscription_found",
@@ -379,7 +370,6 @@ describe("owner onboarding bootstrap", () => {
     const response = await POST(request());
 
     expect(response.status).toBe(503);
-    expect(mocks.adminPendingProfileMaybeSingle).toHaveBeenCalled();
     expect(mocks.adminCompleteProfileMaybeSingle).not.toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
@@ -402,7 +392,6 @@ describe("owner onboarding bootstrap", () => {
     const response = await POST(request());
 
     expect(response.status).toBe(503);
-    expect(mocks.adminPendingProfileMaybeSingle).toHaveBeenCalled();
     expect(mocks.adminCompleteProfileMaybeSingle).not.toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
@@ -505,6 +494,18 @@ describe("owner onboarding bootstrap", () => {
     expect(response.status).toBe(401);
     expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
+  });
+
+  it("never performs a second completed_onboarding=false write after the atomic pending transition", () => {
+    const route = readFileSync(
+      "app/api/onboarding/bootstrap-owner/route.ts",
+      "utf8",
+    );
+
+    expect(route).not.toContain("update({ completed_onboarding: false })");
+    expect(route).toContain(
+      "a duplicate request must never\n    // reopen an owner another request has already finalized successfully",
+    );
   });
 
   it("keeps the same RPC type shape while supporting old-app and new-app completion semantics", () => {

--- a/tests/owner-onboarding-bootstrap.test.ts
+++ b/tests/owner-onboarding-bootstrap.test.ts
@@ -1,16 +1,22 @@
 import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  getUser: vi.fn(),
-  maybeSingle: vi.fn(),
-  rpc: vi.fn(),
-  hashOwnerPin: vi.fn(),
-  setOwnerPinVerifiedCookie: vi.fn((response: Response) => response),
-  admin: { kind: "admin" },
-  stripe: { kind: "stripe" },
-  reconcileShopBillingFromUser: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  const adminFrom = vi.fn();
+  return {
+    getUser: vi.fn(),
+    maybeSingle: vi.fn(),
+    rpc: vi.fn(),
+    hashOwnerPin: vi.fn(),
+    setOwnerPinVerifiedCookie: vi.fn((response: Response) => response),
+    adminFrom,
+    adminShopMaybeSingle: vi.fn(),
+    adminProfileMaybeSingle: vi.fn(),
+    admin: { from: adminFrom },
+    stripe: { kind: "stripe" },
+    reconcileShopBillingFromUser: vi.fn(),
+  };
+});
 
 vi.mock("@/features/shared/lib/supabase/server", () => ({
   createServerSupabaseRoute: () => ({
@@ -68,6 +74,7 @@ describe("owner onboarding bootstrap", () => {
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     process.env.STRIPE_SECRET_KEY = "sk_test_owner_bootstrap";
+
     mocks.getUser.mockResolvedValue({
       data: { user: { id: "owner-user-1" } },
       error: null,
@@ -94,13 +101,55 @@ describe("owner onboarding bootstrap", () => {
       error: null,
     });
     mocks.reconcileShopBillingFromUser.mockResolvedValue({ linked: true });
+    mocks.adminShopMaybeSingle.mockResolvedValue({
+      data: {
+        id: "11111111-1111-4111-8111-111111111111",
+        owner_id: "owner-user-1",
+        stripe_subscription_id: "sub_trial_owner",
+        stripe_subscription_status: "trialing",
+        stripe_pricing_model: "product_packages_v1",
+        plan: "complete",
+      },
+      error: null,
+    });
+    mocks.adminProfileMaybeSingle.mockResolvedValue({
+      data: { id: "owner-user-1", completed_onboarding: true },
+      error: null,
+    });
+    mocks.adminFrom.mockImplementation((table: string) => {
+      if (table === "shops") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({ maybeSingle: mocks.adminShopMaybeSingle })),
+          })),
+        };
+      }
+      if (table === "profiles") {
+        return {
+          update: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  select: vi.fn(() => ({
+                    maybeSingle: mocks.adminProfileMaybeSingle,
+                  })),
+                })),
+              })),
+            })),
+          })),
+        };
+      }
+      throw new Error(`Unexpected admin table: ${table}`);
+    });
   });
 
-  it("restores a real /onboarding page instead of the production 404", () => {
+  it("restores a real /onboarding page and keeps pending owners there", () => {
     const page = readFileSync("app/onboarding/page.tsx", "utf8");
     const form = readFileSync("app/onboarding/OwnerOnboardingForm.tsx", "utf8");
 
     expect(page).toContain("<OwnerOnboardingForm />");
+    expect(page).toContain("if (profile?.completed_onboarding)");
+    expect(page).not.toContain("profile?.shop_id || profile?.completed_onboarding");
     expect(form).toContain('fetch("/api/onboarding/bootstrap-owner"');
     expect(form).toContain("Create shop and continue");
   });
@@ -116,7 +165,7 @@ describe("owner onboarding bootstrap", () => {
     expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
   });
 
-  it("rejects assigned staff before the privileged RPC", async () => {
+  it("rejects assigned non-owner staff before the privileged RPC", async () => {
     mocks.maybeSingle.mockResolvedValue({
       data: {
         shop_id: "22222222-2222-4222-8222-222222222222",
@@ -134,7 +183,7 @@ describe("owner onboarding bootstrap", () => {
     expect(mocks.rpc).not.toHaveBeenCalled();
   });
 
-  it("validates the PIN and supported region before hashing", async () => {
+  it("validates the PIN and supported region before a new shop is hashed", async () => {
     const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
 
     const invalidPin = await POST(request({ pin: "12ab" }));
@@ -181,7 +230,7 @@ describe("owner onboarding bootstrap", () => {
     expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
   });
 
-  it("derives owner scope, bootstraps atomically, and immediately hydrates acquired billing", async () => {
+  it("bootstraps, hydrates billing, then durably completes onboarding before success", async () => {
     const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
@@ -212,6 +261,8 @@ describe("owner onboarding bootstrap", () => {
       userId: "owner-user-1",
       shopId: "11111111-1111-4111-8111-111111111111",
     });
+    expect(mocks.adminShopMaybeSingle).toHaveBeenCalled();
+    expect(mocks.adminProfileMaybeSingle).toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalledWith(
       expect.any(Response),
       {
@@ -222,7 +273,7 @@ describe("owner onboarding bootstrap", () => {
     );
   });
 
-  it("fails closed instead of admitting a newly created shop with unresolved billing", async () => {
+  it("fails closed with onboarding still incomplete when billing is unresolved", async () => {
     mocks.reconcileShopBillingFromUser.mockResolvedValue({
       linked: false,
       reason: "no_subscription_found",
@@ -232,10 +283,56 @@ describe("owner onboarding bootstrap", () => {
     const response = await POST(request());
 
     expect(response.status).toBe(503);
+    expect(mocks.adminProfileMaybeSingle).not.toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
-  it("reconciles acquired billing again on an exact completed-owner retry", async () => {
+  it("fails closed when canonical billing was not actually persisted", async () => {
+    mocks.adminShopMaybeSingle.mockResolvedValue({
+      data: {
+        id: "11111111-1111-4111-8111-111111111111",
+        owner_id: "owner-user-1",
+        stripe_subscription_id: null,
+        stripe_subscription_status: null,
+        stripe_pricing_model: null,
+        plan: null,
+      },
+      error: null,
+    });
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(503);
+    expect(mocks.adminProfileMaybeSingle).not.toHaveBeenCalled();
+    expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
+  });
+
+  it("repairs a pending owner bootstrap without recreating the shop", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: {
+        shop_id: "11111111-1111-4111-8111-111111111111",
+        role: "owner",
+        completed_onboarding: false,
+        stripe_checkout_complete: true,
+        stripe_customer_id: "cus_trial_owner",
+        stripe_subscription_id: "sub_trial_owner",
+      },
+      error: null,
+    });
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.rpc).not.toHaveBeenCalled();
+    expect(mocks.hashOwnerPin).not.toHaveBeenCalled();
+    expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalled();
+    expect(mocks.adminProfileMaybeSingle).toHaveBeenCalled();
+    expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalled();
+  });
+
+  it("reconciles billing and refreshes the PIN cookie on an exact completed-owner retry", async () => {
     mocks.maybeSingle.mockResolvedValue({
       data: {
         shop_id: "11111111-1111-4111-8111-111111111111",
@@ -254,6 +351,13 @@ describe("owner onboarding bootstrap", () => {
     expect(response.status).toBe(200);
     expect(mocks.rpc).not.toHaveBeenCalled();
     expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "owner-user-1",
+        shopId: "11111111-1111-4111-8111-111111111111",
+      }),
+    );
+    expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalledWith(
+      expect.any(Response),
       expect.objectContaining({
         userId: "owner-user-1",
         shopId: "11111111-1111-4111-8111-111111111111",
@@ -280,7 +384,7 @@ describe("owner onboarding bootstrap", () => {
     expect(migration).toContain("to authenticated");
   });
 
-  it("hardens deployed bootstrap recovery with IANA validation and ambiguity rejection", () => {
+  it("hardens recovery and leaves new owner onboarding pending until billing succeeds", () => {
     const migration = readFileSync(
       "supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql",
       "utf8",
@@ -291,6 +395,7 @@ describe("owner onboarding bootstrap", () => {
     expect(migration).toContain("if v_owned_shop_count > 1 then");
     expect(migration).toContain("Ambiguous owner shop recovery");
     expect(migration).not.toContain("order by s.created_at desc");
+    expect(migration).toContain("completed_onboarding = false");
     expect(migration).toContain("security definer");
     expect(migration).toContain("set search_path = public");
     expect(migration).toContain("to authenticated");

--- a/tests/owner-onboarding-bootstrap.test.ts
+++ b/tests/owner-onboarding-bootstrap.test.ts
@@ -7,6 +7,9 @@ const mocks = vi.hoisted(() => ({
   rpc: vi.fn(),
   hashOwnerPin: vi.fn(),
   setOwnerPinVerifiedCookie: vi.fn((response: Response) => response),
+  admin: { kind: "admin" },
+  stripe: { kind: "stripe" },
+  reconcileShopBillingFromUser: vi.fn(),
 }));
 
 vi.mock("@/features/shared/lib/supabase/server", () => ({
@@ -19,6 +22,15 @@ vi.mock("@/features/shared/lib/supabase/server", () => ({
     })),
     rpc: mocks.rpc,
   }),
+  createAdminSupabase: () => mocks.admin,
+}));
+
+vi.mock("@/features/stripe/lib/stripe/client", () => ({
+  createStripeClient: () => mocks.stripe,
+}));
+
+vi.mock("@/features/stripe/lib/server/canonical-shop-billing", () => ({
+  reconcileShopBillingFromUser: mocks.reconcileShopBillingFromUser,
 }));
 
 vi.mock("@/features/shared/lib/server/owner-pin-crypto", () => ({
@@ -55,6 +67,7 @@ describe("owner onboarding bootstrap", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
+    process.env.STRIPE_SECRET_KEY = "sk_test_owner_bootstrap";
     mocks.getUser.mockResolvedValue({
       data: { user: { id: "owner-user-1" } },
       error: null,
@@ -72,9 +85,15 @@ describe("owner onboarding bootstrap", () => {
     });
     mocks.hashOwnerPin.mockResolvedValue("hashed-owner-pin");
     mocks.rpc.mockResolvedValue({
-      data: [{ shop_id: "11111111-1111-4111-8111-111111111111", created_shop: true }],
+      data: [
+        {
+          shop_id: "11111111-1111-4111-8111-111111111111",
+          created_shop: true,
+        },
+      ],
       error: null,
     });
+    mocks.reconcileShopBillingFromUser.mockResolvedValue({ linked: true });
   });
 
   it("restores a real /onboarding page instead of the production 404", () => {
@@ -94,6 +113,7 @@ describe("owner onboarding bootstrap", () => {
 
     expect(response.status).toBe(401);
     expect(mocks.rpc).not.toHaveBeenCalled();
+    expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
   });
 
   it("rejects assigned staff before the privileged RPC", async () => {
@@ -126,6 +146,19 @@ describe("owner onboarding bootstrap", () => {
     expect(mocks.rpc).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["US", "America/Anchorage"],
+    ["US", "Pacific/Honolulu"],
+    ["CA", "America/St_Johns"],
+    ["CA", "America/Regina"],
+  ])("accepts supported regional timezone %s %s", async (country, timezone) => {
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request({ country, timezone }));
+
+    expect(response.status).toBe(200);
+  });
+
   it("requires a completed Stripe trial claim before shop creation", async () => {
     mocks.maybeSingle.mockResolvedValue({
       data: {
@@ -145,19 +178,22 @@ describe("owner onboarding bootstrap", () => {
     expect(response.status).toBe(403);
     expect(mocks.hashOwnerPin).not.toHaveBeenCalled();
     expect(mocks.rpc).not.toHaveBeenCalled();
+    expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
   });
 
-  it("derives owner scope from auth and calls the atomic bootstrap without a client shop id", async () => {
+  it("derives owner scope, bootstraps atomically, and immediately hydrates acquired billing", async () => {
     const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(payload).toEqual(expect.objectContaining({
-      ok: true,
-      destination: "/dashboard/onboarding-v2",
-    }));
+    expect(payload).toEqual(
+      expect.objectContaining({
+        ok: true,
+        destination: "/dashboard/onboarding-v2",
+      }),
+    );
     expect(mocks.hashOwnerPin).toHaveBeenCalledWith("4826");
     expect(mocks.rpc).toHaveBeenCalledWith("bootstrap_owner_atomic", {
       p_business_name: "High Plains Auto & Fleet",
@@ -170,6 +206,12 @@ describe("owner onboarding bootstrap", () => {
       p_timezone: "America/Denver",
       p_owner_pin_hash: "hashed-owner-pin",
     });
+    expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalledWith({
+      stripe: mocks.stripe,
+      supabase: mocks.admin,
+      userId: "owner-user-1",
+      shopId: "11111111-1111-4111-8111-111111111111",
+    });
     expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalledWith(
       expect.any(Response),
       {
@@ -180,7 +222,46 @@ describe("owner onboarding bootstrap", () => {
     );
   });
 
-  it("keeps the database contract RLS-compatible and blocks self-promotion", () => {
+  it("fails closed instead of admitting a newly created shop with unresolved billing", async () => {
+    mocks.reconcileShopBillingFromUser.mockResolvedValue({
+      linked: false,
+      reason: "no_subscription_found",
+    });
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(503);
+    expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
+  });
+
+  it("reconciles acquired billing again on an exact completed-owner retry", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: {
+        shop_id: "11111111-1111-4111-8111-111111111111",
+        role: "owner",
+        completed_onboarding: true,
+        stripe_checkout_complete: true,
+        stripe_customer_id: "cus_trial_owner",
+        stripe_subscription_id: "sub_trial_owner",
+      },
+      error: null,
+    });
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.rpc).not.toHaveBeenCalled();
+    expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "owner-user-1",
+        shopId: "11111111-1111-4111-8111-111111111111",
+      }),
+    );
+  });
+
+  it("keeps the original database contract RLS-compatible and blocks self-promotion", () => {
     const migration = readFileSync(
       "supabase/migrations/20260814041000_restore_secure_owner_bootstrap.sql",
       "utf8",
@@ -196,6 +277,22 @@ describe("owner onboarding bootstrap", () => {
     expect(migration).toContain("Completed trial claim required");
     expect(migration).toContain("from public.shop_members as existing_membership");
     expect(migration).toContain("from public, anon");
+    expect(migration).toContain("to authenticated");
+  });
+
+  it("hardens deployed bootstrap recovery with IANA validation and ambiguity rejection", () => {
+    const migration = readFileSync(
+      "supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql",
+      "utf8",
+    );
+
+    expect(migration).toContain("pg_catalog.pg_timezone_names");
+    expect(migration).toContain("v_owned_shop_count");
+    expect(migration).toContain("if v_owned_shop_count > 1 then");
+    expect(migration).toContain("Ambiguous owner shop recovery");
+    expect(migration).not.toContain("order by s.created_at desc");
+    expect(migration).toContain("security definer");
+    expect(migration).toContain("set search_path = public");
     expect(migration).toContain("to authenticated");
   });
 });

--- a/tests/owner-onboarding-bootstrap.test.ts
+++ b/tests/owner-onboarding-bootstrap.test.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const PROBE_SHOP_ID = "00000000-0000-4000-8000-000000000002";
+const SHOP_ID = "11111111-1111-4111-8111-111111111111";
+
 const mocks = vi.hoisted(() => {
   const adminFrom = vi.fn();
   return {
@@ -12,7 +15,9 @@ const mocks = vi.hoisted(() => {
     setOwnerPinVerifiedCookie: vi.fn((response: Response) => response),
     adminFrom,
     adminShopMaybeSingle: vi.fn(),
-    adminProfileMaybeSingle: vi.fn(),
+    adminShopLookupLimit: vi.fn(),
+    adminPendingProfileMaybeSingle: vi.fn(),
+    adminCompleteProfileMaybeSingle: vi.fn(),
     admin: { from: adminFrom },
     stripe: { kind: "stripe" },
     reconcileShopBillingFromUser: vi.fn(),
@@ -94,19 +99,25 @@ describe("owner onboarding bootstrap", () => {
     });
     mocks.hashOwnerPin.mockResolvedValue("hashed-owner-pin");
     mocks.verifyOwnerPin.mockResolvedValue(true);
-    mocks.rpc.mockResolvedValue({
-      data: [
-        {
-          shop_id: "11111111-1111-4111-8111-111111111111",
-          created_shop: true,
-        },
-      ],
-      error: null,
-    });
+    mocks.rpc.mockImplementation(
+      async (_name: string, args: Record<string, unknown>) => {
+        if (args.p_country === "__PROBE__") {
+          return {
+            data: [{ shop_id: PROBE_SHOP_ID, created_shop: false }],
+            error: null,
+          };
+        }
+        return {
+          data: [{ shop_id: SHOP_ID, created_shop: true }],
+          error: null,
+        };
+      },
+    );
     mocks.reconcileShopBillingFromUser.mockResolvedValue({ linked: true });
+    mocks.adminShopLookupLimit.mockResolvedValue({ data: [], error: null });
     mocks.adminShopMaybeSingle.mockResolvedValue({
       data: {
-        id: "11111111-1111-4111-8111-111111111111",
+        id: SHOP_ID,
         owner_id: "owner-user-1",
         owner_pin_hash: "hashed-existing-owner-pin",
         stripe_subscription_id: "sub_trial_owner",
@@ -116,7 +127,11 @@ describe("owner onboarding bootstrap", () => {
       },
       error: null,
     });
-    mocks.adminProfileMaybeSingle.mockResolvedValue({
+    mocks.adminPendingProfileMaybeSingle.mockResolvedValue({
+      data: { id: "owner-user-1", completed_onboarding: false },
+      error: null,
+    });
+    mocks.adminCompleteProfileMaybeSingle.mockResolvedValue({
       data: { id: "owner-user-1", completed_onboarding: true },
       error: null,
     });
@@ -124,18 +139,25 @@ describe("owner onboarding bootstrap", () => {
       if (table === "shops") {
         return {
           select: vi.fn(() => ({
-            eq: vi.fn(() => ({ maybeSingle: mocks.adminShopMaybeSingle })),
+            eq: vi.fn((column: string) =>
+              column === "owner_id"
+                ? { limit: mocks.adminShopLookupLimit }
+                : { maybeSingle: mocks.adminShopMaybeSingle },
+            ),
           })),
         };
       }
       if (table === "profiles") {
         return {
-          update: vi.fn(() => ({
+          update: vi.fn((patch: { completed_onboarding?: boolean }) => ({
             eq: vi.fn(() => ({
               eq: vi.fn(() => ({
                 eq: vi.fn(() => ({
                   select: vi.fn(() => ({
-                    maybeSingle: mocks.adminProfileMaybeSingle,
+                    maybeSingle:
+                      patch.completed_onboarding === false
+                        ? mocks.adminPendingProfileMaybeSingle
+                        : mocks.adminCompleteProfileMaybeSingle,
                   })),
                 })),
               })),
@@ -234,7 +256,7 @@ describe("owner onboarding bootstrap", () => {
     expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
   });
 
-  it("bootstraps through the pending v2 RPC, verifies persisted PIN, hydrates billing, then completes", async () => {
+  it("probes the hardened contract, bootstraps pending, verifies PIN, hydrates billing, then completes", async () => {
     const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request());
@@ -247,8 +269,19 @@ describe("owner onboarding bootstrap", () => {
         destination: "/dashboard/onboarding-v2",
       }),
     );
+    expect(mocks.rpc).toHaveBeenNthCalledWith(1, "bootstrap_owner_atomic", {
+      p_business_name: "__profixiq_owner_bootstrap_v2_probe__",
+      p_shop_name: "__probe__",
+      p_street: "__probe__",
+      p_city: "__probe__",
+      p_province: "__probe__",
+      p_postal_code: "__probe__",
+      p_country: "__PROBE__",
+      p_timezone: "Etc/UTC",
+      p_owner_pin_hash: "__probe__",
+    });
     expect(mocks.hashOwnerPin).toHaveBeenCalledWith("4826");
-    expect(mocks.rpc).toHaveBeenCalledWith("bootstrap_owner_pending_v2", {
+    expect(mocks.rpc).toHaveBeenNthCalledWith(2, "bootstrap_owner_atomic", {
       p_business_name: "High Plains Auto & Fleet",
       p_shop_name: "High Plains Auto & Fleet",
       p_street: "4250 Trade Center Drive",
@@ -257,29 +290,28 @@ describe("owner onboarding bootstrap", () => {
       p_postal_code: "80216",
       p_country: "US",
       p_timezone: "America/Denver",
-      p_owner_pin_hash: "hashed-owner-pin",
+      p_owner_pin_hash:
+        "profixiq-owner-bootstrap-pending-v2:hashed-owner-pin",
     });
     expect(mocks.verifyOwnerPin).toHaveBeenCalledWith(
       "4826",
       "hashed-existing-owner-pin",
     );
+    expect(mocks.adminPendingProfileMaybeSingle).toHaveBeenCalled();
     expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalledWith({
       stripe: mocks.stripe,
       supabase: mocks.admin,
       userId: "owner-user-1",
-      shopId: "11111111-1111-4111-8111-111111111111",
+      shopId: SHOP_ID,
     });
-    expect(mocks.adminProfileMaybeSingle).toHaveBeenCalled();
+    expect(mocks.adminCompleteProfileMaybeSingle).toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalled();
   });
 
-  it("fails closed instead of falling back to the legacy RPC if v2 is not deployed yet", async () => {
-    mocks.rpc.mockResolvedValue({
+  it("fails closed before any mutation when the hardened database contract is not deployed", async () => {
+    mocks.rpc.mockResolvedValueOnce({
       data: null,
-      error: {
-        code: "PGRST202",
-        message: "Could not find the function public.bootstrap_owner_pending_v2",
-      },
+      error: { code: "P0001", message: "Unsupported country" },
     });
     const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
 
@@ -287,37 +319,57 @@ describe("owner onboarding bootstrap", () => {
 
     expect(response.status).toBe(503);
     expect(mocks.rpc).toHaveBeenCalledTimes(1);
+    expect(mocks.hashOwnerPin).not.toHaveBeenCalled();
+    expect(mocks.adminShopLookupLimit).not.toHaveBeenCalled();
     expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
-  it("rejects a stale concurrent request whose PIN does not match the persisted winner", async () => {
-    mocks.verifyOwnerPin.mockResolvedValue(false);
-    mocks.rpc.mockResolvedValue({
-      data: [
-        {
-          shop_id: "11111111-1111-4111-8111-111111111111",
-          created_shop: false,
-        },
-      ],
+  it("rejects ambiguous historical owner recovery before the real bootstrap RPC", async () => {
+    mocks.adminShopLookupLimit.mockResolvedValue({
+      data: [{ id: "shop-a" }, { id: "shop-b" }],
       error: null,
     });
+    const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
+
+    const response = await POST(request());
+
+    expect(response.status).toBe(409);
+    expect(mocks.rpc).toHaveBeenCalledTimes(1);
+    expect(mocks.hashOwnerPin).not.toHaveBeenCalled();
+    expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects a stale concurrent request whose PIN does not match the persisted winner", async () => {
+    mocks.verifyOwnerPin.mockResolvedValue(false);
+    mocks.rpc.mockImplementation(
+      async (_name: string, args: Record<string, unknown>) =>
+        args.p_country === "__PROBE__"
+          ? {
+              data: [{ shop_id: PROBE_SHOP_ID, created_shop: false }],
+              error: null,
+            }
+          : {
+              data: [{ shop_id: SHOP_ID, created_shop: false }],
+              error: null,
+            },
+    );
     const { POST } = await import("../app/api/onboarding/bootstrap-owner/route");
 
     const response = await POST(request({ pin: "9999" }));
 
     expect(response.status).toBe(401);
-    expect(mocks.rpc).toHaveBeenCalled();
+    expect(mocks.rpc).toHaveBeenCalledTimes(2);
     expect(mocks.verifyOwnerPin).toHaveBeenCalledWith(
       "9999",
       "hashed-existing-owner-pin",
     );
+    expect(mocks.adminPendingProfileMaybeSingle).not.toHaveBeenCalled();
     expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
-    expect(mocks.adminProfileMaybeSingle).not.toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
-  it("fails closed with onboarding still incomplete when billing is unresolved", async () => {
+  it("fails closed with onboarding pending when billing is unresolved", async () => {
     mocks.reconcileShopBillingFromUser.mockResolvedValue({
       linked: false,
       reason: "no_subscription_found",
@@ -327,14 +379,15 @@ describe("owner onboarding bootstrap", () => {
     const response = await POST(request());
 
     expect(response.status).toBe(503);
-    expect(mocks.adminProfileMaybeSingle).not.toHaveBeenCalled();
+    expect(mocks.adminPendingProfileMaybeSingle).toHaveBeenCalled();
+    expect(mocks.adminCompleteProfileMaybeSingle).not.toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
   it("fails closed when canonical billing was not actually persisted", async () => {
     mocks.adminShopMaybeSingle.mockResolvedValue({
       data: {
-        id: "11111111-1111-4111-8111-111111111111",
+        id: SHOP_ID,
         owner_id: "owner-user-1",
         owner_pin_hash: "hashed-existing-owner-pin",
         stripe_subscription_id: null,
@@ -349,14 +402,15 @@ describe("owner onboarding bootstrap", () => {
     const response = await POST(request());
 
     expect(response.status).toBe(503);
-    expect(mocks.adminProfileMaybeSingle).not.toHaveBeenCalled();
+    expect(mocks.adminPendingProfileMaybeSingle).toHaveBeenCalled();
+    expect(mocks.adminCompleteProfileMaybeSingle).not.toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
   it("repairs a pending owner bootstrap only after verifying the stored PIN", async () => {
     mocks.maybeSingle.mockResolvedValue({
       data: {
-        shop_id: "11111111-1111-4111-8111-111111111111",
+        shop_id: SHOP_ID,
         role: "owner",
         completed_onboarding: false,
         stripe_checkout_complete: true,
@@ -377,14 +431,14 @@ describe("owner onboarding bootstrap", () => {
       "hashed-existing-owner-pin",
     );
     expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalled();
-    expect(mocks.adminProfileMaybeSingle).toHaveBeenCalled();
+    expect(mocks.adminCompleteProfileMaybeSingle).toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalled();
   });
 
   it("rejects a wrong PIN on a pending owner before reconciliation", async () => {
     mocks.maybeSingle.mockResolvedValue({
       data: {
-        shop_id: "11111111-1111-4111-8111-111111111111",
+        shop_id: SHOP_ID,
         role: "owner",
         completed_onboarding: false,
         stripe_checkout_complete: true,
@@ -400,14 +454,14 @@ describe("owner onboarding bootstrap", () => {
 
     expect(response.status).toBe(401);
     expect(mocks.reconcileShopBillingFromUser).not.toHaveBeenCalled();
-    expect(mocks.adminProfileMaybeSingle).not.toHaveBeenCalled();
+    expect(mocks.adminCompleteProfileMaybeSingle).not.toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
-  it("reconciles a completed owner retry only after verifying the stored PIN", async () => {
+  it("reconciles and revalidates a completed owner retry only after verifying the stored PIN", async () => {
     mocks.maybeSingle.mockResolvedValue({
       data: {
-        shop_id: "11111111-1111-4111-8111-111111111111",
+        shop_id: SHOP_ID,
         role: "owner",
         completed_onboarding: true,
         stripe_checkout_complete: true,
@@ -427,13 +481,14 @@ describe("owner onboarding bootstrap", () => {
       "hashed-existing-owner-pin",
     );
     expect(mocks.reconcileShopBillingFromUser).toHaveBeenCalled();
+    expect(mocks.adminCompleteProfileMaybeSingle).toHaveBeenCalled();
     expect(mocks.setOwnerPinVerifiedCookie).toHaveBeenCalled();
   });
 
   it("rejects a wrong PIN on a completed owner before refreshing privileges", async () => {
     mocks.maybeSingle.mockResolvedValue({
       data: {
-        shop_id: "11111111-1111-4111-8111-111111111111",
+        shop_id: SHOP_ID,
         role: "owner",
         completed_onboarding: true,
         stripe_checkout_complete: true,
@@ -452,28 +507,30 @@ describe("owner onboarding bootstrap", () => {
     expect(mocks.setOwnerPinVerifiedCookie).not.toHaveBeenCalled();
   });
 
-  it("keeps the deployed legacy RPC untouched during the expand phase", () => {
+  it("keeps the same RPC type shape while supporting old-app and new-app completion semantics", () => {
     const migration = readFileSync(
       "supabase/migrations/20260814160000_harden_owner_bootstrap_recovery.sql",
       "utf8",
     );
 
     expect(migration).toContain(
-      "create or replace function public.bootstrap_owner_pending_v2",
+      "create or replace function public.bootstrap_owner_atomic",
     );
-    expect(migration).not.toContain(
-      "create or replace function public.bootstrap_owner_atomic(",
-    );
-    expect(migration).toContain("completed_onboarding = false");
+    expect(migration).not.toContain("bootstrap_owner_pending_v2");
+    expect(migration).toContain("__profixiq_owner_bootstrap_v2_probe__");
+    expect(migration).toContain("profixiq-owner-bootstrap-pending-v2:");
+    expect(migration).toContain("v_effective_owner_pin_hash");
+    expect(migration).toContain("completed_onboarding = not v_pending_protocol");
     expect(migration).toContain("return query select v_profile.shop_id, false");
     expect(migration).toContain("pg_catalog.pg_timezone_names");
     expect(migration).toContain("Ambiguous owner shop recovery");
+    expect(migration).not.toContain("order by s.created_at desc");
     expect(migration).toContain("security definer");
     expect(migration).toContain("set search_path = public");
     expect(migration).toContain("to authenticated");
   });
 
-  it("preserves the original deployed RPC contract until a later contract phase", () => {
+  it("preserves the original deployed RPC signature for rolling compatibility", () => {
     const deployed = readFileSync(
       "supabase/migrations/20260814041000_restore_secure_owner_bootstrap.sql",
       "utf8",

--- a/tests/owner-onboarding-codex-hardening.test.ts
+++ b/tests/owner-onboarding-codex-hardening.test.ts
@@ -12,6 +12,11 @@ const ownerFormSource = readFileSync(
   "app/onboarding/OwnerOnboardingForm.tsx",
   "utf8",
 );
+const ownerPageSource = readFileSync("app/onboarding/page.tsx", "utf8");
+const bootstrapRouteSource = readFileSync(
+  "app/api/onboarding/bootstrap-owner/route.ts",
+  "utf8",
+);
 const guidedSettingsSource = readFileSync(
   "features/onboarding-v2/components/ShopSettingsSetupModal.tsx",
   "utf8",
@@ -35,8 +40,10 @@ describe("owner onboarding Codex hardening", () => {
     expect(getSupportedShopTimezones("CA").length).toBeGreaterThan(20);
   });
 
-  it("routes Shop Boost only from explicit persisted acquisition provenance", () => {
-    expect(ownerFormSource).toContain("readPersistedActivationContext");
+  it("routes Shop Boost only from provenance on the current acquisition URL", () => {
+    expect(ownerFormSource).toContain("readActivationContextFromSearchParams");
+    expect(ownerFormSource).toContain("appendActivationContextToHref");
+    expect(ownerFormSource).not.toContain("readPersistedActivationContext");
     expect(ownerFormSource).toContain('"/onboarding/shop-boost"');
     expect(middlewareSource).not.toContain("needsShopBoostIntake");
     expect(middlewareSource).not.toContain('from("shop_boost_intakes")');
@@ -48,7 +55,17 @@ describe("owner onboarding Codex hardening", () => {
     expect(middlewareSource).toContain("!isGuidedOnboardingPath");
   });
 
-  it("reuses the verified HTTP-only owner PIN session in guided Shop Settings", () => {
+  it("keeps an owner with a created shop but incomplete billing inside onboarding", () => {
+    expect(middlewareSource).toContain("pendingOwnerBootstrap");
+    expect(middlewareSource).toContain('normalizedRole === "owner"');
+    expect(middlewareSource).toContain("completed = pendingOwnerBootstrap");
+    expect(ownerPageSource).toContain("if (profile?.completed_onboarding)");
+    expect(ownerPageSource).not.toContain("profile?.shop_id || profile?.completed_onboarding");
+    expect(bootstrapRouteSource).toContain("finalizeOwnerOnboarding");
+    expect(bootstrapRouteSource).toContain("canonical_billing_not_ready");
+  });
+
+  it("reuses the verified HTTP-only owner PIN session in guided Shop Settings and retries refreshes", () => {
     expect(pinVerifySource).toContain("export async function GET(req: Request)");
     expect(pinVerifySource).toContain("getOwnerPinCookieFromRequest");
     expect(pinVerifySource).toContain("verifyOwnerPinToken");
@@ -60,13 +77,26 @@ describe("owner onboarding Codex hardening", () => {
     );
     expect(guidedSettingsSource).toContain("pinStatus.verified");
     expect(guidedSettingsSource).toContain("setPinExpiresAt(pinStatus.expiresAt)");
+    expect(bootstrapRouteSource).toContain("successfulBootstrapResponse");
+    expect(bootstrapRouteSource).toContain("replayed: true");
   });
 
-  it("uses the same timezone contract in first-shop and guided settings surfaces", () => {
+  it("treats shop and hours as mandatory load state while PIN status remains optional", () => {
+    expect(guidedSettingsSource).toContain("settingsReady");
+    expect(guidedSettingsSource).toContain("setSettingsReady(false)");
+    expect(guidedSettingsSource).toContain("setSettingsReady(true)");
+    expect(guidedSettingsSource).toContain("Unable to load shop hours.");
+    expect(guidedSettingsSource).toContain("PIN status is optional convenience only");
+    expect(guidedSettingsSource).toContain("saving || loading || !settingsReady");
+  });
+
+  it("uses the shared timezone contract but preserves an existing unmatched stored timezone", () => {
     expect(ownerFormSource).toContain("getSupportedShopTimezones");
     expect(ownerFormSource).toContain("isSupportedShopTimezone");
     expect(guidedSettingsSource).toContain("getSupportedShopTimezones");
     expect(guidedSettingsSource).toContain("isSupportedShopTimezone");
+    expect(guidedSettingsSource).toContain("if (timezone && !supported.includes(timezone))");
+    expect(guidedSettingsSource).toContain("setTimezone(storedTimezone || defaultShopTimezone(shopCountry))");
     expect(guidedSettingsSource).not.toContain("const TIMEZONES = [");
   });
 });

--- a/tests/owner-onboarding-codex-hardening.test.ts
+++ b/tests/owner-onboarding-codex-hardening.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  getSupportedShopTimezones,
+  isSupportedShopTimezone,
+  shopCountryForTimezone,
+} from "@/features/shared/lib/timezones/shopTimezones";
+
+const middlewareSource = readFileSync("middleware.ts", "utf8");
+const ownerFormSource = readFileSync(
+  "app/onboarding/OwnerOnboardingForm.tsx",
+  "utf8",
+);
+const guidedSettingsSource = readFileSync(
+  "features/onboarding-v2/components/ShopSettingsSetupModal.tsx",
+  "utf8",
+);
+const pinVerifySource = readFileSync(
+  "app/api/shop/owner-pin/verify/route.ts",
+  "utf8",
+);
+
+describe("owner onboarding Codex hardening", () => {
+  it("supports the real US and Canada regional timezone set used by onboarding", () => {
+    expect(isSupportedShopTimezone("US", "America/Anchorage")).toBe(true);
+    expect(isSupportedShopTimezone("US", "Pacific/Honolulu")).toBe(true);
+    expect(isSupportedShopTimezone("CA", "America/St_Johns")).toBe(true);
+    expect(isSupportedShopTimezone("CA", "America/Regina")).toBe(true);
+    expect(isSupportedShopTimezone("CA", "America/Vancouver")).toBe(true);
+    expect(isSupportedShopTimezone("US", "America/St_Johns")).toBe(false);
+    expect(shopCountryForTimezone("America/Regina")).toBe("CA");
+    expect(shopCountryForTimezone("America/Anchorage")).toBe("US");
+    expect(getSupportedShopTimezones("US").length).toBeGreaterThan(20);
+    expect(getSupportedShopTimezones("CA").length).toBeGreaterThan(20);
+  });
+
+  it("routes Shop Boost only from explicit persisted acquisition provenance", () => {
+    expect(ownerFormSource).toContain("readPersistedActivationContext");
+    expect(ownerFormSource).toContain('"/onboarding/shop-boost"');
+    expect(middlewareSource).not.toContain("needsShopBoostIntake");
+    expect(middlewareSource).not.toContain('from("shop_boost_intakes")');
+  });
+
+  it("preserves guided onboarding on mobile instead of collapsing it to generic mobile home", () => {
+    expect(middlewareSource).toContain("isGuidedOnboardingPath");
+    expect(middlewareSource).toContain('pathname === "/dashboard/onboarding-v2"');
+    expect(middlewareSource).toContain("!isGuidedOnboardingPath");
+  });
+
+  it("reuses the verified HTTP-only owner PIN session in guided Shop Settings", () => {
+    expect(pinVerifySource).toContain("export async function GET(req: Request)");
+    expect(pinVerifySource).toContain("getOwnerPinCookieFromRequest");
+    expect(pinVerifySource).toContain("verifyOwnerPinToken");
+    expect(pinVerifySource).toContain("expiresAt:");
+    expect(pinVerifySource).toContain('"Cache-Control": "private, no-store"');
+
+    expect(guidedSettingsSource).toContain(
+      'fetch("/api/shop/owner-pin/verify",',
+    );
+    expect(guidedSettingsSource).toContain("pinStatus.verified");
+    expect(guidedSettingsSource).toContain("setPinExpiresAt(pinStatus.expiresAt)");
+  });
+
+  it("uses the same timezone contract in first-shop and guided settings surfaces", () => {
+    expect(ownerFormSource).toContain("getSupportedShopTimezones");
+    expect(ownerFormSource).toContain("isSupportedShopTimezone");
+    expect(guidedSettingsSource).toContain("getSupportedShopTimezones");
+    expect(guidedSettingsSource).toContain("isSupportedShopTimezone");
+    expect(guidedSettingsSource).not.toContain("const TIMEZONES = [");
+  });
+});

--- a/tests/owner-onboarding-codex-hardening.test.ts
+++ b/tests/owner-onboarding-codex-hardening.test.ts
@@ -41,7 +41,7 @@ describe("owner onboarding Codex hardening", () => {
   });
 
   it("routes Shop Boost only from provenance on the current acquisition URL", () => {
-    expect(ownerFormSource).toContain("readActivationContextFromSearchParams");
+    expect(ownerFormSource).toContain("parseActivationContextFromSearchParams");
     expect(ownerFormSource).toContain("appendActivationContextToHref");
     expect(ownerFormSource).not.toContain("readPersistedActivationContext");
     expect(ownerFormSource).toContain('"/onboarding/shop-boost"');

--- a/tests/shop-boost-onboarding-handoff-context.test.ts
+++ b/tests/shop-boost-onboarding-handoff-context.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const handoffSource = readFileSync(
+  "app/onboarding/shop-boost/page.tsx",
+  "utf8",
+);
+
+describe("Shop Boost onboarding handoff context", () => {
+  it("uses the forwarded URL activation context as the authoritative handoff", () => {
+    expect(handoffSource).toContain('useSearchParams');
+    expect(handoffSource).toContain('parseActivationContextFromSearchParams');
+    expect(handoffSource).toContain(
+      'const context = parseActivationContextFromSearchParams(searchParams)',
+    );
+    expect(handoffSource).not.toContain('readPersistedActivationContext');
+    expect(handoffSource).toContain('demoId: context.demoId');
+    expect(handoffSource).toContain('intakeId: context.intakeId');
+  });
+});

--- a/tests/stripe-subscription-status.test.ts
+++ b/tests/stripe-subscription-status.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { isStripeSubscriptionAccessBearing } from "@/features/stripe/lib/stripe/subscriptionStatus";
+
+describe("Stripe subscription access", () => {
+  it.each(["trialing", "active"])("accepts %s subscriptions", (status) => {
+    expect(isStripeSubscriptionAccessBearing(status)).toBe(true);
+  });
+
+  it.each([
+    "incomplete",
+    "incomplete_expired",
+    "past_due",
+    "canceled",
+    "unpaid",
+    "paused",
+    "unknown",
+    null,
+  ])("rejects %s subscriptions", (status) => {
+    expect(isStripeSubscriptionAccessBearing(status)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Scope

Corrects the still-relevant owner-onboarding findings from merged PR #1432 and subsequent Codex review passes without rewriting deployed migration history.

### Fixes
- verifies the submitted Owner PIN against the persisted `shops.owner_pin_hash` before any pending/completed retry can reconcile billing, finalize onboarding, or receive the privileged Owner PIN cookie;
- verifies the persisted PIN again after first-shop bootstrap, covering concurrent requests that pre-read a clean profile;
- reconciles the newly created/recovered shop into the canonical Stripe package/pricing/subscription contract before onboarding reports success;
- keeps the hardened new-app path pending until canonical billing is actually persisted and the server explicitly finalizes the owner profile;
- makes pending/completed retries idempotent without recreating or arbitrarily selecting shops;
- prevents duplicate requests from writing `completed_onboarding=false` after another request has already finalized successfully—the atomic DB bootstrap is the single writer of initial pending state;
- rejects ambiguous historical recovery when more than one owned shop exists;
- removes the unsafe middleware inference that every completed owner/admin without a `shop_boost_intakes` row must be an interrupted Shop Boost activation;
- preserves `/dashboard/onboarding-v2` on iPhone/iPad/Android instead of rewriting it to generic `/mobile`;
- Guided Shop Settings reuses the existing HTTP-only Owner PIN session without exposing the token;
- uses one shared US/Canada timezone contract across first-shop onboarding and Guided Shop Settings;
- Shop Boost consumes the exact forwarded activation context from the current handoff URL rather than falling back to unrelated/stale local storage.

## Rolling-deployment safety

The forward migration keeps the **existing** public RPC signature:

`public.bootstrap_owner_atomic(...)`

No second public function is added, so generated Supabase types do not change.

The same-signature function supports both deployed application generations safely:

1. **Old app + old DB:** existing behavior.
2. **Old app + new DB:** old callers send the ordinary PIN hash, so the RPC retains the legacy completion semantic and remains compatible during migration-first rollout.
3. **New app + old DB:** before any real bootstrap, the route makes a harmless sentinel call. The old RPC rejects that sentinel before mutation, so the new app fails closed with HTTP 503 and does not run the old bootstrap body.
4. **New app + new DB:** the sentinel proves the hardened body is present. The route prefixes the already-string PIN-hash argument with the private `profixiq-owner-bootstrap-pending-v2:` protocol marker. The DB strips that marker before storing the real hash and atomically leaves `completed_onboarding=false`. The route verifies the persisted PIN, reconciles canonical Stripe billing, verifies the canonical shop billing fields, and only then sets `completed_onboarding=true` and issues the privileged Owner-PIN cookie. It does not perform a second pending write, so a duplicate request cannot reopen an owner another request already completed.

The route also preflights owned-shop history so an application rollback cannot use the former `newest shop wins` historical recovery behavior when multiple owner shops exist.

### Database safety

The already-applied migration `20260814041000_restore_secure_owner_bootstrap.sql` remains untouched.

The forward migration is:

`20260814160000_harden_owner_bootstrap_recovery.sql`

It replaces the function body in place while preserving its signature/grants, validates timezone against PostgreSQL's installed IANA catalog, fails closed on ambiguous historical recovery, accepts read-only retries for pending/completed owned shops, strips the private pending protocol marker before persisting the PIN hash, and preserves legacy callers during rolling deployment.

### Validation

Do not merge/apply until the exact current head passes typecheck, changed-file lint, complete tests, production build, Supabase clean replay/runtime integrations, and a fresh Codex review. No production migration has been applied from this PR.

## Stripe trial account handoff

The 14-day acquisition checkout now carries its verified Stripe email into account setup instead of landing on an unbound sign-in form:

- a no-store server route validates the completed acquisition Checkout Session, configured price, checkout email, and access-bearing subscription before returning the account email;
- the handoff defaults to owner-account creation and locks the identifier to the Checkout Session email;
- unconfirmed owners can explicitly resend the Supabase signup verification email while preserving the acquisition callback;
- acquisition linking and owner finalization now reject canceled, unpaid, paused, incomplete, and expired subscriptions.

### Trial-fix validation

- TypeScript: passed
- changed-file ESLint: passed
- API-route audit: passed
- focused Stripe/auth/onboarding regressions: 39 passed
- complete local Vitest run: not claimed; the Windows run reached the 120-second cap after unrelated baseline source/SQL newline assertions failed

### Remaining merge blockers

This PR is still not safe to merge. The unresolved owner-bootstrap migration findings around the client-selectable legacy protocol, old-app pending retries, authorization-bearing RLS membership before billing readiness, and country-specific timezone validation require a staged migration repair. No production migration has been applied from this PR.
