### PR TITLE
Add Agent pipeline recovery and release inspection controls

### DIFF
--- a/app/api/agent/requests/[id]/route.ts
+++ b/app/api/agent/requests/[id]/route.ts
@@ -87,6 +87,27 @@ function projectionFromNormalized(value: unknown): AgentTeamProjection | null {
   const missingInformation = Array.isArray(team.missingInformation)
     ? team.missingInformation.filter((item): item is string => typeof item === "string")
     : [];
+  const specialists = Array.isArray(team.specialists)
+    ? team.specialists.filter(isRecord).flatMap((item) => {
+        const key = nullableString(item.key);
+        if (!key) return [];
+        return [{
+          key,
+          role: nullableString(item.role) ?? key.replace(/_/g, " "),
+          required: item.required === true,
+          decision: nullableString(item.decision),
+          summary: nullableString(item.summary),
+        }];
+      })
+    : [];
+  const conflicts = Array.isArray(team.conflicts)
+    ? team.conflicts.filter(isRecord).flatMap((item) => {
+        const description = nullableString(item.description);
+        return description
+          ? [{ topic: nullableString(item.topic) ?? "specialist_conflict", description }]
+          : [];
+      })
+    : [];
 
   return {
     engineeringCaseId,
@@ -98,6 +119,17 @@ function projectionFromNormalized(value: unknown): AgentTeamProjection | null {
     decision: nullableString(team.decision),
     missingInformation,
     updatedAt: nullableString(team.updatedAt) ?? new Date(0).toISOString(),
+    specialists,
+    conflicts,
+    internalRequirements: stringArray(team.internalRequirements),
+    internalDependency: nullableString(team.internalDependency),
+    nextAction: nullableString(team.nextAction),
+    attemptNumber: Number.isFinite(Number(team.attemptNumber))
+      ? Number(team.attemptNumber)
+      : null,
+    maximumInternalAttempts: Number.isFinite(Number(team.maximumInternalAttempts))
+      ? Number(team.maximumInternalAttempts)
+      : null,
     mission: mission?.id ? mission : null,
     pullRequest: {
       number: Number.isFinite(Number(pullRequest.number))

--- a/app/api/agent/requests/route.ts
+++ b/app/api/agent/requests/route.ts
@@ -93,6 +93,13 @@ function initialProjection(
     decision: null,
     missingInformation: [],
     updatedAt: new Date().toISOString(),
+    specialists: [],
+    conflicts: [],
+    internalRequirements: [],
+    internalDependency: null,
+    nextAction: null,
+    attemptNumber: null,
+    maximumInternalAttempts: null,
     mission: null,
     pullRequest: {
       number: response.github?.prNumber ?? null,

--- a/features/agent/agent-console/app/agent/page.tsx
+++ b/features/agent/agent-console/app/agent/page.tsx
@@ -10,6 +10,12 @@ import Card from "@shared/components/ui/Card";
 import { Badge } from "@shared/components/ui/badge";
 import { Separator } from "@shared/components/ui/separator";
 import { cn } from "@shared/lib/utils";
+import {
+  diagnoseAgentPipelineRequest,
+  partitionAgentQuestions,
+  summarizeAgentPipeline,
+  type AgentPipelineRequestSnapshot,
+} from "@/features/agent/lib/pipelineDiagnostics";
 import { isAgentRequestRetryVisible } from "@/features/agent/lib/requestRetry";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
@@ -46,6 +52,23 @@ type AgentTeamState = {
   decision?: string | null;
   missingInformation?: string[];
   mission?: AgentMissionReview | null;
+  specialists?: Array<{
+    key: string;
+    role: string;
+    required: boolean;
+    decision: string | null;
+    summary: string | null;
+  }>;
+  conflicts?: Array<{
+    topic: string;
+    description: string;
+  }>;
+  internalRequirements?: string[];
+  internalDependency?: string | null;
+  nextAction?: string | null;
+  attemptNumber?: number | null;
+  maximumInternalAttempts?: number | null;
+  updatedAt?: string | null;
   syncedAt?: string;
 };
 
@@ -121,6 +144,48 @@ function isString(v: unknown): v is string {
   return typeof v === "string";
 }
 
+function pipelineSnapshot(request: AgentRequest): AgentPipelineRequestSnapshot {
+  const context = request.normalized_json ?? null;
+  const team = context?.agentTeam && typeof context.agentTeam === "object"
+    ? context.agentTeam
+    : null;
+  const legacyQuestions = Array.isArray(context?.questions)
+    ? context.questions
+        .map((question) => question?.question)
+        .filter(isString)
+    : [];
+  const teamQuestions = Array.isArray(team?.missingInformation)
+    ? team.missingInformation.filter(isString)
+    : [];
+  const { reporterQuestions } = partitionAgentQuestions([
+    ...legacyQuestions,
+    ...teamQuestions,
+  ]);
+
+  return {
+    id: request.id,
+    status: request.status,
+    createdAt: request.created_at,
+    updatedAt: request.updated_at,
+    notes: request.llm_notes,
+    reporterQuestions,
+    team: team
+      ? {
+          currentStage: team.currentStage,
+          caseStatus: team.caseStatus,
+          stepStatus: team.stepStatus,
+          updatedAt: team.updatedAt,
+          syncedAt: team.syncedAt,
+          missionStatus: team.mission?.status,
+          internalDependency: team.internalDependency,
+          internalRequirements: team.internalRequirements,
+          specialists: team.specialists,
+          conflicts: team.conflicts,
+        }
+      : null,
+  };
+}
+
 export default function AgentConsolePage() {
   const [requests, setRequests] = useState<AgentRequest[]>([]);
   const [selected, setSelected] = useState<AgentRequest | null>(null);
@@ -138,6 +203,7 @@ export default function AgentConsolePage() {
   const [replyText, setReplyText] = useState("");
   const [replySending, setReplySending] = useState(false);
   const [retryingRequestId, setRetryingRequestId] = useState<string | null>(null);
+  const [inspectionMode, setInspectionMode] = useState<"explain" | "inspect" | null>(null);
 
   const selectedContext: AgentContext | null = selected?.normalized_json ?? null;
   const selectedTeam = useMemo<AgentTeamState | null>(() => {
@@ -147,7 +213,7 @@ export default function AgentConsolePage() {
       : null;
   }, [selectedContext?.agentTeam]);
 
-  const questions = useMemo<AgentQuestion[]>(() => {
+  const questionGroups = useMemo(() => {
     const raw = selectedContext?.questions;
     const legacy = raw && Array.isArray(raw)
       ? raw
@@ -170,13 +236,34 @@ export default function AgentConsolePage() {
       : [];
 
     const seen = new Set<string>();
-    return [...legacy, ...teamMissing].filter((question) => {
+    const uniqueQuestions = [...legacy, ...teamMissing].filter((question) => {
       const key = question.question.trim().toLowerCase();
       if (!key || seen.has(key)) return false;
       seen.add(key);
       return true;
     });
+    const partitioned = partitionAgentQuestions(
+      uniqueQuestions.map((question) => question.question),
+    );
+    const reporterSet = new Set(
+      partitioned.reporterQuestions.map((question) => question.toLowerCase()),
+    );
+
+    return {
+      reporterQuestions: uniqueQuestions.filter((question) =>
+        reporterSet.has(question.question.trim().toLowerCase()),
+      ),
+      internalRequirements: partitioned.internalRequirements,
+    };
   }, [selectedContext?.questions, selectedTeam]);
+  const questions = questionGroups.reporterQuestions;
+  const internalRequirements = useMemo(
+    () => [...new Set([
+      ...(selectedTeam?.internalRequirements ?? []).filter(isString),
+      ...questionGroups.internalRequirements,
+    ])],
+    [questionGroups.internalRequirements, selectedTeam?.internalRequirements],
+  );
 
   const responses = useMemo<AgentResponse[]>(() => {
     const raw = selectedContext?.responses;
@@ -231,6 +318,17 @@ export default function AgentConsolePage() {
     });
   }, [selectedContext?.responses]);
 
+  const pipelineSummary = useMemo(
+    () => summarizeAgentPipeline(requests.map(pipelineSnapshot)),
+    [requests],
+  );
+  const selectedDiagnostic = useMemo(
+    () => selected
+      ? diagnoseAgentPipelineRequest(pipelineSnapshot(selected))
+      : null,
+    [selected],
+  );
+
   const missionAwaitingApproval = selectedTeam?.mission?.status === "awaiting_approval";
   const missionReviewComplete = isMissionReviewComplete(selectedTeam?.mission);
   const releaseAwaitingApproval = selectedTeam?.caseStatus === "ready_for_human_approval"
@@ -247,10 +345,23 @@ export default function AgentConsolePage() {
         stepStatus: selectedTeam?.stepStatus,
       })
     : false;
-  const retryLabel = selectedTeam?.caseStatus === "blocked"
-    ? "Restart Investigation"
-    : "Retry Request";
+  const retryLabel = selectedDiagnostic?.kind === "authorization_failure"
+    ? "Retry dispatch"
+    : selectedTeam?.caseStatus === "blocked"
+      ? `Restart from ${selectedTeam.currentStage?.replace(/_/g, " ") ?? "stage"}`
+      : selected?.status === "submitted"
+        ? "Replay dispatch"
+        : "Retry Request";
   const actionBusy = isPending || retryingRequestId === selected?.id;
+
+  function inspectFirstPipelineIssue() {
+    const requestId = pipelineSummary.issueIds[0];
+    if (!requestId) return;
+    const request = requests.find((item) => item.id === requestId);
+    if (!request) return;
+    setSelected(request);
+    setInspectionMode("explain");
+  }
 
   async function loadRequests() {
     try {
@@ -577,6 +688,62 @@ export default function AgentConsolePage() {
         </div>
       </div>
 
+      <Card
+        className="mb-6 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card"
+        aria-label="Agent request pipeline health"
+      >
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-xs font-semibold uppercase tracking-[0.15em] text-[color:var(--theme-text-secondary)]">
+                Request pipeline
+              </h2>
+              <Badge
+                className={cn(
+                  "border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                  pipelineSummary.state === "healthy"
+                    ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-300"
+                    : "border-amber-500/50 bg-amber-500/10 text-amber-200",
+                )}
+              >
+                {pipelineSummary.state === "healthy" ? "Healthy" : "Needs attention"}
+              </Badge>
+            </div>
+            <p className="text-xs text-[color:var(--theme-text-secondary)]">
+              {pipelineSummary.issueCount > 0
+                ? `${pipelineSummary.issueCount} request${pipelineSummary.issueCount === 1 ? "" : "s"} need inspection or recovery.`
+                : "No failed, blocked, or stale request transitions were detected."}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
+            <span className="rounded-lg border border-[color:var(--theme-border-soft)] px-2 py-1">
+              {pipelineSummary.failedCount} failed
+            </span>
+            <span className="rounded-lg border border-[color:var(--theme-border-soft)] px-2 py-1">
+              {pipelineSummary.blockedCount} blocked
+            </span>
+            <span className="rounded-lg border border-[color:var(--theme-border-soft)] px-2 py-1">
+              {pipelineSummary.staleCount} stale
+            </span>
+            <span className="rounded-lg border border-[color:var(--theme-border-soft)] px-2 py-1">
+              {pipelineSummary.approvalCount} awaiting approval
+            </span>
+            {pipelineSummary.issueCount > 0 && (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="border-orange-500/70 text-xs font-semibold text-orange-300 hover:bg-orange-600 hover:text-[color:var(--theme-text-on-accent)]"
+                onClick={inspectFirstPipelineIssue}
+              >
+                Inspect issues
+              </Button>
+            )}
+          </div>
+        </div>
+      </Card>
+
       <div className="grid gap-6 md:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)]">
         {/* LEFT LIST */}
         <Card className="flex h-[70vh] flex-col rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 shadow-card backdrop-blur-md">
@@ -602,7 +769,10 @@ export default function AgentConsolePage() {
               <button
                 key={req.id}
                 type="button"
-                onClick={() => setSelected(req)}
+                onClick={() => {
+                  setSelected(req);
+                  setInspectionMode(null);
+                }}
                 className={cn(
                   "w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-left text-xs text-[color:var(--theme-text-primary)] transition hover:border-orange-500/70 hover:bg-orange-500/5",
                   selected?.id === req.id &&
@@ -749,9 +919,178 @@ export default function AgentConsolePage() {
                       {selectedTeam.mission?.id ? (
                         <AgentMissionDetails mission={selectedTeam.mission} />
                       ) : null}
+                      <div className="flex flex-wrap gap-2 pt-1">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          aria-pressed={inspectionMode === "explain"}
+                          className="border-sky-500/50 text-[0.7rem] font-semibold text-sky-200 hover:bg-sky-600 hover:text-[color:var(--theme-text-on-accent)]"
+                          onClick={() => setInspectionMode((mode) =>
+                            mode === "explain" ? null : "explain"
+                          )}
+                        >
+                          Explain issue
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          aria-pressed={inspectionMode === "inspect"}
+                          className="border-orange-500/60 text-[0.7rem] font-semibold text-orange-300 hover:bg-orange-600 hover:text-[color:var(--theme-text-on-accent)]"
+                          onClick={() => setInspectionMode((mode) =>
+                            mode === "inspect" ? null : "inspect"
+                          )}
+                        >
+                          Inspect run
+                        </Button>
+                      </div>
+                      {inspectionMode && selectedDiagnostic && (
+                        <div className="space-y-3 rounded-lg border border-sky-500/30 bg-sky-500/5 p-3">
+                          <div className="space-y-1">
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div className="text-xs font-semibold text-[color:var(--theme-text-primary)]">
+                                {selectedDiagnostic.title}
+                              </div>
+                              {selectedDiagnostic.actionLabel && (
+                                <Badge className="border border-sky-500/40 bg-sky-500/10 text-[10px] text-sky-200">
+                                  Next: {selectedDiagnostic.actionLabel}
+                                </Badge>
+                              )}
+                            </div>
+                            <p className="text-xs text-[color:var(--theme-text-secondary)]">
+                              {selectedDiagnostic.explanation}
+                            </p>
+                          </div>
+
+                          <dl className="grid gap-2 text-[0.7rem] sm:grid-cols-3">
+                            <div>
+                              <dt className="text-[color:var(--theme-text-muted)]">Stage</dt>
+                              <dd className="text-[color:var(--theme-text-primary)]">
+                                {selectedTeam.currentStage?.replace(/_/g, " ") ?? "Unknown"}
+                              </dd>
+                            </div>
+                            <div>
+                              <dt className="text-[color:var(--theme-text-muted)]">Stage status</dt>
+                              <dd className="text-[color:var(--theme-text-primary)]">
+                                {selectedTeam.stepStatus?.replace(/_/g, " ") ?? "Unknown"}
+                              </dd>
+                            </div>
+                            <div>
+                              <dt className="text-[color:var(--theme-text-muted)]">Last progress</dt>
+                              <dd className="text-[color:var(--theme-text-primary)]">
+                                {selectedDiagnostic.ageMinutes == null
+                                  ? "Unavailable"
+                                  : `${selectedDiagnostic.ageMinutes} min ago`}
+                              </dd>
+                            </div>
+                          </dl>
+
+                          {inspectionMode === "inspect" && (
+                            <>
+                              {(selectedTeam.specialists?.length ?? 0) > 0 && (
+                                <div className="space-y-2">
+                                  <div className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--theme-text-secondary)]">
+                                    Specialist results
+                                  </div>
+                                  <ul className="space-y-2">
+                                    {selectedTeam.specialists?.map((specialist) => (
+                                      <li
+                                        key={specialist.key}
+                                        className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2"
+                                      >
+                                        <div className="flex flex-wrap items-center justify-between gap-2">
+                                          <span className="font-medium text-[color:var(--theme-text-primary)]">
+                                            {specialist.role}
+                                          </span>
+                                          <Badge className="border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] text-[10px] text-[color:var(--theme-text-primary)]">
+                                            {specialist.decision ?? "unknown"}
+                                          </Badge>
+                                        </div>
+                                        {specialist.summary && (
+                                          <p className="mt-1 text-[color:var(--theme-text-secondary)]">
+                                            {specialist.summary}
+                                          </p>
+                                        )}
+                                      </li>
+                                    ))}
+                                  </ul>
+                                </div>
+                              )}
+
+                              {(selectedTeam.conflicts?.length ?? 0) > 0 && (
+                                <div className="space-y-1 rounded-md border border-amber-500/30 bg-amber-500/5 p-2">
+                                  <div className="font-medium text-amber-200">Internal conflicts</div>
+                                  {selectedTeam.conflicts?.map((conflict) => (
+                                    <p key={`${conflict.topic}-${conflict.description}`} className="text-[color:var(--theme-text-secondary)]">
+                                      {conflict.description}
+                                    </p>
+                                  ))}
+                                </div>
+                              )}
+
+                              {internalRequirements.length > 0 && (
+                                <div className="space-y-1 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2">
+                                  <div className="font-medium text-[color:var(--theme-text-primary)]">
+                                    Engineering evidence still required
+                                  </div>
+                                  <ul className="list-disc space-y-1 pl-4 text-[color:var(--theme-text-secondary)]">
+                                    {internalRequirements.map((requirement) => (
+                                      <li key={requirement}>{requirement}</li>
+                                    ))}
+                                  </ul>
+                                </div>
+                              )}
+                            </>
+                          )}
+                        </div>
+                      )}
                       {selectedTeam.caseStatus === "blocked" && questions.length === 0 && (
                         <div className="text-xs text-[color:var(--theme-text-muted)]">
-                          The engineering team is blocked on an internal dependency. No reporter input is requested.
+                          The engineering team is blocked on an internal dependency. Inspect the run or restart the current stage; no reporter input is requested.
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+
+                {!selectedTeam && selectedDiagnostic && (
+                  <>
+                    <Separator className="bg-[color:var(--theme-surface-subtle)]" />
+                    <div className="space-y-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-[0.75rem]">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div>
+                          <div className="text-[0.7rem] font-semibold uppercase tracking-[0.13em] text-[color:var(--theme-text-secondary)]">
+                            Pipeline diagnosis
+                          </div>
+                          <div className="mt-1 text-xs font-semibold text-[color:var(--theme-text-primary)]">
+                            {selectedDiagnostic.title}
+                          </div>
+                        </div>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          aria-pressed={inspectionMode === "inspect"}
+                          className="border-orange-500/60 text-[0.7rem] font-semibold text-orange-300 hover:bg-orange-600 hover:text-[color:var(--theme-text-on-accent)]"
+                          onClick={() => setInspectionMode((mode) =>
+                            mode === "inspect" ? null : "inspect"
+                          )}
+                        >
+                          Inspect failure
+                        </Button>
+                      </div>
+                      <p className="text-xs text-[color:var(--theme-text-secondary)]">
+                        {selectedDiagnostic.explanation}
+                      </p>
+                      {inspectionMode === "inspect" && (
+                        <div className="space-y-1 rounded-md border border-red-500/30 bg-red-500/5 p-2 text-[0.7rem]">
+                          <div className="text-[color:var(--theme-text-muted)]">
+                            Recorded failure
+                          </div>
+                          <p className="whitespace-pre-wrap text-[color:var(--theme-text-primary)]">
+                            {selected.llm_notes ?? "No structured Agent error was recorded."}
+                          </p>
                         </div>
                       )}
                     </div>

--- a/features/agent/lib/pipelineDiagnostics.ts
+++ b/features/agent/lib/pipelineDiagnostics.ts
@@ -1,0 +1,244 @@
+export type AgentPipelineSpecialist = {
+  key: string;
+  role: string;
+  required: boolean;
+  decision: string | null;
+  summary: string | null;
+};
+
+export type AgentPipelineConflict = {
+  topic: string;
+  description: string;
+};
+
+export type AgentPipelineTeamSnapshot = {
+  currentStage?: string | null;
+  caseStatus?: string | null;
+  stepStatus?: string | null;
+  updatedAt?: string | null;
+  syncedAt?: string | null;
+  missionStatus?: string | null;
+  internalDependency?: string | null;
+  internalRequirements?: string[];
+  specialists?: AgentPipelineSpecialist[];
+  conflicts?: AgentPipelineConflict[];
+};
+
+export type AgentPipelineRequestSnapshot = {
+  id: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  notes?: string | null;
+  reporterQuestions?: string[];
+  team?: AgentPipelineTeamSnapshot | null;
+};
+
+export type AgentPipelineDiagnosticKind =
+  | "authorization_failure"
+  | "request_failure"
+  | "reporter_input"
+  | "internal_blocker"
+  | "stalled"
+  | "awaiting_approval"
+  | "active"
+  | "complete";
+
+export type AgentPipelineDiagnostic = {
+  kind: AgentPipelineDiagnosticKind;
+  severity: "healthy" | "info" | "warning" | "error";
+  title: string;
+  explanation: string;
+  actionLabel: string | null;
+  ageMinutes: number | null;
+};
+
+const STALE_ACTIVE_MINUTES = 30;
+const INTERNAL_REQUIREMENT_PATTERNS = [
+  /\b(import|call)\s+chain\b/i,
+  /\bruntime\s+trace\b/i,
+  /\bstate\s+matrix\b/i,
+  /\bcross[-\s]?client\b/i,
+  /\b(repository|source\s+file|code\s*path|handler|endpoint|rpc|schema|table|column|rls|polic(?:y|ies)|trigger|constraint|test|fixture)\b/i,
+  /\b(deterministic|exhaustive|proven|proof|verification)\b.*\b(trace|mapping|matrix|coverage|evidence)\b/i,
+  /\b(role|capability|tenant)\b.*\b(mapping|matrix|contract|coverage|demonstration|evidence)\b/i,
+] as const;
+
+function normalizedText(value: unknown): string | null {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text || null;
+}
+
+function timestamp(value: string | null | undefined): number | null {
+  const parsed = value ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function elapsedMinutes(value: string | null | undefined, now: number): number | null {
+  const parsed = timestamp(value);
+  return parsed == null ? null : Math.max(0, Math.floor((now - parsed) / 60_000));
+}
+
+export function partitionAgentQuestions(items: string[]): {
+  reporterQuestions: string[];
+  internalRequirements: string[];
+} {
+  const reporterQuestions: string[] = [];
+  const internalRequirements: string[] = [];
+  const seen = new Set<string>();
+
+  for (const value of items) {
+    const item = normalizedText(value);
+    if (!item) continue;
+    const key = item.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    if (INTERNAL_REQUIREMENT_PATTERNS.some((pattern) => pattern.test(item))) {
+      internalRequirements.push(item);
+    } else {
+      reporterQuestions.push(item);
+    }
+  }
+
+  return { reporterQuestions, internalRequirements };
+}
+
+export function diagnoseAgentPipelineRequest(
+  request: AgentPipelineRequestSnapshot,
+  now = Date.now(),
+): AgentPipelineDiagnostic {
+  const team = request.team ?? null;
+  const lastProgressAt = team?.updatedAt
+    ?? team?.syncedAt
+    ?? request.updatedAt
+    ?? request.createdAt;
+  const ageMinutes = elapsedMinutes(lastProgressAt, now);
+  const status = request.status.trim().toLowerCase();
+  const caseStatus = team?.caseStatus?.trim().toLowerCase() ?? null;
+  const stage = team?.currentStage?.replace(/_/g, " ") ?? "current stage";
+  const notes = request.notes?.toLowerCase() ?? "";
+  const authorizationFailure = status === "failed"
+    && (/\b40[13]\b/.test(notes) || notes.includes("access denied") || notes.includes("unauthorized"));
+
+  if (authorizationFailure) {
+    return {
+      kind: "authorization_failure",
+      severity: "error",
+      title: "Agent authorization failed",
+      explanation: "The request reached the Agent boundary but its bridge or API credential was rejected. Validate the protected Agent readiness path before replaying it.",
+      actionLabel: "Retry dispatch",
+      ageMinutes,
+    };
+  }
+
+  if (status === "failed") {
+    return {
+      kind: "request_failure",
+      severity: "error",
+      title: "Agent request failed",
+      explanation: "The request did not complete its current pipeline transition. Inspect the recorded error before retrying the durable request.",
+      actionLabel: "Retry request",
+      ageMinutes,
+    };
+  }
+
+  if (caseStatus === "blocked") {
+    if ((request.reporterQuestions?.length ?? 0) > 0) {
+      return {
+        kind: "reporter_input",
+        severity: "warning",
+        title: "Reporter input required",
+        explanation: `The ${stage} stage is paused for information only the reporter can provide. Engineering evidence tasks remain internal to the Agent.`,
+        actionLabel: "Provide evidence",
+        ageMinutes,
+      };
+    }
+
+    const conflictCount = team?.conflicts?.length ?? 0;
+    return {
+      kind: "internal_blocker",
+      severity: "error",
+      title: conflictCount > 0 ? "Specialist review blocked" : "Internal Agent dependency blocked",
+      explanation: conflictCount > 0
+        ? `${conflictCount} specialist decision conflict${conflictCount === 1 ? "" : "s"} must be resolved inside engineering; the reporter is not responsible for producing code evidence.`
+        : `The ${stage} stage is blocked on internal engineering work${team?.internalDependency ? ` (${team.internalDependency.replace(/_/g, " ")})` : ""}.`,
+      actionLabel: "Restart from stage",
+      ageMinutes,
+    };
+  }
+
+  const missionAwaitingApproval = status === "awaiting_approval"
+    || team?.missionStatus === "awaiting_approval"
+    || caseStatus === "ready_for_human_approval";
+  if (missionAwaitingApproval) {
+    return {
+      kind: "awaiting_approval",
+      severity: "info",
+      title: "Ready for owner approval",
+      explanation: "The automated review completed and the pipeline is intentionally waiting for a human approval decision.",
+      actionLabel: "Review approval package",
+      ageMinutes,
+    };
+  }
+
+  if (["submitted", "in_progress", "approved"].includes(status)
+    && ageMinutes != null
+    && ageMinutes >= STALE_ACTIVE_MINUTES) {
+    return {
+      kind: "stalled",
+      severity: "warning",
+      title: "Pipeline progress is stale",
+      explanation: `No Agent stage progress has been recorded for ${ageMinutes} minutes while the request remains ${status.replace(/_/g, " ")}.`,
+      actionLabel: "Inspect run",
+      ageMinutes,
+    };
+  }
+
+  if (["submitted", "in_progress", "approved"].includes(status)) {
+    return {
+      kind: "active",
+      severity: "healthy",
+      title: "Pipeline is progressing",
+      explanation: `The request is active in ${stage}.`,
+      actionLabel: "Inspect run",
+      ageMinutes,
+    };
+  }
+
+  return {
+    kind: "complete",
+    severity: "healthy",
+    title: "Pipeline work is complete",
+    explanation: `The request is ${status.replace(/_/g, " ")}.`,
+    actionLabel: "View evidence",
+    ageMinutes,
+  };
+}
+
+export function summarizeAgentPipeline(
+  requests: AgentPipelineRequestSnapshot[],
+  now = Date.now(),
+) {
+  const diagnostics = requests.map((request) => ({
+    requestId: request.id,
+    diagnostic: diagnoseAgentPipelineRequest(request, now),
+  }));
+  const attention = diagnostics.filter(({ diagnostic }) =>
+    diagnostic.severity === "warning" || diagnostic.severity === "error",
+  );
+
+  return {
+    state: attention.length > 0 ? "needs_attention" as const : "healthy" as const,
+    issueCount: attention.length,
+    issueIds: attention.map(({ requestId }) => requestId),
+    failedCount: diagnostics.filter(({ diagnostic }) =>
+      diagnostic.kind === "authorization_failure" || diagnostic.kind === "request_failure",
+    ).length,
+    blockedCount: diagnostics.filter(({ diagnostic }) =>
+      diagnostic.kind === "internal_blocker" || diagnostic.kind === "reporter_input",
+    ).length,
+    staleCount: diagnostics.filter(({ diagnostic }) => diagnostic.kind === "stalled").length,
+    approvalCount: diagnostics.filter(({ diagnostic }) => diagnostic.kind === "awaiting_approval").length,
+  };
+}

--- a/features/agent/lib/requestRetry.ts
+++ b/features/agent/lib/requestRetry.ts
@@ -24,16 +24,16 @@ export function decideAgentRequestRetry(
   const stepStatus = state.stepStatus?.trim().toLowerCase() || null;
 
   if (!caseStatus) {
-    return requestStatus === "failed"
+    return requestStatus === "failed" || requestStatus === "submitted"
       ? {
           allowed: true,
           action: "resubmit",
-          reason: "The failed request has no engineering case yet.",
+          reason: "The durable request has no engineering case and can be dispatched idempotently.",
         }
       : {
           allowed: false,
           action: null,
-          reason: "Only failed requests without an engineering case can be resubmitted.",
+          reason: "Only failed or undispatched submitted requests can be resubmitted.",
         };
   }
 
@@ -69,5 +69,7 @@ export function decideAgentRequestRetry(
 }
 
 export function isAgentRequestRetryVisible(state: RetryState): boolean {
-  return state.requestStatus === "failed" || state.caseStatus === "blocked";
+  return state.requestStatus === "failed"
+    || (state.requestStatus === "submitted" && !state.caseStatus)
+    || state.caseStatus === "blocked";
 }

--- a/features/agent/server/teamClient.ts
+++ b/features/agent/server/teamClient.ts
@@ -67,6 +67,13 @@ export type AgentTeamCaseEnvelope = {
   } | null;
 };
 
+export type AgentTeamReadiness = {
+  ok?: boolean;
+  service?: string;
+  workflow?: string;
+  dependencies?: Record<string, { ok?: boolean; [key: string]: unknown }>;
+};
+
 export type AgentTeamProjection = {
   engineeringCaseId: string;
   requestId: string;
@@ -77,6 +84,22 @@ export type AgentTeamProjection = {
   decision: string | null;
   missingInformation: string[];
   updatedAt: string;
+  specialists: Array<{
+    key: string;
+    role: string;
+    required: boolean;
+    decision: string | null;
+    summary: string | null;
+  }>;
+  conflicts: Array<{
+    topic: string;
+    description: string;
+  }>;
+  internalRequirements: string[];
+  internalDependency: string | null;
+  nextAction: string | null;
+  attemptNumber: number | null;
+  maximumInternalAttempts: number | null;
   mission: {
     id: string;
     status: string;
@@ -329,6 +352,12 @@ export async function readAgentTeamCase(
   );
 }
 
+export async function readAgentTeamReadiness(
+  signal?: AbortSignal,
+): Promise<AgentTeamReadiness> {
+  return agentTeamRequest<AgentTeamReadiness>("/ready", { signal });
+}
+
 export async function resumeAgentTeamCase(params: {
   engineeringCaseId: string;
   resumedBy: string;
@@ -416,6 +445,37 @@ export function projectAgentTeamCase(
   const rawMissingInformation = envelope.caseSummary?.missingInformation
     ?? currentStep?.result?.missingInformation
     ?? [];
+  const currentData = isRecord(currentStep?.result?.data)
+    ? currentStep.result.data
+    : {};
+  const specialists = Array.isArray(currentData.specialists)
+    ? currentData.specialists.filter(isRecord).flatMap((item) => {
+        const key = nullableString(item.key);
+        if (!key) return [];
+        return [{
+          key,
+          role: nullableString(item.role) ?? key.replace(/_/g, " "),
+          required: item.required === true,
+          decision: nullableString(item.decision),
+          summary: nullableString(item.summary),
+        }];
+      })
+    : [];
+  const conflicts = Array.isArray(currentData.conflicts)
+    ? currentData.conflicts.filter(isRecord).flatMap((item) => {
+        const description = nullableString(item.description);
+        if (!description) return [];
+        return [{
+          topic: nullableString(item.topic) ?? "specialist_conflict",
+          description,
+        }];
+      })
+    : [];
+  const internalRequirements = Array.isArray(currentData.internalRequirements)
+    ? currentData.internalRequirements
+        .map((item) => nullableString(item))
+        .filter((item): item is string => Boolean(item))
+    : [];
   const metadata = isRecord(engineeringCase.ticket.metadata)
     ? engineeringCase.ticket.metadata
     : {};
@@ -455,6 +515,13 @@ export function projectAgentTeamCase(
         ? rawMissingInformation.filter((value): value is string => typeof value === "string")
         : [],
     updatedAt: engineeringCase.updatedAt,
+    specialists,
+    conflicts,
+    internalRequirements,
+    internalDependency: nullableString(currentData.internalDependency),
+    nextAction: nullableString(currentData.nextAction),
+    attemptNumber: nullableNumber(currentData.attemptNumber),
+    maximumInternalAttempts: nullableNumber(currentData.maximumInternalAttempts),
     mission: mission
       ? {
           id: mission.id,

--- a/features/ops/components/OpsReleaseHealth.tsx
+++ b/features/ops/components/OpsReleaseHealth.tsx
@@ -53,14 +53,14 @@ function formatTime(value: string | null): string {
   }).format(new Date(value));
 }
 
-function StatusPill({ state }: { state: ReleaseState }) {
+function StatusPill({ state, label }: { state: ReleaseState; label?: string }) {
   return (
     <span className={cn(
       "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em]",
       stateTone(state),
     )}>
       <StateIcon state={state} />
-      {stateLabel(state)}
+      {label ?? stateLabel(state)}
     </span>
   );
 }
@@ -84,6 +84,58 @@ function migrationStatusLabel(status: OpsReleaseHealthSnapshot["migrations"]["st
 }
 
 export default function OpsReleaseHealth({ snapshot }: { snapshot: OpsReleaseHealthSnapshot }) {
+  const ciUnavailable = snapshot.ci.canonicalName === "Unavailable"
+    || snapshot.ci.conclusion === null;
+  const migrationParityFailed = snapshot.migrations.pending.length > 0
+    || snapshot.migrations.drift.length > 0
+    || snapshot.migrations.status === "failed";
+  const releaseIssues = [
+    snapshot.production.state !== "healthy"
+      ? {
+          id: "app-release-evidence",
+          title: "App commit parity needs attention",
+          explanation: snapshot.production.behindMain
+            ? "Production is serving an older commit than GitHub main."
+            : "The production deployment identity could not be verified.",
+        }
+      : null,
+    snapshot.agent.state !== "healthy"
+      ? {
+          id: "agent-release-evidence",
+          title: "Agent generation evidence needs attention",
+          explanation: "The Agent runtime or its deployment fingerprint could not be verified.",
+        }
+      : null,
+    snapshot.ci.state !== "healthy"
+      ? {
+          id: "ci-evidence",
+          title: ciUnavailable ? "CI verification is unavailable" : "Release CI needs attention",
+          explanation: ciUnavailable
+            ? "No canonical CI result is available; zero recorded failures is not proof that CI passed."
+            : `${snapshot.ci.failingChecks} completed check${snapshot.ci.failingChecks === 1 ? "" : "s"} failed.`,
+        }
+      : null,
+    snapshot.migrations.state !== "healthy"
+      ? {
+          id: "migration-evidence",
+          title: migrationParityFailed ? "Migration parity failed" : "Migration evidence is unavailable",
+          explanation: migrationParityFailed
+            ? "The repository and production ledgers do not contain the same migration identities."
+            : "The production migration ledger could not be verified.",
+        }
+      : null,
+    snapshot.failures.state !== "healthy"
+      ? {
+          id: "release-failure-evidence",
+          title: snapshot.failures.countSinceRelease === null
+            ? "Failure capture is unverified"
+            : "Failures were captured after release",
+          explanation: snapshot.failures.countSinceRelease === null
+            ? "Operational failure evidence could not be retrieved."
+            : `${snapshot.failures.countSinceRelease} captured failure${snapshot.failures.countSinceRelease === 1 ? "" : "s"} need inspection.`,
+        }
+      : null,
+  ].filter((issue): issue is { id: string; title: string; explanation: string } => issue !== null);
   const migrationSummary = snapshot.migrations.status === "pending"
     ? `${snapshot.migrations.pending.length} repository migration${snapshot.migrations.pending.length === 1 ? "" : "s"} not applied in production.`
     : snapshot.migrations.status === "drift"
@@ -138,15 +190,43 @@ export default function OpsReleaseHealth({ snapshot }: { snapshot: OpsReleaseHea
           </div>
           <p className="text-xs font-semibold opacity-80">Checked {formatTime(snapshot.checkedAt)} MT</p>
         </div>
+        {releaseIssues.length > 0 ? (
+          <div className="mt-4 border-t border-current/15 pt-4">
+            <p className="text-sm font-semibold">
+              {snapshot.overall === "down" ? "Blocked by" : "Needs attention from"}{" "}
+              {releaseIssues.length} release gate{releaseIssues.length === 1 ? "" : "s"}: {releaseIssues.map((issue) => issue.title).join("; ")}.
+            </p>
+            <div className="mt-3 flex flex-wrap items-start gap-2">
+              <a
+                href={`#${releaseIssues[0]?.id ?? "ci-evidence"}`}
+                className="inline-flex items-center justify-center rounded-lg border border-current/30 bg-black/5 px-3 py-2 text-xs font-bold transition hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10"
+              >
+                Inspect {releaseIssues.length} issue{releaseIssues.length === 1 ? "" : "s"}
+              </a>
+              <details className="max-w-2xl rounded-lg border border-current/20 bg-black/5 px-3 py-2 text-xs dark:bg-white/5">
+                <summary className="cursor-pointer font-bold">Explain blockers</summary>
+                <ul className="mt-2 space-y-2">
+                  {releaseIssues.map((issue) => (
+                    <li key={issue.id}>
+                      <a href={`#${issue.id}`} className="font-semibold underline-offset-2 hover:underline">{issue.title}</a>
+                      <span className="opacity-80"> — {issue.explanation}</span>
+                    </li>
+                  ))}
+                </ul>
+                <p className="mt-2 opacity-75">This explanation is read-only and derived from the release evidence shown below.</p>
+              </details>
+            </div>
+          </div>
+        ) : null}
       </section>
 
       <section className="grid gap-4 xl:grid-cols-2">
-        <article className="overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-card">
+        <article id="app-release-evidence" className="scroll-mt-6 overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-card">
           <div className="flex items-start justify-between gap-4 border-b border-[color:var(--theme-border-soft)] p-4 sm:p-5">
             <div className="flex items-start gap-3">
               <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-orange-500/10 text-orange-500"><Server className="h-5 w-5" /></span>
               <div>
-                <h2 className="text-sm font-bold">ProFixIQ production</h2>
+                <h2 className="text-sm font-bold">App commit parity</h2>
                 <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
                   {snapshot.production.behindMain === false
                     ? "The live application SHA matches GitHub main."
@@ -164,16 +244,16 @@ export default function OpsReleaseHealth({ snapshot }: { snapshot: OpsReleaseHea
             <Detail label="Deployment" value={shortId(snapshot.production.deploymentId)} />
             <Detail label="Environment" value={snapshot.production.environment} />
             <Detail label="Release commit time" value={formatTime(snapshot.production.releaseCommitAt)} />
-            <Detail label="Release PR" value={snapshot.production.releasePr ? `#${snapshot.production.releasePr.number} ${snapshot.production.releasePr.title}` : "Unavailable"} />
+            <Detail label="Release PR (metadata)" value={snapshot.production.releasePr ? `#${snapshot.production.releasePr.number} ${snapshot.production.releasePr.title}` : "Unavailable — non-blocking"} />
           </dl>
         </article>
 
-        <article className="overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-card">
+        <article id="agent-release-evidence" className="scroll-mt-6 overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-card">
           <div className="flex items-start justify-between gap-4 border-b border-[color:var(--theme-border-soft)] p-4 sm:p-5">
             <div className="flex items-start gap-3">
               <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-sky-500/10 text-sky-500"><Bot className="h-5 w-5" /></span>
               <div>
-                <h2 className="text-sm font-bold">ProFixIQ Agent production</h2>
+                <h2 className="text-sm font-bold">Agent reachability &amp; generation integrity</h2>
                 <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
                   {snapshot.agent.generationVerified
                     ? "The Agent is reachable and its production generation is cryptographically fingerprinted."
@@ -193,27 +273,43 @@ export default function OpsReleaseHealth({ snapshot }: { snapshot: OpsReleaseHea
       </section>
 
       <section className="grid gap-4 xl:grid-cols-3">
-        <article className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
+        <article id="ci-evidence" className="scroll-mt-6 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
           <div className="flex items-start justify-between gap-3">
             <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-violet-500/10 text-violet-500"><Workflow className="h-5 w-5" /></span>
-            <StatusPill state={snapshot.ci.state} />
+            <StatusPill
+              state={snapshot.ci.state}
+              label={ciUnavailable ? "Blocking — no CI evidence" : undefined}
+            />
           </div>
-          <h2 className="mt-4 text-sm font-bold">Latest release CI</h2>
+          <h2 className="mt-4 text-sm font-bold">{ciUnavailable ? "CI verification unavailable" : "Latest release CI"}</h2>
           <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
-            Canonical check: {snapshot.ci.canonicalName}. {snapshot.ci.failingChecks === 0 ? "No completed checks are failing." : `${snapshot.ci.failingChecks} completed checks failed.`}
+            {ciUnavailable
+              ? "No canonical result is available. No completed checks are known to be failing, but absence of evidence is not a passing result."
+              : `Canonical check: ${snapshot.ci.canonicalName}. ${snapshot.ci.failingChecks === 0 ? "No completed checks are failing." : `${snapshot.ci.failingChecks} completed checks failed.`}`}
           </p>
           <div className="mt-4 grid gap-2 text-xs">
             <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Conclusion</span><span className="font-mono">{snapshot.ci.conclusion ?? "Unavailable"}</span></div>
             <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Completed</span><span>{formatTime(snapshot.ci.completedAt)}</span></div>
           </div>
+          <a
+            href={snapshot.ci.detailsUrl ?? `https://github.com/EdwardLakin/ProFixIQ/commit/${snapshot.production.commitSha ?? snapshot.production.expectedMainSha ?? "main"}/checks`}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-4 inline-flex rounded-lg border border-violet-500/30 px-3 py-2 text-xs font-bold text-violet-600 transition hover:bg-violet-500/10 dark:text-violet-300"
+          >
+            Inspect CI evidence
+          </a>
         </article>
 
-        <article className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
+        <article id="migration-evidence" className="scroll-mt-6 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
           <div className="flex items-start justify-between gap-3">
             <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-500"><Database className="h-5 w-5" /></span>
-            <StatusPill state={snapshot.migrations.state} />
+            <StatusPill
+              state={snapshot.migrations.state}
+              label={migrationParityFailed ? "Blocking — parity failed" : undefined}
+            />
           </div>
-          <h2 className="mt-4 text-sm font-bold">Migration release state</h2>
+          <h2 className="mt-4 text-sm font-bold">{migrationParityFailed ? "Migration parity failed" : "Migration release state"}</h2>
           <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">{migrationSummary}</p>
           <div className="mt-4 grid gap-2 text-xs">
             <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Status</span><span className="font-semibold">{migrationStatusLabel(snapshot.migrations.status)}</span></div>
@@ -221,12 +317,20 @@ export default function OpsReleaseHealth({ snapshot }: { snapshot: OpsReleaseHea
             <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Main / production</span><span className="font-mono">{snapshot.migrations.repoCount} / {snapshot.migrations.appliedCount ?? "Unavailable"}</span></div>
             <div className="flex justify-between gap-3"><span className="text-[color:var(--theme-text-muted)]">Supabase check</span><span className="font-mono">{snapshot.migrations.supabaseCheck ?? "Unavailable"}</span></div>
           </div>
+          {(snapshot.migrations.pending.length > 0 || snapshot.migrations.drift.length > 0) ? (
+            <a href="#migration-reconciliation" className="mt-4 inline-flex rounded-lg border border-emerald-500/30 px-3 py-2 text-xs font-bold text-emerald-700 transition hover:bg-emerald-500/10 dark:text-emerald-300">
+              Compare migration ledgers
+            </a>
+          ) : null}
         </article>
 
-        <article className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
+        <article id="release-failure-evidence" className="scroll-mt-6 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card sm:p-5">
           <div className="flex items-start justify-between gap-3">
             <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-amber-500/10 text-amber-600 dark:text-amber-400"><ShieldCheck className="h-5 w-5" /></span>
-            <StatusPill state={snapshot.failures.state} />
+            <StatusPill
+              state={snapshot.failures.state}
+              label={snapshot.failures.countSinceRelease === null ? "Unverified" : undefined}
+            />
           </div>
           <h2 className="mt-4 text-sm font-bold">Failures since release</h2>
           <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">{failureSummary}</p>
@@ -239,14 +343,20 @@ export default function OpsReleaseHealth({ snapshot }: { snapshot: OpsReleaseHea
       </section>
 
       {(snapshot.migrations.pending.length > 0 || snapshot.migrations.drift.length > 0) ? (
-        <section className="rounded-2xl border border-amber-500/30 bg-amber-500/5 p-4 shadow-card sm:p-5">
+        <section id="migration-reconciliation" className="scroll-mt-6 rounded-2xl border border-amber-500/30 bg-amber-500/5 p-4 shadow-card sm:p-5">
           <h2 className="text-sm font-bold">Migration reconciliation required</h2>
+          <p className="mt-2 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+            Equal totals do not prove parity. Inspect the filenames, SQL, checksums, and ledger timestamps before choosing a repair; ledger history must not be rewritten from this read-only page.
+          </p>
           {snapshot.migrations.pending.length > 0 ? (
-            <p className="mt-2 break-words font-mono text-xs text-[color:var(--theme-text-secondary)]">Pending: {snapshot.migrations.pending.join(", ")}</p>
+            <p className="mt-2 break-words font-mono text-xs text-[color:var(--theme-text-secondary)]">In main, not production: {snapshot.migrations.pending.join(", ")}</p>
           ) : null}
           {snapshot.migrations.drift.length > 0 ? (
-            <p className="mt-2 break-words font-mono text-xs text-[color:var(--theme-text-secondary)]">Production-only: {snapshot.migrations.drift.join(", ")}</p>
+            <p className="mt-2 break-words font-mono text-xs text-[color:var(--theme-text-secondary)]">In production, not main: {snapshot.migrations.drift.join(", ")}</p>
           ) : null}
+          <Link href="/ops/agent-control" className="mt-4 inline-flex rounded-lg border border-amber-500/40 px-3 py-2 text-xs font-bold text-amber-700 transition hover:bg-amber-500/10 dark:text-amber-300">
+            Open Agent Control for a fix plan
+          </Link>
         </section>
       ) : null}
 
@@ -275,12 +385,21 @@ export default function OpsReleaseHealth({ snapshot }: { snapshot: OpsReleaseHea
 
       <section className="grid gap-3 sm:grid-cols-3" aria-label="Release evidence sources">
         {[
-          { label: "GitHub release evidence", state: snapshot.sources.github },
-          { label: "Supabase release evidence", state: snapshot.sources.database },
-          { label: "Agent runtime evidence", state: snapshot.sources.agent },
+          { label: "GitHub evidence retrieval", state: snapshot.sources.github, detail: "Commit, pull request, and check evidence." },
+          {
+            label: "Supabase evidence retrieval",
+            state: snapshot.sources.database,
+            detail: snapshot.sources.database === "healthy" && snapshot.migrations.state !== "healthy"
+              ? "Ledger read succeeded; migration parity failed."
+              : "Production ledger evidence retrieval.",
+          },
+          { label: "Agent evidence retrieval", state: snapshot.sources.agent, detail: "Runtime generation and release evidence." },
         ].map((source) => (
-          <div key={source.label} className="flex items-center justify-between gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
-            <span className="text-xs font-semibold">{source.label}</span>
+          <div key={source.label} className="flex items-start justify-between gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
+            <span>
+              <span className="block text-xs font-semibold">{source.label}</span>
+              <span className="mt-1 block text-[10px] leading-4 text-[color:var(--theme-text-muted)]">{source.detail}</span>
+            </span>
             <StatusPill state={source.state} />
           </div>
         ))}

--- a/features/ops/server/get-system-health.ts
+++ b/features/ops/server/get-system-health.ts
@@ -1,5 +1,9 @@
 import "server-only";
 
+import {
+  AgentTeamRequestError,
+  readAgentTeamReadiness,
+} from "@/features/agent/server/teamClient";
 import { requireOpsOperatorPageAccess } from "@/features/ops/server/operator-access";
 
 export type OpsHealthState = "healthy" | "degraded" | "down";
@@ -95,10 +99,12 @@ function agentDetails(
   responseStatus: number,
   runtime: OpsRuntimeGeneration | null,
   generationVerifiable: boolean,
+  pipelineReady: boolean,
 ): Array<{ label: string; value: string }> {
   return [
     { label: "HTTP", value: String(responseStatus) },
     { label: "Generation", value: generationVerifiable ? "Verified" : "Unverified" },
+    { label: "Pipeline readiness", value: pipelineReady ? "Passed" : "Failed" },
     { label: "Commit", value: shortSha(runtime?.commitSha ?? null) },
     { label: "Deployment", value: runtime?.deploymentId ?? "Unavailable" },
     { label: "Fingerprint", value: runtime?.fingerprint ? runtime.fingerprint.slice(0, 16) : "Unavailable" },
@@ -120,14 +126,26 @@ async function agentHealth(): Promise<OpsHealthService> {
 
   const started = Date.now();
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 4_000);
+  const timeout = setTimeout(() => controller.abort(), 8_000);
   try {
-    const response = await fetch(`${baseUrl}/health`, {
-      method: "GET",
-      cache: "no-store",
-      signal: controller.signal,
-      headers: { accept: "application/json" },
-    });
+    const [response, readiness] = await Promise.all([
+      fetch(`${baseUrl}/health`, {
+        method: "GET",
+        cache: "no-store",
+        signal: controller.signal,
+        headers: { accept: "application/json" },
+      }),
+      readAgentTeamReadiness(controller.signal)
+        .then((payload) => ({ ok: payload.ok === true, error: null as string | null }))
+        .catch((error: unknown) => ({
+          ok: false,
+          error: error instanceof AgentTeamRequestError
+            ? error.status === 403
+              ? "Authenticated Agent API access was denied."
+              : "A required Agent pipeline dependency is unavailable."
+            : "Authenticated Agent pipeline readiness is unreachable.",
+        })),
+    ]);
     const latencyMs = Date.now() - started;
     const raw = await response.text();
     let payload: Record<string, unknown> | null = null;
@@ -141,14 +159,19 @@ async function agentHealth(): Promise<OpsHealthService> {
     const runtime = normalizeAgentRuntime(payload?.runtime);
     const serviceStatus = text(payload?.status);
     const generationVerifiable = runtime?.verifiable === true;
-    const details = agentDetails(response.status, runtime, generationVerifiable);
+    const details = agentDetails(
+      response.status,
+      runtime,
+      generationVerifiable,
+      readiness.ok,
+    );
 
-    if (response.ok && serviceStatus === "ok" && generationVerifiable) {
+    if (response.ok && serviceStatus === "ok" && generationVerifiable && readiness.ok) {
       return {
         key: "agent",
         label: "ProFixIQ Agent",
         state: "healthy",
-        summary: "Agent worker and deployment generation are verifiable.",
+        summary: "Agent worker, protected API, dependencies, and deployment generation are verifiable.",
         latencyMs,
         details,
       };
@@ -169,9 +192,10 @@ async function agentHealth(): Promise<OpsHealthService> {
       key: "agent",
       label: "ProFixIQ Agent",
       state: "degraded",
-      summary: !generationVerifiable
+      summary: readiness.error
+        ?? (!generationVerifiable
         ? "Agent is reachable, but its deployment generation is not yet verifiable."
-        : text(payload.error) ?? `Agent health returned HTTP ${response.status}.`,
+        : text(payload.error) ?? `Agent health returned HTTP ${response.status}.`),
       latencyMs,
       details,
     };

--- a/tests/agent-pipeline-diagnostics.test.ts
+++ b/tests/agent-pipeline-diagnostics.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  diagnoseAgentPipelineRequest,
+  partitionAgentQuestions,
+  summarizeAgentPipeline,
+} from "@/features/agent/lib/pipelineDiagnostics";
+
+const NOW = Date.parse("2026-08-14T20:00:00.000Z");
+
+describe("Agent pipeline diagnostics", () => {
+  it("keeps engineering evidence tasks out of reporter Q&A", () => {
+    expect(partitionAgentQuestions([
+      "No proven import/call chain from PartsUsedList to the return API.",
+      "No state matrix mapping allocation through UI confirmation.",
+      "Which device and browser did you use?",
+    ])).toEqual({
+      reporterQuestions: ["Which device and browser did you use?"],
+      internalRequirements: [
+        "No proven import/call chain from PartsUsedList to the return API.",
+        "No state matrix mapping allocation through UI confirmation.",
+      ],
+    });
+  });
+
+  it("explains historical bridge authorization failures", () => {
+    expect(diagnoseAgentPipelineRequest({
+      id: "request-1",
+      status: "failed",
+      createdAt: "2026-08-14T18:00:00.000Z",
+      updatedAt: "2026-08-14T18:00:00.000Z",
+      notes: 'ProFixIQ-Agent request failed: HTTP 403: {"error":"agent API access denied"}',
+    }, NOW)).toMatchObject({
+      kind: "authorization_failure",
+      title: "Agent authorization failed",
+      actionLabel: "Retry dispatch",
+    });
+  });
+
+  it("marks internally blocked specialist work without asking the reporter", () => {
+    expect(diagnoseAgentPipelineRequest({
+      id: "request-2",
+      status: "in_progress",
+      createdAt: "2026-08-14T18:00:00.000Z",
+      updatedAt: "2026-08-14T19:00:00.000Z",
+      reporterQuestions: [],
+      team: {
+        caseStatus: "blocked",
+        currentStage: "planning",
+        updatedAt: "2026-08-14T19:00:00.000Z",
+        internalDependency: "specialist_conflict",
+        conflicts: [{ topic: "specialist_decision", description: "Reviewers disagree" }],
+      },
+    }, NOW)).toMatchObject({
+      kind: "internal_blocker",
+      title: "Specialist review blocked",
+      actionLabel: "Restart from stage",
+    });
+  });
+
+  it("summarizes failed, blocked, stale, and approval queues", () => {
+    const requests = [
+      {
+        id: "failed",
+        status: "failed",
+        createdAt: "2026-08-14T18:00:00.000Z",
+        updatedAt: "2026-08-14T18:00:00.000Z",
+        notes: "HTTP 403 access denied",
+      },
+      {
+        id: "stale",
+        status: "in_progress",
+        createdAt: "2026-08-14T18:00:00.000Z",
+        updatedAt: "2026-08-14T18:00:00.000Z",
+      },
+      {
+        id: "approval",
+        status: "awaiting_approval",
+        createdAt: "2026-08-14T18:00:00.000Z",
+        updatedAt: "2026-08-14T19:59:00.000Z",
+      },
+    ];
+
+    expect(summarizeAgentPipeline(requests, NOW)).toMatchObject({
+      state: "needs_attention",
+      issueCount: 2,
+      failedCount: 1,
+      staleCount: 1,
+      approvalCount: 1,
+    });
+  });
+});

--- a/tests/agent-production-handoff.test.ts
+++ b/tests/agent-production-handoff.test.ts
@@ -46,8 +46,21 @@ describe("production agent request handoff", () => {
     expect(route).toContain("projection.missingInformation.map");
     expect(route).toContain("questions: projectionQuestions(projection)");
     expect(consolePage).toContain("selectedTeam?.missingInformation");
+    expect(consolePage).toContain("partitionAgentQuestions");
+    expect(consolePage).toContain("internalRequirements");
     expect(consolePage).toContain("The engineering team needs this information to continue:");
     expect(replyRoute).toContain("resumeAgentTeamCase");
+  });
+
+  it("exposes grounded specialist diagnostics and contextual recovery controls", () => {
+    expect(teamClient).toContain("specialists,");
+    expect(teamClient).toContain("conflicts,");
+    expect(teamClient).toContain("internalDependency: nullableString(currentData.internalDependency)");
+    expect(consolePage).toContain("Request pipeline");
+    expect(consolePage).toContain("Explain issue");
+    expect(consolePage).toContain("Inspect run");
+    expect(consolePage).toContain("Specialist results");
+    expect(consolePage).toContain("Engineering evidence still required");
   });
 
   it("projects an awaiting mission as diagnosis plus repair proposal rather than a fake Q&A blocker", () => {

--- a/tests/agent-request-retry.test.ts
+++ b/tests/agent-request-retry.test.ts
@@ -26,6 +26,14 @@ describe("agent request retry policy", () => {
     });
   });
 
+  it("replays a submitted request that never received an engineering case", () => {
+    expect(decideAgentRequestRetry({ requestStatus: "submitted" })).toMatchObject({
+      allowed: true,
+      action: "resubmit",
+    });
+    expect(isAgentRequestRetryVisible({ requestStatus: "submitted" })).toBe(true);
+  });
+
   it("resumes blocked cases and failed current stages", () => {
     expect(decideAgentRequestRetry({
       requestStatus: "in_progress",
@@ -92,7 +100,7 @@ describe("agent request retry integration contract", () => {
   it("provisions private owner-scoped evidence storage from migrations", () => {
     expect(evidenceMigration).toContain("insert into storage.buckets");
     expect(evidenceMigration).toContain("'agent_uploads'");
-    expect(evidenceMigration).toContain("false,\n  20971520");
+    expect(evidenceMigration).toMatch(/false,\r?\n\s+20971520/);
     expect(evidenceMigration).toContain("agent_uploads_insert_own");
     expect(evidenceMigration).toContain("agent_uploads_select_own_or_operator");
     expect(evidenceMigration).toContain("(storage.foldername(name))[1] = (select auth.uid())::text");
@@ -100,9 +108,11 @@ describe("agent request retry integration contract", () => {
     expect(evidenceMigration).not.toContain("for all");
   });
 
-  it("offers separate retry and restart labels in Agent Control", () => {
+  it("offers contextual retry and restart labels in Agent Control", () => {
     expect(consolePage).toContain("/retry");
     expect(consolePage).toContain('"Retry Request"');
-    expect(consolePage).toContain('"Restart Investigation"');
+    expect(consolePage).toContain('"Retry dispatch"');
+    expect(consolePage).toContain("Restart from");
+    expect(consolePage).toContain('"Replay dispatch"');
   });
 });

--- a/tests/ops-release-health.test.ts
+++ b/tests/ops-release-health.test.ts
@@ -82,4 +82,18 @@ describe("Ops deployments and release health", () => {
     expect(component).toContain("Failures since release");
     expect(component).toContain("Release evidence sources");
   });
+
+  it("explains release blockers and provides evidence-first inspection actions", () => {
+    const component = source("features/ops/components/OpsReleaseHealth.tsx");
+    expect(component).toContain("releaseIssues");
+    expect(component).toContain("Explain blockers");
+    expect(component).toContain("Inspect CI evidence");
+    expect(component).toContain("Blocking — no CI evidence");
+    expect(component).toContain("Migration parity failed");
+    expect(component).toContain("Compare migration ledgers");
+    expect(component).toContain("In main, not production");
+    expect(component).toContain("In production, not main");
+    expect(component).toContain("Open Agent Control for a fix plan");
+    expect(component).toContain("Ledger read succeeded; migration parity failed.");
+  });
 });

--- a/tests/ops-system-health.test.ts
+++ b/tests/ops-system-health.test.ts
@@ -25,6 +25,9 @@ describe("Ops System Health", () => {
   it("treats Agent deployment generation as required health evidence", () => {
     const server = source("features/ops/server/get-system-health.ts");
     expect(server).toContain('`${baseUrl}/health`');
+    expect(server).toContain("readAgentTeamReadiness");
+    expect(server).toContain('Pipeline readiness", value: pipelineReady ? "Passed" : "Failed"');
+    expect(server).toContain("Authenticated Agent API access was denied.");
     expect(server).toContain("generationVerifiable");
     expect(server).toContain('state: "down"');
     expect(server).toContain('state: "degraded"');


### PR DESCRIPTION
## Summary

- add a request-pipeline health summary to Agent Control with failed, blocked, stale, and approval counts
- add grounded “Explain issue” and “Inspect run” views with specialist results, conflicts, internal requirements, stage status, and last progress
- keep internal engineering requirements out of reporter Q&A
- allow idempotent replay of submitted requests that never received an engineering case
- give retries contextual actions such as retry dispatch, replay dispatch, and restart from the current stage
- verify the authenticated Agent `/ready` path in System Health rather than treating public `/health` reachability as full pipeline health
- make Deployments explain its release gates, distinguish missing CI evidence from a failed check, label migration identity divergence clearly, and provide evidence-first inspection actions

## Root cause

The Ops surfaces conflated service reachability with pipeline readiness and treated internal specialist evidence requests as reporter questions. The Deployments page also used broad “Healthy” labels for evidence retrieval and equal migration counts, which obscured the actual ledger identity mismatch.

## Impact

Operators can now see why a request is blocked, inspect the specialist evidence, choose the correct recovery action, and distinguish evidence availability from release parity. The page remains read-only; potentially destructive migration repair is not exposed as a one-click action.

## Validation

- 35/35 focused Vitest checks passed after rebasing onto current main
- full `tsc --noEmit` passed
- ESLint passed for all changed files
- Next.js production build completed successfully across 451 routes

## Database and rollout

- no schema or migration changes
- depends on [ProFixIQ-Agent #53](https://github.com/EdwardLakin/ProFixIQ-Agent/pull/53)
- merge and deploy Agent PR #53 first, then merge and deploy this PR