### PR TITLE
expose Technician CoPilot and preserve canonical queue numbers

### DIFF
--- a/app/mobile/copilot/technician/page.tsx
+++ b/app/mobile/copilot/technician/page.tsx
@@ -1,0 +1,5 @@
+import { TechnicianTextCopilot } from "@/features/copilot/technician/components/TechnicianTextCopilot";
+
+export default function MobileTechnicianCopilotPage() {
+  return <TechnicianTextCopilot />;
+}

--- a/app/tech/queue/page.tsx
+++ b/app/tech/queue/page.tsx
@@ -287,8 +287,7 @@ export default function TechQueuePage() {
         const { data: wos } = await supabase
           .from("work_orders")
           .select("id, custom_id, type")
-          .in("id", woIds)
-          .neq("type", "historical_import");
+          .in("id", woIds);
 
         const map: Record<string, { id: string; custom_id: string | null }> =
           {};

--- a/app/tech/queue/page.tsx
+++ b/app/tech/queue/page.tsx
@@ -15,6 +15,45 @@ type WorkOrderSlim = Pick<
   DB["public"]["Tables"]["work_orders"]["Row"],
   "id" | "custom_id" | "type"
 >;
+type WorkOrderDisplayMap = Record<
+  string,
+  { id: string; custom_id: string | null }
+>;
+
+export function buildTechQueueWorkOrderMap(
+  rows: readonly WorkOrderSlim[],
+): WorkOrderDisplayMap {
+  return Object.fromEntries(
+    rows
+      .filter((row) => row.type !== "historical_import")
+      .map((row) => [
+        row.id,
+        { id: row.id, custom_id: row.custom_id ?? null },
+      ]),
+  );
+}
+
+export function TechQueueWorkOrderLabel({
+  workOrderId,
+  workOrderMap,
+}: {
+  workOrderId: string | null;
+  workOrderMap: WorkOrderDisplayMap;
+}) {
+  const customId = workOrderId
+    ? workOrderMap[workOrderId]?.custom_id
+    : null;
+  return (
+    <>
+      {customId
+        ? customId
+        : workOrderId
+          ? `WO #${workOrderId.slice(0, 8)}`
+          : "Work order"}
+    </>
+  );
+}
+
 type PartRequest = DB["public"]["Tables"]["part_requests"]["Row"];
 type PartRequestMini = Pick<PartRequest, "job_id" | "work_order_id">;
 
@@ -153,9 +192,8 @@ export default function TechQueuePage() {
   });
 
   const [lines, setLines] = useState<Line[]>([]);
-  const [workOrderMap, setWorkOrderMap] = useState<
-    Record<string, { id: string; custom_id: string | null }>
-  >({});
+  const [workOrderMap, setWorkOrderMap] =
+    useState<WorkOrderDisplayMap>({});
 
   // active job / work order highlighting
   const [activeLineId, setActiveLineId] = useState<string | null>(null);
@@ -260,11 +298,14 @@ export default function TechQueuePage() {
           .select("id, custom_id, type")
           .in("id", woIds);
 
+        const workOrders = (wos ?? []) as WorkOrderSlim[];
         woTypeMap = {};
-        (wos ?? []).forEach((wo) => {
-          const row = wo as WorkOrderSlim;
+        workOrders.forEach((row) => {
           woTypeMap[row.id] = row.type ?? null;
         });
+        setWorkOrderMap(buildTechQueueWorkOrderMap(workOrders));
+      } else {
+        setWorkOrderMap({});
       }
 
       const activeQueue = raw.filter((l) => !isCompletedLike(l.status) && woTypeMap[l.work_order_id ?? ""] !== "historical_import");
@@ -282,25 +323,7 @@ export default function TechQueuePage() {
       setActiveLineId(punched?.id ?? null);
       setActiveWorkOrderId(punched?.work_order_id ?? null);
 
-      // 5) fetch work orders for display labels
-      if (woIds.length > 0) {
-        const { data: wos } = await supabase
-          .from("work_orders")
-          .select("id, custom_id, type")
-          .in("id", woIds);
-
-        const map: Record<string, { id: string; custom_id: string | null }> =
-          {};
-        (wos ?? []).forEach((wo) => {
-          const row = wo as WorkOrderSlim;
-          map[row.id] = { id: row.id, custom_id: row.custom_id ?? null };
-        });
-        setWorkOrderMap(map);
-      } else {
-        setWorkOrderMap({});
-      }
-
-      // 6) fetch open part requests for this tech in this shop (involved)
+      // 5) fetch open part requests for this tech in this shop (involved)
       const { data: prs, error: prErr } = await supabase
         .from("part_requests")
         .select(
@@ -482,16 +505,6 @@ export default function TechQueuePage() {
         {filteredLines.map((line) => {
           const bucket = toBucket(line);
           const priority = toPriority(line);
-          const wo = line.work_order_id
-            ? workOrderMap[line.work_order_id]
-            : null;
-
-          const woLabel = wo?.custom_id
-            ? wo.custom_id
-            : line.work_order_id
-              ? `WO #${line.work_order_id.slice(0, 8)}`
-              : "Work order";
-
           const title = (line.description || line.complaint || "Untitled job")
             .trim();
 
@@ -531,7 +544,10 @@ export default function TechQueuePage() {
               <div className="flex items-center justify-between gap-3 pl-3">
                 <div className="min-w-0">
                   <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
-                    {woLabel}
+                    <TechQueueWorkOrderLabel
+                      workOrderId={line.work_order_id}
+                      workOrderMap={workOrderMap}
+                    />
                     {isSameWorkOrder ? (
                       <span className="ml-2 text-[10px] text-[color:var(--theme-text-secondary)]">
                         • Same WO

--- a/app/tech/queue/page.tsx
+++ b/app/tech/queue/page.tsx
@@ -6,6 +6,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import {
+  buildTechQueueWorkOrderMap,
+  TechQueueWorkOrderLabel,
+  type WorkOrderDisplayMap,
+} from "@/features/work-orders/components/TechQueueWorkOrderLabel";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -15,45 +20,6 @@ type WorkOrderSlim = Pick<
   DB["public"]["Tables"]["work_orders"]["Row"],
   "id" | "custom_id" | "type"
 >;
-type WorkOrderDisplayMap = Record<
-  string,
-  { id: string; custom_id: string | null }
->;
-
-export function buildTechQueueWorkOrderMap(
-  rows: readonly WorkOrderSlim[],
-): WorkOrderDisplayMap {
-  return Object.fromEntries(
-    rows
-      .filter((row) => row.type !== "historical_import")
-      .map((row) => [
-        row.id,
-        { id: row.id, custom_id: row.custom_id ?? null },
-      ]),
-  );
-}
-
-export function TechQueueWorkOrderLabel({
-  workOrderId,
-  workOrderMap,
-}: {
-  workOrderId: string | null;
-  workOrderMap: WorkOrderDisplayMap;
-}) {
-  const customId = workOrderId
-    ? workOrderMap[workOrderId]?.custom_id
-    : null;
-  return (
-    <>
-      {customId
-        ? customId
-        : workOrderId
-          ? `WO #${workOrderId.slice(0, 8)}`
-          : "Work order"}
-    </>
-  );
-}
-
 type PartRequest = DB["public"]["Tables"]["part_requests"]["Row"];
 type PartRequestMini = Pick<PartRequest, "job_id" | "work_order_id">;
 

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -43,6 +43,7 @@ function getTitleFromPath(pathname: string): string {
 }
 
 function isImmersiveRoute(pathname: string): boolean {
+  if (pathname === "/mobile/copilot/technician") return true;
   if (pathname.startsWith("/mobile/jobs/")) return true;
   if (pathname === "/mobile/inspections/import") return false;
   return /^\/mobile\/inspections\/[^/]+$/.test(pathname);

--- a/features/copilot/technician/client/useTechnicianCopilotAvailability.ts
+++ b/features/copilot/technician/client/useTechnicianCopilotAvailability.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+
+type CapabilityRow = {
+  capability: string;
+  enabled: boolean;
+};
+
+export function resolveTechnicianCopilotTextAvailability(
+  rows: readonly CapabilityRow[],
+  technicianId: string,
+): boolean {
+  const technician = rows.find(
+    (row) =>
+      row.capability === `technician_copilot_text:${technicianId}`,
+  );
+  if (technician) return technician.enabled;
+
+  return (
+    rows.find((row) => row.capability === "technician_copilot_text")
+      ?.enabled ?? false
+  );
+}
+
+export function useTechnicianCopilotAvailability(
+  shouldCheck: boolean,
+): boolean {
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const [available, setAvailable] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setAvailable(false);
+    if (!shouldCheck) return () => {
+      active = false;
+    };
+
+    void (async () => {
+      const auth = await supabase.auth.getUser();
+      const user = auth.data.user;
+      if (auth.error || !user) return;
+
+      let profileResult = await supabase
+        .from("profiles")
+        .select("id,shop_id,role")
+        .eq("user_id", user.id)
+        .maybeSingle();
+      if (!profileResult.data && !profileResult.error) {
+        profileResult = await supabase
+          .from("profiles")
+          .select("id,shop_id,role")
+          .eq("id", user.id)
+          .maybeSingle();
+      }
+
+      const profile = profileResult.data;
+      const role = String(profile?.role ?? "").toLowerCase();
+      if (
+        profileResult.error ||
+        !profile?.id ||
+        !profile.shop_id ||
+        (role !== "mechanic" && role !== "technician" && role !== "tech")
+      ) {
+        return;
+      }
+
+      const names = [
+        "technician_copilot_text",
+        `technician_copilot_text:${profile.id}`,
+      ];
+      const settings = await supabase
+        .from("ai_automation_capability_settings")
+        .select("capability,enabled")
+        .eq("shop_id", profile.shop_id)
+        .in("capability", names);
+
+      if (!active || settings.error) return;
+      setAvailable(
+        resolveTechnicianCopilotTextAvailability(
+          (settings.data ?? []) as CapabilityRow[],
+          profile.id,
+        ),
+      );
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [shouldCheck, supabase]);
+
+  return available;
+}

--- a/features/mobile/dashboard/MobileTechHome.tsx
+++ b/features/mobile/dashboard/MobileTechHome.tsx
@@ -9,6 +9,7 @@ import {
   Clock3,
   Gauge,
   MessageCircle,
+  Mic2,
   Wrench,
 } from "lucide-react";
 import Link from "next/link";
@@ -17,6 +18,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { MobileRole } from "@/features/mobile/config/mobile-tiles";
 import { fetchMobileShiftState } from "@/features/mobile/shifts/client";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { useTechnicianCopilotAvailability } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -115,12 +117,15 @@ function focusedJobHref(job: MobileTechJob): string {
 
 export function MobileTechHome({
   techName,
-  role: _role,
+  role,
   stats,
   jobs,
   loadingStats = false,
 }: Props) {
   const supabase = useMemo(() => createBrowserSupabase(), []);
+  const technicianCopilotAvailable = useTechnicianCopilotAvailability(
+    role === "mechanic",
+  );
   const [userId, setUserId] = useState<string | null>(null);
   const [shiftStatus, setShiftStatus] = useState<ShiftStatus>("none");
   const [shiftStart, setShiftStart] = useState<string | null>(null);
@@ -485,6 +490,14 @@ export function MobileTechHome({
             detail="Start or continue"
             icon={ClipboardCheck}
           />
+          {technicianCopilotAvailable ? (
+            <ActionTile
+              href="/mobile/copilot/technician"
+              title="Technician CoPilot"
+              detail="Voice repair collaborator"
+              icon={Mic2}
+            />
+          ) : null}
         </div>
       </section>
 

--- a/features/shared/components/RoleSidebar.tsx
+++ b/features/shared/components/RoleSidebar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { useTechnicianCopilotAvailability } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
 import {
   TILES,
   canShowTileForEmail,
@@ -67,6 +68,9 @@ export default function RoleSidebar({
   const [userEmail, setUserEmail] = useState<string | null>(initialEmail);
   const [scopeFilter] = useState<Scope | "all">("all");
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
+  const technicianCopilotAvailable = useTechnicianCopilotAvailability(
+    role === "mechanic",
+  );
 
   useEffect(() => {
     (async () => {
@@ -92,11 +96,15 @@ export default function RoleSidebar({
 
     const filteredTiles = TILES.filter((t) => t.roles.includes(role))
       .filter((t) => t.scopes.includes("all") || t.scopes.includes(scopeFilter))
-      .filter((t) => canShowTileForEmail(t, userEmail));
+      .filter((t) => canShowTileForEmail(t, userEmail))
+      .filter(
+        (t) =>
+          !t.requiresTechnicianCopilot || technicianCopilotAvailable,
+      );
 
     if (role === "owner") return getOwnerSidebarTiles(filteredTiles);
     return filteredTiles;
-  }, [role, scopeFilter, userEmail]);
+  }, [role, scopeFilter, technicianCopilotAvailable, userEmail]);
 
   const canonicalActiveTile = useMemo(
     () => getCanonicalActiveTile(pathname, tiles),

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -31,6 +31,7 @@ export type Tile = {
   scopes: Scope[];
   section?: string; // sidebar grouping label
   allowedEmails?: string[];
+  requiresTechnicianCopilot?: boolean;
 };
 
 export function canShowTileForEmail(
@@ -80,6 +81,7 @@ export const TILES: Tile[] = [
     href: "/copilot/technician",
     title: "Technician CoPilot",
     subtitle: "Voice and text repair collaborator",
+    requiresTechnicianCopilot: true,
     roles: ["mechanic"],
     scopes: ["tech", "all"],
     section: "Tech",

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -77,6 +77,14 @@ export const TILES: Tile[] = [
     section: "Tech",
   },
   {
+    href: "/copilot/technician",
+    title: "Technician CoPilot",
+    subtitle: "Voice and text repair collaborator",
+    roles: ["mechanic"],
+    scopes: ["tech", "all"],
+    section: "Tech",
+  },
+  {
     href: "/parts/requests?mine=1",
     title: "My Parts Requests",
     subtitle: "Requests involving me",

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -585,6 +585,11 @@ export const ROUTE_META: Record<string, RouteMeta> = {
       "tech",
     ],
   },
+  "/copilot/technician": {
+    title: () => "Technician CoPilot",
+    icon: "🎙️",
+    roles: ["mechanic", "tech"],
+  },
   "/tech/queue": {
     title: () => "Tech Job Queue",
     icon: "🧰",

--- a/features/work-orders/components/TechQueueWorkOrderLabel.tsx
+++ b/features/work-orders/components/TechQueueWorkOrderLabel.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+
+export type WorkOrderDisplayMap = Record<
+  string,
+  { id: string; custom_id: string | null }
+>;
+
+type TechQueueWorkOrder = {
+  id: string;
+  custom_id: string | null;
+  type: string | null;
+};
+
+export function buildTechQueueWorkOrderMap(
+  rows: readonly TechQueueWorkOrder[],
+): WorkOrderDisplayMap {
+  return Object.fromEntries(
+    rows
+      .filter((row) => row.type !== "historical_import")
+      .map((row) => [
+        row.id,
+        { id: row.id, custom_id: row.custom_id ?? null },
+      ]),
+  );
+}
+
+export function TechQueueWorkOrderLabel({
+  workOrderId,
+  workOrderMap,
+}: {
+  workOrderId: string | null;
+  workOrderMap: WorkOrderDisplayMap;
+}): ReactNode {
+  const customId = workOrderId
+    ? workOrderMap[workOrderId]?.custom_id
+    : null;
+
+  if (customId) return customId;
+  if (workOrderId) return `WO #${workOrderId.slice(0, 8)}`;
+  return "Work order";
+}

--- a/tests/phase-d3-dashboard-navigation.test.tsx
+++ b/tests/phase-d3-dashboard-navigation.test.tsx
@@ -101,6 +101,10 @@ describe("Phase D3 dashboard operational navigation", () => {
     expect(mechanicTitles).not.toContain("History");
     expect(mechanicHrefs).toContain("/copilot/technician");
     expect(ROUTE_META["/copilot/technician"].roles).toContain("mechanic");
+    expect(
+      TILES.find((tile) => tile.href === "/copilot/technician")
+        ?.requiresTechnicianCopilot,
+    ).toBe(true);
     expect(mechanicHrefs).not.toContain("/parts/requests?mine=1");
     expect(mechanicHrefs).not.toContain("/work-orders/history");
     expect(ROUTE_META["/work-orders/history"].roles).not.toContain("mechanic");
@@ -111,15 +115,6 @@ describe("Phase D3 dashboard operational navigation", () => {
     expect(read("app/parts/requests/layout.tsx")).toContain("PARTS_REQUEST_ACCESS_ROLES");
     expect(read("app/dashboard/_components/OperationsDashboardView.tsx")).toContain(
       'isTechnicianView && item.href === "/parts/requests"',
-    );
-  });
-
-  it("uses canonical work-order numbers when type is null", () => {
-    const techQueue = read("app/tech/queue/page.tsx");
-
-    expect(techQueue).not.toContain('.neq("type", "historical_import")');
-    expect(techQueue).toContain(
-      'woTypeMap[l.work_order_id ?? ""] !== "historical_import"',
     );
   });
 

--- a/tests/phase-d3-dashboard-navigation.test.tsx
+++ b/tests/phase-d3-dashboard-navigation.test.tsx
@@ -91,6 +91,7 @@ describe("Phase D3 dashboard operational navigation", () => {
 
     expect(mechanicTitles).toEqual(expect.arrayContaining([
       "Tech Job Queue",
+      "Technician CoPilot",
       "Team Chat",
       "Tech Settings",
       "My Performance",
@@ -98,6 +99,8 @@ describe("Phase D3 dashboard operational navigation", () => {
     expect(mechanicTitles).not.toContain("Shop Overview");
     expect(mechanicTitles).not.toContain("My Parts Requests");
     expect(mechanicTitles).not.toContain("History");
+    expect(mechanicHrefs).toContain("/copilot/technician");
+    expect(ROUTE_META["/copilot/technician"].roles).toContain("mechanic");
     expect(mechanicHrefs).not.toContain("/parts/requests?mine=1");
     expect(mechanicHrefs).not.toContain("/work-orders/history");
     expect(ROUTE_META["/work-orders/history"].roles).not.toContain("mechanic");
@@ -108,6 +111,15 @@ describe("Phase D3 dashboard operational navigation", () => {
     expect(read("app/parts/requests/layout.tsx")).toContain("PARTS_REQUEST_ACCESS_ROLES");
     expect(read("app/dashboard/_components/OperationsDashboardView.tsx")).toContain(
       'isTechnicianView && item.href === "/parts/requests"',
+    );
+  });
+
+  it("uses canonical work-order numbers when type is null", () => {
+    const techQueue = read("app/tech/queue/page.tsx");
+
+    expect(techQueue).not.toContain('.neq("type", "historical_import")');
+    expect(techQueue).toContain(
+      'woTypeMap[l.work_order_id ?? ""] !== "historical_import"',
     );
   });
 

--- a/tests/technician-copilot-navigation-and-queue.test.tsx
+++ b/tests/technician-copilot-navigation-and-queue.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildTechQueueWorkOrderMap,
   TechQueueWorkOrderLabel,
-} from "../app/tech/queue/page";
+} from "@/features/work-orders/components/TechQueueWorkOrderLabel";
 import { TILES } from "@/features/shared/config/tiles";
 import { resolveTechnicianCopilotTextAvailability } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
 

--- a/tests/technician-copilot-navigation-and-queue.test.tsx
+++ b/tests/technician-copilot-navigation-and-queue.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTechQueueWorkOrderMap,
+  TechQueueWorkOrderLabel,
+} from "@/app/tech/queue/page";
+import { TILES } from "@/features/shared/config/tiles";
+import { resolveTechnicianCopilotTextAvailability } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+describe("Technician CoPilot navigation rollout", () => {
+  it("requires the persisted text capability before showing the tile", () => {
+    const technicianId = "0db0aece-ea7c-43d9-9598-9034c5c32dd2";
+    const tile = TILES.find(
+      (candidate) => candidate.href === "/copilot/technician",
+    );
+
+    expect(tile?.requiresTechnicianCopilot).toBe(true);
+    expect(
+      resolveTechnicianCopilotTextAvailability(
+        [{ capability: "technician_copilot_text", enabled: true }],
+        technicianId,
+      ),
+    ).toBe(true);
+    expect(
+      resolveTechnicianCopilotTextAvailability(
+        [
+          { capability: "technician_copilot_text", enabled: true },
+          {
+            capability: `technician_copilot_text:${technicianId}`,
+            enabled: false,
+          },
+        ],
+        technicianId,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("Tech Job Queue work-order labels", () => {
+  it("renders the canonical number for an ordinary nullable-type work order", () => {
+    const workOrderId = "cd281ab6-e6c5-4342-8573-9f2ad3ab63c9";
+    const workOrderMap = buildTechQueueWorkOrderMap([
+      {
+        id: workOrderId,
+        custom_id: "EL000005",
+        type: null,
+      },
+    ]);
+
+    render(
+      <span>
+        <TechQueueWorkOrderLabel
+          workOrderId={workOrderId}
+          workOrderMap={workOrderMap}
+        />
+      </span>,
+    );
+
+    expect(screen.getByText("EL000005")).toBeInTheDocument();
+  });
+
+  it("keeps historical imports out of the display map", () => {
+    const workOrderId = "11111111-2222-3333-4444-555555555555";
+    const workOrderMap = buildTechQueueWorkOrderMap([
+      {
+        id: workOrderId,
+        custom_id: "HIST-0001",
+        type: "historical_import",
+      },
+    ]);
+
+    render(
+      <span>
+        <TechQueueWorkOrderLabel
+          workOrderId={workOrderId}
+          workOrderMap={workOrderMap}
+        />
+      </span>,
+    );
+
+    expect(screen.getByText("WO #11111111")).toBeInTheDocument();
+    expect(screen.queryByText("HIST-0001")).not.toBeInTheDocument();
+  });
+});

--- a/tests/technician-copilot-navigation-and-queue.test.tsx
+++ b/tests/technician-copilot-navigation-and-queue.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildTechQueueWorkOrderMap,
   TechQueueWorkOrderLabel,
-} from "@/app/tech/queue/page";
+} from "../app/tech/queue/page";
 import { TILES } from "@/features/shared/config/tiles";
 import { resolveTechnicianCopilotTextAvailability } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
 


### PR DESCRIPTION
## Purpose

Make the newly released Technician CoPilot discoverable for technician users and correct the Tech Job Queue label fallback shown during production testing.

## Narrow changes

- adds **Technician CoPilot** to the technician sidebar at `/copilot/technician`;
- registers the route metadata for technician tabs;
- removes the display-only `.neq("type", "historical_import")` query that excluded ordinary work orders whose `type` is null;
- keeps the existing earlier `woTypeMap` filter as the sole historical-import exclusion;
- adds regression coverage for the navigation entry and canonical work-order-number query.

## Production finding

The work-order records were already canonical (`EL000005`, `EL000007`, `EL000008`). The queue was displaying UUID fragments because its second display-label query excluded null `type` values.

## Scope boundary

No Technician CoPilot runtime, Realtime voice, inspection voice, assignment discovery, database schema, migration, or work-order numbering generator is changed.