### PR TITLE
repair Technician CoPilot runtime integrity

### DIFF
--- a/.github/workflows/technician-copilot-runtime-integrity.yml
+++ b/.github/workflows/technician-copilot-runtime-integrity.yml
@@ -1,0 +1,86 @@
+name: Technician CoPilot Runtime Integrity
+
+on:
+  pull_request:
+    paths:
+      - "supabase/migrations/20260814223500_technician_copilot_runtime_integrity.sql"
+      - "tests/security/technician-copilot-runtime-integrity.runtime.sql"
+      - ".github/workflows/technician-copilot-runtime-integrity.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: technician-copilot-runtime-integrity-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v2
+        with:
+          version: 2.101.0
+          github-token: ${{ github.token }}
+
+      - name: Initialize ephemeral Supabase configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f supabase/config.toml ]]; then
+            supabase init
+          fi
+          supabase --version
+
+      - name: Start fresh local Supabase
+        shell: bash
+        run: |
+          set -euo pipefail
+          supabase db start 2>&1 | tee supabase-db-start.log
+
+      - name: Replay complete migration chain
+        shell: bash
+        run: |
+          set -euo pipefail
+          supabase db reset --local --no-seed --debug \
+            2>&1 | tee supabase-db-reset.log
+
+      - name: Execute Technician CoPilot lifecycle runtime integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/technician-copilot-runtime-integrity.runtime.sql \
+            2>&1 | tee technician-copilot-runtime-integrity.log
+
+      - name: Verify runtime test leaves no committed fixture rows
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          remaining="$(psql "$DB_URL" -Atv ON_ERROR_STOP=1 -c "
+            select
+              (select count(*) from copilot.repair_sessions where shop_id = 'a1438000-0000-4000-8000-000000000010')
+              +
+              (select count(*) from copilot.repair_session_events e join copilot.repair_sessions rs on rs.id = e.repair_session_id where rs.shop_id = 'a1438000-0000-4000-8000-000000000010');
+          ")"
+          if [[ "$remaining" != "0" ]]; then
+            echo "Technician CoPilot runtime integration leaked $remaining fixture rows"
+            exit 1
+          fi
+
+      - name: Stop local Supabase
+        if: always()
+        shell: bash
+        run: supabase stop --no-backup || true

--- a/app/api/copilot/technician/chat/route.ts
+++ b/app/api/copilot/technician/chat/route.ts
@@ -5,9 +5,29 @@ import {
   requireTechnicianCopilotAccess,
   TechnicianCopilotAccessError,
 } from "@/features/copilot/technician/server/auth";
-import { runTechnicianCopilotTurn } from "@/features/copilot/technician/server/chat";
+import {
+  runTechnicianCopilotTurn,
+  TechnicianCopilotConflictError,
+} from "@/features/copilot/technician/server/chat";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 export const runtime = "nodejs";
+
+function runtimeConflict(error: unknown): TechnicianCopilotConflictError | null {
+  if (error instanceof TechnicianCopilotConflictError) return error;
+  const message = error instanceof Error ? error.message : "";
+  if (
+    message === "copilot_session_not_active" ||
+    message === "copilot_work_order_not_actionable" ||
+    message === "copilot_work_order_assignment_required"
+  ) {
+    return new TechnicianCopilotConflictError(
+      "technician_copilot_session_stale",
+      "The active CoPilot repair context changed. Reload before continuing.",
+    );
+  }
+  return null;
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -50,7 +70,7 @@ export async function POST(request: NextRequest) {
         shopId: access.shopId,
         documentationEnabled: access.capabilities.documentation,
         voiceEnabled: access.capabilities.voice,
-        supabase: access.supabase,
+        supabase: createAdminSupabase(),
       },
       message,
       turnId,
@@ -64,6 +84,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: error.message, code: error.code },
         { status: error.status },
+      );
+    }
+    const conflict = runtimeConflict(error);
+    if (conflict) {
+      return NextResponse.json(
+        { error: conflict.message, code: conflict.code },
+        { status: conflict.status },
       );
     }
     console.error("[technician-copilot] chat failed", error);

--- a/app/api/copilot/technician/session/route.ts
+++ b/app/api/copilot/technician/session/route.ts
@@ -7,12 +7,13 @@ import type {
   RepairSessionStatus,
 } from "@/features/copilot/technician/session/types";
 import { projectTechnicianContext } from "@/features/copilot/technician/session/projectTechnicianContext";
-import { listTechnicianWorkCandidates } from "@/features/copilot/technician/server/assignedWork";
+import { loadTechnicianWorkCandidateForWorkOrder } from "@/features/copilot/technician/server/assignedWork";
 import {
   requireTechnicianCopilotAccess,
   TechnicianCopilotAccessError,
 } from "@/features/copilot/technician/server/auth";
 import { sendCopilotServerCommand } from "@/features/copilot/technician/server/transport";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 export const runtime = "nodejs";
 
@@ -40,15 +41,14 @@ async function snapshot(
     action: "session.read",
     args: { sessionId },
   });
-  const candidates = await listTechnicianWorkCandidates({
-    supabase: access.supabase,
-    shopId: access.shopId,
-    technicianIds: [access.authUserId, access.profileId],
-  });
+
   const workOrder = envelope.session
-    ? candidates.find(
-        (candidate) => candidate.id === envelope.session?.workOrderId,
-      ) ?? null
+    ? await loadTechnicianWorkCandidateForWorkOrder({
+        supabase: createAdminSupabase(),
+        shopId: access.shopId,
+        technicianIds: [access.authUserId, access.profileId],
+        workOrderId: envelope.session.workOrderId,
+      })
     : null;
   const context = envelope.session
     ? projectTechnicianContext({

--- a/features/copilot/technician/server/assignedWork.ts
+++ b/features/copilot/technician/server/assignedWork.ts
@@ -2,6 +2,10 @@ import "server-only";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/features/shared/types/types/supabase";
+import {
+  getWorkOrderLineStatusDbFilter,
+  type WorkOrderLineStatus,
+} from "@/features/work-orders/lib/line-status";
 
 export type TechnicianWorkCandidate = {
   id: string;
@@ -14,7 +18,7 @@ export type TechnicianWorkCandidate = {
   vehicleModel: string | null;
   vehicleVin: string | null;
   vehicleUnitNumber: string | null;
-  /** Only line IDs canonically assigned to this technician. */
+  /** Only active job line IDs canonically assigned to this technician. */
   lineIds: string[];
   /** Readable complaints on the assigned work order for conversational context. */
   lineComplaints: string[];
@@ -26,7 +30,67 @@ export type TechnicianWorkScope = {
   technicianIds: string[];
 };
 
-type AssignedLine = { id: string; work_order_id: string };
+type AssignedLine = {
+  id: string;
+  work_order_id: string;
+  created_at?: string | null;
+};
+
+type SharedAssignmentRow = {
+  id: string;
+  work_order_line_id: string;
+  assigned_at: string | null;
+  work_order_lines: AssignedLine | AssignedLine[] | null;
+};
+
+type WorkOrderCandidateRow = {
+  id: string;
+  custom_id: string | null;
+  status: string | null;
+  notes: string | null;
+  intake_json: unknown;
+  vehicle_year: number | null;
+  vehicle_make: string | null;
+  vehicle_model: string | null;
+  vehicle_vin: string | null;
+  vehicle_unit_number: string | null;
+  updated_at: string | null;
+};
+
+type ComplaintLine = {
+  id: string;
+  work_order_id: string;
+  complaint: string | null;
+};
+
+const ACTIVE_CANONICAL_LINE_STATUSES = [
+  "pending",
+  "approved",
+  "awaiting",
+  "awaiting_approval",
+  "in_progress",
+  "waiting_parts",
+  "on_hold",
+] as const satisfies readonly WorkOrderLineStatus[];
+
+export const ACTIVE_TECHNICIAN_LINE_DB_STATUSES =
+  getWorkOrderLineStatusDbFilter(ACTIVE_CANONICAL_LINE_STATUSES);
+
+const TERMINAL_WORK_ORDER_STATUSES = [
+  "completed",
+  "ready_to_invoice",
+  "invoiced",
+  "cancelled",
+  "canceled",
+  "closed",
+  "paid",
+  "void",
+  "voided",
+  "archived",
+] as const;
+
+const MAX_ASSIGNED_LINES_PER_PATH = 250;
+const MAX_WORK_ORDER_CANDIDATES = 30;
 
 function object(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -52,6 +116,107 @@ function directAssignmentFilter(technicianIds: readonly string[]): string {
     .join(",");
 }
 
+function embeddedAssignedLine(row: SharedAssignmentRow): AssignedLine | null {
+  const relation = row.work_order_lines;
+  if (Array.isArray(relation)) return relation[0] ?? null;
+  return relation ?? null;
+}
+
+function buildCandidate(
+  row: WorkOrderCandidateRow,
+  assignedLineIds: readonly string[],
+  complaints: readonly string[],
+): TechnicianWorkCandidate {
+  return {
+    id: row.id,
+    customId: row.custom_id,
+    status: row.status,
+    concern: readCanonicalWorkOrderConcern(row.intake_json),
+    description: text(row.notes),
+    vehicleYear: row.vehicle_year,
+    vehicleMake: row.vehicle_make,
+    vehicleModel: row.vehicle_model,
+    vehicleVin: row.vehicle_vin,
+    vehicleUnitNumber: row.vehicle_unit_number,
+    lineIds: uniqueIds(assignedLineIds),
+    lineComplaints: [...new Set(complaints.map((value) => value.trim()).filter(Boolean))],
+  };
+}
+
+async function collectAssignedLines(
+  input: TechnicianWorkScope,
+  workOrderId?: string | null,
+): Promise<AssignedLine[]> {
+  const technicianIds = uniqueIds(input.technicianIds);
+  if (!input.shopId || technicianIds.length === 0) return [];
+
+  let directQuery = input.supabase
+    .from("work_order_lines")
+    .select("id,work_order_id,created_at")
+    .eq("shop_id", input.shopId)
+    .eq("line_type", "job")
+    .in("status", ACTIVE_TECHNICIAN_LINE_DB_STATUSES)
+    .or(directAssignmentFilter(technicianIds))
+    .order("created_at", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(MAX_ASSIGNED_LINES_PER_PATH);
+
+  let sharedQuery = input.supabase
+    .from("work_order_line_technicians")
+    .select(
+      "id,work_order_line_id,assigned_at,work_order_lines!inner(id,work_order_id,created_at,shop_id,line_type,status)",
+    )
+    .in("technician_id", technicianIds)
+    .eq("work_order_lines.shop_id", input.shopId)
+    .eq("work_order_lines.line_type", "job")
+    .in("work_order_lines.status", ACTIVE_TECHNICIAN_LINE_DB_STATUSES)
+    .order("assigned_at", { ascending: false })
+    .order("id", { ascending: false })
+    .limit(MAX_ASSIGNED_LINES_PER_PATH);
+
+  if (workOrderId) {
+    directQuery = directQuery.eq("work_order_id", workOrderId);
+    sharedQuery = sharedQuery.eq("work_order_lines.work_order_id", workOrderId);
+  }
+
+  const [directResult, sharedResult] = await Promise.all([
+    directQuery,
+    sharedQuery,
+  ]);
+
+  if (directResult.error) throw new Error(directResult.error.message);
+  if (sharedResult.error) throw new Error(sharedResult.error.message);
+
+  const assignedById = new Map<string, AssignedLine>();
+  for (const line of (directResult.data ?? []) as AssignedLine[]) {
+    assignedById.set(line.id, line);
+  }
+
+  for (const row of (sharedResult.data ?? []) as unknown as SharedAssignmentRow[]) {
+    const line = embeddedAssignedLine(row);
+    if (line) assignedById.set(line.id, line);
+  }
+
+  return [...assignedById.values()];
+}
+
+async function loadComplaintLines(
+  input: TechnicianWorkScope,
+  workOrderIds: readonly string[],
+): Promise<ComplaintLine[]> {
+  if (workOrderIds.length === 0) return [];
+
+  const result = await input.supabase
+    .from("work_order_lines")
+    .select("id,work_order_id,complaint")
+    .eq("shop_id", input.shopId)
+    .eq("line_type", "job")
+    .in("work_order_id", [...workOrderIds]);
+
+  if (result.error) throw new Error(result.error.message);
+  return (result.data ?? []) as ComplaintLine[];
+}
+
 export function readCanonicalWorkOrderConcern(intakeJson: unknown): string | null {
   const intake = object(intakeJson);
   const concern = object(intake?.concern);
@@ -67,49 +232,7 @@ export function readCanonicalWorkOrderConcern(intakeJson: unknown): string | nul
 export async function listTechnicianWorkCandidates(
   input: TechnicianWorkScope,
 ): Promise<TechnicianWorkCandidate[]> {
-  const technicianIds = uniqueIds(input.technicianIds);
-  if (!input.shopId || technicianIds.length === 0) return [];
-
-  // Discover assignment identity first. This intentionally mirrors the
-  // canonical technician work surfaces instead of asking for the newest shop
-  // work orders and assuming RLS alone defines the candidate list.
-  const [directResult, sharedResult] = await Promise.all([
-    input.supabase
-      .from("work_order_lines")
-      .select("id,work_order_id")
-      .eq("shop_id", input.shopId)
-      .eq("line_type", "job")
-      .or(directAssignmentFilter(technicianIds)),
-    input.supabase
-      .from("work_order_line_technicians")
-      .select("work_order_line_id")
-      .in("technician_id", technicianIds),
-  ]);
-
-  if (directResult.error) throw new Error(directResult.error.message);
-  if (sharedResult.error) throw new Error(sharedResult.error.message);
-
-  const sharedLineIds = uniqueIds(
-    (sharedResult.data ?? []).map((row) => row.work_order_line_id),
-  );
-
-  let sharedLines: AssignedLine[] = [];
-  if (sharedLineIds.length > 0) {
-    const sharedLinesResult = await input.supabase
-      .from("work_order_lines")
-      .select("id,work_order_id")
-      .eq("shop_id", input.shopId)
-      .eq("line_type", "job")
-      .in("id", sharedLineIds);
-    if (sharedLinesResult.error) throw new Error(sharedLinesResult.error.message);
-    sharedLines = sharedLinesResult.data ?? [];
-  }
-
-  const assignedById = new Map<string, AssignedLine>();
-  for (const row of [...(directResult.data ?? []), ...sharedLines]) {
-    assignedById.set(row.id, row);
-  }
-  const assignedLines = [...assignedById.values()];
+  const assignedLines = await collectAssignedLines(input);
   if (assignedLines.length === 0) return [];
 
   const workOrderIds = uniqueIds(
@@ -122,28 +245,25 @@ export async function listTechnicianWorkCandidates(
     )
     .eq("shop_id", input.shopId)
     .in("id", workOrderIds)
+    .not("status", "in", `(${TERMINAL_WORK_ORDER_STATUSES.join(",")})`)
     .or("type.neq.historical_import,type.is.null")
     .order("updated_at", { ascending: false })
-    .limit(30);
+    .order("id", { ascending: false })
+    .limit(MAX_WORK_ORDER_CANDIDATES);
+
   if (workOrders.error) throw new Error(workOrders.error.message);
-  const rows = workOrders.data ?? [];
+  const rows = (workOrders.data ?? []) as WorkOrderCandidateRow[];
   if (!rows.length) return [];
 
   const visibleWorkOrderIds = rows.map((row) => row.id);
-  const lines = await input.supabase
-    .from("work_order_lines")
-    .select("id,work_order_id,complaint")
-    .eq("shop_id", input.shopId)
-    .eq("line_type", "job")
-    .in("work_order_id", visibleWorkOrderIds);
-  if (lines.error) throw new Error(lines.error.message);
-
+  const lines = await loadComplaintLines(input, visibleWorkOrderIds);
   const assignedLineIds = new Set(assignedLines.map((line) => line.id));
   const byWorkOrder = new Map<
     string,
     { assignedIds: string[]; complaints: string[] }
   >();
-  for (const line of lines.data ?? []) {
+
+  for (const line of lines) {
     const value = byWorkOrder.get(line.work_order_id) ?? {
       assignedIds: [],
       complaints: [],
@@ -159,20 +279,52 @@ export async function listTechnicianWorkCandidates(
         assignedIds: [],
         complaints: [],
       };
-      return {
-        id: row.id,
-        customId: row.custom_id,
-        status: row.status,
-        concern: readCanonicalWorkOrderConcern(row.intake_json),
-        description: text(row.notes),
-        vehicleYear: row.vehicle_year,
-        vehicleMake: row.vehicle_make,
-        vehicleModel: row.vehicle_model,
-        vehicleVin: row.vehicle_vin,
-        vehicleUnitNumber: row.vehicle_unit_number,
-        lineIds: linesForOrder.assignedIds,
-        lineComplaints: [...new Set(linesForOrder.complaints)],
-      } satisfies TechnicianWorkCandidate;
+      return buildCandidate(
+        row,
+        linesForOrder.assignedIds,
+        linesForOrder.complaints,
+      );
     })
     .filter((candidate) => candidate.lineIds.length > 0);
+}
+
+export async function loadTechnicianWorkCandidateForWorkOrder(
+  input: TechnicianWorkScope & { workOrderId: string },
+): Promise<TechnicianWorkCandidate | null> {
+  const workOrderId = input.workOrderId.trim();
+  if (!workOrderId) return null;
+
+  const assignedLines = await collectAssignedLines(input, workOrderId);
+  if (assignedLines.length === 0) return null;
+
+  const workOrderResult = await input.supabase
+    .from("work_orders")
+    .select(
+      "id,custom_id,status,notes,intake_json,vehicle_year,vehicle_make,vehicle_model,vehicle_vin,vehicle_unit_number,updated_at",
+    )
+    .eq("shop_id", input.shopId)
+    .eq("id", workOrderId)
+    .not("status", "in", `(${TERMINAL_WORK_ORDER_STATUSES.join(",")})`)
+    .or("type.neq.historical_import,type.is.null")
+    .maybeSingle();
+
+  if (workOrderResult.error) throw new Error(workOrderResult.error.message);
+  if (!workOrderResult.data) return null;
+
+  const complaintLines = await loadComplaintLines(input, [workOrderId]);
+  const assignedLineIds = new Set(assignedLines.map((line) => line.id));
+  const assignedIds: string[] = [];
+  const complaints: string[] = [];
+
+  for (const line of complaintLines) {
+    if (assignedLineIds.has(line.id)) assignedIds.push(line.id);
+    if (line.complaint?.trim()) complaints.push(line.complaint.trim());
+  }
+
+  const candidate = buildCandidate(
+    workOrderResult.data as WorkOrderCandidateRow,
+    assignedIds,
+    complaints,
+  );
+  return candidate.lineIds.length > 0 ? candidate : null;
 }

--- a/features/copilot/technician/server/chat.ts
+++ b/features/copilot/technician/server/chat.ts
@@ -12,6 +12,7 @@ import {
 import { projectTechnicianContext } from "../session/projectTechnicianContext";
 import {
   listTechnicianWorkCandidates,
+  loadTechnicianWorkCandidateForWorkOrder,
   type TechnicianWorkCandidate,
   type TechnicianWorkScope,
 } from "./assignedWork";
@@ -19,6 +20,15 @@ import { extractTechnicianDocumentationTurn } from "./documentation";
 import { decideTechnicianCopilotTurn } from "./model";
 import { deriveCopilotOperationId } from "./operationId";
 import { sendCopilotServerCommand } from "./transport";
+
+export class TechnicianCopilotConflictError extends Error {
+  readonly status = 409;
+
+  constructor(public readonly code: string, message: string) {
+    super(message);
+    this.name = "TechnicianCopilotConflictError";
+  }
+}
 
 export type CopilotIdentity = {
   authUserId: string;
@@ -80,12 +90,84 @@ function candidateFor(
     : null;
 }
 
+async function candidateForSession(
+  identity: CopilotIdentity,
+  session: Session,
+  discovered: TechnicianWorkCandidate[],
+): Promise<TechnicianWorkCandidate | null> {
+  const discoveredCandidate = candidateFor(discovered, session.workOrderId);
+  if (discoveredCandidate) return discoveredCandidate;
+
+  return loadTechnicianWorkCandidateForWorkOrder({
+    supabase: identity.supabase,
+    shopId: identity.shopId,
+    technicianIds: [identity.authUserId, identity.profileId],
+    workOrderId: session.workOrderId,
+  });
+}
+
 function complaintFor(candidate: TechnicianWorkCandidate | null): string | null {
   if (!candidate) return null;
   const values = [candidate.concern, ...candidate.lineComplaints]
     .map((value) => value?.trim())
     .filter(Boolean) as string[];
   return values.length ? [...new Set(values)].join(" | ") : null;
+}
+
+function storedTurnSource(event: RepairSessionEvent): TechnicianTurnSource {
+  return event.payload?.inputMode === "voice" ? "voice" : "ui";
+}
+
+function storedTurnText(event: RepairSessionEvent): string {
+  return typeof event.payload?.text === "string" ? event.payload.text.trim() : "";
+}
+
+function assertActiveSession(session: Session | null): asserts session is Session {
+  if (!session || session.status !== "active") {
+    throw new TechnicianCopilotConflictError(
+      "technician_copilot_session_stale",
+      "This CoPilot tab is no longer the active repair session. Reload before continuing.",
+    );
+  }
+}
+
+function bindTurnToPersistedInput(input: {
+  envelope: Envelope;
+  turnId: string;
+  requestedMessage: string;
+  requestedSource: TechnicianTurnSource;
+}): { message: string; source: TechnicianTurnSource; alreadyStored: boolean } {
+  const stored = input.envelope.events.find(
+    (event) =>
+      event.eventType === "conversation.user" &&
+      event.payload?.turnId === input.turnId,
+  );
+  if (!stored) {
+    return {
+      message: input.requestedMessage,
+      source: input.requestedSource,
+      alreadyStored: false,
+    };
+  }
+
+  const persistedMessage = storedTurnText(stored);
+  const persistedSource = storedTurnSource(stored);
+  if (
+    !persistedMessage ||
+    persistedMessage !== input.requestedMessage ||
+    persistedSource !== input.requestedSource
+  ) {
+    throw new TechnicianCopilotConflictError(
+      "technician_copilot_turn_conflict",
+      "This CoPilot turn ID is already bound to different input.",
+    );
+  }
+
+  return {
+    message: persistedMessage,
+    source: persistedSource,
+    alreadyStored: true,
+  };
 }
 
 async function append(
@@ -180,6 +262,7 @@ export async function runTechnicianCopilotTurn(input: {
   sessionId?: string | null;
   inputSource?: TechnicianTurnSource;
 }) {
+  const requestedMessage = input.message.trim();
   const inputSource: TechnicianTurnSource =
     input.inputSource === "voice" ? "voice" : "ui";
   if (inputSource === "voice" && !input.identity.voiceEnabled) {
@@ -190,12 +273,20 @@ export async function runTechnicianCopilotTurn(input: {
     documentation: input.identity.documentationEnabled,
     voice: input.identity.voiceEnabled,
   };
+
   const candidates = await listTechnicianWorkCandidates({
     supabase: input.identity.supabase,
     shopId: input.identity.shopId,
     technicianIds: [input.identity.authUserId, input.identity.profileId],
   });
   let envelope = await read(input.identity, input.sessionId);
+  if (input.sessionId && !envelope.session) {
+    throw new TechnicianCopilotConflictError(
+      "technician_copilot_session_stale",
+      "This CoPilot tab no longer owns an active repair session. Reload before continuing.",
+    );
+  }
+
   let context = envelope.session
     ? projectTechnicianContext({
         repairSessionId: envelope.session.id,
@@ -204,12 +295,30 @@ export async function runTechnicianCopilotTurn(input: {
         events: envelope.events,
       })
     : null;
+  if (envelope.session) assertActiveSession(envelope.session);
 
-  const existingAssistant = context?.conversation.find(
+  let activeWorkOrder = envelope.session
+    ? await candidateForSession(input.identity, envelope.session, candidates)
+    : null;
+  if (envelope.session && !activeWorkOrder) {
+    throw new TechnicianCopilotConflictError(
+      "technician_copilot_work_not_actionable",
+      "The active CoPilot work order is no longer assigned and actionable.",
+    );
+  }
+
+  let boundTurn = bindTurnToPersistedInput({
+    envelope,
+    turnId: input.turnId,
+    requestedMessage,
+    requestedSource: inputSource,
+  });
+  let existingAssistant = context?.conversation.find(
     (turn) => turn.turnId === input.turnId && turn.role === "assistant",
   );
-  const documentationAlreadyFinalized =
+  let documentationAlreadyFinalized =
     envelope.documentationTurns?.includes(input.turnId) ?? false;
+
   if (
     existingAssistant &&
     envelope.session &&
@@ -219,7 +328,7 @@ export async function runTechnicianCopilotTurn(input: {
       sessionId: envelope.session.id,
       reply: existingAssistant.text,
       context,
-      workOrder: candidateFor(candidates, envelope.session.workOrderId),
+      workOrder: activeWorkOrder,
       capabilities,
       replayed: true,
     };
@@ -227,7 +336,7 @@ export async function runTechnicianCopilotTurn(input: {
 
   if (!envelope.session) {
     const decision = await decideTechnicianCopilotTurn({
-      message: input.message,
+      message: requestedMessage,
       activeSession: null,
       assignedWork: candidates,
     });
@@ -267,19 +376,31 @@ export async function runTechnicianCopilotTurn(input: {
       },
     );
     envelope = await read(input.identity, started.sessionId);
+    assertActiveSession(envelope.session);
+    activeWorkOrder = selected;
+    context = projectTechnicianContext({
+      repairSessionId: envelope.session.id,
+      mode: envelope.session.mode,
+      status: envelope.session.status,
+      events: envelope.events,
+    });
+    boundTurn = bindTurnToPersistedInput({
+      envelope,
+      turnId: input.turnId,
+      requestedMessage,
+      requestedSource: inputSource,
+    });
+    existingAssistant = context.conversation.find(
+      (turn) => turn.turnId === input.turnId && turn.role === "assistant",
+    );
+    documentationAlreadyFinalized =
+      envelope.documentationTurns?.includes(input.turnId) ?? false;
   }
 
   const session = envelope.session;
-  if (!session) {
-    throw new Error("Technician CoPilot could not establish a repair session.");
-  }
+  assertActiveSession(session);
 
-  const userAlreadyStored = envelope.events.some(
-    (event) =>
-      event.eventType === "conversation.user" &&
-      event.payload?.turnId === input.turnId,
-  );
-  if (!userAlreadyStored) {
+  if (!boundTurn.alreadyStored) {
     await append(input.identity, {
       sessionId: session.id,
       eventType: "conversation.user",
@@ -287,14 +408,13 @@ export async function runTechnicianCopilotTurn(input: {
       suffix: "user",
       origin: inputSource,
       details: {
-        text: input.message,
+        text: boundTurn.message,
         turnId: input.turnId,
         inputMode: inputSource,
       },
     });
   }
 
-  const activeWorkOrder = candidateFor(candidates, session.workOrderId);
   const existingComplaint = complaintFor(activeWorkOrder);
   if (
     existingComplaint &&
@@ -313,17 +433,24 @@ export async function runTechnicianCopilotTurn(input: {
   }
 
   envelope = await read(input.identity, session.id);
+  assertActiveSession(envelope.session);
   context = projectTechnicianContext({
     repairSessionId: session.id,
     mode: session.mode,
     status: session.status,
     events: envelope.events,
   });
+  if (!context) {
+    throw new TechnicianCopilotConflictError(
+      "technician_copilot_session_stale",
+      "The active CoPilot context could not be restored. Reload before continuing.",
+    );
+  }
 
   const replyPromise = existingAssistant
     ? Promise.resolve(existingAssistant.text)
     : decideTechnicianCopilotTurn({
-        message: input.message,
+        message: boundTurn.message,
         activeSession: {
           id: session.id,
           workOrderId: session.workOrderId,
@@ -335,7 +462,7 @@ export async function runTechnicianCopilotTurn(input: {
     replyPromise,
     extractDocumentation({
       enabled: input.identity.documentationEnabled,
-      message: input.message,
+      message: boundTurn.message,
       turnId: input.turnId,
       context,
       workOrder: activeWorkOrder,
@@ -346,7 +473,11 @@ export async function runTechnicianCopilotTurn(input: {
     envelope.events,
     documentationExtraction.events,
   );
-  if (documentationExtraction.completed) {
+  if (
+    input.identity.documentationEnabled &&
+    !documentationAlreadyFinalized &&
+    documentationExtraction.completed
+  ) {
     try {
       await appendDocumentationTurn(input.identity, {
         sessionId: session.id,
@@ -364,16 +495,19 @@ export async function runTechnicianCopilotTurn(input: {
     }
   }
 
-  await append(input.identity, {
-    sessionId: session.id,
-    eventType: "conversation.assistant",
-    turnId: input.turnId,
-    suffix: "assistant",
-    origin: "copilot",
-    details: { text: reply, turnId: input.turnId },
-  });
+  if (!existingAssistant) {
+    await append(input.identity, {
+      sessionId: session.id,
+      eventType: "conversation.assistant",
+      turnId: input.turnId,
+      suffix: "assistant",
+      origin: "copilot",
+      details: { text: reply, turnId: input.turnId },
+    });
+  }
 
   const finalEnvelope = await read(input.identity, session.id);
+  assertActiveSession(finalEnvelope.session);
   const finalContext = projectTechnicianContext({
     repairSessionId: session.id,
     mode: session.mode,

--- a/features/copilot/technician/server/transport.ts
+++ b/features/copilot/technician/server/transport.ts
@@ -21,34 +21,51 @@ export async function sendCopilotServerCommand<T>(input: {
   args: Record<string, unknown>;
 }): Promise<T> {
   const admin = createAdminSupabase();
-  const response = await admin
-    .from("ai_action_events")
-    .insert({
-      shop_id: input.shopId,
-      event_type: "technician_copilot_command",
-      actor_id: input.profileId,
-      actor_role: "mechanic",
-      source: "technician_copilot_command",
-      payload: {
-        authUserId: input.authUserId,
-        action: input.action,
-        ...input.args,
-      } as Json,
-      metadata: {} as Json,
-    })
-    .select("id,metadata")
-    .single();
+  let commandRowId: string | null = null;
 
-  if (response.error) throw new Error(response.error.message);
-  const metadata = asObject(response.data.metadata);
-  const commandError = asObject(metadata.copilotCommandError);
-  const result = metadata.copilotCommandResult as T;
+  try {
+    const response = await admin
+      .from("ai_action_events")
+      .insert({
+        shop_id: input.shopId,
+        event_type: "technician_copilot_command",
+        actor_id: input.profileId,
+        actor_role: "mechanic",
+        source: "technician_copilot_command",
+        payload: {
+          authUserId: input.authUserId,
+          action: input.action,
+          ...input.args,
+        } as Json,
+        metadata: {} as Json,
+      })
+      .select("id,metadata")
+      .single();
 
-  void admin.from("ai_action_events").delete().eq("id", response.data.id);
+    if (response.error) throw new Error(response.error.message);
+    commandRowId = response.data.id;
 
-  if (commandError.message) throw new Error(String(commandError.message));
-  if (result == null) {
-    throw new Error("Technician CoPilot command returned no result.");
+    const metadata = asObject(response.data.metadata);
+    const commandError = asObject(metadata.copilotCommandError);
+    const result = metadata.copilotCommandResult as T;
+
+    if (commandError.message) throw new Error(String(commandError.message));
+    if (result == null) {
+      throw new Error("Technician CoPilot command returned no result.");
+    }
+    return result;
+  } finally {
+    if (commandRowId) {
+      const cleanup = await admin
+        .from("ai_action_events")
+        .delete()
+        .eq("id", commandRowId);
+      if (cleanup.error) {
+        console.error("[technician-copilot] command cleanup failed", {
+          commandRowId,
+          message: cleanup.error.message,
+        });
+      }
+    }
   }
-  return result;
 }

--- a/supabase/migrations/20260814223500_technician_copilot_runtime_integrity.sql
+++ b/supabase/migrations/20260814223500_technician_copilot_runtime_integrity.sql
@@ -1,0 +1,935 @@
+-- Technician CoPilot runtime integrity rescue.
+-- Align the private runtime with the Phase-1 append-only event ledger and
+-- enforce actionable assignment/session boundaries in the database.
+
+begin;
+
+create or replace function copilot.technician_is_assigned(
+  p_auth_user_id uuid,
+  p_profile_id uuid,
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_work_order_line_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.work_order_lines wol
+    join public.work_orders wo
+      on wo.id = wol.work_order_id
+     and wo.shop_id = wol.shop_id
+    where wol.shop_id = p_shop_id
+      and wol.work_order_id = p_work_order_id
+      and wol.line_type = 'job'
+      and lower(replace(replace(btrim(wol.status), ' ', '_'), '-', '_')) not in (
+        'completed',
+        'ready_to_invoice',
+        'invoiced',
+        'declined',
+        'deferred',
+        'cancelled',
+        'canceled',
+        'closed'
+      )
+      and lower(replace(replace(btrim(wo.status), ' ', '_'), '-', '_')) not in (
+        'completed',
+        'ready_to_invoice',
+        'invoiced',
+        'cancelled',
+        'canceled',
+        'closed',
+        'paid',
+        'void',
+        'voided',
+        'archived'
+      )
+      and (p_work_order_line_id is null or wol.id = p_work_order_line_id)
+      and (
+        wol.assigned_tech_id in (p_auth_user_id, p_profile_id)
+        or wol.assigned_to in (p_auth_user_id, p_profile_id)
+        or exists (
+          select 1
+          from public.work_order_line_technicians wolt
+          where wolt.work_order_line_id = wol.id
+            and wolt.technician_id in (p_auth_user_id, p_profile_id)
+        )
+      )
+  )
+$$;
+
+create or replace function copilot.guard_repair_session_anchors()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_work_order_shop_id uuid;
+  v_work_order_vehicle_id uuid;
+begin
+  select wo.shop_id, wo.vehicle_id
+    into v_work_order_shop_id, v_work_order_vehicle_id
+  from public.work_orders wo
+  where wo.id = new.work_order_id;
+
+  if not found then
+    raise exception 'copilot_work_order_not_found' using errcode = 'P0001';
+  end if;
+
+  if new.shop_id is distinct from v_work_order_shop_id then
+    raise exception 'copilot_session_shop_mismatch' using errcode = '23514';
+  end if;
+
+  if new.vehicle_id is distinct from v_work_order_vehicle_id then
+    raise exception 'copilot_session_vehicle_mismatch' using errcode = '23514';
+  end if;
+
+  if new.active_work_order_line_id is not null
+    and not exists (
+      select 1
+      from public.work_order_lines wol
+      where wol.id = new.active_work_order_line_id
+        and wol.shop_id = new.shop_id
+        and wol.work_order_id = new.work_order_id
+        and wol.line_type = 'job'
+    )
+  then
+    raise exception 'copilot_session_line_mismatch' using errcode = '23514';
+  end if;
+
+  if new.service_visit_id is not null
+    and not exists (
+      select 1
+      from public.service_visits sv
+      where sv.id = new.service_visit_id
+        and sv.shop_id = new.shop_id
+        and sv.work_order_id = new.work_order_id
+    )
+  then
+    raise exception 'copilot_session_service_visit_mismatch' using errcode = '23514';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists repair_sessions_guard_anchors
+  on copilot.repair_sessions;
+create trigger repair_sessions_guard_anchors
+before insert or update of
+  shop_id,
+  work_order_id,
+  active_work_order_line_id,
+  vehicle_id,
+  service_visit_id
+on copilot.repair_sessions
+for each row
+execute function copilot.guard_repair_session_anchors();
+
+create or replace function copilot.append_repair_event_internal(
+  p_session_id uuid,
+  p_shop_id uuid,
+  p_technician_id uuid,
+  p_event_type text,
+  p_origin text,
+  p_operation_id uuid,
+  p_details jsonb,
+  p_occurred_at timestamptz
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_existing_event_id uuid;
+  v_existing_session_id uuid;
+  v_existing_seq bigint;
+  v_event_id uuid;
+  v_next_seq bigint;
+  v_session_status text;
+  v_occurred_at timestamptz := coalesce(p_occurred_at, now());
+begin
+  if p_operation_id is null then
+    raise exception 'copilot_operation_id_required' using errcode = '22023';
+  end if;
+
+  if p_event_type is null
+    or char_length(btrim(p_event_type)) not between 1 and 120
+  then
+    raise exception 'copilot_event_type_invalid' using errcode = '22023';
+  end if;
+
+  if p_origin not in (
+    'voice',
+    'ui',
+    'system',
+    'offline',
+    'integration',
+    'copilot'
+  ) then
+    raise exception 'copilot_event_origin_not_allowed' using errcode = '22023';
+  end if;
+
+  if p_details is null
+    or jsonb_typeof(p_details) <> 'object'
+    or octet_length(p_details::text) > 262144
+  then
+    raise exception 'copilot_event_details_invalid' using errcode = '22023';
+  end if;
+
+  select rs.last_event_seq + 1, rs.status
+    into v_next_seq, v_session_status
+  from copilot.repair_sessions rs
+  where rs.id = p_session_id
+    and rs.shop_id = p_shop_id
+    and rs.technician_id = p_technician_id
+  for update;
+
+  if not found then
+    raise exception 'copilot_session_not_found' using errcode = 'P0001';
+  end if;
+
+  if v_session_status <> 'active'
+    and p_event_type not in (
+      'session.paused',
+      'session.resumed',
+      'session.closed'
+    )
+  then
+    raise exception 'copilot_session_not_active' using errcode = '55000';
+  end if;
+
+  select e.id, e.repair_session_id, e.event_seq
+    into v_existing_event_id, v_existing_session_id, v_existing_seq
+  from copilot.repair_session_event_context c
+  join copilot.repair_session_events e
+    on e.id = c.event_id
+  where c.operation_id = p_operation_id;
+
+  if found then
+    if v_existing_session_id <> p_session_id then
+      raise exception 'copilot_operation_id_conflict' using errcode = '23505';
+    end if;
+    return jsonb_build_object(
+      'eventId', v_existing_event_id,
+      'eventSeq', v_existing_seq,
+      'replayed', true
+    );
+  end if;
+
+  begin
+    insert into copilot.repair_session_events (
+      repair_session_id,
+      event_seq,
+      event_type,
+      occurred_at
+    )
+    values (
+      p_session_id,
+      v_next_seq,
+      p_event_type,
+      v_occurred_at
+    )
+    returning id into v_event_id;
+
+    insert into copilot.repair_session_event_context (
+      event_id,
+      operation_id,
+      origin,
+      details
+    )
+    values (
+      v_event_id,
+      p_operation_id,
+      p_origin,
+      p_details
+    );
+  exception when unique_violation then
+    select e.id, e.repair_session_id, e.event_seq
+      into v_existing_event_id, v_existing_session_id, v_existing_seq
+    from copilot.repair_session_event_context c
+    join copilot.repair_session_events e
+      on e.id = c.event_id
+    where c.operation_id = p_operation_id;
+
+    if not found then
+      raise;
+    end if;
+    if v_existing_session_id <> p_session_id then
+      raise exception 'copilot_operation_id_conflict' using errcode = '23505';
+    end if;
+    return jsonb_build_object(
+      'eventId', v_existing_event_id,
+      'eventSeq', v_existing_seq,
+      'replayed', true
+    );
+  end;
+
+  update copilot.repair_sessions
+  set last_event_seq = v_next_seq,
+      context_version = context_version + 1,
+      last_activity_at = greatest(last_activity_at, v_occurred_at),
+      updated_at = now()
+  where id = p_session_id;
+
+  return jsonb_build_object(
+    'eventId', v_event_id,
+    'eventSeq', v_next_seq,
+    'replayed', false
+  );
+end;
+$$;
+
+create or replace function copilot.technician_session_read_internal(
+  p_auth_user_id uuid,
+  p_session_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_profile_id uuid;
+  v_session copilot.repair_sessions%rowtype;
+  v_events jsonb;
+  v_documentation_turns jsonb;
+  v_explicit boolean := p_session_id is not null;
+begin
+  v_profile_id := copilot.technician_profile_id(p_auth_user_id);
+
+  if not v_explicit then
+    select rs.*
+      into v_session
+    from copilot.repair_sessions rs
+    where rs.technician_id = v_profile_id
+      and rs.status = 'active'
+      and copilot.technician_is_assigned(
+        p_auth_user_id,
+        v_profile_id,
+        rs.shop_id,
+        rs.work_order_id,
+        null
+      )
+    order by rs.last_activity_at desc
+    limit 1;
+  else
+    select rs.*
+      into v_session
+    from copilot.repair_sessions rs
+    where rs.id = p_session_id
+      and rs.technician_id = v_profile_id;
+  end if;
+
+  if not found then
+    return jsonb_build_object(
+      'session', null,
+      'events', '[]'::jsonb,
+      'documentationTurns', '[]'::jsonb
+    );
+  end if;
+
+  if v_explicit
+    and not copilot.technician_is_assigned(
+      p_auth_user_id,
+      v_profile_id,
+      v_session.shop_id,
+      v_session.work_order_id,
+      null
+    )
+  then
+    raise exception 'copilot_work_order_assignment_required'
+      using errcode = '42501';
+  end if;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', e.id,
+        'repairSessionId', e.repair_session_id,
+        'eventSeq', e.event_seq,
+        'eventType', e.event_type,
+        'source', c.origin,
+        'payload', c.details,
+        'operationId', c.operation_id,
+        'occurredAt', e.occurred_at
+      )
+      order by e.event_seq
+    ),
+    '[]'::jsonb
+  )
+    into v_events
+  from copilot.repair_session_events e
+  join copilot.repair_session_event_context c
+    on c.event_id = e.id
+  where e.repair_session_id = v_session.id;
+
+  select coalesce(
+    jsonb_agg(dt.source_turn_id order by dt.created_at, dt.id),
+    '[]'::jsonb
+  )
+    into v_documentation_turns
+  from copilot.repair_session_documentation_turns dt
+  where dt.session_id = v_session.id;
+
+  return jsonb_build_object(
+    'session',
+    jsonb_build_object(
+      'id', v_session.id,
+      'shopId', v_session.shop_id,
+      'technicianId', v_session.technician_id,
+      'workOrderId', v_session.work_order_id,
+      'activeWorkOrderLineId', v_session.active_work_order_line_id,
+      'vehicleId', v_session.vehicle_id,
+      'serviceVisitId', v_session.service_visit_id,
+      'mode', v_session.mode,
+      'status', v_session.status,
+      'currentTask', v_session.current_task,
+      'contextVersion', v_session.context_version,
+      'lastEventSeq', v_session.last_event_seq,
+      'startedAt', v_session.started_at,
+      'lastActivityAt', v_session.last_activity_at,
+      'endedAt', v_session.ended_at
+    ),
+    'events', v_events,
+    'documentationTurns', v_documentation_turns
+  );
+end;
+$$;
+
+create or replace function copilot.technician_session_start_internal(
+  p_auth_user_id uuid,
+  p_work_order_id uuid,
+  p_work_order_line_id uuid,
+  p_mode text,
+  p_operation_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_profile_id uuid;
+  v_shop_id uuid;
+  v_vehicle_id uuid;
+  v_work_order_status text;
+  v_existing_session_id uuid;
+  v_existing_technician_id uuid;
+  v_active_session_id uuid;
+  v_target_session_id uuid;
+  v_event jsonb;
+begin
+  if p_mode not in ('shop', 'field', 'fleet') then
+    raise exception 'copilot_invalid_session_mode' using errcode = '22023';
+  end if;
+  if p_operation_id is null then
+    raise exception 'copilot_operation_id_required' using errcode = '22023';
+  end if;
+
+  v_profile_id := copilot.technician_profile_id(p_auth_user_id);
+
+  select p.shop_id
+    into v_shop_id
+  from public.profiles p
+  where p.id = v_profile_id;
+
+  select
+    wo.vehicle_id,
+    lower(replace(replace(btrim(wo.status), ' ', '_'), '-', '_'))
+    into v_vehicle_id, v_work_order_status
+  from public.work_orders wo
+  where wo.id = p_work_order_id
+    and wo.shop_id = v_shop_id
+  for share;
+
+  if not found then
+    raise exception 'copilot_work_order_not_found' using errcode = 'P0001';
+  end if;
+
+  if v_work_order_status in (
+    'completed',
+    'ready_to_invoice',
+    'invoiced',
+    'cancelled',
+    'canceled',
+    'closed',
+    'paid',
+    'void',
+    'voided',
+    'archived'
+  ) then
+    raise exception 'copilot_work_order_not_actionable' using errcode = '55000';
+  end if;
+
+  if not copilot.technician_is_assigned(
+    p_auth_user_id,
+    v_profile_id,
+    v_shop_id,
+    p_work_order_id,
+    p_work_order_line_id
+  ) then
+    raise exception 'copilot_work_order_assignment_required'
+      using errcode = '42501';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended('copilot:technician:' || v_profile_id::text, 0)
+  );
+
+  select e.repair_session_id, rs.technician_id
+    into v_existing_session_id, v_existing_technician_id
+  from copilot.repair_session_event_context c
+  join copilot.repair_session_events e
+    on e.id = c.event_id
+  join copilot.repair_sessions rs
+    on rs.id = e.repair_session_id
+  where c.operation_id = p_operation_id;
+
+  if found then
+    if v_existing_technician_id <> v_profile_id then
+      raise exception 'copilot_operation_id_conflict' using errcode = '23505';
+    end if;
+    return jsonb_build_object(
+      'sessionId', v_existing_session_id,
+      'replayed', true
+    );
+  end if;
+
+  select rs.id
+    into v_active_session_id
+  from copilot.repair_sessions rs
+  where rs.technician_id = v_profile_id
+    and rs.status = 'active'
+  for update;
+
+  if found
+    and exists (
+      select 1
+      from copilot.repair_sessions rs
+      where rs.id = v_active_session_id
+        and rs.work_order_id = p_work_order_id
+    )
+  then
+    update copilot.repair_sessions
+    set active_work_order_line_id = coalesce(
+          p_work_order_line_id,
+          active_work_order_line_id
+        ),
+        last_activity_at = now(),
+        updated_at = now()
+    where id = v_active_session_id;
+
+    return jsonb_build_object(
+      'sessionId', v_active_session_id,
+      'replayed', false,
+      'alreadyActive', true
+    );
+  end if;
+
+  if v_active_session_id is not null then
+    v_event := copilot.append_repair_event_internal(
+      v_active_session_id,
+      v_shop_id,
+      v_profile_id,
+      'session.paused',
+      'system',
+      md5(p_operation_id::text || ':auto-pause')::uuid,
+      jsonb_build_object('reason', 'switched_work_order'),
+      now()
+    );
+
+    update copilot.repair_sessions
+    set status = 'paused',
+        updated_at = now()
+    where id = v_active_session_id;
+  end if;
+
+  select rs.id
+    into v_target_session_id
+  from copilot.repair_sessions rs
+  where rs.technician_id = v_profile_id
+    and rs.work_order_id = p_work_order_id
+    and rs.status = 'paused'
+  order by rs.last_activity_at desc
+  limit 1
+  for update;
+
+  if found then
+    update copilot.repair_sessions
+    set status = 'active',
+        active_work_order_line_id = coalesce(
+          p_work_order_line_id,
+          active_work_order_line_id
+        ),
+        ended_at = null,
+        last_activity_at = now(),
+        updated_at = now()
+    where id = v_target_session_id;
+
+    v_event := copilot.append_repair_event_internal(
+      v_target_session_id,
+      v_shop_id,
+      v_profile_id,
+      'session.resumed',
+      'system',
+      p_operation_id,
+      jsonb_build_object(
+        'workOrderId', p_work_order_id,
+        'workOrderLineId', p_work_order_line_id
+      ),
+      now()
+    );
+  else
+    insert into copilot.repair_sessions (
+      shop_id,
+      technician_id,
+      work_order_id,
+      active_work_order_line_id,
+      vehicle_id,
+      mode,
+      status
+    )
+    values (
+      v_shop_id,
+      v_profile_id,
+      p_work_order_id,
+      p_work_order_line_id,
+      v_vehicle_id,
+      p_mode,
+      'active'
+    )
+    returning id into v_target_session_id;
+
+    v_event := copilot.append_repair_event_internal(
+      v_target_session_id,
+      v_shop_id,
+      v_profile_id,
+      'session.started',
+      'system',
+      p_operation_id,
+      jsonb_build_object(
+        'workOrderId', p_work_order_id,
+        'workOrderLineId', p_work_order_line_id,
+        'mode', p_mode
+      ),
+      now()
+    );
+  end if;
+
+  return jsonb_build_object(
+    'sessionId', v_target_session_id,
+    'replayed', coalesce((v_event ->> 'replayed')::boolean, false)
+  );
+end;
+$$;
+
+create or replace function copilot.technician_event_append_internal(
+  p_auth_user_id uuid,
+  p_session_id uuid,
+  p_event_type text,
+  p_origin text,
+  p_operation_id uuid,
+  p_details jsonb,
+  p_occurred_at timestamptz
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_profile_id uuid;
+  v_shop_id uuid;
+  v_work_order_id uuid;
+  v_result jsonb;
+begin
+  if p_event_type not in (
+    'conversation.user',
+    'conversation.assistant',
+    'task.changed',
+    'complaint.recorded',
+    'observation.recorded',
+    'measurement.recorded',
+    'dtc.observed',
+    'diagnostic.finding',
+    'evidence.attached',
+    'component.removed',
+    'component.installed',
+    'component.disconnected',
+    'component.connected',
+    'fluid.drained',
+    'fluid.filled',
+    'action.pending',
+    'action.completed'
+  ) then
+    raise exception 'copilot_event_type_not_allowed' using errcode = '22023';
+  end if;
+
+  if p_origin not in (
+    'voice',
+    'ui',
+    'system',
+    'offline',
+    'integration',
+    'copilot'
+  ) then
+    raise exception 'copilot_event_origin_not_allowed' using errcode = '22023';
+  end if;
+
+  if p_details is null
+    or jsonb_typeof(p_details) <> 'object'
+    or octet_length(p_details::text) > 262144
+  then
+    raise exception 'copilot_event_details_invalid' using errcode = '22023';
+  end if;
+
+  v_profile_id := copilot.technician_profile_id(p_auth_user_id);
+
+  select rs.shop_id, rs.work_order_id
+    into v_shop_id, v_work_order_id
+  from copilot.repair_sessions rs
+  where rs.id = p_session_id
+    and rs.technician_id = v_profile_id
+    and rs.status = 'active';
+
+  if not found then
+    raise exception 'copilot_session_not_active' using errcode = '55000';
+  end if;
+
+  if not copilot.technician_is_assigned(
+    p_auth_user_id,
+    v_profile_id,
+    v_shop_id,
+    v_work_order_id,
+    null
+  ) then
+    raise exception 'copilot_work_order_assignment_required'
+      using errcode = '42501';
+  end if;
+
+  v_result := copilot.append_repair_event_internal(
+    p_session_id,
+    v_shop_id,
+    v_profile_id,
+    p_event_type,
+    p_origin,
+    p_operation_id,
+    p_details,
+    coalesce(p_occurred_at, now())
+  );
+
+  if coalesce((v_result ->> 'replayed')::boolean, false) = false
+    and p_event_type = 'task.changed'
+  then
+    update copilot.repair_sessions
+    set current_task = nullif(btrim(p_details ->> 'task'), ''),
+        updated_at = now()
+    where id = p_session_id;
+  end if;
+
+  return v_result;
+end;
+$$;
+
+create or replace function copilot.guard_documentation_turn_active()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+begin
+  perform 1
+  from copilot.repair_sessions rs
+  where rs.id = new.session_id
+    and rs.shop_id = new.shop_id
+    and rs.technician_id = new.technician_id
+    and rs.status = 'active'
+  for update;
+
+  if not found then
+    raise exception 'copilot_session_not_active' using errcode = '55000';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists repair_session_documentation_turns_require_active
+  on copilot.repair_session_documentation_turns;
+create trigger repair_session_documentation_turns_require_active
+before insert on copilot.repair_session_documentation_turns
+for each row
+execute function copilot.guard_documentation_turn_active();
+
+revoke all on function copilot.technician_is_assigned(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  uuid
+) from public, anon, authenticated, service_role;
+revoke all on function copilot.guard_repair_session_anchors()
+  from public, anon, authenticated, service_role;
+revoke all on function copilot.append_repair_event_internal(
+  uuid,
+  uuid,
+  uuid,
+  text,
+  text,
+  uuid,
+  jsonb,
+  timestamptz
+) from public, anon, authenticated, service_role;
+revoke all on function copilot.technician_session_read_internal(uuid, uuid)
+  from public, anon, authenticated, service_role;
+revoke all on function copilot.technician_session_start_internal(
+  uuid,
+  uuid,
+  uuid,
+  text,
+  uuid
+) from public, anon, authenticated, service_role;
+revoke all on function copilot.technician_event_append_internal(
+  uuid,
+  uuid,
+  text,
+  text,
+  uuid,
+  jsonb,
+  timestamptz
+) from public, anon, authenticated, service_role;
+revoke all on function copilot.guard_documentation_turn_active()
+  from public, anon, authenticated, service_role;
+
+comment on function copilot.append_repair_event_internal(
+  uuid,
+  uuid,
+  uuid,
+  text,
+  text,
+  uuid,
+  jsonb,
+  timestamptz
+) is
+  'Private ordered append against repair_session_events.repair_session_id with operation replay protection.';
+comment on function copilot.technician_session_start_internal(
+  uuid,
+  uuid,
+  uuid,
+  text,
+  uuid
+) is
+  'Starts or switches one active Technician CoPilot session only for actionable assigned work.';
+
+-- Ephemeral command rows are transport envelopes, not durable AI audit events.
+delete from public.ai_action_events
+where source = 'technician_copilot_command';
+
+do $technician_copilot_runtime_integrity_postcheck$
+declare
+  v_append_definition text;
+  v_read_definition text;
+  v_start_definition text;
+begin
+  if not exists (
+    select 1
+    from information_schema.columns c
+    where c.table_schema = 'copilot'
+      and c.table_name = 'repair_session_events'
+      and c.column_name = 'repair_session_id'
+  )
+  or exists (
+    select 1
+    from information_schema.columns c
+    where c.table_schema = 'copilot'
+      and c.table_name = 'repair_session_events'
+      and c.column_name in ('session_id', 'shop_id', 'technician_id')
+  )
+  then
+    raise exception 'Technician CoPilot runtime postcheck failed: event ledger columns are incoherent';
+  end if;
+
+  if exists (
+    select 1
+    from information_schema.columns c
+    where c.table_schema = 'copilot'
+      and c.table_name = 'repair_session_event_context'
+      and c.column_name in ('shop_id', 'technician_id', 'occurred_at')
+  )
+  then
+    raise exception 'Technician CoPilot runtime postcheck failed: context ledger columns are incoherent';
+  end if;
+
+  select pg_get_functiondef(p.oid)
+    into v_append_definition
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'copilot'
+    and p.proname = 'append_repair_event_internal';
+
+  select pg_get_functiondef(p.oid)
+    into v_read_definition
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'copilot'
+    and p.proname = 'technician_session_read_internal';
+
+  select pg_get_functiondef(p.oid)
+    into v_start_definition
+  from pg_proc p
+  join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'copilot'
+    and p.proname = 'technician_session_start_internal';
+
+  if v_append_definition is null
+    or position('repair_session_id' in v_append_definition) = 0
+    or position('repair_session_events(session_id' in v_append_definition) > 0
+    or position('repair_session_event_context(event_id,shop_id' in v_append_definition) > 0
+  then
+    raise exception 'Technician CoPilot runtime postcheck failed: append helper still targets obsolete columns';
+  end if;
+
+  if v_read_definition is null
+    or position('e.repair_session_id' in v_read_definition) = 0
+    or position('e.session_id' in v_read_definition) > 0
+  then
+    raise exception 'Technician CoPilot runtime postcheck failed: session read still targets obsolete columns';
+  end if;
+
+  if v_start_definition is null
+    or position('e.repair_session_id' in v_start_definition) = 0
+    or position('copilot_work_order_not_actionable' in v_start_definition) = 0
+    or position('pg_advisory_xact_lock' in v_start_definition) = 0
+  then
+    raise exception 'Technician CoPilot runtime postcheck failed: session start integrity guard missing';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_trigger t
+    where t.tgrelid = 'copilot.repair_sessions'::regclass
+      and t.tgname = 'repair_sessions_guard_anchors'
+      and not t.tgisinternal
+  )
+  or not exists (
+    select 1
+    from pg_trigger t
+    where t.tgrelid = 'copilot.repair_session_documentation_turns'::regclass
+      and t.tgname = 'repair_session_documentation_turns_require_active'
+      and not t.tgisinternal
+  )
+  then
+    raise exception 'Technician CoPilot runtime postcheck failed: integrity triggers missing';
+  end if;
+end
+$technician_copilot_runtime_integrity_postcheck$;
+
+commit;

--- a/tests/security/technician-copilot-runtime-integrity.runtime.sql
+++ b/tests/security/technician-copilot-runtime-integrity.runtime.sql
@@ -69,7 +69,7 @@ values
   (
     'a1438000-0000-4000-8000-000000000103',
     'a1438000-0000-4000-8000-000000000010',
-    'ready_to_invoice',
+    'completed',
     'COPILOT-RT-TERMINAL'
   )
 on conflict (id) do nothing;

--- a/tests/security/technician-copilot-runtime-integrity.runtime.sql
+++ b/tests/security/technician-copilot-runtime-integrity.runtime.sql
@@ -117,6 +117,13 @@ values
   )
 on conflict (id) do nothing;
 
+-- The existing line-status refresh trigger recalculates a parent work order
+-- after line insertion. Reassert the terminal parent state after the assigned
+-- line exists so this fixture actually exercises CoPilot's terminal-work guard.
+update public.work_orders
+set status = 'completed'
+where id = 'a1438000-0000-4000-8000-000000000103';
+
 set constraints all immediate;
 
 do $technician_copilot_runtime_lifecycle$

--- a/tests/security/technician-copilot-runtime-integrity.runtime.sql
+++ b/tests/security/technician-copilot-runtime-integrity.runtime.sql
@@ -1,0 +1,287 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values
+  (
+    'a1438000-0000-4000-8000-000000000001',
+    'copilot-runtime-owner@example.com',
+    '{"full_name":"CoPilot Runtime Owner"}'::jsonb
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000002',
+    'copilot-runtime-tech@example.com',
+    '{"full_name":"CoPilot Runtime Technician"}'::jsonb
+  )
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name)
+values
+  (
+    'a1438000-0000-4000-8000-000000000001',
+    'a1438000-0000-4000-8000-000000000001',
+    'owner',
+    'CoPilot Runtime Owner'
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000002',
+    'a1438000-0000-4000-8000-000000000002',
+    'mechanic',
+    'CoPilot Runtime Technician'
+  )
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name;
+
+insert into public.shops (id, owner_id, business_name, name, user_limit)
+values (
+  'a1438000-0000-4000-8000-000000000010',
+  'a1438000-0000-4000-8000-000000000001',
+  'CoPilot Runtime Shop',
+  'CoPilot Runtime Shop',
+  10
+)
+on conflict (id) do nothing;
+
+update public.profiles
+set shop_id = 'a1438000-0000-4000-8000-000000000010'
+where id in (
+  'a1438000-0000-4000-8000-000000000001',
+  'a1438000-0000-4000-8000-000000000002'
+);
+
+insert into public.work_orders (id, shop_id, status, custom_id)
+values
+  (
+    'a1438000-0000-4000-8000-000000000101',
+    'a1438000-0000-4000-8000-000000000010',
+    'queued',
+    'COPILOT-RT-1'
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000102',
+    'a1438000-0000-4000-8000-000000000010',
+    'in_progress',
+    'COPILOT-RT-2'
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000103',
+    'a1438000-0000-4000-8000-000000000010',
+    'ready_to_invoice',
+    'COPILOT-RT-TERMINAL'
+  )
+on conflict (id) do nothing;
+
+insert into public.work_order_lines (
+  id,
+  work_order_id,
+  shop_id,
+  line_type,
+  status,
+  assigned_tech_id,
+  assigned_to,
+  description
+)
+values
+  (
+    'a1438000-0000-4000-8000-000000000201',
+    'a1438000-0000-4000-8000-000000000101',
+    'a1438000-0000-4000-8000-000000000010',
+    'job',
+    'active',
+    'a1438000-0000-4000-8000-000000000002',
+    'a1438000-0000-4000-8000-000000000002',
+    'Runtime lifecycle one'
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000202',
+    'a1438000-0000-4000-8000-000000000102',
+    'a1438000-0000-4000-8000-000000000010',
+    'job',
+    'waiting_parts',
+    'a1438000-0000-4000-8000-000000000002',
+    'a1438000-0000-4000-8000-000000000002',
+    'Runtime lifecycle two'
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000203',
+    'a1438000-0000-4000-8000-000000000103',
+    'a1438000-0000-4000-8000-000000000010',
+    'job',
+    'active',
+    'a1438000-0000-4000-8000-000000000002',
+    'a1438000-0000-4000-8000-000000000002',
+    'Runtime terminal guard'
+  )
+on conflict (id) do nothing;
+
+set constraints all immediate;
+
+do $technician_copilot_runtime_lifecycle$
+declare
+  v_first jsonb;
+  v_replayed_start jsonb;
+  v_second jsonb;
+  v_read jsonb;
+  v_append jsonb;
+  v_append_replay jsonb;
+  v_first_session_id uuid;
+  v_second_session_id uuid;
+begin
+  v_first := copilot.technician_session_start_internal(
+    'a1438000-0000-4000-8000-000000000002',
+    'a1438000-0000-4000-8000-000000000101',
+    'a1438000-0000-4000-8000-000000000201',
+    'shop',
+    'a1438000-0000-4000-8000-000000000301'
+  );
+  v_first_session_id := (v_first ->> 'sessionId')::uuid;
+
+  if v_first_session_id is null
+    or coalesce((v_first ->> 'replayed')::boolean, false)
+  then
+    raise exception 'CoPilot runtime assertion failed: first session did not start';
+  end if;
+
+  v_replayed_start := copilot.technician_session_start_internal(
+    'a1438000-0000-4000-8000-000000000002',
+    'a1438000-0000-4000-8000-000000000101',
+    'a1438000-0000-4000-8000-000000000201',
+    'shop',
+    'a1438000-0000-4000-8000-000000000301'
+  );
+
+  if (v_replayed_start ->> 'sessionId')::uuid <> v_first_session_id
+    or not coalesce((v_replayed_start ->> 'replayed')::boolean, false)
+  then
+    raise exception 'CoPilot runtime assertion failed: session-start replay was not idempotent';
+  end if;
+
+  v_read := copilot.technician_session_read_internal(
+    'a1438000-0000-4000-8000-000000000002',
+    v_first_session_id
+  );
+
+  if v_read #>> '{session,id}' <> v_first_session_id::text
+    or jsonb_array_length(v_read -> 'events') <> 1
+    or v_read #>> '{events,0,eventType}' <> 'session.started'
+    or v_read #>> '{events,0,repairSessionId}' <> v_first_session_id::text
+  then
+    raise exception 'CoPilot runtime assertion failed: session read does not project the Phase-1 ledger';
+  end if;
+
+  v_append := copilot.technician_event_append_internal(
+    'a1438000-0000-4000-8000-000000000002',
+    v_first_session_id,
+    'conversation.user',
+    'voice',
+    'a1438000-0000-4000-8000-000000000302',
+    '{"text":"Rear U-joint has play","turnId":"runtime-turn-1","inputMode":"voice"}'::jsonb,
+    now()
+  );
+
+  v_append_replay := copilot.technician_event_append_internal(
+    'a1438000-0000-4000-8000-000000000002',
+    v_first_session_id,
+    'conversation.user',
+    'voice',
+    'a1438000-0000-4000-8000-000000000302',
+    '{"text":"Rear U-joint has play","turnId":"runtime-turn-1","inputMode":"voice"}'::jsonb,
+    now()
+  );
+
+  if coalesce((v_append ->> 'replayed')::boolean, true)
+    or not coalesce((v_append_replay ->> 'replayed')::boolean, false)
+    or v_append ->> 'eventId' <> v_append_replay ->> 'eventId'
+  then
+    raise exception 'CoPilot runtime assertion failed: event replay was not idempotent';
+  end if;
+
+  v_second := copilot.technician_session_start_internal(
+    'a1438000-0000-4000-8000-000000000002',
+    'a1438000-0000-4000-8000-000000000102',
+    'a1438000-0000-4000-8000-000000000202',
+    'shop',
+    'a1438000-0000-4000-8000-000000000303'
+  );
+  v_second_session_id := (v_second ->> 'sessionId')::uuid;
+
+  if v_second_session_id is null
+    or v_second_session_id = v_first_session_id
+    or not exists (
+      select 1
+      from copilot.repair_sessions rs
+      where rs.id = v_first_session_id
+        and rs.status = 'paused'
+    )
+    or not exists (
+      select 1
+      from copilot.repair_sessions rs
+      where rs.id = v_second_session_id
+        and rs.status = 'active'
+    )
+  then
+    raise exception 'CoPilot runtime assertion failed: canonical session switch is incoherent';
+  end if;
+
+  begin
+    perform copilot.technician_event_append_internal(
+      'a1438000-0000-4000-8000-000000000002',
+      v_first_session_id,
+      'observation.recorded',
+      'voice',
+      'a1438000-0000-4000-8000-000000000304',
+      '{"text":"Must not reach paused work"}'::jsonb,
+      now()
+    );
+    raise exception 'CoPilot runtime assertion failed: paused session accepted a repair fact';
+  exception when sqlstate '55000' then
+    if sqlerrm <> 'copilot_session_not_active' then
+      raise;
+    end if;
+  end;
+
+  begin
+    perform copilot.technician_session_start_internal(
+      'a1438000-0000-4000-8000-000000000002',
+      'a1438000-0000-4000-8000-000000000103',
+      'a1438000-0000-4000-8000-000000000203',
+      'shop',
+      'a1438000-0000-4000-8000-000000000305'
+    );
+    raise exception 'CoPilot runtime assertion failed: terminal work order started a session';
+  exception when sqlstate '55000' then
+    if sqlerrm <> 'copilot_work_order_not_actionable' then
+      raise;
+    end if;
+  end;
+end
+$technician_copilot_runtime_lifecycle$;
+
+do $technician_copilot_runtime_schema$
+begin
+  if exists (
+    select 1
+    from copilot.repair_session_events e
+    left join copilot.repair_sessions rs
+      on rs.id = e.repair_session_id
+    where rs.id is null
+  ) then
+    raise exception 'CoPilot runtime assertion failed: orphan repair event exists';
+  end if;
+
+  if exists (
+    select 1
+    from copilot.repair_session_event_context c
+    left join copilot.repair_session_events e
+      on e.id = c.event_id
+    where e.id is null
+  ) then
+    raise exception 'CoPilot runtime assertion failed: orphan event context exists';
+  end if;
+end
+$technician_copilot_runtime_schema$;
+
+rollback;

--- a/tests/technician-copilot-documentation-atomicity.test.ts
+++ b/tests/technician-copilot-documentation-atomicity.test.ts
@@ -26,7 +26,9 @@ describe("Technician CoPilot turn-scoped documentation atomicity", () => {
   it("finalizes only successful extraction attempts, including valid empty results", () => {
     expect(chat).toContain("completed: true");
     expect(chat).toContain("completed: false");
-    expect(chat).toContain("if (documentationExtraction.completed)");
+    expect(chat).toContain("documentationExtraction.completed");
+    expect(chat).toContain("!documentationAlreadyFinalized");
+    expect(chat).toContain("await appendDocumentationTurn");
   });
 
   it("recovers unfinished documentation without replacing a persisted reply", () => {

--- a/tests/technician-copilot-runtime-integrity.test.ts
+++ b/tests/technician-copilot-runtime-integrity.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260814223500_technician_copilot_runtime_integrity.sql",
+  "utf8",
+);
+const assignedWork = readFileSync(
+  "features/copilot/technician/server/assignedWork.ts",
+  "utf8",
+);
+const sessionRoute = readFileSync(
+  "app/api/copilot/technician/session/route.ts",
+  "utf8",
+);
+const chatRuntime = readFileSync(
+  "features/copilot/technician/server/chat.ts",
+  "utf8",
+);
+const chatRoute = readFileSync(
+  "app/api/copilot/technician/chat/route.ts",
+  "utf8",
+);
+const transport = readFileSync(
+  "features/copilot/technician/server/transport.ts",
+  "utf8",
+);
+const runtimeIntegration = readFileSync(
+  "tests/security/technician-copilot-runtime-integrity.runtime.sql",
+  "utf8",
+);
+
+describe("Technician CoPilot runtime integrity rescue", () => {
+  it("targets the deployed Phase-1 event ledger rather than obsolete columns", () => {
+    expect(migration).toContain("repair_session_id");
+    expect(migration).toContain(
+      "insert into copilot.repair_session_events (\n      repair_session_id,",
+    );
+    expect(migration).toContain(
+      "insert into copilot.repair_session_event_context (\n      event_id,\n      operation_id,",
+    );
+    expect(migration).not.toContain(
+      "insert into copilot.repair_session_events(session_id,shop_id,technician_id",
+    );
+    expect(migration).not.toContain(
+      "insert into copilot.repair_session_event_context(event_id,shop_id,technician_id",
+    );
+  });
+
+  it("enforces active actionable sessions at the database boundary", () => {
+    expect(migration).toContain("copilot_work_order_not_actionable");
+    expect(migration).toContain("copilot_session_not_active");
+    expect(migration).toContain("pg_advisory_xact_lock");
+    expect(migration).toContain("repair_sessions_guard_anchors");
+    expect(migration).toContain(
+      "repair_session_documentation_turns_require_active",
+    );
+  });
+
+  it("filters active canonical assignments before applying candidate limits", () => {
+    expect(assignedWork).toContain("ACTIVE_CANONICAL_LINE_STATUSES");
+    expect(assignedWork).toContain(
+      '.in("status", ACTIVE_TECHNICIAN_LINE_DB_STATUSES)',
+    );
+    expect(assignedWork).toContain(
+      '.in("work_order_lines.status", ACTIVE_TECHNICIAN_LINE_DB_STATUSES)',
+    );
+    expect(assignedWork).toContain("work_order_lines!inner");
+    expect(assignedWork).toContain("MAX_ASSIGNED_LINES_PER_PATH");
+    expect(assignedWork).toContain("MAX_WORK_ORDER_CANDIDATES");
+  });
+
+  it("hydrates existing sessions through the targeted assigned-work loader", () => {
+    expect(sessionRoute).toContain(
+      "loadTechnicianWorkCandidateForWorkOrder({",
+    );
+    expect(sessionRoute).not.toContain("listTechnicianWorkCandidates({");
+  });
+
+  it("rejects stale sessions and conflicting turn reuse with a 409", () => {
+    expect(chatRuntime).toContain("TechnicianCopilotConflictError");
+    expect(chatRuntime).toContain("session.status !== \"active\"");
+    expect(chatRuntime).toContain("persistedMessage !== input.requestedMessage");
+    expect(chatRuntime).toContain("persistedSource !== input.requestedSource");
+    expect(chatRoute).toContain("{ status: conflict.status }");
+  });
+
+  it("awaits command-row cleanup on every exit path", () => {
+    expect(transport).toContain("} finally {");
+    expect(transport).toContain("const cleanup = await admin");
+    expect(transport).not.toContain(
+      'void admin.from("ai_action_events").delete()',
+    );
+  });
+
+  it("ships an executable transaction-level lifecycle integration", () => {
+    expect(runtimeIntegration).toContain(
+      "copilot.technician_session_start_internal(",
+    );
+    expect(runtimeIntegration).toContain(
+      "copilot.technician_event_append_internal(",
+    );
+    expect(runtimeIntegration).toContain(
+      "copilot.technician_session_read_internal(",
+    );
+    expect(runtimeIntegration).toContain("paused session accepted a repair fact");
+    expect(runtimeIntegration).toContain("terminal work order started a session");
+    expect(runtimeIntegration.trimEnd()).toMatch(/rollback;$/);
+  });
+});


### PR DESCRIPTION
## Purpose

Restore the released Technician CoPilot runtime against the schema that is actually deployed, without expanding the Realtime transport or unrelated work-order code.

## Root cause

The private CoPilot functions were written against event-ledger columns that never existed (`session_id`, event-level `shop_id` / `technician_id`, and context-level `occurred_at`). The deployed Phase-1 ledger uses `repair_session_events.repair_session_id` plus a narrow `repair_session_event_context` row. As a result, the first real `session.start` could not append `session.started`.

## Narrow repair

- adds forward migration `20260814223500_technician_copilot_runtime_integrity.sql`;
- rewrites private append/read/start/event functions against the real Phase-1 ledger;
- rejects terminal work and non-active session writes in the database;
- serializes concurrent session switches and preserves operation replay;
- validates repair-session shop/work-order/line/vehicle/service-visit anchors;
- requires an active session before a documentation-turn receipt can be created;
- filters active canonical direct/shared assignments before candidate limits;
- hydrates an existing session through one targeted assigned-work lookup;
- binds a reused turn ID to its original persisted text and input mode;
- returns stale-session conflicts as HTTP 409;
- awaits temporary command-row cleanup in `finally`;
- adds focused source contracts and an executable transaction-level lifecycle integration.

## Scope boundary

No inspection voice, Realtime microphone lifecycle, work-order numbering, quote/parts actions, billing, Fleet workflow, or owner settings UI is changed.

## Release order

1. Exact PR head must pass Agent PR Checks and Supabase Clean Replay.
2. Review the effective migration and unresolved threads on that exact head.
3. Merge the code.
4. Apply `20260814223500_technician_copilot_runtime_integrity.sql` before or alongside the production deployment.
5. Run the technician acceptance flow and confirm zero temporary command rows.

## Database status

The migration is committed to this PR but has **not** been applied to production. Production remains unchanged and currently still has the broken function definitions.

## Local validation completed before publish

- all eight uploaded Git blobs matched the locally validated files by SHA;
- changed TypeScript/TSX syntax transpilation passed;
- focused source-contract assertions passed;
- live schema, statuses, FKs, RLS, capability rows, and private function ACLs were reconciled before writing the migration.

## Pending gates

- Agent PR Checks
- Supabase Clean Replay
- exact-head review
- transaction-level lifecycle execution against the replayed schema
