### PR TITLE
fix: preserve technician completion integrity

### DIFF
--- a/app/api/work-orders/lines/[id]/finish/route.ts
+++ b/app/api/work-orders/lines/[id]/finish/route.ts
@@ -2,8 +2,7 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobPunchTransition";
-import { upsertMenuRepairItemFromCompletedLine } from "@/features/menu-repair-items/server/upsertMenuRepairItemFromCompletedLine";
+import { completeWorkOrderLine } from "@/features/work-orders/server/completeWorkOrderLine";
 
 type Body = {
   cause?: string | null;
@@ -51,56 +50,18 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const result = await applyJobPunchTransition({
+  const result = await completeWorkOrderLine({
     supabase,
     lineId: id,
-    action: "finish",
     technicianId: user.id,
-    options: {
-      operationKey,
-      finish: {
-        cause: body.cause,
-        correction: body.correction,
-      },
-    },
+    actorUserId: user.id,
+    operationKey,
+    cause: body.cause,
+    correction: body.correction,
   });
 
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: result.status });
-  }
-
-  let menuRepairLearned = false;
-
-  const { data: completedLine, error: completedLineError } = await supabase
-    .from("work_order_lines")
-    .select("id, shop_id")
-    .eq("id", id)
-    .maybeSingle<{ id: string; shop_id: string | null }>();
-
-  if (completedLineError || !completedLine?.shop_id) {
-    console.error("[work-orders] completed repair memory update failed", {
-      workOrderLineId: id,
-      error:
-        completedLineError?.message ?? "Completed line is missing shop context",
-    });
-  } else {
-    try {
-      await upsertMenuRepairItemFromCompletedLine({
-        supabase,
-        shopId: completedLine.shop_id,
-        workOrderLineId: completedLine.id,
-        actorUserId: user.id,
-      });
-      menuRepairLearned = true;
-    } catch (learningError) {
-      console.error("[work-orders] completed repair memory update failed", {
-        workOrderLineId: id,
-        error:
-          learningError instanceof Error
-            ? learningError.message
-            : "Completed repair memory update failed",
-      });
-    }
   }
 
   const payload =
@@ -109,6 +70,6 @@ export async function POST(req: NextRequest) {
       : { success: true };
   return NextResponse.json({
     ...payload,
-    menuRepairLearning: { ok: menuRepairLearned },
+    menuRepairLearning: result.menuRepairLearning,
   });
 }

--- a/features/copilot/technician/components/TechnicianTextCopilot.tsx
+++ b/features/copilot/technician/components/TechnicianTextCopilot.tsx
@@ -159,8 +159,11 @@ export function TechnicianTextCopilot() {
           ...current,
           ...body,
           session:
-            body.session ??
-            (body.sessionId ? { id: body.sessionId } : current.session),
+            Object.prototype.hasOwnProperty.call(body, "session")
+              ? body.session
+              : body.sessionId
+                ? { id: body.sessionId }
+                : current.session,
         }));
         return body;
       } catch (reason) {

--- a/features/copilot/technician/server/actions.ts
+++ b/features/copilot/technician/server/actions.ts
@@ -1,10 +1,12 @@
 import "server-only";
 
 import { normalizeWorkOrderLineStatus } from "@/features/work-orders/lib/line-status";
+import { learnFromCompletedWorkOrderLine } from "@/features/work-orders/server/completeWorkOrderLine";
 import type { TechnicianCopilotAction } from "./actionContract";
 import type {
   TechnicianWorkCandidate,
   TechnicianWorkLine,
+  TechnicianWorkScope,
 } from "./assignedWork";
 import { sendCopilotServerCommand } from "./transport";
 
@@ -12,6 +14,7 @@ type CopilotMutationIdentity = {
   authUserId: string;
   profileId: string;
   shopId: string;
+  supabase: TechnicianWorkScope["supabase"];
 };
 
 type ExecutableAction = Exclude<
@@ -36,7 +39,7 @@ export type TechnicianCopilotActionResult = {
   eventDetail?: string;
 };
 
-function lineLabel(line: TechnicianWorkLine): string {
+export function technicianWorkLineLabel(line: TechnicianWorkLine): string {
   return line.complaint ?? line.description ?? `job ${line.id.slice(0, 8)}`;
 }
 
@@ -53,7 +56,7 @@ function statusLabel(value: string | null): string {
 function choiceReply(lines: readonly TechnicianWorkLine[]): string {
   const choices = lines
     .slice(0, 4)
-    .map((line) => lineLabel(line))
+    .map((line) => technicianWorkLineLabel(line))
     .join(", ");
   return `Which job line do you mean: ${choices}?`;
 }
@@ -113,7 +116,7 @@ export function describeNextTechnicianWork(
   const next = choices[0];
   if (!next) return "You don't have another assigned job line right now.";
 
-  const label = lineLabel(next.line);
+  const label = technicianWorkLineLabel(next.line);
   const order = workOrderLabel(next.workOrder);
   const status = normalizeWorkOrderLineStatus(next.line.status);
   if (status === "in_progress") {
@@ -169,7 +172,7 @@ export function prepareTechnicianCopilotAction(input: {
   if (input.action.type === "job.hold" && !input.action.reason) {
     return {
       kind: "reply",
-      reply: `What is the hold reason for ${lineLabel(line)}?`,
+      reply: `What is the hold reason for ${technicianWorkLineLabel(line)}?`,
     };
   }
 
@@ -181,7 +184,7 @@ export function prepareTechnicianCopilotAction(input: {
   ) {
     return {
       kind: "reply",
-      reply: `${lineLabel(line)} is not currently on hold.`,
+      reply: `${technicianWorkLineLabel(line)} is not currently on hold.`,
     };
   }
 
@@ -192,7 +195,7 @@ export function prepareTechnicianCopilotAction(input: {
     if (!line.updatedAt) {
       return {
         kind: "reply",
-        reply: `I couldn't verify the latest job story for ${lineLabel(line)}. Refresh the work order and try again.`,
+        reply: `I couldn't verify the latest job story for ${technicianWorkLineLabel(line)}. Refresh the work order and try again.`,
       };
     }
     const cause = input.action.cause ?? line.cause;
@@ -203,7 +206,7 @@ export function prepareTechnicianCopilotAction(input: {
     ) {
       return {
         kind: "reply",
-        reply: `Start ${lineLabel(line)} before completing it.`,
+        reply: `Start ${technicianWorkLineLabel(line)} before completing it.`,
       };
     }
     if (input.action.type === "job.complete" && (!cause || !correction)) {
@@ -215,13 +218,13 @@ export function prepareTechnicianCopilotAction(input: {
             : "correction";
       return {
         kind: "reply",
-        reply: `What ${missing} should I record before completing ${lineLabel(line)}?`,
+        reply: `What ${missing} should I record before completing ${technicianWorkLineLabel(line)}?`,
       };
     }
     if (!cause && !correction) {
       return {
         kind: "reply",
-        reply: `What cause or correction should I add to ${lineLabel(line)}?`,
+        reply: `What cause or correction should I add to ${technicianWorkLineLabel(line)}?`,
       };
     }
     return {
@@ -273,6 +276,9 @@ function safeFailure(action: ExecutableAction, message: string): string {
   if (normalized.includes("labor time must be greater than 0")) {
     return "Labor time must be entered before I can complete that job.";
   }
+  if (normalized.includes("inspection_completion_required")) {
+    return "Complete and sign the inspection before I can finish that job.";
+  }
   if (
     normalized.includes("copilot_job_not_active") ||
     normalized.includes("copilot_job_punch_not_active")
@@ -307,14 +313,23 @@ function safeFailure(action: ExecutableAction, message: string): string {
   return `I couldn't confirm whether I could ${verb}. Refresh the job before trying again.`;
 }
 
-export async function executeTechnicianCopilotAction(input: {
+export type BoundTechnicianCopilotAction = {
+  action: ExecutableAction;
+  lineId: string;
+  lineLabel: string;
+  lineCause: string | null;
+  lineCorrection: string | null;
+  lineUpdatedAt: string | null;
+};
+
+export async function executeBoundTechnicianCopilotAction(input: {
   identity: CopilotMutationIdentity;
   sessionId: string;
-  prepared: Extract<PreparedTechnicianCopilotAction, { kind: "execute" }>;
+  bound: BoundTechnicianCopilotAction;
   operationId: string;
   expectedLineUpdatedAt?: string | null;
 }): Promise<TechnicianCopilotActionResult> {
-  const { action, line } = input.prepared;
+  const { action } = input.bound;
   const command = {
     authUserId: input.identity.authUserId,
     profileId: input.identity.profileId,
@@ -322,7 +337,7 @@ export async function executeTechnicianCopilotAction(input: {
     action: "job.action" as const,
     args: {
       sessionId: input.sessionId,
-      workOrderLineId: line.id,
+      workOrderLineId: input.bound.lineId,
       jobAction: action.type,
       operationId: input.operationId,
       reason: action.type === "job.hold" ? action.reason : null,
@@ -336,7 +351,7 @@ export async function executeTechnicianCopilotAction(input: {
           : null,
       expectedLineUpdatedAt:
         input.expectedLineUpdatedAt === undefined
-          ? line.updatedAt
+          ? input.bound.lineUpdatedAt
           : input.expectedLineUpdatedAt,
     },
   };
@@ -352,7 +367,7 @@ export async function executeTechnicianCopilotAction(input: {
   } catch (error) {
     console.error("[technician-copilot] canonical job action failed", {
       action: action.type,
-      workOrderLineId: line.id,
+      workOrderLineId: input.bound.lineId,
       error: error instanceof Error ? error.message : String(error),
     });
     return {
@@ -364,7 +379,15 @@ export async function executeTechnicianCopilotAction(input: {
     };
   }
 
-  const label = lineLabel(line);
+  if (action.type === "job.complete") {
+    await learnFromCompletedWorkOrderLine({
+      supabase: input.identity.supabase,
+      lineId: input.bound.lineId,
+      actorUserId: input.identity.authUserId,
+    });
+  }
+
+  const label = input.bound.lineLabel;
   if (action.type === "job.start") {
     return {
       ok: true,
@@ -399,8 +422,8 @@ export async function executeTechnicianCopilotAction(input: {
   }
 
   const saved = [
-    action.cause !== line.cause ? "cause" : null,
-    action.correction !== line.correction ? "correction" : null,
+    action.cause !== input.bound.lineCause ? "cause" : null,
+    action.correction !== input.bound.lineCorrection ? "correction" : null,
   ]
     .filter(Boolean)
     .join(" and ");
@@ -410,4 +433,28 @@ export async function executeTechnicianCopilotAction(input: {
     eventLabel: "Saved job story",
     eventDetail: label,
   };
+}
+
+export async function executeTechnicianCopilotAction(input: {
+  identity: CopilotMutationIdentity;
+  sessionId: string;
+  prepared: Extract<PreparedTechnicianCopilotAction, { kind: "execute" }>;
+  operationId: string;
+  expectedLineUpdatedAt?: string | null;
+}): Promise<TechnicianCopilotActionResult> {
+  const { action, line } = input.prepared;
+  return executeBoundTechnicianCopilotAction({
+    identity: input.identity,
+    sessionId: input.sessionId,
+    operationId: input.operationId,
+    expectedLineUpdatedAt: input.expectedLineUpdatedAt,
+    bound: {
+      action,
+      lineId: line.id,
+      lineLabel: technicianWorkLineLabel(line),
+      lineCause: line.cause,
+      lineCorrection: line.correction,
+      lineUpdatedAt: line.updatedAt,
+    },
+  });
 }

--- a/features/copilot/technician/server/chat.ts
+++ b/features/copilot/technician/server/chat.ts
@@ -12,9 +12,10 @@ import {
 import { projectTechnicianContext } from "../session/projectTechnicianContext";
 import {
   describeNextTechnicianWork,
-  executeTechnicianCopilotAction,
+  executeBoundTechnicianCopilotAction,
   prepareTechnicianCopilotAction,
-  type PreparedTechnicianCopilotAction,
+  technicianWorkLineLabel,
+  type BoundTechnicianCopilotAction,
 } from "./actions";
 import {
   parseTechnicianCopilotAction,
@@ -132,6 +133,11 @@ function storedTurnText(event: RepairSessionEvent): string {
 type StoredActionTurn = {
   action: TechnicianCopilotAction;
   key: string;
+  workOrderId: string | null;
+  workOrderLineId: string | null;
+  lineLabel: string | null;
+  lineCause: string | null;
+  lineCorrection: string | null;
   lineUpdatedAt: string | null;
   result: {
     ok: boolean;
@@ -175,6 +181,26 @@ function storedActionTurn(
   return {
     action,
     key,
+    workOrderId:
+      typeof pending.payload?.workOrderId === "string"
+        ? pending.payload.workOrderId
+        : null,
+    workOrderLineId:
+      typeof pending.payload?.workOrderLineId === "string"
+        ? pending.payload.workOrderLineId
+        : null,
+    lineLabel:
+      typeof pending.payload?.lineLabel === "string"
+        ? pending.payload.lineLabel
+        : null,
+    lineCause:
+      typeof pending.payload?.lineCause === "string"
+        ? pending.payload.lineCause
+        : null,
+    lineCorrection:
+      typeof pending.payload?.lineCorrection === "string"
+        ? pending.payload.lineCorrection
+        : null,
     lineUpdatedAt:
       typeof pending.payload?.lineUpdatedAt === "string"
         ? pending.payload.lineUpdatedAt
@@ -194,6 +220,30 @@ function storedActionTurn(
                 : null,
           }
         : null,
+  };
+}
+
+function isStoredCompletion(
+  storedAction: StoredActionTurn | null,
+): storedAction is StoredActionTurn & {
+  action: Extract<TechnicianCopilotAction, { type: "job.complete" }>;
+} {
+  return storedAction?.action.type === "job.complete";
+}
+
+function boundActionFromStored(
+  storedAction: StoredActionTurn,
+): BoundTechnicianCopilotAction | null {
+  if (!storedAction.workOrderLineId) return null;
+  return {
+    action: storedAction.action,
+    lineId: storedAction.workOrderLineId,
+    lineLabel:
+      storedAction.lineLabel ??
+      `job ${storedAction.workOrderLineId.slice(0, 8)}`,
+    lineCause: storedAction.lineCause,
+    lineCorrection: storedAction.lineCorrection,
+    lineUpdatedAt: storedAction.lineUpdatedAt,
   };
 }
 
@@ -370,18 +420,6 @@ export async function runTechnicianCopilotTurn(input: {
         events: envelope.events,
       })
     : null;
-  if (envelope.session) assertActiveSession(envelope.session);
-
-  let activeWorkOrder = envelope.session
-    ? await candidateForSession(input.identity, envelope.session, candidates)
-    : null;
-  if (envelope.session && !activeWorkOrder) {
-    throw new TechnicianCopilotConflictError(
-      "technician_copilot_work_not_actionable",
-      "The active CoPilot work order is no longer assigned and actionable.",
-    );
-  }
-
   let boundTurn = bindTurnToPersistedInput({
     envelope,
     turnId: input.turnId,
@@ -393,14 +431,51 @@ export async function runTechnicianCopilotTurn(input: {
   );
   let documentationAlreadyFinalized =
     envelope.documentationTurns?.includes(input.turnId) ?? false;
+  let storedAction = storedActionTurn(envelope.events, input.turnId);
+  let activeWorkOrder =
+    envelope.session?.status === "active"
+      ? await candidateForSession(input.identity, envelope.session, candidates)
+      : null;
+
+  if (envelope.session?.status === "closed") {
+    if (existingAssistant && isStoredCompletion(storedAction)) {
+      return {
+        sessionId: null,
+        session: null,
+        reply: existingAssistant.text,
+        context,
+        workOrder: null,
+        capabilities,
+        replayed: true,
+      };
+    }
+    throw new TechnicianCopilotConflictError(
+      "technician_copilot_session_stale",
+      "This CoPilot repair session is closed. Start from your current assigned work.",
+    );
+  }
+
+  if (envelope.session) assertActiveSession(envelope.session);
+  if (
+    envelope.session &&
+    !activeWorkOrder &&
+    !isStoredCompletion(storedAction)
+  ) {
+    throw new TechnicianCopilotConflictError(
+      "technician_copilot_work_not_actionable",
+      "The active CoPilot work order is no longer assigned and actionable.",
+    );
+  }
 
   if (
     existingAssistant &&
     envelope.session &&
-    (!input.identity.documentationEnabled || documentationAlreadyFinalized)
+    (!input.identity.documentationEnabled || documentationAlreadyFinalized) &&
+    !(isStoredCompletion(storedAction) && storedAction.result?.ok)
   ) {
     return {
       sessionId: envelope.session.id,
+      session: envelope.session,
       reply: existingAssistant.text,
       context,
       workOrder: activeWorkOrder,
@@ -551,8 +626,10 @@ export async function runTechnicianCopilotTurn(input: {
     );
   }
 
-  const storedAction = storedActionTurn(envelope.events, input.turnId);
+  storedAction = storedActionTurn(envelope.events, input.turnId);
   let replayedActionResult = Boolean(storedAction?.result);
+  let completionNeedsDisposition =
+    isStoredCompletion(storedAction) && storedAction.result?.ok === true;
   const decisionPromise =
     existingAssistant || storedAction?.result || storedAction
       ? Promise.resolve(null)
@@ -578,188 +655,6 @@ export async function runTechnicianCopilotTurn(input: {
     }),
   ]);
 
-  let reply =
-    existingAssistant?.text ??
-    storedAction?.result?.reply ??
-    decision?.reply ??
-    "I'm with you.";
-  if (!existingAssistant && !storedAction?.result) {
-    const requestedAction =
-      storedAction?.action ?? decision?.action ?? { type: "none" as const };
-    const prepared = prepareTechnicianCopilotAction({
-      action: requestedAction,
-      activeWorkOrder,
-      assignedWork: candidates,
-      activeWorkOrderLineId: session.activeWorkOrderLineId,
-    });
-
-    if (prepared.kind === "reply") {
-      reply = prepared.reply;
-      if (storedAction) {
-        await append(input.identity, {
-          sessionId: session.id,
-          eventType: "action.completed",
-          turnId: input.turnId,
-          suffix: "canonical-action-result",
-          origin: "system",
-          details: {
-            action: `Attempted ${storedAction.action.type}`,
-            key: storedAction.key,
-            turnId: input.turnId,
-            ok: false,
-            reply,
-            tool: storedAction.action.type,
-          },
-        });
-      }
-    } else if (prepared.kind === "execute") {
-      let executable: Extract<
-        PreparedTechnicianCopilotAction,
-        { kind: "execute" }
-      > | null = prepared;
-      let actionKey =
-        storedAction?.key ??
-        deriveCopilotOperationId(input.turnId, "canonical-action");
-      let expectedLineUpdatedAt =
-        storedAction ? storedAction.lineUpdatedAt : prepared.line.updatedAt;
-
-      if (!storedAction) {
-        await append(input.identity, {
-          sessionId: session.id,
-          eventType: "action.pending",
-          turnId: input.turnId,
-          suffix: "canonical-action-pending",
-          origin: "system",
-          details: {
-            action: prepared.action.type,
-            key: actionKey,
-            turnId: input.turnId,
-            request: prepared.action,
-            workOrderId: prepared.workOrder.id,
-            workOrderLineId: prepared.line.id,
-            lineUpdatedAt: expectedLineUpdatedAt,
-          },
-        });
-
-        const bindingEnvelope = await read(input.identity, session.id);
-        assertActiveSession(bindingEnvelope.session);
-        const persistedAction = storedActionTurn(
-          bindingEnvelope.events,
-          input.turnId,
-        );
-        if (!persistedAction) {
-          throw new TechnicianCopilotConflictError(
-            "technician_copilot_action_binding_failed",
-            "The spoken action could not be bound safely. Try that request again.",
-          );
-        }
-
-        actionKey = persistedAction.key;
-        expectedLineUpdatedAt = persistedAction.lineUpdatedAt;
-        if (persistedAction.result) {
-          reply = persistedAction.result.reply;
-          replayedActionResult = true;
-          executable = null;
-        } else {
-          const rebound = prepareTechnicianCopilotAction({
-            action: persistedAction.action,
-            activeWorkOrder,
-            assignedWork: candidates,
-            activeWorkOrderLineId: session.activeWorkOrderLineId,
-          });
-          if (rebound.kind === "execute") {
-            executable = rebound;
-          } else {
-            reply =
-              rebound.kind === "reply"
-                ? rebound.reply
-                : "That job action is no longer available.";
-            await append(input.identity, {
-              sessionId: session.id,
-              eventType: "action.completed",
-              turnId: input.turnId,
-              suffix: "canonical-action-result",
-              origin: "system",
-              details: {
-                action: `Attempted ${persistedAction.action.type}`,
-                key: actionKey,
-                turnId: input.turnId,
-                ok: false,
-                reply,
-                tool: persistedAction.action.type,
-              },
-            });
-            executable = null;
-          }
-        }
-      }
-
-      if (executable && session.activeWorkOrderLineId !== executable.line.id) {
-        await command<{ sessionId: string }>(input.identity, "session.start", {
-          workOrderId: executable.workOrder.id,
-          workOrderLineId: executable.line.id,
-          mode: session.mode,
-          operationId: deriveCopilotOperationId(
-            input.turnId,
-            "action-line-anchor",
-          ),
-        });
-        session.activeWorkOrderLineId = executable.line.id;
-      }
-
-      if (executable) {
-        const actionResult = await executeTechnicianCopilotAction({
-          identity: {
-            authUserId: input.identity.authUserId,
-            profileId: input.identity.profileId,
-            shopId: input.identity.shopId,
-          },
-          sessionId: session.id,
-          prepared: executable,
-          operationId: actionKey,
-          expectedLineUpdatedAt,
-        });
-        reply = actionResult.reply;
-
-        await append(input.identity, {
-          sessionId: session.id,
-          eventType: "action.completed",
-          turnId: input.turnId,
-          suffix: "canonical-action-result",
-          origin: "system",
-          details: {
-            action:
-              actionResult.eventLabel ??
-              `Attempted ${executable.action.type}`,
-            key: actionKey,
-            turnId: input.turnId,
-            ok: actionResult.ok,
-            reply,
-            eventLabel: actionResult.eventLabel,
-            eventDetail: actionResult.eventDetail,
-            detail: actionResult.eventDetail,
-            tool: executable.action.type,
-            workOrderId: executable.workOrder.id,
-            workOrderLineId: executable.line.id,
-          },
-        });
-
-        if (actionResult.ok) {
-          activeWorkOrder =
-            (await loadTechnicianWorkCandidateForWorkOrder({
-              supabase: input.identity.supabase,
-              shopId: input.identity.shopId,
-              technicianIds: [
-                input.identity.authUserId,
-                input.identity.profileId,
-              ],
-              workOrderId: executable.workOrder.id,
-            })) ?? activeWorkOrder;
-        }
-      }
-    }
-  }
-
   const documentationEvents = dedupeDocumentationEvents(
     envelope.events,
     documentationExtraction.events,
@@ -775,6 +670,7 @@ export async function runTechnicianCopilotTurn(input: {
         turnId: input.turnId,
         events: documentationEvents,
       });
+      documentationAlreadyFinalized = true;
     } catch (error) {
       console.error(
         "[technician-copilot] silent documentation persistence failed",
@@ -783,6 +679,157 @@ export async function runTechnicianCopilotTurn(input: {
           error: error instanceof Error ? error.message : String(error),
         },
       );
+    }
+  }
+
+  let reply =
+    existingAssistant?.text ??
+    storedAction?.result?.reply ??
+    decision?.reply ??
+    "I'm with you.";
+  if (!existingAssistant && !storedAction?.result) {
+    let actionKey =
+      storedAction?.key ??
+      deriveCopilotOperationId(input.turnId, "canonical-action");
+    let actionWorkOrderId = storedAction?.workOrderId ?? session.workOrderId;
+    let boundAction = storedAction
+      ? boundActionFromStored(storedAction)
+      : null;
+
+    if (!storedAction) {
+      const prepared = prepareTechnicianCopilotAction({
+        action: decision?.action ?? { type: "none" },
+        activeWorkOrder,
+        assignedWork: candidates,
+        activeWorkOrderLineId: session.activeWorkOrderLineId,
+      });
+
+      if (prepared.kind === "reply") {
+        reply = prepared.reply;
+      } else if (prepared.kind === "execute") {
+        actionWorkOrderId = prepared.workOrder.id;
+        await append(input.identity, {
+          sessionId: session.id,
+          eventType: "action.pending",
+          turnId: input.turnId,
+          suffix: "canonical-action-pending",
+          origin: "system",
+          details: {
+            action: prepared.action.type,
+            key: actionKey,
+            turnId: input.turnId,
+            request: prepared.action,
+            workOrderId: prepared.workOrder.id,
+            workOrderLineId: prepared.line.id,
+            lineLabel: technicianWorkLineLabel(prepared.line),
+            lineCause: prepared.line.cause,
+            lineCorrection: prepared.line.correction,
+            lineUpdatedAt: prepared.line.updatedAt,
+          },
+        });
+
+        const bindingEnvelope = await read(input.identity, session.id);
+        assertActiveSession(bindingEnvelope.session);
+        storedAction = storedActionTurn(bindingEnvelope.events, input.turnId);
+        if (!storedAction) {
+          throw new TechnicianCopilotConflictError(
+            "technician_copilot_action_binding_failed",
+            "The spoken action could not be bound safely. Try that request again.",
+          );
+        }
+        actionKey = storedAction.key;
+        actionWorkOrderId = storedAction.workOrderId ?? actionWorkOrderId;
+        if (storedAction.result) {
+          reply = storedAction.result.reply;
+          replayedActionResult = true;
+        } else {
+          boundAction = boundActionFromStored(storedAction);
+        }
+      }
+    }
+
+    if (storedAction && !boundAction && !storedAction.result) {
+      reply = "That persisted job action is missing its line binding. Try a new request.";
+      await append(input.identity, {
+        sessionId: session.id,
+        eventType: "action.completed",
+        turnId: input.turnId,
+        suffix: "canonical-action-result",
+        origin: "system",
+        details: {
+          action: `Attempted ${storedAction.action.type}`,
+          key: actionKey,
+          turnId: input.turnId,
+          ok: false,
+          reply,
+          tool: storedAction.action.type,
+        },
+      });
+    }
+
+    if (boundAction) {
+      if (
+        activeWorkOrder?.lines.some((line) => line.id === boundAction.lineId) &&
+        session.activeWorkOrderLineId !== boundAction.lineId
+      ) {
+        await command<{ sessionId: string }>(input.identity, "session.start", {
+          workOrderId: actionWorkOrderId,
+          workOrderLineId: boundAction.lineId,
+          mode: session.mode,
+          operationId: deriveCopilotOperationId(
+            input.turnId,
+            "action-line-anchor",
+          ),
+        });
+        session.activeWorkOrderLineId = boundAction.lineId;
+      }
+
+      const actionResult = await executeBoundTechnicianCopilotAction({
+        identity: input.identity,
+        sessionId: session.id,
+        bound: boundAction,
+        operationId: actionKey,
+        expectedLineUpdatedAt: storedAction?.lineUpdatedAt,
+      });
+      reply = actionResult.reply;
+
+      await append(input.identity, {
+        sessionId: session.id,
+        eventType: "action.completed",
+        turnId: input.turnId,
+        suffix: "canonical-action-result",
+        origin: "system",
+        details: {
+          action:
+            actionResult.eventLabel ??
+            `Attempted ${boundAction.action.type}`,
+          key: actionKey,
+          turnId: input.turnId,
+          ok: actionResult.ok,
+          reply,
+          eventLabel: actionResult.eventLabel,
+          eventDetail: actionResult.eventDetail,
+          detail: actionResult.eventDetail,
+          tool: boundAction.action.type,
+          workOrderId: actionWorkOrderId,
+          workOrderLineId: boundAction.lineId,
+        },
+      });
+
+      if (actionResult.ok) {
+        activeWorkOrder = await loadTechnicianWorkCandidateForWorkOrder({
+          supabase: input.identity.supabase,
+          shopId: input.identity.shopId,
+          technicianIds: [
+            input.identity.authUserId,
+            input.identity.profileId,
+          ],
+          workOrderId: actionWorkOrderId,
+        });
+        if (boundAction.action.type === "job.complete") {
+          completionNeedsDisposition = true;
+        }
+      }
     }
   }
 
@@ -797,12 +844,49 @@ export async function runTechnicianCopilotTurn(input: {
     });
   }
 
+  if (completionNeedsDisposition) {
+    const completionWorkOrderId = storedAction?.workOrderId ?? session.workOrderId;
+    activeWorkOrder = await loadTechnicianWorkCandidateForWorkOrder({
+      supabase: input.identity.supabase,
+      shopId: input.identity.shopId,
+      technicianIds: [input.identity.authUserId, input.identity.profileId],
+      workOrderId: completionWorkOrderId,
+    });
+    const nextLine = activeWorkOrder?.lines[0] ?? null;
+    if (nextLine) {
+      await command<{ sessionId: string }>(input.identity, "session.start", {
+        workOrderId: completionWorkOrderId,
+        workOrderLineId: nextLine.id,
+        mode: session.mode,
+        operationId: deriveCopilotOperationId(
+          input.turnId,
+          "completion-session-reanchor",
+        ),
+      });
+      session.activeWorkOrderLineId = nextLine.id;
+    } else {
+      await command(input.identity, "session.close", {
+        sessionId: session.id,
+        operationId: deriveCopilotOperationId(
+          input.turnId,
+          "completion-session-close",
+        ),
+        reason: "completed_last_actionable_line",
+      });
+    }
+  }
+
   const finalEnvelope = await read(input.identity, session.id);
-  assertActiveSession(finalEnvelope.session);
+  if (!finalEnvelope.session) {
+    throw new TechnicianCopilotConflictError(
+      "technician_copilot_session_stale",
+      "The CoPilot completion result could not be restored.",
+    );
+  }
   const finalContext = projectTechnicianContext({
     repairSessionId: session.id,
-    mode: session.mode,
-    status: session.status,
+    mode: finalEnvelope.session.mode,
+    status: finalEnvelope.session.status,
     events: finalEnvelope.events,
   });
   const persistedAssistant = finalContext.conversation.find(
@@ -810,7 +894,14 @@ export async function runTechnicianCopilotTurn(input: {
   );
 
   return {
-    sessionId: session.id,
+    sessionId:
+      finalEnvelope.session.status === "active"
+        ? finalEnvelope.session.id
+        : null,
+    session:
+      finalEnvelope.session.status === "active"
+        ? finalEnvelope.session
+        : null,
     reply: persistedAssistant?.text ?? reply,
     context: finalContext,
     workOrder: activeWorkOrder,

--- a/features/copilot/technician/server/chat.ts
+++ b/features/copilot/technician/server/chat.ts
@@ -131,7 +131,7 @@ function storedTurnText(event: RepairSessionEvent): string {
 }
 
 type StoredActionTurn = {
-  action: TechnicianCopilotAction;
+  action: BoundTechnicianCopilotAction["action"];
   key: string;
   workOrderId: string | null;
   workOrderLineId: string | null;

--- a/features/copilot/technician/server/transport.ts
+++ b/features/copilot/technician/server/transport.ts
@@ -12,6 +12,7 @@ function asObject(value: unknown): Record<string, unknown> {
 export type CopilotServerCommandAction =
   | "session.read"
   | "session.start"
+  | "session.close"
   | "event.append"
   | "documentation.append"
   | "job.action";

--- a/features/work-orders/server/applyJobPunchTransition.ts
+++ b/features/work-orders/server/applyJobPunchTransition.ts
@@ -61,6 +61,7 @@ function cleanString(value: unknown): string | null {
 function errorStatus(message: string): number {
   const normalized = message.toLowerCase();
   if (normalized.includes("not found")) return 404;
+  if (normalized.includes("inspection_completion_required")) return 409;
   if (
     normalized.includes("financially_locked") ||
     normalized.includes("shift_shop_mismatch") ||

--- a/features/work-orders/server/completeWorkOrderLine.ts
+++ b/features/work-orders/server/completeWorkOrderLine.ts
@@ -1,0 +1,85 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { upsertMenuRepairItemFromCompletedLine } from "@/features/menu-repair-items/server/upsertMenuRepairItemFromCompletedLine";
+import type { Database } from "@/features/shared/types/types/supabase";
+import { applyJobPunchTransition } from "./applyJobPunchTransition";
+
+type DB = Database;
+
+type CompletionInput = {
+  supabase: SupabaseClient<DB>;
+  lineId: string;
+  technicianId: string;
+  actorUserId: string;
+  operationKey: string;
+  cause?: string | null;
+  correction?: string | null;
+};
+
+export async function learnFromCompletedWorkOrderLine(input: {
+  supabase: SupabaseClient<DB>;
+  lineId: string;
+  actorUserId: string;
+}): Promise<{ ok: boolean }> {
+  const { data: completedLine, error } = await input.supabase
+    .from("work_order_lines")
+    .select("id, shop_id")
+    .eq("id", input.lineId)
+    .maybeSingle<{ id: string; shop_id: string | null }>();
+
+  if (error || !completedLine?.shop_id) {
+    console.error("[work-orders] completed repair memory update failed", {
+      workOrderLineId: input.lineId,
+      error: error?.message ?? "Completed line is missing shop context",
+    });
+    return { ok: false };
+  }
+
+  try {
+    await upsertMenuRepairItemFromCompletedLine({
+      supabase: input.supabase,
+      shopId: completedLine.shop_id,
+      workOrderLineId: completedLine.id,
+      actorUserId: input.actorUserId,
+    });
+    return { ok: true };
+  } catch (learningError) {
+    console.error("[work-orders] completed repair memory update failed", {
+      workOrderLineId: input.lineId,
+      error:
+        learningError instanceof Error
+          ? learningError.message
+          : "Completed repair memory update failed",
+    });
+    return { ok: false };
+  }
+}
+
+export async function completeWorkOrderLine(input: CompletionInput) {
+  const result = await applyJobPunchTransition({
+    supabase: input.supabase,
+    lineId: input.lineId,
+    action: "finish",
+    technicianId: input.technicianId,
+    options: {
+      operationKey: input.operationKey,
+      finish: {
+        cause: input.cause,
+        correction: input.correction,
+      },
+    },
+  });
+
+  if (!result.ok) return result;
+
+  const menuRepairLearning = await learnFromCompletedWorkOrderLine({
+    supabase: input.supabase,
+    lineId: input.lineId,
+    actorUserId: input.actorUserId,
+  });
+
+  return {
+    ...result,
+    menuRepairLearning,
+  };
+}

--- a/supabase/migrations/20260815232321_technician_completion_integrity.sql
+++ b/supabase/migrations/20260815232321_technician_completion_integrity.sql
@@ -1,0 +1,1434 @@
+-- Canonical job-completion integrity for technician screens and CoPilot.
+-- Preserve profile/auth identity boundaries, require explicit inspection
+-- signing, recover receipt-bound turns, and close or re-anchor repair sessions.
+
+begin;
+
+create or replace function copilot.technician_has_bound_completion_receipt(
+  p_auth_user_id uuid,
+  p_session_id uuid,
+  p_turn_id text default null
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+  select exists (
+    select 1
+    from copilot.repair_sessions rs
+    join public.profiles p
+      on p.id = rs.technician_id
+     and (p.id = p_auth_user_id or p.user_id = p_auth_user_id)
+    join copilot.repair_session_events e
+      on e.repair_session_id = rs.id
+     and e.event_type = 'action.pending'
+    join copilot.repair_session_event_context c
+      on c.event_id = e.id
+    join public.workforce_operation_keys wok
+      on wok.shop_id = rs.shop_id
+     and wok.operation_name = 'job_punch:finish'
+     and wok.operation_key = 'technician-copilot:' || (c.details ->> 'key')
+     and wok.actor_user_id = p_auth_user_id
+     and wok.work_order_id = rs.work_order_id
+     and wok.work_order_line_id = case
+       when c.details ->> 'workOrderLineId'
+         ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+       then (c.details ->> 'workOrderLineId')::uuid
+       else null
+     end
+    where rs.id = p_session_id
+      and c.details ->> 'action' = 'job.complete'
+      and c.details ->> 'key'
+        ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      and c.details ->> 'workOrderLineId'
+        ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      and (p_turn_id is null or c.details ->> 'turnId' = p_turn_id)
+  )
+$$;
+
+create or replace function public.apply_job_punch_transition_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_action text,
+  p_technician_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_allow_concurrent boolean default false,
+  p_at timestamptz default now(),
+  p_start_source text default null,
+  p_hold_reason text default null,
+  p_notes text default null,
+  p_preserve_line_status boolean default false,
+  p_release_to_awaiting boolean default false,
+  p_cause text default null,
+  p_correction text default null,
+  p_event text default null,
+  p_details jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_shift public.tech_shifts%rowtype;
+  v_status text;
+  v_approval text;
+  v_action text := lower(trim(coalesce(p_action, '')));
+  v_now timestamptz := coalesce(p_at, now());
+  v_existing jsonb;
+  v_result jsonb;
+  v_final_cause text;
+  v_final_correction text;
+  v_segment_id uuid;
+  v_earliest timestamptz;
+  v_latest timestamptz;
+  v_has_open boolean;
+  v_closed_count integer := 0;
+  v_technician_profile_id uuid;
+  v_actor_profile_id uuid;
+  v_actor_auth_user_id uuid;
+  v_existing_actor_user_id uuid;
+  v_existing_line_id uuid;
+begin
+  if v_action not in ('start','resume','pause','finish') then
+    raise exception using errcode = 'P0001', message = 'Unsupported job punch action.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+
+  select p.id
+    into v_technician_profile_id
+  from public.profiles p
+  where p.shop_id = p_shop_id
+    and (p.id = p_technician_id or p.user_id = p_technician_id)
+  order by case when p.id = p_technician_id then 0 else 1 end
+  limit 1
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Technician is not available for this shop.';
+  end if;
+
+  select p.id, coalesce(p.user_id, p.id)
+    into v_actor_profile_id, v_actor_auth_user_id
+  from public.profiles p
+  where p.shop_id = p_shop_id
+    and (p.id = p_actor_user_id or p.user_id = p_actor_user_id)
+  order by case when p.id = p_actor_user_id then 0 else 1 end
+  limit 1;
+  if not found
+    or not exists (
+      select 1 from auth.users u where u.id = v_actor_auth_user_id
+    )
+    or (
+      auth.uid() is not null
+      and auth.uid() is distinct from v_actor_auth_user_id
+    )
+  then
+    raise exception using errcode = 'P0001', message = 'Actor is not available for this shop.';
+  end if;
+
+  select wok.result, wok.actor_user_id, wok.work_order_line_id
+    into v_existing, v_existing_actor_user_id, v_existing_line_id
+  from public.workforce_operation_keys wok
+  where wok.shop_id = p_shop_id
+    and wok.operation_name = 'job_punch:' || v_action
+    and wok.operation_key = p_operation_key;
+  if found then
+    if v_existing_actor_user_id is distinct from v_actor_auth_user_id
+      or v_existing_line_id is distinct from p_work_order_line_id
+    then
+      raise exception using errcode = '23505', message = 'JOB_PUNCH_OPERATION_CONFLICT';
+    end if;
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  select *
+    into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id
+    and wol.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work-order line not found for shop.';
+  end if;
+  if v_line.work_order_id is null then
+    raise exception using errcode = 'P0001', message = 'Work-order line is missing its work-order anchor.';
+  end if;
+  if coalesce(v_line.line_type::text, 'job') = 'info' then
+    raise exception using errcode = 'P0001', message = 'Info lines are non-actionable.';
+  end if;
+  if public.work_order_is_financially_locked(p_shop_id, v_line.work_order_id) then
+    raise exception using errcode = 'P0001', message = 'FINANCIALLY_LOCKED: job labor cannot change after invoice finalization.';
+  end if;
+
+  v_status := lower(coalesce(v_line.status::text, 'awaiting'));
+  v_approval := lower(coalesce(v_line.approval_state::text, ''));
+
+  perform 1
+  from public.work_order_line_technicians wolt
+  where wolt.work_order_line_id = p_work_order_line_id
+  for update;
+
+  perform 1
+  from public.work_order_line_labor_segments seg
+  where seg.shop_id = p_shop_id
+    and (
+      seg.work_order_line_id = p_work_order_line_id
+      or (seg.technician_id = v_technician_profile_id and seg.ended_at is null)
+    )
+  for update;
+
+  if v_action in ('start','resume') and p_release_to_awaiting then
+    if v_status in ('completed','invoiced') then
+      raise exception using errcode = 'P0001', message = 'Cannot release hold on a closed line.';
+    end if;
+
+    update public.work_order_lines
+    set status = 'awaiting',
+        hold_reason = null,
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+  elsif v_action in ('start','resume') then
+    if v_status in ('completed','invoiced') then
+      raise exception using errcode = 'P0001', message = 'Cannot start or resume a closed line.';
+    end if;
+    if v_status = 'awaiting_approval'
+       and v_approval <> 'approved'
+       and not coalesce(v_line.punchable, false) then
+      raise exception using errcode = 'P0001', message = 'Line is awaiting approval and cannot be started.';
+    end if;
+
+    select *
+      into v_shift
+    from public.tech_shifts ts
+    where ts.user_id = v_technician_profile_id
+      and ts.shop_id = p_shop_id
+      and ts.status::text = 'active'
+      and ts.end_time is null
+    order by ts.start_time desc, ts.id desc
+    limit 1
+    for update;
+    if not found then
+      if exists (
+        select 1
+        from public.tech_shifts ts
+        where ts.user_id = v_technician_profile_id
+          and ts.end_time is null
+          and (ts.shop_id is null or ts.shop_id <> p_shop_id)
+      ) then
+        raise exception using errcode = 'P0001', message = 'SHIFT_SHOP_MISMATCH: an open shift exists outside this shop and cannot authorize job labor.';
+      end if;
+      raise exception using errcode = 'P0001', message = 'You need an active shift in this shop before starting job labor.';
+    end if;
+
+    if exists (
+      select 1
+      from public.work_order_line_labor_segments seg
+      where seg.shop_id = p_shop_id
+        and seg.technician_id = v_technician_profile_id
+        and seg.work_order_line_id = p_work_order_line_id
+        and seg.ended_at is null
+    ) then
+      raise exception using errcode = 'P0001', message = 'Technician already has active labor on this line.';
+    end if;
+
+    if not p_allow_concurrent and exists (
+      select 1
+      from public.work_order_line_labor_segments seg
+      where seg.shop_id = p_shop_id
+        and seg.technician_id = v_technician_profile_id
+        and seg.work_order_line_id <> p_work_order_line_id
+        and seg.ended_at is null
+    ) then
+      raise exception using errcode = 'P0001', message = 'Technician already has an active job punch.';
+    end if;
+
+    insert into public.work_order_line_technicians(
+      work_order_line_id, technician_id, assigned_by
+    ) values (
+      p_work_order_line_id, v_technician_profile_id, v_actor_profile_id
+    )
+    on conflict (work_order_line_id, technician_id)
+    do update set assigned_by = excluded.assigned_by;
+
+    update public.work_order_lines
+    set assigned_tech_id = coalesce(assigned_tech_id, v_technician_profile_id),
+        status = 'in_progress',
+        hold_reason = null,
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+    insert into public.work_order_line_labor_segments(
+      shop_id, work_order_id, work_order_line_id, technician_id,
+      created_by, started_at, source
+    ) values (
+      p_shop_id, v_line.work_order_id, p_work_order_line_id, v_technician_profile_id,
+      v_actor_profile_id, v_now,
+      coalesce(nullif(trim(p_start_source), ''), case when v_action = 'start' then 'job_start' else 'job_resume' end)
+    ) returning id into v_segment_id;
+
+  elsif v_action = 'pause' then
+    if v_status in ('completed','invoiced') then
+      raise exception using errcode = 'P0001', message = 'Cannot pause a closed line.';
+    end if;
+
+    update public.work_order_line_labor_segments
+    set ended_at = v_now,
+        pause_reason = case
+          when p_preserve_line_status then coalesce(nullif(trim(p_hold_reason), ''), 'labor_pause')
+          when nullif(trim(p_hold_reason), '') is not null then 'hold:' || trim(p_hold_reason)
+          else 'hold'
+        end
+    where shop_id = p_shop_id
+      and work_order_line_id = p_work_order_line_id
+      and technician_id = v_technician_profile_id
+      and ended_at is null;
+    get diagnostics v_closed_count = row_count;
+
+    update public.work_order_lines
+    set status = case when p_preserve_line_status then status else 'on_hold' end,
+        hold_reason = case
+          when p_preserve_line_status then hold_reason
+          else coalesce(nullif(trim(p_hold_reason), ''), 'Paused by technician')
+        end,
+        notes = case when p_preserve_line_status then notes else coalesce(p_notes, notes) end,
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+  else
+    if v_status = 'invoiced' then
+      raise exception using errcode = 'P0001', message = 'Cannot finish an invoiced line.';
+    end if;
+
+    v_final_cause := coalesce(nullif(trim(p_cause), ''), nullif(trim(v_line.cause), ''));
+    v_final_correction := coalesce(nullif(trim(p_correction), ''), nullif(trim(v_line.correction), ''));
+    if v_final_cause is null then
+      raise exception using errcode = 'P0001', message = 'Cause is required before finishing this job.';
+    end if;
+    if v_final_correction is null then
+      raise exception using errcode = 'P0001', message = 'Correction is required before finishing this job.';
+    end if;
+    if coalesce(v_line.labor_time, 0) <= 0 then
+      raise exception using errcode = 'P0001', message = 'Labor time must be greater than 0 before finishing this job.';
+    end if;
+
+    perform 1
+    from public.inspections i
+    where i.work_order_line_id = p_work_order_line_id
+    for update;
+
+    if exists (
+      select 1
+      from public.inspections i
+      where i.work_order_line_id = p_work_order_line_id
+        and (
+          not coalesce(i.completed, false)
+          or coalesce(i.is_draft, true)
+          or not coalesce(i.locked, false)
+          or lower(coalesce(i.status, 'draft')) not in ('completed', 'finalized', 'signed')
+          or i.finalized_at is null
+          or i.finalized_by is null
+          or not exists (
+            select 1
+            from public.inspection_signatures s
+            where s.inspection_id = i.id
+              and s.signing_cycle = coalesce(i.signing_cycle, 0)
+          )
+        )
+    ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'INSPECTION_COMPLETION_REQUIRED: complete and sign the inspection before finishing this job.';
+    end if;
+
+    update public.work_order_line_labor_segments
+    set ended_at = v_now,
+        pause_reason = 'completed'
+    where shop_id = p_shop_id
+      and work_order_line_id = p_work_order_line_id
+      and technician_id = v_technician_profile_id
+      and ended_at is null;
+    get diagnostics v_closed_count = row_count;
+
+    -- The completed-line constraint is immediate. Persist the punch timeline in
+    -- the same row update that changes status so no invalid intermediate row
+    -- can be observed by PostgreSQL.
+    update public.work_order_lines
+    set status = 'completed',
+        cause = v_final_cause,
+        correction = v_final_correction,
+        hold_reason = null,
+        punched_in_at = coalesce(
+          (
+            select min(seg.started_at)
+            from public.work_order_line_labor_segments seg
+            where seg.work_order_line_id = p_work_order_line_id
+          ),
+          v_line.punched_in_at
+        ),
+        punched_out_at = coalesce(
+          (
+            select max(seg.ended_at)
+            from public.work_order_line_labor_segments seg
+            where seg.work_order_line_id = p_work_order_line_id
+              and seg.ended_at is not null
+          ),
+          v_line.punched_out_at,
+          v_now
+        ),
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+  end if;
+
+  select min(seg.started_at),
+         max(seg.ended_at) filter (where seg.ended_at is not null),
+         bool_or(seg.ended_at is null)
+    into v_earliest, v_latest, v_has_open
+  from public.work_order_line_labor_segments seg
+  where seg.work_order_line_id = p_work_order_line_id;
+
+  update public.work_order_lines
+  set punched_in_at = coalesce(v_earliest, punched_in_at),
+      punched_out_at = case
+        when v_action = 'finish' then coalesce(v_latest, punched_out_at, v_now)
+        when coalesce(v_has_open, false) then null
+        else v_latest
+      end,
+      updated_at = v_now
+  where id = p_work_order_line_id;
+
+  select jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'action', v_action,
+    'shop_id', p_shop_id,
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'technician_id', v_technician_profile_id,
+    'shift_id', v_shift.id,
+    'labor_segment_id', v_segment_id,
+    'closed_segment_count', v_closed_count,
+    'line', (
+      select to_jsonb(wol)
+      from public.work_order_lines wol
+      where wol.id = p_work_order_line_id
+    )
+  ) into v_result;
+
+  insert into public.activity_logs(action, user_id, timestamp, target_table, target_id, context)
+  values (
+    coalesce(nullif(trim(p_event), ''), v_action),
+    v_actor_auth_user_id,
+    v_now,
+    'work_order_line',
+    p_work_order_line_id,
+    coalesce(p_details, '{}'::jsonb) || jsonb_build_object(
+      'shop_id', p_shop_id,
+      'work_order_id', v_line.work_order_id,
+      'technician_id', v_technician_profile_id,
+      'shift_id', v_shift.id,
+      'operation_key', p_operation_key
+    )
+  );
+
+  insert into public.workforce_operation_keys(
+    shop_id, operation_name, operation_key, actor_user_id,
+    work_order_id, work_order_line_id, result
+  ) values (
+    p_shop_id, 'job_punch:' || v_action, p_operation_key, v_actor_auth_user_id,
+    v_line.work_order_id, p_work_order_line_id, v_result
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.apply_job_punch_transition_atomic(
+  uuid,uuid,text,uuid,uuid,text,boolean,timestamptz,text,text,text,
+  boolean,boolean,text,text,text,jsonb
+) from public, anon;
+grant execute on function public.apply_job_punch_transition_atomic(
+  uuid,uuid,text,uuid,uuid,text,boolean,timestamptz,text,text,text,
+  boolean,boolean,text,text,text,jsonb
+) to authenticated, service_role;
+
+
+create or replace function copilot.technician_job_action_internal(
+  p_auth_user_id uuid,
+  p_session_id uuid,
+  p_work_order_line_id uuid,
+  p_action text,
+  p_operation_id uuid,
+  p_reason text default null,
+  p_cause text default null,
+  p_correction text default null,
+  p_expected_line_updated_at timestamptz default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_profile_id uuid;
+  v_shop_id uuid;
+  v_work_order_id uuid;
+  v_line_status text;
+  v_line_updated_at timestamptz;
+  v_line_cause text;
+  v_line_correction text;
+  v_action text := lower(btrim(coalesce(p_action, '')));
+  v_operation_key text;
+  v_operation_name text;
+  v_existing_actor_id uuid;
+  v_existing_line_id uuid;
+  v_existing_action_type text;
+  v_existing_entity_type text;
+  v_existing_result jsonb;
+  v_payload jsonb;
+  v_result jsonb;
+begin
+  if p_operation_id is null then
+    raise exception 'copilot_operation_id_required' using errcode = '22023';
+  end if;
+  if v_action not in (
+    'job.start',
+    'job.hold',
+    'job.release_hold',
+    'job.story.save',
+    'job.complete'
+  ) then
+    raise exception 'copilot_job_action_not_allowed' using errcode = '22023';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended('copilot:job-action:' || p_operation_id::text, 0)
+  );
+
+  v_profile_id := copilot.technician_profile_id(p_auth_user_id);
+
+  -- Match the canonical punch function's profile-then-line lock order.
+  perform 1
+  from public.profiles p
+  where p.id = v_profile_id
+  for update;
+
+  select
+      rs.shop_id,
+      rs.work_order_id,
+      lower(btrim(wol.status::text)),
+      wol.updated_at,
+      wol.cause,
+      wol.correction
+    into
+      v_shop_id,
+      v_work_order_id,
+      v_line_status,
+      v_line_updated_at,
+      v_line_cause,
+      v_line_correction
+  from copilot.repair_sessions rs
+  join public.work_order_lines wol
+    on wol.id = p_work_order_line_id
+   and wol.shop_id = rs.shop_id
+   and wol.work_order_id = rs.work_order_id
+   and wol.line_type = 'job'
+  where rs.id = p_session_id
+    and rs.technician_id = v_profile_id
+    and rs.status = 'active'
+  for update of rs, wol;
+
+  if not found then
+    raise exception 'copilot_job_action_session_or_line_not_actionable'
+      using errcode = '55000';
+  end if;
+
+  v_operation_key := 'technician-copilot:' || p_operation_id::text;
+
+  -- Completion makes the line non-actionable. Resolve a bound finish replay
+  -- before rechecking current assignment/actionability, while still requiring
+  -- the same active session, shop, actor, line, and operation identity.
+  if v_action = 'job.complete'
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = v_profile_id
+        and p.shop_id = v_shop_id
+    )
+    and exists (
+      select 1
+      from public.work_order_lines wol
+      where wol.id = p_work_order_line_id
+        and wol.shop_id = v_shop_id
+        and wol.work_order_id = v_work_order_id
+        and (
+          wol.assigned_tech_id in (p_auth_user_id, v_profile_id)
+          or wol.assigned_to in (p_auth_user_id, v_profile_id)
+          or exists (
+            select 1
+            from public.work_order_line_technicians wolt
+            where wolt.work_order_line_id = wol.id
+              and wolt.technician_id in (p_auth_user_id, v_profile_id)
+          )
+        )
+    )
+  then
+    select
+        wok.operation_name,
+        wok.actor_user_id,
+        wok.work_order_line_id,
+        wok.result
+      into
+        v_operation_name,
+        v_existing_actor_id,
+        v_existing_line_id,
+        v_existing_result
+    from public.workforce_operation_keys wok
+    where wok.shop_id = v_shop_id
+      and wok.operation_key = v_operation_key;
+
+    if found then
+      if v_operation_name is distinct from 'job_punch:finish'
+        or v_existing_actor_id is distinct from p_auth_user_id
+        or v_existing_line_id is distinct from p_work_order_line_id
+      then
+        raise exception 'copilot_operation_id_conflict' using errcode = '23505';
+      end if;
+      return coalesce(v_existing_result, '{}'::jsonb)
+        || jsonb_build_object(
+          'idempotent', true,
+          'copilotAction', v_action,
+          'workOrderId', v_work_order_id,
+          'workOrderLineId', p_work_order_line_id
+        );
+    end if;
+  end if;
+
+  perform 1
+  from public.work_order_line_technicians wolt
+  where wolt.work_order_line_id = p_work_order_line_id
+  for update;
+
+  if not copilot.technician_is_assigned(
+    p_auth_user_id,
+    v_profile_id,
+    v_shop_id,
+    v_work_order_id,
+    p_work_order_line_id
+  ) then
+    raise exception 'copilot_work_order_assignment_required'
+      using errcode = '42501';
+  end if;
+
+  if v_action = 'job.story.save' then
+    if exists (
+      select 1
+      from public.workforce_operation_keys wok
+      where wok.shop_id = v_shop_id
+        and wok.operation_key = v_operation_key
+    ) then
+      raise exception 'copilot_operation_id_conflict' using errcode = '23505';
+    end if;
+
+    select
+      receipt.actor_user_id,
+      receipt.entity_id,
+      receipt.action_type,
+      receipt.entity_type
+      into
+        v_existing_actor_id,
+        v_existing_line_id,
+        v_existing_action_type,
+        v_existing_entity_type
+    from public.offline_mutation_receipts receipt
+    where receipt.shop_id = v_shop_id
+      and receipt.operation_key = v_operation_key;
+
+    if found and (
+      v_existing_actor_id is distinct from v_profile_id
+      or v_existing_line_id is distinct from p_work_order_line_id
+      or v_existing_action_type is distinct from 'save_story_draft'
+      or v_existing_entity_type is distinct from 'work_order_line'
+    ) then
+      raise exception 'copilot_operation_id_conflict' using errcode = '23505';
+    end if;
+  elsif exists (
+    select 1
+    from public.offline_mutation_receipts receipt
+    where receipt.shop_id = v_shop_id
+      and receipt.operation_key = v_operation_key
+  ) then
+    raise exception 'copilot_operation_id_conflict' using errcode = '23505';
+  end if;
+
+  if v_action <> 'job.story.save' then
+    v_operation_name := case v_action
+      when 'job.start' then 'job_punch:start'
+      when 'job.hold' then 'job_punch:pause'
+      when 'job.release_hold' then 'job_punch:resume'
+      else 'job_punch:finish'
+    end;
+
+    if exists (
+      select 1
+      from public.workforce_operation_keys wok
+      where wok.shop_id = v_shop_id
+        and wok.operation_key = v_operation_key
+        and (
+          wok.operation_name is distinct from v_operation_name
+          or wok.actor_user_id is distinct from p_auth_user_id
+          or wok.work_order_line_id is distinct from p_work_order_line_id
+        )
+    ) then
+      raise exception 'copilot_operation_id_conflict' using errcode = '23505';
+    end if;
+
+    select wok.actor_user_id, wok.work_order_line_id, wok.result
+      into v_existing_actor_id, v_existing_line_id, v_existing_result
+    from public.workforce_operation_keys wok
+    where wok.shop_id = v_shop_id
+      and wok.operation_key = v_operation_key
+      and wok.operation_name = v_operation_name;
+
+    if found then
+      if v_existing_actor_id is distinct from p_auth_user_id
+        or v_existing_line_id is distinct from p_work_order_line_id
+      then
+        raise exception 'copilot_operation_id_conflict' using errcode = '23505';
+      end if;
+      return coalesce(v_existing_result, '{}'::jsonb)
+        || jsonb_build_object(
+          'idempotent', true,
+          'copilotAction', v_action,
+          'workOrderId', v_work_order_id,
+          'workOrderLineId', p_work_order_line_id
+        );
+    end if;
+  end if;
+
+  if v_action = 'job.start' then
+    v_result := public.apply_job_punch_transition_atomic(
+      p_shop_id => v_shop_id,
+      p_work_order_line_id => p_work_order_line_id,
+      p_action => 'start',
+      p_technician_id => v_profile_id,
+      p_actor_user_id => p_auth_user_id,
+      p_operation_key => v_operation_key,
+      p_at => now(),
+      p_start_source => 'technician_copilot'
+    );
+  elsif v_action = 'job.hold' then
+    if nullif(btrim(p_reason), '') is null then
+      raise exception 'copilot_hold_reason_required' using errcode = '22023';
+    end if;
+    v_result := public.apply_job_punch_transition_atomic(
+      p_shop_id => v_shop_id,
+      p_work_order_line_id => p_work_order_line_id,
+      p_action => 'pause',
+      p_technician_id => v_profile_id,
+      p_actor_user_id => p_auth_user_id,
+      p_operation_key => v_operation_key,
+      p_at => now(),
+      p_hold_reason => btrim(p_reason)
+    );
+  elsif v_action = 'job.release_hold' then
+    if v_line_status not in ('on_hold', 'paused', 'waiting_parts') then
+      raise exception 'copilot_job_not_on_hold' using errcode = '55000';
+    end if;
+    v_result := public.apply_job_punch_transition_atomic(
+      p_shop_id => v_shop_id,
+      p_work_order_line_id => p_work_order_line_id,
+      p_action => 'resume',
+      p_technician_id => v_profile_id,
+      p_actor_user_id => p_auth_user_id,
+      p_operation_key => v_operation_key,
+      p_at => now(),
+      p_release_to_awaiting => true
+    );
+  elsif v_action = 'job.complete' then
+    perform 1
+    from public.work_order_line_labor_segments segment
+    where segment.shop_id = v_shop_id
+      and (
+        segment.work_order_line_id = p_work_order_line_id
+        or (segment.technician_id = v_profile_id and segment.ended_at is null)
+      )
+    for update;
+
+    if v_line_status not in ('active', 'in_progress') then
+      raise exception 'copilot_job_not_active' using errcode = '55000';
+    end if;
+    if not exists (
+      select 1
+      from public.work_order_line_labor_segments segment
+      where segment.shop_id = v_shop_id
+        and segment.work_order_line_id = p_work_order_line_id
+        and segment.technician_id = v_profile_id
+        and segment.ended_at is null
+    ) then
+      raise exception 'copilot_job_punch_not_active' using errcode = '55000';
+    end if;
+    if p_expected_line_updated_at is null then
+      raise exception 'copilot_line_version_required' using errcode = '22023';
+    end if;
+    if v_line_updated_at is distinct from p_expected_line_updated_at then
+      raise exception 'copilot_line_version_conflict' using errcode = '55000';
+    end if;
+    if coalesce(nullif(btrim(p_cause), ''), nullif(btrim(v_line_cause), '')) is null then
+      raise exception 'Cause is required before finishing this job.' using errcode = '22023';
+    end if;
+    if coalesce(nullif(btrim(p_correction), ''), nullif(btrim(v_line_correction), '')) is null then
+      raise exception 'Correction is required before finishing this job.' using errcode = '22023';
+    end if;
+
+    v_result := public.apply_job_punch_transition_atomic(
+      p_shop_id => v_shop_id,
+      p_work_order_line_id => p_work_order_line_id,
+      p_action => 'finish',
+      p_technician_id => v_profile_id,
+      p_actor_user_id => p_auth_user_id,
+      p_operation_key => v_operation_key,
+      p_at => now(),
+      p_cause => p_cause,
+      p_correction => p_correction,
+      p_event => 'job_completed_via_technician_copilot',
+      p_details => jsonb_build_object(
+        'source', 'technician_copilot',
+        'repair_session_id', p_session_id
+      )
+    );
+  else
+    if p_expected_line_updated_at is null then
+      raise exception 'copilot_line_version_required' using errcode = '22023';
+    end if;
+    if nullif(btrim(coalesce(p_cause, '')), '') is null
+      and nullif(btrim(coalesce(p_correction, '')), '') is null
+    then
+      raise exception 'copilot_job_story_required' using errcode = '22023';
+    end if;
+
+    v_payload := jsonb_build_object(
+      'lineId', p_work_order_line_id,
+      'cause', coalesce(p_cause, ''),
+      'correction', coalesce(p_correction, ''),
+      'baseUpdatedAt', p_expected_line_updated_at,
+      'source', 'technician_copilot'
+    );
+    v_result := public.apply_offline_line_mutation_atomic(
+      v_shop_id,
+      v_profile_id,
+      v_operation_key,
+      'save_story_draft',
+      p_work_order_line_id,
+      v_payload
+    );
+  end if;
+
+  return coalesce(v_result, '{}'::jsonb) || jsonb_build_object(
+    'copilotAction', v_action,
+    'workOrderId', v_work_order_id,
+    'workOrderLineId', p_work_order_line_id
+  );
+end;
+$$;
+
+revoke all on function copilot.technician_job_action_internal(
+  uuid,
+  uuid,
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  text,
+  timestamptz
+) from public, anon, authenticated, service_role;
+
+comment on function copilot.technician_job_action_internal(
+  uuid,
+  uuid,
+  uuid,
+  text,
+  uuid,
+  text,
+  text,
+  text,
+  timestamptz
+) is
+  'Private assigned-technician bridge to canonical job punch, completion, and story mutation functions.';
+
+do $technician_copilot_job_completion_postcheck$
+declare
+  v_definition text;
+begin
+  select pg_get_functiondef(
+    'copilot.technician_job_action_internal(uuid,uuid,uuid,text,uuid,text,text,text,timestamptz)'::regprocedure
+  ) into v_definition;
+
+  if v_definition is null
+    or position('''job.complete''' in v_definition) = 0
+    or position('p_action => ''finish''' in v_definition) = 0
+    or position('copilot_line_version_conflict' in v_definition) = 0
+    or position('copilot_job_punch_not_active' in v_definition) = 0
+    or position('apply_job_punch_transition_atomic' in v_definition) = 0
+  then
+    raise exception 'Technician CoPilot canonical job completion is incomplete';
+  end if;
+
+  if has_function_privilege(
+    'authenticated',
+    'copilot.technician_job_action_internal(uuid,uuid,uuid,text,uuid,text,text,text,timestamptz)',
+    'EXECUTE'
+  ) or has_function_privilege(
+    'service_role',
+    'copilot.technician_job_action_internal(uuid,uuid,uuid,text,uuid,text,text,text,timestamptz)',
+    'EXECUTE'
+  ) then
+    raise exception 'Technician CoPilot private job completion has an unsafe direct grant';
+  end if;
+end
+$technician_copilot_job_completion_postcheck$;
+
+
+create or replace function copilot.technician_session_read_internal(
+  p_auth_user_id uuid,
+  p_session_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_profile_id uuid;
+  v_session copilot.repair_sessions%rowtype;
+  v_events jsonb;
+  v_documentation_turns jsonb;
+  v_explicit boolean := p_session_id is not null;
+begin
+  v_profile_id := copilot.technician_profile_id(p_auth_user_id);
+
+  if not v_explicit then
+    select rs.*
+      into v_session
+    from copilot.repair_sessions rs
+    where rs.technician_id = v_profile_id
+      and rs.status = 'active'
+      and copilot.technician_is_assigned(
+        p_auth_user_id,
+        v_profile_id,
+        rs.shop_id,
+        rs.work_order_id,
+        null
+      )
+    order by rs.last_activity_at desc
+    limit 1;
+  else
+    select rs.*
+      into v_session
+    from copilot.repair_sessions rs
+    where rs.id = p_session_id
+      and rs.technician_id = v_profile_id;
+  end if;
+
+  if not found then
+    return jsonb_build_object(
+      'session', null,
+      'events', '[]'::jsonb,
+      'documentationTurns', '[]'::jsonb
+    );
+  end if;
+
+  if v_explicit
+    and v_session.status <> 'closed'
+    and not copilot.technician_is_assigned(
+      p_auth_user_id,
+      v_profile_id,
+      v_session.shop_id,
+      v_session.work_order_id,
+      null
+    )
+    and not copilot.technician_has_bound_completion_receipt(
+      p_auth_user_id,
+      v_session.id,
+      null
+    )
+  then
+    raise exception 'copilot_work_order_assignment_required'
+      using errcode = '42501';
+  end if;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', e.id,
+        'repairSessionId', e.repair_session_id,
+        'eventSeq', e.event_seq,
+        'eventType', e.event_type,
+        'source', c.origin,
+        'payload', c.details,
+        'operationId', c.operation_id,
+        'occurredAt', e.occurred_at
+      )
+      order by e.event_seq
+    ),
+    '[]'::jsonb
+  )
+    into v_events
+  from copilot.repair_session_events e
+  join copilot.repair_session_event_context c
+    on c.event_id = e.id
+  where e.repair_session_id = v_session.id;
+
+  select coalesce(
+    jsonb_agg(dt.source_turn_id order by dt.created_at, dt.id),
+    '[]'::jsonb
+  )
+    into v_documentation_turns
+  from copilot.repair_session_documentation_turns dt
+  where dt.session_id = v_session.id;
+
+  return jsonb_build_object(
+    'session',
+    jsonb_build_object(
+      'id', v_session.id,
+      'shopId', v_session.shop_id,
+      'technicianId', v_session.technician_id,
+      'workOrderId', v_session.work_order_id,
+      'activeWorkOrderLineId', v_session.active_work_order_line_id,
+      'vehicleId', v_session.vehicle_id,
+      'serviceVisitId', v_session.service_visit_id,
+      'mode', v_session.mode,
+      'status', v_session.status,
+      'currentTask', v_session.current_task,
+      'contextVersion', v_session.context_version,
+      'lastEventSeq', v_session.last_event_seq,
+      'startedAt', v_session.started_at,
+      'lastActivityAt', v_session.last_activity_at,
+      'endedAt', v_session.ended_at
+    ),
+    'events', v_events,
+    'documentationTurns', v_documentation_turns
+  );
+end;
+$$;
+
+create or replace function copilot.technician_event_append_internal(
+  p_auth_user_id uuid,
+  p_session_id uuid,
+  p_event_type text,
+  p_origin text,
+  p_operation_id uuid,
+  p_details jsonb,
+  p_occurred_at timestamptz
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_profile_id uuid;
+  v_shop_id uuid;
+  v_work_order_id uuid;
+  v_result jsonb;
+begin
+  if p_event_type not in (
+    'conversation.user',
+    'conversation.assistant',
+    'task.changed',
+    'complaint.recorded',
+    'observation.recorded',
+    'measurement.recorded',
+    'dtc.observed',
+    'diagnostic.finding',
+    'evidence.attached',
+    'component.removed',
+    'component.installed',
+    'component.disconnected',
+    'component.connected',
+    'fluid.drained',
+    'fluid.filled',
+    'action.pending',
+    'action.completed'
+  ) then
+    raise exception 'copilot_event_type_not_allowed' using errcode = '22023';
+  end if;
+
+  if p_origin not in (
+    'voice',
+    'ui',
+    'system',
+    'offline',
+    'integration',
+    'copilot'
+  ) then
+    raise exception 'copilot_event_origin_not_allowed' using errcode = '22023';
+  end if;
+
+  if p_details is null
+    or jsonb_typeof(p_details) <> 'object'
+    or octet_length(p_details::text) > 262144
+  then
+    raise exception 'copilot_event_details_invalid' using errcode = '22023';
+  end if;
+
+  v_profile_id := copilot.technician_profile_id(p_auth_user_id);
+
+  select rs.shop_id, rs.work_order_id
+    into v_shop_id, v_work_order_id
+  from copilot.repair_sessions rs
+  where rs.id = p_session_id
+    and rs.technician_id = v_profile_id
+    and rs.status = 'active';
+
+  if not found then
+    raise exception 'copilot_session_not_active' using errcode = '55000';
+  end if;
+
+  if not copilot.technician_is_assigned(
+    p_auth_user_id,
+    v_profile_id,
+    v_shop_id,
+    v_work_order_id,
+    null
+  ) and not (
+    p_event_type in ('action.completed', 'conversation.assistant')
+    and copilot.technician_has_bound_completion_receipt(
+      p_auth_user_id,
+      p_session_id,
+      nullif(btrim(p_details ->> 'turnId'), '')
+    )
+  ) then
+    raise exception 'copilot_work_order_assignment_required'
+      using errcode = '42501';
+  end if;
+
+  v_result := copilot.append_repair_event_internal(
+    p_session_id,
+    v_shop_id,
+    v_profile_id,
+    p_event_type,
+    p_origin,
+    p_operation_id,
+    p_details,
+    coalesce(p_occurred_at, now())
+  );
+
+  if coalesce((v_result ->> 'replayed')::boolean, false) = false
+    and p_event_type = 'task.changed'
+  then
+    update copilot.repair_sessions
+    set current_task = nullif(btrim(p_details ->> 'task'), ''),
+        updated_at = now()
+    where id = p_session_id;
+  end if;
+
+  return v_result;
+end;
+$$;
+
+create or replace function copilot.technician_session_close_internal(
+  p_auth_user_id uuid,
+  p_session_id uuid,
+  p_operation_id uuid,
+  p_reason text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_profile_id uuid;
+  v_session copilot.repair_sessions%rowtype;
+  v_existing_session_id uuid;
+  v_event jsonb;
+begin
+  if p_operation_id is null then
+    raise exception 'copilot_operation_id_required' using errcode = '22023';
+  end if;
+
+  v_profile_id := copilot.technician_profile_id(p_auth_user_id);
+  perform pg_advisory_xact_lock(
+    hashtextextended('copilot:technician:' || v_profile_id::text, 0)
+  );
+
+  select rs.*
+    into v_session
+  from copilot.repair_sessions rs
+  where rs.id = p_session_id
+    and rs.technician_id = v_profile_id
+  for update;
+
+  if not found then
+    raise exception 'copilot_session_not_found' using errcode = 'P0001';
+  end if;
+
+  select e.repair_session_id
+    into v_existing_session_id
+  from copilot.repair_session_event_context c
+  join copilot.repair_session_events e on e.id = c.event_id
+  where c.operation_id = p_operation_id;
+
+  if found then
+    if v_existing_session_id is distinct from p_session_id then
+      raise exception 'copilot_operation_id_conflict' using errcode = '23505';
+    end if;
+    return jsonb_build_object(
+      'sessionId', p_session_id,
+      'status', v_session.status,
+      'replayed', true
+    );
+  end if;
+
+  if v_session.status = 'closed' then
+    return jsonb_build_object(
+      'sessionId', p_session_id,
+      'status', 'closed',
+      'replayed', true
+    );
+  end if;
+
+  if v_session.status <> 'active' then
+    raise exception 'copilot_session_not_active' using errcode = '55000';
+  end if;
+
+  if not copilot.technician_is_assigned(
+    p_auth_user_id,
+    v_profile_id,
+    v_session.shop_id,
+    v_session.work_order_id,
+    null
+  ) and not copilot.technician_has_bound_completion_receipt(
+    p_auth_user_id,
+    p_session_id,
+    null
+  ) then
+    raise exception 'copilot_work_order_assignment_required'
+      using errcode = '42501';
+  end if;
+
+  v_event := copilot.append_repair_event_internal(
+    p_session_id,
+    v_session.shop_id,
+    v_profile_id,
+    'session.closed',
+    'system',
+    p_operation_id,
+    jsonb_build_object(
+      'reason',
+      coalesce(nullif(btrim(p_reason), ''), 'completed')
+    ),
+    now()
+  );
+
+  update copilot.repair_sessions
+  set status = 'closed',
+      active_work_order_line_id = null,
+      ended_at = now(),
+      updated_at = now()
+  where id = p_session_id;
+
+  return jsonb_build_object(
+    'sessionId', p_session_id,
+    'status', 'closed',
+    'replayed', coalesce((v_event ->> 'replayed')::boolean, false)
+  );
+end;
+$$;
+
+create or replace function copilot.process_ai_action_command()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_auth_user_id uuid;
+  v_profile_id uuid;
+  v_profile_shop_id uuid;
+  v_action text;
+  v_result jsonb;
+begin
+  v_auth_user_id := (new.payload ->> 'authUserId')::uuid;
+  v_profile_id := copilot.technician_profile_id(v_auth_user_id);
+  select p.shop_id
+    into v_profile_shop_id
+  from public.profiles p
+  where p.id = v_profile_id;
+
+  if new.shop_id <> v_profile_shop_id
+    or new.actor_id is distinct from v_profile_id
+  then
+    raise exception 'copilot_command_identity_mismatch'
+      using errcode = '42501';
+  end if;
+
+  v_action := new.payload ->> 'action';
+  begin
+    case v_action
+      when 'session.read' then
+        v_result := copilot.technician_session_read_internal(
+          v_auth_user_id,
+          nullif(new.payload ->> 'sessionId', '')::uuid
+        );
+      when 'session.close' then
+        v_result := copilot.technician_session_close_internal(
+          v_auth_user_id,
+          (new.payload ->> 'sessionId')::uuid,
+          (new.payload ->> 'operationId')::uuid,
+          nullif(new.payload ->> 'reason', '')
+        );
+      when 'session.start' then
+        v_result := copilot.technician_session_start_internal(
+          v_auth_user_id,
+          (new.payload ->> 'workOrderId')::uuid,
+          nullif(new.payload ->> 'workOrderLineId', '')::uuid,
+          coalesce(nullif(new.payload ->> 'mode', ''), 'shop'),
+          (new.payload ->> 'operationId')::uuid
+        );
+      when 'event.append' then
+        v_result := copilot.technician_event_append_internal(
+          v_auth_user_id,
+          (new.payload ->> 'sessionId')::uuid,
+          new.payload ->> 'eventType',
+          coalesce(nullif(new.payload ->> 'origin', ''), 'ui'),
+          (new.payload ->> 'operationId')::uuid,
+          coalesce(new.payload -> 'details', '{}'::jsonb),
+          coalesce(
+            nullif(new.payload ->> 'occurredAt', '')::timestamptz,
+            now()
+          )
+        );
+      when 'documentation.append' then
+        v_result := copilot.technician_documentation_append_internal(
+          v_auth_user_id,
+          (new.payload ->> 'sessionId')::uuid,
+          new.payload ->> 'sourceTurnId',
+          (new.payload ->> 'operationId')::uuid,
+          coalesce(new.payload -> 'events', '[]'::jsonb),
+          coalesce(
+            nullif(new.payload ->> 'occurredAt', '')::timestamptz,
+            now()
+          )
+        );
+      when 'job.action' then
+        v_result := copilot.technician_job_action_internal(
+          v_auth_user_id,
+          (new.payload ->> 'sessionId')::uuid,
+          (new.payload ->> 'workOrderLineId')::uuid,
+          new.payload ->> 'jobAction',
+          (new.payload ->> 'operationId')::uuid,
+          nullif(new.payload ->> 'reason', ''),
+          new.payload ->> 'cause',
+          new.payload ->> 'correction',
+          nullif(new.payload ->> 'expectedLineUpdatedAt', '')::timestamptz
+        );
+      else
+        raise exception 'copilot_command_not_allowed'
+          using errcode = '22023';
+    end case;
+
+    new.metadata := coalesce(new.metadata, '{}'::jsonb)
+      || jsonb_build_object(
+        'copilotCommandResult', v_result,
+        'copilotCommandError', null
+      );
+  exception when others then
+    new.metadata := coalesce(new.metadata, '{}'::jsonb)
+      || jsonb_build_object(
+        'copilotCommandResult', null,
+        'copilotCommandError', jsonb_build_object(
+          'code', sqlstate,
+          'message', sqlerrm
+        )
+      );
+  end;
+
+  return new;
+end;
+$$;
+
+revoke all on function copilot.technician_has_bound_completion_receipt(
+  uuid, uuid, text
+) from public, anon, authenticated, service_role;
+revoke all on function copilot.technician_session_read_internal(
+  uuid, uuid
+) from public, anon, authenticated, service_role;
+revoke all on function copilot.technician_event_append_internal(
+  uuid, uuid, text, text, uuid, jsonb, timestamptz
+) from public, anon, authenticated, service_role;
+revoke all on function copilot.technician_session_close_internal(
+  uuid, uuid, uuid, text
+) from public, anon, authenticated, service_role;
+
+comment on function copilot.technician_session_close_internal(
+  uuid, uuid, uuid, text
+) is
+  'Closes one owned active repair session after assignment ends only when a bound canonical completion receipt exists.';
+
+do $technician_completion_integrity_postcheck$
+declare
+  v_finish_definition text;
+  v_action_definition text;
+  v_read_definition text;
+  v_event_definition text;
+  v_close_definition text;
+  v_command_definition text;
+begin
+  select pg_get_functiondef(
+    'public.apply_job_punch_transition_atomic(uuid,uuid,text,uuid,uuid,text,boolean,timestamptz,text,text,text,boolean,boolean,text,text,text,jsonb)'::regprocedure
+  ) into v_finish_definition;
+  select pg_get_functiondef(
+    'copilot.technician_job_action_internal(uuid,uuid,uuid,text,uuid,text,text,text,timestamptz)'::regprocedure
+  ) into v_action_definition;
+  select pg_get_functiondef(
+    'copilot.technician_session_read_internal(uuid,uuid)'::regprocedure
+  ) into v_read_definition;
+  select pg_get_functiondef(
+    'copilot.technician_event_append_internal(uuid,uuid,text,text,uuid,jsonb,timestamptz)'::regprocedure
+  ) into v_event_definition;
+  select pg_get_functiondef(
+    'copilot.technician_session_close_internal(uuid,uuid,uuid,text)'::regprocedure
+  ) into v_close_definition;
+  select pg_get_functiondef(
+    'copilot.process_ai_action_command()'::regprocedure
+  ) into v_command_definition;
+
+  if position('INSPECTION_COMPLETION_REQUIRED' in v_finish_definition) = 0
+    or position('update public.inspections' in v_finish_definition) > 0
+    or position('v_actor_auth_user_id' in v_finish_definition) = 0
+    or position('p_actor_user_id => p_auth_user_id' in v_action_definition) = 0
+    or position('technician_has_bound_completion_receipt' in v_read_definition) = 0
+    or position('technician_has_bound_completion_receipt' in v_event_definition) = 0
+    or position('session.closed' in v_close_definition) = 0
+    or position('when ''session.close''' in v_command_definition) = 0
+  then
+    raise exception 'Technician completion-integrity runtime is incomplete';
+  end if;
+
+  if has_function_privilege(
+    'authenticated',
+    'copilot.technician_session_close_internal(uuid,uuid,uuid,text)',
+    'EXECUTE'
+  ) or has_function_privilege(
+    'service_role',
+    'copilot.technician_session_close_internal(uuid,uuid,uuid,text)',
+    'EXECUTE'
+  ) then
+    raise exception 'Technician completion session close has an unsafe direct grant';
+  end if;
+end
+$technician_completion_integrity_postcheck$;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/menu-repair-completed-lifecycle.test.ts
+++ b/tests/menu-repair-completed-lifecycle.test.ts
@@ -117,6 +117,9 @@ describe("completed repair memory", () => {
 
   it("keeps completion authoritative and repair learning fail-open", () => {
     const finishRoute = read("app/api/work-orders/lines/[id]/finish/route.ts");
+    const completionService = read(
+      "features/work-orders/server/completeWorkOrderLine.ts",
+    );
     const completedHelper = read(
       "features/menu-repair-items/server/upsertMenuRepairItemFromCompletedLine.ts",
     );
@@ -124,10 +127,13 @@ describe("completed repair memory", () => {
       "app/api/work-orders/quotes/add-from-menu-repair/route.ts",
     );
 
-    expect(finishRoute.indexOf("await applyJobPunchTransition")).toBeLessThan(
-      finishRoute.indexOf("await upsertMenuRepairItemFromCompletedLine"),
+    expect(finishRoute).toContain("await completeWorkOrderLine");
+    expect(
+      completionService.indexOf("await applyJobPunchTransition"),
+    ).toBeLessThan(
+      completionService.indexOf("await learnFromCompletedWorkOrderLine"),
     );
-    expect(finishRoute).toContain("completed repair memory update failed");
+    expect(completionService).toContain("completed repair memory update failed");
     expect(completedHelper).toContain('.from("work_order_parts")');
     expect(completedHelper).toContain('.from("menu_repair_item_pricing_parts")');
     expect(completedHelper).toContain("completedNetQuantity");

--- a/tests/phase5-quote-lifecycle-routes.test.ts
+++ b/tests/phase5-quote-lifecycle-routes.test.ts
@@ -21,6 +21,9 @@ const readiness = read(
 const finishRoute = read(
   "app/api/work-orders/lines/[id]/finish/route.ts",
 );
+const completionService = read(
+  "features/work-orders/server/completeWorkOrderLine.ts",
+);
 const partsQuotingPage = read("app/parts/quoting/page.tsx");
 const legacyMenuCaptureRoute = read(
   "app/api/menu-items/upsert-from-line/route.ts",
@@ -61,9 +64,10 @@ describe("Phase 5 route and helper contract", () => {
     );
     expect(legacyMenuCaptureRoute).not.toContain('.from("menu_items")');
 
-    const finishCall = finishRoute.indexOf("await applyJobPunchTransition");
-    const learningCall = finishRoute.indexOf(
-      "await upsertMenuRepairItemFromCompletedLine",
+    expect(finishRoute).toContain("await completeWorkOrderLine");
+    const finishCall = completionService.indexOf("await applyJobPunchTransition");
+    const learningCall = completionService.indexOf(
+      "await learnFromCompletedWorkOrderLine",
     );
     expect(finishCall).toBeGreaterThan(-1);
     expect(learningCall).toBeGreaterThan(finishCall);

--- a/tests/security/technician-copilot-runtime-integrity.runtime.sql
+++ b/tests/security/technician-copilot-runtime-integrity.runtime.sql
@@ -13,6 +13,11 @@ values
     'a1438000-0000-4000-8000-000000000002',
     'copilot-runtime-tech@example.com',
     '{"full_name":"CoPilot Runtime Technician"}'::jsonb
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000003',
+    'copilot-runtime-split-tech@example.com',
+    '{"full_name":"CoPilot Split Identity Technician"}'::jsonb
   )
 on conflict (id) do nothing;
 
@@ -29,6 +34,12 @@ values
     'a1438000-0000-4000-8000-000000000002',
     'mechanic',
     'CoPilot Runtime Technician'
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000004',
+    'a1438000-0000-4000-8000-000000000003',
+    'mechanic',
+    'CoPilot Split Identity Technician'
   )
 on conflict (id) do update
 set user_id = excluded.user_id,
@@ -57,7 +68,8 @@ update public.profiles
 set shop_id = 'a1438000-0000-4000-8000-000000000010'
 where id in (
   'a1438000-0000-4000-8000-000000000001',
-  'a1438000-0000-4000-8000-000000000002'
+  'a1438000-0000-4000-8000-000000000002',
+  'a1438000-0000-4000-8000-000000000004'
 );
 
 insert into public.work_orders (id, shop_id, status, custom_id)
@@ -79,6 +91,12 @@ values
     'a1438000-0000-4000-8000-000000000010',
     'completed',
     'COPILOT-RT-TERMINAL'
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000104',
+    'a1438000-0000-4000-8000-000000000010',
+    'in_progress',
+    'COPILOT-RT-SPLIT-ID'
   ),
   (
     'a1438000-0000-4000-8000-000000000105',
@@ -148,6 +166,16 @@ values
     null,
     null,
     'Runtime cross-tenant guard'
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000209',
+    'a1438000-0000-4000-8000-000000000104',
+    'a1438000-0000-4000-8000-000000000010',
+    'job',
+    'awaiting',
+    'a1438000-0000-4000-8000-000000000004',
+    'a1438000-0000-4000-8000-000000000004',
+    'Runtime split-identity completion'
   )
 on conflict (id) do nothing;
 
@@ -160,15 +188,25 @@ insert into public.tech_shifts (
   start_time,
   end_time
 )
-values (
-  'a1438000-0000-4000-8000-000000000206',
-  'a1438000-0000-4000-8000-000000000010',
-  'a1438000-0000-4000-8000-000000000002',
-  'active',
-  'shift',
-  now() - interval '1 hour',
-  null
-)
+values
+  (
+    'a1438000-0000-4000-8000-000000000206',
+    'a1438000-0000-4000-8000-000000000010',
+    'a1438000-0000-4000-8000-000000000002',
+    'active',
+    'shift',
+    now() - interval '1 hour',
+    null
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000207',
+    'a1438000-0000-4000-8000-000000000010',
+    'a1438000-0000-4000-8000-000000000004',
+    'active',
+    'shift',
+    now() - interval '1 hour',
+    null
+  )
 on conflict (id) do nothing;
 
 -- The existing line-status refresh trigger recalculates a parent work order
@@ -393,6 +431,8 @@ declare
   v_story_replay jsonb;
   v_complete jsonb;
   v_complete_replay jsonb;
+  v_close jsonb;
+  v_closed_read jsonb;
   v_line_updated_at timestamptz;
 begin
   select rs.id
@@ -695,6 +735,113 @@ begin
     end if;
   end;
 
+  insert into public.inspections (
+    id,
+    shop_id,
+    work_order_id,
+    work_order_line_id,
+    status,
+    completed,
+    is_draft,
+    locked,
+    signing_cycle
+  ) values (
+    'a1438000-0000-4000-8000-000000000220',
+    'a1438000-0000-4000-8000-000000000010',
+    'a1438000-0000-4000-8000-000000000102',
+    'a1438000-0000-4000-8000-000000000202',
+    'draft',
+    false,
+    true,
+    false,
+    0
+  );
+
+  begin
+    perform copilot.technician_job_action_internal(
+      'a1438000-0000-4000-8000-000000000002',
+      v_active_session_id,
+      'a1438000-0000-4000-8000-000000000202',
+      'job.complete',
+      'a1438000-0000-5000-a000-000000000413',
+      null,
+      'Confirmed seized inner pad',
+      'Clean and lubricate bracket',
+      v_line_updated_at
+    );
+    raise exception 'CoPilot job-completion assertion failed: unsigned inspection was finalized';
+  exception when sqlstate 'P0001' then
+    if position('INSPECTION_COMPLETION_REQUIRED' in sqlerrm) = 0 then
+      raise;
+    end if;
+  end;
+
+  if not exists (
+    select 1
+    from public.inspections i
+    where i.id = 'a1438000-0000-4000-8000-000000000220'
+      and not coalesce(i.completed, false)
+      and coalesce(i.is_draft, true)
+      and not coalesce(i.locked, false)
+      and i.finalized_at is null
+      and i.finalized_by is null
+  ) or not exists (
+    select 1
+    from public.work_order_line_labor_segments segment
+    where segment.work_order_line_id = 'a1438000-0000-4000-8000-000000000202'
+      and segment.technician_id = 'a1438000-0000-4000-8000-000000000002'
+      and segment.ended_at is null
+  ) then
+    raise exception 'CoPilot job-completion assertion failed: draft inspection rejection mutated completion state';
+  end if;
+
+  perform set_config('profixiq.inspection_sign', 'on', true);
+  update public.inspections
+  set status = 'completed',
+      completed = true,
+      is_draft = false,
+      locked = true,
+      finalized_at = now(),
+      finalized_by = 'a1438000-0000-4000-8000-000000000002'
+  where id = 'a1438000-0000-4000-8000-000000000220';
+  perform set_config('profixiq.inspection_sign', 'off', true);
+
+  insert into public.inspection_signatures (
+    id,
+    inspection_id,
+    role,
+    signed_by,
+    signed_name,
+    signing_cycle,
+    signed_at
+  ) values (
+    'a1438000-0000-4000-8000-000000000221',
+    'a1438000-0000-4000-8000-000000000220',
+    'technician',
+    'a1438000-0000-4000-8000-000000000002',
+    'CoPilot Runtime Technician',
+    0,
+    now()
+  );
+
+  perform copilot.technician_event_append_internal(
+    'a1438000-0000-4000-8000-000000000002',
+    v_active_session_id,
+    'action.pending',
+    'system',
+    'a1438000-0000-5000-a000-000000000414',
+    jsonb_build_object(
+      'action', 'job.complete',
+      'key', 'a1438000-0000-5000-a000-000000000412',
+      'turnId', 'runtime-complete-turn',
+      'request', jsonb_build_object('type', 'job.complete'),
+      'workOrderId', 'a1438000-0000-4000-8000-000000000102',
+      'workOrderLineId', 'a1438000-0000-4000-8000-000000000202',
+      'lineUpdatedAt', v_line_updated_at
+    ),
+    now()
+  );
+
   v_complete := copilot.technician_job_action_internal(
     'a1438000-0000-4000-8000-000000000002',
     v_active_session_id,
@@ -739,8 +886,123 @@ begin
   then
     raise exception 'CoPilot job-completion assertion failed: completion or replay was incoherent';
   end if;
+
+  perform copilot.technician_event_append_internal(
+    'a1438000-0000-4000-8000-000000000002',
+    v_active_session_id,
+    'action.completed',
+    'system',
+    'a1438000-0000-5000-a000-000000000415',
+    jsonb_build_object(
+      'action', 'Completed job',
+      'key', 'a1438000-0000-5000-a000-000000000412',
+      'turnId', 'runtime-complete-turn',
+      'ok', true,
+      'reply', 'Completed runtime job.',
+      'tool', 'job.complete',
+      'workOrderId', 'a1438000-0000-4000-8000-000000000102',
+      'workOrderLineId', 'a1438000-0000-4000-8000-000000000202'
+    ),
+    now()
+  );
+
+  v_close := copilot.technician_session_close_internal(
+    'a1438000-0000-4000-8000-000000000002',
+    v_active_session_id,
+    'a1438000-0000-5000-a000-000000000416',
+    'completed_last_actionable_line'
+  );
+  v_closed_read := copilot.technician_session_read_internal(
+    'a1438000-0000-4000-8000-000000000002',
+    v_active_session_id
+  );
+
+  if v_close ->> 'status' <> 'closed'
+    or v_closed_read #>> '{session,status}' <> 'closed'
+    or not exists (
+      select 1
+      from copilot.repair_session_events event
+      where event.repair_session_id = v_active_session_id
+        and event.event_type = 'session.closed'
+    )
+  then
+    raise exception 'CoPilot job-completion assertion failed: completed repair session did not close durably';
+  end if;
 end
 $technician_copilot_job_actions$;
+
+do $technician_copilot_split_identity_completion$
+declare
+  v_session_id uuid;
+  v_line_updated_at timestamptz;
+begin
+  v_session_id := (
+    copilot.technician_session_start_internal(
+      'a1438000-0000-4000-8000-000000000003',
+      'a1438000-0000-4000-8000-000000000104',
+      'a1438000-0000-4000-8000-000000000209',
+      'shop',
+      'a1438000-0000-5000-a000-000000000420'
+    ) ->> 'sessionId'
+  )::uuid;
+
+  perform copilot.technician_job_action_internal(
+    'a1438000-0000-4000-8000-000000000003',
+    v_session_id,
+    'a1438000-0000-4000-8000-000000000209',
+    'job.start',
+    'a1438000-0000-5000-a000-000000000421'
+  );
+
+  update public.work_order_lines
+  set labor_time = 1.0,
+      cause = 'Split identity cause',
+      correction = 'Split identity correction',
+      updated_at = now()
+  where id = 'a1438000-0000-4000-8000-000000000209'
+  returning updated_at into v_line_updated_at;
+
+  perform copilot.technician_job_action_internal(
+    'a1438000-0000-4000-8000-000000000003',
+    v_session_id,
+    'a1438000-0000-4000-8000-000000000209',
+    'job.complete',
+    'a1438000-0000-5000-a000-000000000422',
+    null,
+    'Split identity cause',
+    'Split identity correction',
+    v_line_updated_at
+  );
+
+  if not exists (
+    select 1
+    from public.work_order_lines wol
+    where wol.id = 'a1438000-0000-4000-8000-000000000209'
+      and lower(wol.status::text) = 'completed'
+  ) or not exists (
+    select 1
+    from public.work_order_line_labor_segments segment
+    where segment.work_order_line_id = 'a1438000-0000-4000-8000-000000000209'
+      and segment.technician_id = 'a1438000-0000-4000-8000-000000000004'
+      and segment.created_by = 'a1438000-0000-4000-8000-000000000004'
+      and segment.ended_at is not null
+  ) or not exists (
+    select 1
+    from public.workforce_operation_keys receipt
+    where receipt.operation_key =
+      'technician-copilot:a1438000-0000-5000-a000-000000000422'
+      and receipt.actor_user_id = 'a1438000-0000-4000-8000-000000000003'
+      and receipt.work_order_line_id = 'a1438000-0000-4000-8000-000000000209'
+  ) or not exists (
+    select 1
+    from public.activity_logs log
+    where log.target_id = 'a1438000-0000-4000-8000-000000000209'
+      and log.user_id = 'a1438000-0000-4000-8000-000000000003'
+  ) then
+    raise exception 'CoPilot split-identity assertion failed: auth/profile ownership was conflated';
+  end if;
+end
+$technician_copilot_split_identity_completion$;
 
 do $technician_copilot_runtime_schema$
 begin

--- a/tests/security/technician-copilot-runtime-integrity.runtime.sql
+++ b/tests/security/technician-copilot-runtime-integrity.runtime.sql
@@ -51,6 +51,12 @@ set user_id = excluded.user_id,
     role = excluded.role,
     full_name = excluded.full_name;
 
+-- The legacy before-insert trigger initially mirrors profiles.id into user_id.
+-- Re-link this imported-style profile after insert to exercise split identity.
+update public.profiles
+set user_id = 'a1438000-0000-4000-8000-000000000003'
+where id = 'a1438000-0000-4000-8000-000000000004';
+
 insert into public.shops (id, owner_id, business_name, name, user_limit)
 values
   (
@@ -181,6 +187,16 @@ values
     'a1438000-0000-4000-8000-000000000004',
     'a1438000-0000-4000-8000-000000000004',
     'Runtime split-identity completion'
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000210',
+    'a1438000-0000-4000-8000-000000000104',
+    'a1438000-0000-4000-8000-000000000010',
+    'job',
+    'awaiting',
+    null,
+    null,
+    'Runtime split-identity sibling'
   )
 on conflict (id) do nothing;
 

--- a/tests/security/technician-copilot-runtime-integrity.runtime.sql
+++ b/tests/security/technician-copilot-runtime-integrity.runtime.sql
@@ -18,6 +18,11 @@ values
     'a1438000-0000-4000-8000-000000000003',
     'copilot-runtime-split-tech@example.com',
     '{"full_name":"CoPilot Split Identity Technician"}'::jsonb
+  ),
+  (
+    'a1438000-0000-4000-8000-000000000004',
+    'copilot-runtime-split-profile@example.com',
+    '{"full_name":"CoPilot Split Identity Profile Anchor"}'::jsonb
   )
 on conflict (id) do nothing;
 

--- a/tests/technician-completion-integrity.test.ts
+++ b/tests/technician-completion-integrity.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260815232321_technician_completion_integrity.sql",
+  "utf8",
+);
+const chat = readFileSync(
+  "features/copilot/technician/server/chat.ts",
+  "utf8",
+);
+const actions = readFileSync(
+  "features/copilot/technician/server/actions.ts",
+  "utf8",
+);
+const completionService = readFileSync(
+  "features/work-orders/server/completeWorkOrderLine.ts",
+  "utf8",
+);
+const copilotClient = readFileSync(
+  "features/copilot/technician/components/TechnicianTextCopilot.tsx",
+  "utf8",
+);
+
+function section(start: string, end: string): string {
+  const startIndex = migration.indexOf(start);
+  const endIndex = migration.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    throw new Error(`Missing migration section: ${start}`);
+  }
+  return migration.slice(startIndex, endIndex);
+}
+
+describe("technician completion integrity", () => {
+  it("keeps auth-owned receipts separate from profile-owned labor", () => {
+    const finish = section(
+      "create or replace function public.apply_job_punch_transition_atomic(",
+      "create or replace function copilot.technician_job_action_internal(",
+    );
+    expect(finish).toContain("v_technician_profile_id");
+    expect(finish).toContain("v_actor_profile_id");
+    expect(finish).toContain("v_actor_auth_user_id");
+    expect(finish).toContain(
+      "p_shop_id, 'job_punch:' || v_action, p_operation_key, v_actor_auth_user_id",
+    );
+    expect(finish).toContain("v_actor_profile_id, v_now");
+    expect(migration).toContain("p_actor_user_id => p_auth_user_id");
+  });
+
+  it("requires explicit current-cycle inspection evidence without signing it", () => {
+    const finish = section(
+      "create or replace function public.apply_job_punch_transition_atomic(",
+      "create or replace function copilot.technician_job_action_internal(",
+    );
+    expect(finish).toContain("INSPECTION_COMPLETION_REQUIRED");
+    expect(finish).toContain("from public.inspection_signatures s");
+    expect(finish).not.toContain("update public.inspections");
+  });
+
+  it("recovers only receipt-bound completion turns and settles the session", () => {
+    expect(migration).toContain(
+      "copilot.technician_has_bound_completion_receipt(",
+    );
+    expect(migration).toContain("wok.operation_name = 'job_punch:finish'");
+    expect(migration).toContain("when 'session.close' then");
+    expect(migration).toContain(
+      ") from public, anon, authenticated, service_role;",
+    );
+    expect(chat.indexOf("storedActionTurn(envelope.events")).toBeLessThan(
+      chat.indexOf("technician_copilot_work_not_actionable"),
+    );
+    expect(chat).toContain("completion-session-reanchor");
+    expect(chat).toContain("completion-session-close");
+    expect(copilotClient).toContain(
+      'Object.prototype.hasOwnProperty.call(body, "session")',
+    );
+  });
+
+  it("uses the same fail-open repair-learning hook for screen and voice completion", () => {
+    expect(completionService).toContain("learnFromCompletedWorkOrderLine");
+    expect(completionService).toContain("await applyJobPunchTransition");
+    expect(actions).toContain("await learnFromCompletedWorkOrderLine");
+  });
+});

--- a/tests/technician-copilot-job-actions.test.ts
+++ b/tests/technician-copilot-job-actions.test.ts
@@ -4,10 +4,15 @@ import type { TechnicianWorkCandidate } from "@/features/copilot/technician/serv
 
 const mocks = vi.hoisted(() => ({
   sendCopilotServerCommand: vi.fn(),
+  learnFromCompletedWorkOrderLine: vi.fn(),
 }));
 
 vi.mock("@/features/copilot/technician/server/transport", () => ({
   sendCopilotServerCommand: mocks.sendCopilotServerCommand,
+}));
+
+vi.mock("@/features/work-orders/server/completeWorkOrderLine", () => ({
+  learnFromCompletedWorkOrderLine: mocks.learnFromCompletedWorkOrderLine,
 }));
 
 import {
@@ -64,6 +69,7 @@ describe("Technician CoPilot canonical job actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.sendCopilotServerCommand.mockResolvedValue({ ok: true });
+    mocks.learnFromCompletedWorkOrderLine.mockResolvedValue({ ok: true });
   });
 
   it("answers what's next from assigned line state without claiming or mutating work", () => {
@@ -187,6 +193,7 @@ describe("Technician CoPilot canonical job actions", () => {
       authUserId: "00000000-0000-4000-8000-000000000011",
       profileId: "00000000-0000-4000-8000-000000000010",
       shopId: "00000000-0000-4000-8000-000000000001",
+      supabase: {} as never,
     };
     await executeTechnicianCopilotAction({
       identity,
@@ -204,7 +211,9 @@ describe("Technician CoPilot canonical job actions", () => {
     const first = mocks.sendCopilotServerCommand.mock.calls[0][0];
     const replay = mocks.sendCopilotServerCommand.mock.calls[1][0];
     expect(first).toMatchObject({
-      ...identity,
+      authUserId: identity.authUserId,
+      profileId: identity.profileId,
+      shopId: identity.shopId,
       action: "job.action",
       args: {
         sessionId: "00000000-0000-4000-8000-000000000300",
@@ -237,6 +246,7 @@ describe("Technician CoPilot canonical job actions", () => {
         authUserId: "00000000-0000-4000-8000-000000000011",
         profileId: "00000000-0000-4000-8000-000000000010",
         shopId: "00000000-0000-4000-8000-000000000001",
+        supabase: {} as never,
       },
       sessionId: "00000000-0000-4000-8000-000000000300",
       prepared,
@@ -283,6 +293,7 @@ describe("Technician CoPilot canonical job actions", () => {
         authUserId: "00000000-0000-4000-8000-000000000011",
         profileId: "00000000-0000-4000-8000-000000000010",
         shopId: "00000000-0000-4000-8000-000000000001",
+        supabase: {} as never,
       },
       sessionId: "00000000-0000-4000-8000-000000000300",
       prepared,
@@ -307,6 +318,11 @@ describe("Technician CoPilot canonical job actions", () => {
       eventLabel: "Completed job",
       eventDetail: "Brake inspection",
     });
+    expect(mocks.learnFromCompletedWorkOrderLine).toHaveBeenCalledWith({
+      supabase: expect.anything(),
+      lineId: activeWorkOrder.lines[0].id,
+      actorUserId: "00000000-0000-4000-8000-000000000011",
+    });
   });
 
   it("replays the same durable operation after an unknown transport outcome", async () => {
@@ -327,6 +343,7 @@ describe("Technician CoPilot canonical job actions", () => {
         authUserId: "00000000-0000-4000-8000-000000000011",
         profileId: "00000000-0000-4000-8000-000000000010",
         shopId: "00000000-0000-4000-8000-000000000001",
+        supabase: {} as never,
       },
       sessionId: "00000000-0000-4000-8000-000000000300",
       prepared,
@@ -363,6 +380,7 @@ describe("Technician CoPilot canonical job actions", () => {
         authUserId: "00000000-0000-4000-8000-000000000011",
         profileId: "00000000-0000-4000-8000-000000000010",
         shopId: "00000000-0000-4000-8000-000000000001",
+        supabase: {} as never,
       },
       sessionId: "00000000-0000-4000-8000-000000000300",
       prepared,
@@ -376,5 +394,52 @@ describe("Technician CoPilot canonical job actions", () => {
         "That job story changed on another device. Review the latest cause and correction, then try again.",
     });
     expect(result.reply).not.toContain("server-only details");
+  });
+
+  it("requires explicit inspection signing without exposing database details", async () => {
+    const activeWorkOrder: TechnicianWorkCandidate = {
+      ...workOrder,
+      lines: workOrder.lines.map((line, index) =>
+        index === 0 ? { ...line, status: "in_progress" } : line,
+      ),
+    };
+    const prepared = prepareTechnicianCopilotAction({
+      action: {
+        type: "job.complete",
+        workOrderLineId: activeWorkOrder.lines[0].id,
+        cause: null,
+        correction: null,
+      },
+      activeWorkOrder,
+      assignedWork: [activeWorkOrder],
+      activeWorkOrderLineId: activeWorkOrder.lines[0].id,
+    });
+    if (prepared.kind !== "execute") throw new Error("Expected executable action");
+
+    mocks.sendCopilotServerCommand.mockRejectedValue(
+      new Error(
+        "INSPECTION_COMPLETION_REQUIRED: internal inspection identifier 123",
+      ),
+    );
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    const result = await executeTechnicianCopilotAction({
+      identity: {
+        authUserId: "00000000-0000-4000-8000-000000000011",
+        profileId: "00000000-0000-4000-8000-000000000010",
+        shopId: "00000000-0000-4000-8000-000000000001",
+        supabase: {} as never,
+      },
+      sessionId: "00000000-0000-4000-8000-000000000300",
+      prepared,
+      operationId: "00000000-0000-5000-a000-000000000311",
+    });
+    errorLog.mockRestore();
+
+    expect(result).toEqual({
+      ok: false,
+      reply: "Complete and sign the inspection before I can finish that job.",
+    });
+    expect(result.reply).not.toContain("123");
+    expect(mocks.learnFromCompletedWorkOrderLine).not.toHaveBeenCalled();
   });
 });

--- a/tests/technician-copilot-text-runtime.test.ts
+++ b/tests/technician-copilot-text-runtime.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   decideTechnicianCopilotTurn: vi.fn(),
   extractTechnicianDocumentationTurn: vi.fn(),
   sendCopilotServerCommand: vi.fn(),
+  learnFromCompletedWorkOrderLine: vi.fn(),
 }));
 
 vi.mock("@/features/copilot/technician/server/assignedWork", async () => {
@@ -33,6 +34,10 @@ vi.mock("@/features/copilot/technician/server/documentation", () => ({
 
 vi.mock("@/features/copilot/technician/server/transport", () => ({
   sendCopilotServerCommand: mocks.sendCopilotServerCommand,
+}));
+
+vi.mock("@/features/work-orders/server/completeWorkOrderLine", () => ({
+  learnFromCompletedWorkOrderLine: mocks.learnFromCompletedWorkOrderLine,
 }));
 
 import { runTechnicianCopilotTurn } from "@/features/copilot/technician/server/chat";
@@ -71,7 +76,7 @@ type RuntimeSession = {
   workOrderId: string;
   activeWorkOrderLineId: string | null;
   mode: "shop";
-  status: "active";
+  status: "active" | "closed";
 };
 
 describe("Technician CoPilot persistent text runtime", () => {
@@ -88,6 +93,7 @@ describe("Technician CoPilot persistent text runtime", () => {
     documentationTurns = [];
     eventCounter = 0;
     finalReasoningContext = null;
+    mocks.learnFromCompletedWorkOrderLine.mockResolvedValue({ ok: true });
 
     mocks.listTechnicianWorkCandidates.mockResolvedValue([candidate]);
     mocks.loadTechnicianWorkCandidateForWorkOrder.mockResolvedValue(candidate);
@@ -114,6 +120,21 @@ describe("Technician CoPilot persistent text runtime", () => {
             workOrderLineId: "line-driveline",
             action: { type: "job.start", workOrderLineId: "line-driveline" },
             reply: "Starting the Ford.",
+          };
+        }
+
+        if (message === "Complete the Ford." && activeSession) {
+          return {
+            mode: "reply",
+            workOrderId: null,
+            workOrderLineId: "line-driveline",
+            action: {
+              type: "job.complete",
+              workOrderLineId: "line-driveline",
+              cause: "Failed rear U-joint",
+              correction: "Replaced rear U-joint",
+            },
+            reply: "Completing the Ford.",
           };
         }
 
@@ -254,10 +275,21 @@ describe("Technician CoPilot persistent text runtime", () => {
               workOrderId: session.workOrderId,
               workOrderLineId: session.activeWorkOrderLineId,
             });
+          } else if (typeof input.args.workOrderLineId === "string") {
+            session.activeWorkOrderLineId = input.args.workOrderLineId;
           }
           return { sessionId: session.id, replayed: false };
         }
 
+        if (input.action === "session.close") {
+          if (!session) throw new Error("Test session is not active");
+          appendEvent("session.closed", "system", {
+            reason: input.args.reason,
+          });
+          session.status = "closed";
+          session.activeWorkOrderLineId = null;
+          return { sessionId: session.id, status: "closed", replayed: false };
+        }
         if (input.action === "event.append") {
           return appendEvent(
             String(input.args.eventType),
@@ -438,5 +470,206 @@ describe("Technician CoPilot persistent text runtime", () => {
     expect(first.reply).toContain("Started Driveline vibration");
     expect(replay.reply).toBe(first.reply);
     expect(replay.replayed).toBe(true);
+  });
+
+  it("recovers a persisted completion turn after the line leaves the actionable queue", async () => {
+    const started = await runTechnicianCopilotTurn({
+      identity: {
+        authUserId: "auth-tech",
+        profileId: "profile-tech",
+        shopId: "shop-1",
+        documentationEnabled: true,
+        voiceEnabled: true,
+        supabase: {} as never,
+      },
+      message: "Start the Ford.",
+      turnId: "turn-start-before-completion",
+      inputSource: "voice",
+    });
+
+    const completionCandidate = {
+      ...candidate,
+      lines: [
+        {
+          ...candidate.lines[0],
+          status: "in_progress",
+          cause: "Failed rear U-joint",
+          correction: "Replaced rear U-joint",
+        },
+      ],
+    };
+    let completionCommitted = false;
+    let dropFirstActionResult = true;
+    mocks.listTechnicianWorkCandidates.mockImplementation(async () =>
+      completionCommitted ? [] : [completionCandidate],
+    );
+    mocks.loadTechnicianWorkCandidateForWorkOrder.mockImplementation(
+      async () => (completionCommitted ? null : completionCandidate),
+    );
+
+    const baseCommand = mocks.sendCopilotServerCommand.getMockImplementation();
+    if (!baseCommand) throw new Error("Missing command test harness");
+    mocks.sendCopilotServerCommand.mockImplementation(async (input: {
+      action: string;
+      args: Record<string, unknown>;
+    }) => {
+      if (
+        input.action === "job.action" &&
+        input.args.jobAction === "job.complete"
+      ) {
+        completionCommitted = true;
+      }
+      if (
+        input.action === "event.append" &&
+        input.args.eventType === "action.completed" &&
+        dropFirstActionResult
+      ) {
+        dropFirstActionResult = false;
+        throw new Error("Response connection dropped after completion commit");
+      }
+      return baseCommand(input);
+    });
+
+    await expect(
+      runTechnicianCopilotTurn({
+        identity: {
+          authUserId: "auth-tech",
+          profileId: "profile-tech",
+          shopId: "shop-1",
+          documentationEnabled: true,
+          voiceEnabled: true,
+          supabase: {} as never,
+        },
+        message: "Complete the Ford.",
+        turnId: "turn-complete-retry",
+        sessionId: started.sessionId,
+        inputSource: "voice",
+      }),
+    ).rejects.toThrow("Response connection dropped");
+
+    const recovered = await runTechnicianCopilotTurn({
+      identity: {
+        authUserId: "auth-tech",
+        profileId: "profile-tech",
+        shopId: "shop-1",
+        documentationEnabled: true,
+        voiceEnabled: true,
+        supabase: {} as never,
+      },
+      message: "Complete the Ford.",
+      turnId: "turn-complete-retry",
+      sessionId: started.sessionId,
+      inputSource: "voice",
+    });
+
+    expect(recovered.reply).toContain("Completed Driveline vibration");
+    expect(recovered.sessionId).toBeNull();
+    expect(recovered.session).toBeNull();
+    expect(
+      mocks.sendCopilotServerCommand.mock.calls.filter(
+        ([call]) =>
+          call.action === "job.action" &&
+          call.args.jobAction === "job.complete",
+      ),
+    ).toHaveLength(2);
+    expect(
+      mocks.sendCopilotServerCommand.mock.calls.some(
+        ([call]) => call.action === "session.close",
+      ),
+    ).toBe(true);
+  });
+
+  it("re-anchors the repair session when another assigned line remains", async () => {
+    const started = await runTechnicianCopilotTurn({
+      identity: {
+        authUserId: "auth-tech",
+        profileId: "profile-tech",
+        shopId: "shop-1",
+        documentationEnabled: true,
+        voiceEnabled: true,
+        supabase: {} as never,
+      },
+      message: "Start the Ford.",
+      turnId: "turn-start-before-reanchor",
+      inputSource: "voice",
+    });
+    const remainingLine = {
+      ...candidate.lines[0],
+      id: "line-road-test",
+      complaint: "Final road test",
+      status: "awaiting",
+      cause: null,
+      correction: null,
+    };
+    const beforeCompletion = {
+      ...candidate,
+      lineIds: ["line-driveline", remainingLine.id],
+      lines: [
+        {
+          ...candidate.lines[0],
+          status: "in_progress",
+          cause: "Failed rear U-joint",
+          correction: "Replaced rear U-joint",
+        },
+        remainingLine,
+      ],
+    };
+    const afterCompletion = {
+      ...beforeCompletion,
+      lineIds: [remainingLine.id],
+      lines: [remainingLine],
+    };
+    let completionCommitted = false;
+    mocks.listTechnicianWorkCandidates.mockResolvedValue([beforeCompletion]);
+    mocks.loadTechnicianWorkCandidateForWorkOrder.mockImplementation(
+      async () => (completionCommitted ? afterCompletion : beforeCompletion),
+    );
+    const baseCommand = mocks.sendCopilotServerCommand.getMockImplementation();
+    if (!baseCommand) throw new Error("Missing command test harness");
+    mocks.sendCopilotServerCommand.mockImplementation(async (input: {
+      action: string;
+      args: Record<string, unknown>;
+    }) => {
+      if (
+        input.action === "job.action" &&
+        input.args.jobAction === "job.complete"
+      ) {
+        completionCommitted = true;
+      }
+      return baseCommand(input);
+    });
+
+    const completed = await runTechnicianCopilotTurn({
+      identity: {
+        authUserId: "auth-tech",
+        profileId: "profile-tech",
+        shopId: "shop-1",
+        documentationEnabled: true,
+        voiceEnabled: true,
+        supabase: {} as never,
+      },
+      message: "Complete the Ford.",
+      turnId: "turn-complete-reanchor",
+      sessionId: started.sessionId,
+      inputSource: "voice",
+    });
+
+    expect(completed.sessionId).toBe("session-ford");
+    expect(completed.session).toMatchObject({
+      status: "active",
+      activeWorkOrderLineId: remainingLine.id,
+    });
+    expect(
+      mocks.sendCopilotServerCommand.mock.calls.some(
+        ([call]) =>
+          call.action === "session.start" &&
+          call.args.workOrderLineId === remainingLine.id,
+      ),
+    ).toBe(true);
+    expect(
+      mocks.sendCopilotServerCommand.mock.calls.some(
+        ([call]) => call.action === "session.close",
+      ),
+    ).toBe(false);
   });
 });

--- a/tests/work-order-completion-service.test.ts
+++ b/tests/work-order-completion-service.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  applyJobPunchTransition: vi.fn(),
+  upsertMenuRepairItemFromCompletedLine: vi.fn(),
+}));
+
+vi.mock("@/features/work-orders/server/applyJobPunchTransition", () => ({
+  applyJobPunchTransition: mocks.applyJobPunchTransition,
+}));
+
+vi.mock(
+  "@/features/menu-repair-items/server/upsertMenuRepairItemFromCompletedLine",
+  () => ({
+    upsertMenuRepairItemFromCompletedLine:
+      mocks.upsertMenuRepairItemFromCompletedLine,
+  }),
+);
+
+import { completeWorkOrderLine } from "@/features/work-orders/server/completeWorkOrderLine";
+
+function completionClient() {
+  const maybeSingle = vi.fn().mockResolvedValue({
+    data: { id: "line-1", shop_id: "shop-1" },
+    error: null,
+  });
+  const eq = vi.fn(() => ({ maybeSingle }));
+  const select = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ select }));
+  return { client: { from } as never, from, select, eq, maybeSingle };
+}
+
+describe("canonical work-order line completion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.applyJobPunchTransition.mockResolvedValue({
+      ok: true,
+      payload: { action: "finish" },
+    });
+    mocks.upsertMenuRepairItemFromCompletedLine.mockResolvedValue(undefined);
+  });
+
+  it("runs idempotent repair learning after the canonical finish succeeds", async () => {
+    const { client } = completionClient();
+    const result = await completeWorkOrderLine({
+      supabase: client,
+      lineId: "line-1",
+      technicianId: "profile-tech",
+      actorUserId: "auth-tech",
+      operationKey: "finish-key",
+      cause: "Failed bearing",
+      correction: "Replaced bearing",
+    });
+
+    expect(mocks.applyJobPunchTransition).toHaveBeenCalledWith({
+      supabase: client,
+      lineId: "line-1",
+      action: "finish",
+      technicianId: "profile-tech",
+      options: {
+        operationKey: "finish-key",
+        finish: {
+          cause: "Failed bearing",
+          correction: "Replaced bearing",
+        },
+      },
+    });
+    expect(mocks.upsertMenuRepairItemFromCompletedLine).toHaveBeenCalledWith({
+      supabase: client,
+      shopId: "shop-1",
+      workOrderLineId: "line-1",
+      actorUserId: "auth-tech",
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      menuRepairLearning: { ok: true },
+    });
+  });
+
+  it("keeps completion successful when repair learning fails", async () => {
+    const { client } = completionClient();
+    mocks.upsertMenuRepairItemFromCompletedLine.mockRejectedValue(
+      new Error("learning unavailable"),
+    );
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await completeWorkOrderLine({
+      supabase: client,
+      lineId: "line-1",
+      technicianId: "profile-tech",
+      actorUserId: "auth-tech",
+      operationKey: "finish-key",
+    });
+    errorLog.mockRestore();
+
+    expect(result).toMatchObject({
+      ok: true,
+      menuRepairLearning: { ok: false },
+    });
+  });
+
+  it("does not learn from a completion that did not commit", async () => {
+    const { client } = completionClient();
+    mocks.applyJobPunchTransition.mockResolvedValue({
+      ok: false,
+      status: 409,
+      error: "INSPECTION_COMPLETION_REQUIRED",
+    });
+
+    const result = await completeWorkOrderLine({
+      supabase: client,
+      lineId: "line-1",
+      technicianId: "profile-tech",
+      actorUserId: "auth-tech",
+      operationKey: "finish-key",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 409,
+      error: "INSPECTION_COMPLETION_REQUIRED",
+    });
+    expect(mocks.upsertMenuRepairItemFromCompletedLine).not.toHaveBeenCalled();
+  });
+});

--- a/tests/work-order-job-punch-transition.test.ts
+++ b/tests/work-order-job-punch-transition.test.ts
@@ -141,4 +141,25 @@ describe("applyJobPunchTransition atomic boundary", () => {
       error: "FINANCIALLY_LOCKED: invoice issued",
     });
   });
+
+  it("maps unsigned inspection completion to a retryable conflict", async () => {
+    const db = new FakeSupabase();
+    db.rpcError = {
+      message:
+        "INSPECTION_COMPLETION_REQUIRED: complete and sign the inspection before finishing this job.",
+    };
+
+    const result = await applyJobPunchTransition({
+      supabase: db as never,
+      lineId: "line-1",
+      action: "finish",
+      technicianId: "tech-1",
+      options: { operationKey: "finish-1" },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 409,
+    });
+  });
 });


### PR DESCRIPTION
## Scope

Canonical technician job-completion integrity only. This starts from current `main` at `670618cb3a802d1453d25fe779a1b850eac6788f` and addresses the four completion findings from the prior voice slice without adding new voice capabilities or changing the Copilot shell.

- share one completion service between the technician screen and Copilot, including fail-open repair-memory learning
- preserve profile-owned workforce rows while recording auth-owned receipts and activity
- require attached DVIs to be explicitly completed and signed; job completion never finalizes or signs an inspection
- recover a persisted completion turn after an unknown response, then close or re-anchor the repair session
- clear the client session snapshot when the final assigned line closes
- add focused full-turn retry, split-identity, inspection-draft, session re-anchoring, and repair-learning coverage

## Database

Adds forward migration `20260815232321_technician_completion_integrity.sql`.

The migration is applied to the healthy PR preview only. It has **not** been applied to production.

## Validation

Exact head: `7841d3cb54d0d294b8e0dc7479ea6d47c2182abf`

- branch shape: four commits ahead of current `main`, zero behind
- local `git diff --check`: pass
- Agent PR Checks: pass (regression inventory, type-check, changed-file lint, complete test suite, production build, regression gate)
- Phase 2, 3, 4, 5, 7, and 8 validation: pass
- Supabase Clean Replay: pass (fresh apply, generated types, reset/replay, and runtime integrations)
- Supabase PR preview: healthy, functions deployed, migration `20260815232321` present

## Explicitly out of scope

- persistent application-shell voice activation
- continuous listening / barge-in changes
- new technician actions or capability-registry expansion
- production migration or merge
