### PR TITLE
Fix authenticated homepage routing

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -358,28 +358,6 @@ export async function middleware(req: NextRequest) {
     }
   }
 
-  if (pathname === "/" && user) {
-    if (isPortalOnlyAccount) {
-      const access = await resolvePortalAccessServer(supabase, user.id);
-      const target = productRequestUrl(
-        req,
-        access.fleet && !access.customer ? "/portal/fleet" : "/portal",
-        fleetProductRequest,
-      );
-      return redirectWithResponseHeaders(target, res);
-    }
-    const target = productRequestUrl(
-      req,
-      !completed
-        ? "/onboarding"
-        : mobileDeviceRequest
-          ? "/mobile"
-          : "/dashboard",
-      fleetProductRequest,
-    );
-    return redirectWithResponseHeaders(target, res);
-  }
-
   if (isPublic) {
     const requestedRedirect = safeRedirectPath(
       req.nextUrl.searchParams.get("redirect"),

--- a/tests/fleet-product-middleware-boundary.test.ts
+++ b/tests/fleet-product-middleware-boundary.test.ts
@@ -9,8 +9,8 @@ const authFixture = vi.hoisted(() => ({
   },
   profile: null as null | {
     id: string;
-    role: string;
-    shop_id: string;
+    role: string | null;
+    shop_id: string | null;
     completed_onboarding: boolean;
   },
   memberships: [] as Array<{
@@ -99,7 +99,44 @@ function shopRequest(pathname: string): NextRequest {
   });
 }
 
-describe("Fleet product middleware boundary", () => {
+describe("Product host middleware boundary", () => {
+  it("keeps the Shop marketing root public for an incomplete authenticated account", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
+    authFixture.user = { id: "user-1", app_metadata: {} };
+    authFixture.profile = {
+      id: "user-1",
+      role: null,
+      shop_id: null,
+      completed_onboarding: false,
+    };
+
+    const response = await middleware(shopRequest("/"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("still routes an incomplete authenticated account from protected Shop routes to onboarding", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
+    authFixture.user = { id: "user-1", app_metadata: {} };
+    authFixture.profile = {
+      id: "user-1",
+      role: null,
+      shop_id: null,
+      completed_onboarding: false,
+    };
+
+    const response = await middleware(shopRequest("/dashboard"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://profixiq.com/onboarding",
+    );
+  });
+
   it("moves legacy Fleet workspace URLs off the Shop hostname", async () => {
     const response = await middleware(
       shopRequest("/portal/fleet/units/unit-42?tab=history"),


### PR DESCRIPTION
## Summary
- keep the Shop marketing homepage public for authenticated users
- preserve onboarding redirects when incomplete accounts open protected Shop routes
- add regression coverage for both behaviors

## Root cause
Middleware treated `/` as public, then overrode that behavior for every authenticated user. A partially created account therefore landed on `/onboarding` whenever it visited `profixiq.com`.

## Validation
- GitHub `Agent PR Checks` — passed, including typecheck, changed-file lint, complete test suite, and production build
- local focused middleware suite — 15/15 passed
- local full Vitest JSON comparison — branch and clean `main` had the same 39 Windows CRLF-sensitive failures; no branch-only failures
- local production build — compiled successfully, then page-data collection stopped because `OPENAI_API_KEY` is not configured locally