### PR TITLE
start Technician CoPilot as a one-tap voice call

### DIFF
--- a/app/api/copilot/technician/session/route.ts
+++ b/app/api/copilot/technician/session/route.ts
@@ -64,11 +64,19 @@ async function snapshot(
 function capabilities(
   access: Awaited<ReturnType<typeof requireTechnicianCopilotAccess>>,
 ) {
-  return { documentation: access.capabilities.documentation };
+  return {
+    documentation: access.capabilities.documentation,
+    voice: access.capabilities.voice,
+  };
 }
 
 export async function GET(request: NextRequest) {
   try {
+    if (request.nextUrl.searchParams.get("accessOnly") === "1") {
+      const access = await requireTechnicianCopilotAccess();
+      return NextResponse.json({ capabilities: capabilities(access) });
+    }
+
     const result = await snapshot(request);
     return NextResponse.json({
       session: result.envelope.session,

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -43,7 +43,6 @@ function getTitleFromPath(pathname: string): string {
 }
 
 function isImmersiveRoute(pathname: string): boolean {
-  if (pathname === "/mobile/copilot/technician") return true;
   if (pathname.startsWith("/mobile/jobs/")) return true;
   if (pathname === "/mobile/inspections/import") return false;
   return /^\/mobile\/inspections\/[^/]+$/.test(pathname);

--- a/features/copilot/technician/client/useTechnicianCopilotAvailability.ts
+++ b/features/copilot/technician/client/useTechnicianCopilotAvailability.ts
@@ -1,95 +1,35 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-
-type CapabilityRow = {
-  capability: string;
-  enabled: boolean;
-};
-
-export function resolveTechnicianCopilotTextAvailability(
-  rows: readonly CapabilityRow[],
-  technicianId: string,
-): boolean {
-  const technician = rows.find(
-    (row) =>
-      row.capability === `technician_copilot_text:${technicianId}`,
-  );
-  if (technician) return technician.enabled;
-
-  return (
-    rows.find((row) => row.capability === "technician_copilot_text")
-      ?.enabled ?? false
-  );
-}
+import { useEffect, useState } from "react";
 
 export function useTechnicianCopilotAvailability(
   shouldCheck: boolean,
 ): boolean {
-  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [available, setAvailable] = useState(false);
 
   useEffect(() => {
     let active = true;
     setAvailable(false);
-    if (!shouldCheck) return () => {
-      active = false;
-    };
+    if (!shouldCheck) {
+      return () => {
+        active = false;
+      };
+    }
 
-    void (async () => {
-      const auth = await supabase.auth.getUser();
-      const user = auth.data.user;
-      if (auth.error || !user) return;
-
-      let profileResult = await supabase
-        .from("profiles")
-        .select("id,shop_id,role")
-        .eq("user_id", user.id)
-        .maybeSingle();
-      if (!profileResult.data && !profileResult.error) {
-        profileResult = await supabase
-          .from("profiles")
-          .select("id,shop_id,role")
-          .eq("id", user.id)
-          .maybeSingle();
-      }
-
-      const profile = profileResult.data;
-      const role = String(profile?.role ?? "").toLowerCase();
-      if (
-        profileResult.error ||
-        !profile?.id ||
-        !profile.shop_id ||
-        (role !== "mechanic" && role !== "technician" && role !== "tech")
-      ) {
-        return;
-      }
-
-      const names = [
-        "technician_copilot_text",
-        `technician_copilot_text:${profile.id}`,
-      ];
-      const settings = await supabase
-        .from("ai_automation_capability_settings")
-        .select("capability,enabled")
-        .eq("shop_id", profile.shop_id)
-        .in("capability", names);
-
-      if (!active || settings.error) return;
-      setAvailable(
-        resolveTechnicianCopilotTextAvailability(
-          (settings.data ?? []) as CapabilityRow[],
-          profile.id,
-        ),
-      );
-    })();
+    void fetch("/api/copilot/technician/session?accessOnly=1", {
+      cache: "no-store",
+    })
+      .then((response) => {
+        if (active) setAvailable(response.ok);
+      })
+      .catch(() => {
+        if (active) setAvailable(false);
+      });
 
     return () => {
       active = false;
     };
-  }, [shouldCheck, supabase]);
+  }, [shouldCheck]);
 
   return available;
 }

--- a/features/copilot/technician/components/TechnicianTextCopilot.tsx
+++ b/features/copilot/technician/components/TechnicianTextCopilot.tsx
@@ -187,6 +187,7 @@ export function TechnicianTextCopilot() {
 
   const voice = useTechnicianInteractionGateway({
     enabled: voiceEnabled,
+    autoStart: true,
     onUtterance: handleVoiceUtterance,
   });
 

--- a/features/copilot/technician/voice/useTechnicianInteractionGateway.ts
+++ b/features/copilot/technician/voice/useTechnicianInteractionGateway.ts
@@ -20,6 +20,7 @@ export type TechnicianVoiceTurnResult = {
 
 type TechnicianInteractionGatewayOptions = {
   enabled: boolean;
+  autoStart?: boolean;
   onUtterance: (text: string) => Promise<TechnicianVoiceTurnResult>;
 };
 
@@ -37,6 +38,7 @@ function normalizedTranscript(text: string): string | null {
 
 export function useTechnicianInteractionGateway({
   enabled,
+  autoStart = false,
   onUtterance,
 }: TechnicianInteractionGatewayOptions) {
   const [phase, setPhase] = useState<TechnicianVoicePhase>("idle");
@@ -45,6 +47,7 @@ export function useTechnicianInteractionGateway({
   const [error, setError] = useState<string | null>(null);
 
   const activeRef = useRef(false);
+  const autoStartAttemptedRef = useRef(false);
   const phaseRef = useRef<TechnicianVoicePhase>("idle");
   const generationRef = useRef(0);
   const inFlightRef = useRef(false);
@@ -289,6 +292,12 @@ export function useTechnicianInteractionGateway({
     setError(null);
     await startListeningRef.current();
   }, [enabled, invalidateGeneration]);
+
+  useEffect(() => {
+    if (!enabled || !autoStart || autoStartAttemptedRef.current) return;
+    autoStartAttemptedRef.current = true;
+    void start();
+  }, [autoStart, enabled, start]);
 
   const stop = useCallback(() => {
     invalidateGeneration();

--- a/tests/mobile-technician-first-ux.test.ts
+++ b/tests/mobile-technician-first-ux.test.ts
@@ -136,6 +136,9 @@ describe("technician-first mobile UX", () => {
     expect(mobileShell).toContain("isImmersiveRoute(pathname)");
     expect(mobileShell).toContain("/^\\/mobile\\/inspections\\/[^/]+$/");
     expect(mobileShell).toContain("mobile-command-main");
+    expect(mobileShell).not.toContain(
+      'pathname === "/mobile/copilot/technician"',
+    );
   });
 
   it("makes mobile photo capture direct while preserving the desktop flow", () => {

--- a/tests/technician-copilot-navigation-and-queue.test.tsx
+++ b/tests/technician-copilot-navigation-and-queue.test.tsx
@@ -1,42 +1,39 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildTechQueueWorkOrderMap,
   TechQueueWorkOrderLabel,
 } from "@/features/work-orders/components/TechQueueWorkOrderLabel";
 import { TILES } from "@/features/shared/config/tiles";
-import { resolveTechnicianCopilotTextAvailability } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
+import { useTechnicianCopilotAvailability } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
 describe("Technician CoPilot navigation rollout", () => {
-  it("requires the persisted text capability before showing the tile", () => {
-    const technicianId = "0db0aece-ea7c-43d9-9598-9034c5c32dd2";
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the canonical server access gate before showing the tile", async () => {
+    const request = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("fetch", request);
+
     const tile = TILES.find(
       (candidate) => candidate.href === "/copilot/technician",
     );
+    const { result } = renderHook(() =>
+      useTechnicianCopilotAvailability(true),
+    );
 
     expect(tile?.requiresTechnicianCopilot).toBe(true);
-    expect(
-      resolveTechnicianCopilotTextAvailability(
-        [{ capability: "technician_copilot_text", enabled: true }],
-        technicianId,
-      ),
-    ).toBe(true);
-    expect(
-      resolveTechnicianCopilotTextAvailability(
-        [
-          { capability: "technician_copilot_text", enabled: true },
-          {
-            capability: `technician_copilot_text:${technicianId}`,
-            enabled: false,
-          },
-        ],
-        technicianId,
-      ),
-    ).toBe(false);
+    expect(result.current).toBe(false);
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(request).toHaveBeenCalledWith(
+      "/api/copilot/technician/session?accessOnly=1",
+      { cache: "no-store" },
+    );
   });
 });
 

--- a/tests/technician-copilot-voice-gateway.test.tsx
+++ b/tests/technician-copilot-voice-gateway.test.tsx
@@ -96,6 +96,31 @@ describe("Technician CoPilot voice interaction gateway", () => {
     Reflect.deleteProperty(window, "speechSynthesis");
   });
 
+  it("starts one call automatically when voice access becomes available", async () => {
+    const onUtterance = vi.fn(async () => ({ reply: null }));
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useTechnicianInteractionGateway({
+          enabled,
+          autoStart: true,
+          onUtterance,
+        }),
+      { initialProps: { enabled: false } },
+    );
+
+    expect(realtime.start).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe("listening");
+    });
+    expect(realtime.start).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: true });
+    expect(realtime.start).toHaveBeenCalledTimes(1);
+  });
+
   it("pauses the live Realtime session for a CoPilot turn, speaks the persisted reply, then resumes it", async () => {
     const onUtterance = vi.fn(async (text: string) => ({
       reply: `Reply to ${text}`,

--- a/tests/technician-copilot-voice-runtime-contract.test.ts
+++ b/tests/technician-copilot-voice-runtime-contract.test.ts
@@ -5,6 +5,10 @@ const routeSource = readFileSync(
   "app/api/copilot/technician/chat/route.ts",
   "utf8",
 );
+const sessionRouteSource = readFileSync(
+  "app/api/copilot/technician/session/route.ts",
+  "utf8",
+);
 const runtimeSource = readFileSync(
   "features/copilot/technician/server/chat.ts",
   "utf8",
@@ -23,6 +27,12 @@ const inspectionRealtimeSource = readFileSync(
 );
 
 describe("Technician CoPilot Realtime voice bridge boundaries", () => {
+  it("returns the resolved voice capability to the call surface", () => {
+    expect(sessionRouteSource).toContain(
+      "voice: access.capabilities.voice",
+    );
+  });
+
   it("requires the explicit technician voice capability before a voice turn", () => {
     expect(routeSource).toContain('body.inputMode === "voice"');
     expect(routeSource).toContain("!access.capabilities.voice");


### PR DESCRIPTION
## Result

Technician CoPilot now behaves as a one-tap call entry for an authorized technician:

- the session API returns the already-resolved voice capability instead of dropping it;
- opening CoPilot automatically starts the existing continuous voice gateway once;
- spoken turns continue through the same persisted Repair Session and transcript, so the technician does not press **Send**;
- the existing manual start remains only as recovery after permission or transport failure;
- navigation availability now uses the canonical server authorization path, including imported technician profiles;
- the mobile shell remains available so an installed PWA always has an exit.

## Scope boundary

This is intentionally limited to CoPilot access and call startup. It does **not** add a second work-order/inspection mutation path. The current CoPilot model runtime still cannot execute canonical operational mutations; click-parity voice actions must be added by adapting the existing authorized, audited domain handlers one workflow at a time.

## Safety

- server-side technician role, tenant, and capability checks remain authoritative;
- voice turns still re-check the voice capability;
- no work-order, inspection, parts, labor, approval, or billing mutation code changes;
- no environment-variable changes;
- no database migration.

## Validation

Exact head `feaf65714f0c72390830cb2d655b89415466f9d9` passed Agent PR Checks:

- full-app regression inventory;
- type-check;
- changed-file lint;
- complete test suite;
- production build.

Focused regressions cover automatic call start, voice capability propagation, canonical server-gated navigation availability, and mobile exit preservation. Supabase correctly skipped preview creation because there are no `supabase/` changes.