### PR TITLE
fix: address technician completion review findings

### DIFF
--- a/features/copilot/technician/server/actions.ts
+++ b/features/copilot/technician/server/actions.ts
@@ -92,6 +92,29 @@ function nextRank(line: TechnicianWorkLine): number {
   return 4;
 }
 
+export function compareTechnicianWorkLines(
+  left: TechnicianWorkLine,
+  right: TechnicianWorkLine,
+): number {
+  const rank = nextRank(left) - nextRank(right);
+  if (rank !== 0) return rank;
+  const priority =
+    (left.priority ?? Number.MAX_SAFE_INTEGER) -
+    (right.priority ?? Number.MAX_SAFE_INTEGER);
+  if (priority !== 0) return priority;
+  const createdAt = String(left.createdAt ?? "").localeCompare(
+    String(right.createdAt ?? ""),
+  );
+  if (createdAt !== 0) return createdAt;
+  return left.id.localeCompare(right.id);
+}
+
+export function selectNextTechnicianWorkLine(
+  lines: readonly TechnicianWorkLine[],
+): TechnicianWorkLine | null {
+  return [...lines].sort(compareTechnicianWorkLines)[0] ?? null;
+}
+
 export function describeNextTechnicianWork(
   assignedWork: readonly TechnicianWorkCandidate[],
 ): string {
@@ -99,19 +122,9 @@ export function describeNextTechnicianWork(
     .flatMap((workOrder) =>
       workOrder.lines.map((line) => ({ workOrder, line })),
     )
-    .sort((left, right) => {
-      const rank = nextRank(left.line) - nextRank(right.line);
-      if (rank !== 0) return rank;
-      const priority =
-        (left.line.priority ?? Number.MAX_SAFE_INTEGER) -
-        (right.line.priority ?? Number.MAX_SAFE_INTEGER);
-      if (priority !== 0) return priority;
-      const createdAt = String(left.line.createdAt ?? "").localeCompare(
-        String(right.line.createdAt ?? ""),
-      );
-      if (createdAt !== 0) return createdAt;
-      return left.line.id.localeCompare(right.line.id);
-    });
+    .sort((left, right) =>
+      compareTechnicianWorkLines(left.line, right.line),
+    );
 
   const next = choices[0];
   if (!next) return "You don't have another assigned job line right now.";
@@ -384,6 +397,7 @@ export async function executeBoundTechnicianCopilotAction(input: {
       supabase: input.identity.supabase,
       lineId: input.bound.lineId,
       actorUserId: input.identity.authUserId,
+      operationKey: input.operationId,
     });
   }
 

--- a/features/copilot/technician/server/chat.ts
+++ b/features/copilot/technician/server/chat.ts
@@ -14,6 +14,7 @@ import {
   describeNextTechnicianWork,
   executeBoundTechnicianCopilotAction,
   prepareTechnicianCopilotAction,
+  selectNextTechnicianWorkLine,
   technicianWorkLineLabel,
   type BoundTechnicianCopilotAction,
 } from "./actions";
@@ -852,7 +853,9 @@ export async function runTechnicianCopilotTurn(input: {
       technicianIds: [input.identity.authUserId, input.identity.profileId],
       workOrderId: completionWorkOrderId,
     });
-    const nextLine = activeWorkOrder?.lines[0] ?? null;
+    const nextLine = selectNextTechnicianWorkLine(
+      activeWorkOrder?.lines ?? [],
+    );
     if (nextLine) {
       await command<{ sessionId: string }>(input.identity, "session.start", {
         workOrderId: completionWorkOrderId,

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -28173,18 +28173,6 @@ export type Database = {
         }
         Returns: Json
       }
-      finish_completed_repair_learning_atomic: {
-        Args: {
-          p_actor_user_id: string
-          p_at?: string
-          p_lease_token: string
-          p_result?: Json
-          p_shop_id: string
-          p_succeeded: boolean
-          p_work_order_line_id: string
-        }
-        Returns: Json
-      }
       finalize_estimate_send_atomic: {
         Args: {
           p_actor_profile_id: string
@@ -28282,6 +28270,18 @@ export type Database = {
           p_phone?: string
           p_shop_id: string
           p_vin?: string
+        }
+        Returns: Json
+      }
+      finish_completed_repair_learning_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_at?: string
+          p_lease_token: string
+          p_result?: Json
+          p_shop_id: string
+          p_succeeded: boolean
+          p_work_order_line_id: string
         }
         Returns: Json
       }

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -27443,6 +27443,17 @@ export type Database = {
         Returns: string
       }
       check_plan_limit: { Args: { _feature: string }; Returns: boolean }
+      claim_completed_repair_learning_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_at?: string
+          p_lease_token: string
+          p_operation_key: string
+          p_shop_id: string
+          p_work_order_line_id: string
+        }
+        Returns: Json
+      }
       claim_financial_outbox_batch: {
         Args: {
           p_lease_seconds?: number
@@ -28158,6 +28169,18 @@ export type Database = {
           p_quantity: number
           p_service_visit_id: string
           p_shop_id: string
+          p_work_order_line_id: string
+        }
+        Returns: Json
+      }
+      finish_completed_repair_learning_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_at?: string
+          p_lease_token: string
+          p_result?: Json
+          p_shop_id: string
+          p_succeeded: boolean
           p_work_order_line_id: string
         }
         Returns: Json

--- a/features/work-orders/server/completeWorkOrderLine.ts
+++ b/features/work-orders/server/completeWorkOrderLine.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { upsertMenuRepairItemFromCompletedLine } from "@/features/menu-repair-items/server/upsertMenuRepairItemFromCompletedLine";
@@ -16,10 +18,27 @@ type CompletionInput = {
   correction?: string | null;
 };
 
+type RepairLearningClaim = {
+  claimed?: boolean;
+  completed?: boolean;
+  inProgress?: boolean;
+};
+
+type RepairLearningRpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{
+    data: RepairLearningClaim | null;
+    error: { message: string } | null;
+  }>;
+};
+
 export async function learnFromCompletedWorkOrderLine(input: {
   supabase: SupabaseClient<DB>;
   lineId: string;
   actorUserId: string;
+  operationKey: string;
 }): Promise<{ ok: boolean }> {
   const { data: completedLine, error } = await input.supabase
     .from("work_order_lines")
@@ -35,6 +54,47 @@ export async function learnFromCompletedWorkOrderLine(input: {
     return { ok: false };
   }
 
+  const leaseToken = randomUUID();
+  const rpc = input.supabase as unknown as RepairLearningRpcClient;
+  let claim: RepairLearningClaim | null = null;
+  let claimError: { message: string } | null = null;
+  try {
+    const response = await rpc.rpc(
+      "claim_completed_repair_learning_atomic",
+      {
+        p_shop_id: completedLine.shop_id,
+        p_work_order_line_id: completedLine.id,
+        p_actor_user_id: input.actorUserId,
+        p_operation_key: input.operationKey,
+        p_lease_token: leaseToken,
+      },
+    );
+    claim = response.data;
+    claimError = response.error;
+  } catch (error) {
+    claimError = {
+      message: error instanceof Error ? error.message : "Learning claim failed",
+    };
+  }
+  if (claimError) {
+    console.error("[work-orders] completed repair memory claim failed", {
+      workOrderLineId: input.lineId,
+      error: claimError.message,
+    });
+    return { ok: false };
+  }
+  if (!claim) {
+    console.error("[work-orders] completed repair memory claim failed", {
+      workOrderLineId: input.lineId,
+      error: "Learning claim returned no result",
+    });
+    return { ok: false };
+  }
+  if (claim.completed || claim.inProgress) {
+    return { ok: true };
+  }
+  if (!claim.claimed) return { ok: false };
+
   try {
     await upsertMenuRepairItemFromCompletedLine({
       supabase: input.supabase,
@@ -42,8 +102,32 @@ export async function learnFromCompletedWorkOrderLine(input: {
       workOrderLineId: completedLine.id,
       actorUserId: input.actorUserId,
     });
+    const { error: finishError } = await rpc.rpc(
+      "finish_completed_repair_learning_atomic",
+      {
+        p_shop_id: completedLine.shop_id,
+        p_work_order_line_id: completedLine.id,
+        p_actor_user_id: input.actorUserId,
+        p_lease_token: leaseToken,
+        p_succeeded: true,
+        p_result: { ok: true },
+      },
+    );
+    if (finishError) throw new Error(finishError.message);
     return { ok: true };
   } catch (learningError) {
+    try {
+      await rpc.rpc("finish_completed_repair_learning_atomic", {
+        p_shop_id: completedLine.shop_id,
+        p_work_order_line_id: completedLine.id,
+        p_actor_user_id: input.actorUserId,
+        p_lease_token: leaseToken,
+        p_succeeded: false,
+        p_result: { ok: false, code: "repair_learning_failed" },
+      });
+    } catch {
+      // The lease expires and permits a later completion replay to recover.
+    }
     console.error("[work-orders] completed repair memory update failed", {
       workOrderLineId: input.lineId,
       error:
@@ -76,6 +160,7 @@ export async function completeWorkOrderLine(input: CompletionInput) {
     supabase: input.supabase,
     lineId: input.lineId,
     actorUserId: input.actorUserId,
+    operationKey: input.operationKey,
   });
 
   return {

--- a/supabase/migrations/20260816013256_technician_completion_review_hotfix.sql
+++ b/supabase/migrations/20260816013256_technician_completion_review_hotfix.sql
@@ -1,0 +1,929 @@
+-- Forward repair for the completion-integrity review findings that arrived
+-- after PR #1445 merged. Keep receipt recovery line-bound, serialize repair
+-- learning, normalize legacy receipt ownership, and use canonical inspections.
+
+begin;
+
+create or replace function copilot.technician_has_bound_completion_receipt(
+  p_auth_user_id uuid,
+  p_session_id uuid,
+  p_turn_id text default null
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+  select exists (
+    select 1
+    from copilot.repair_sessions rs
+    join public.profiles p
+      on p.id = rs.technician_id
+     and (p.id = p_auth_user_id or p.user_id = p_auth_user_id)
+    join copilot.repair_session_events e
+      on e.repair_session_id = rs.id
+     and e.event_type = 'action.pending'
+    join copilot.repair_session_event_context c
+      on c.event_id = e.id
+    join public.workforce_operation_keys wok
+      on wok.shop_id = rs.shop_id
+     and wok.operation_name = 'job_punch:finish'
+     and wok.operation_key = 'technician-copilot:' || (c.details ->> 'key')
+     and wok.actor_user_id = p_auth_user_id
+     and wok.work_order_id = rs.work_order_id
+     and wok.work_order_line_id = case
+       when c.details ->> 'workOrderLineId'
+         ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+       then (c.details ->> 'workOrderLineId')::uuid
+       else null
+     end
+    where rs.id = p_session_id
+      -- A completion receipt is recovery authority only while the session is
+      -- still anchored to that exact line. Re-anchoring makes every older
+      -- receipt historical and removes its authorization effect.
+      and rs.active_work_order_line_id = wok.work_order_line_id
+      and c.details ->> 'action' = 'job.complete'
+      and c.details ->> 'key'
+        ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      and c.details ->> 'workOrderLineId'
+        ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      and (p_turn_id is null or c.details ->> 'turnId' = p_turn_id)
+  )
+$$;
+
+revoke all on function copilot.technician_has_bound_completion_receipt(
+  uuid,uuid,text
+) from public, anon, authenticated, service_role;
+
+create table if not exists copilot.completed_repair_learning_receipts (
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  work_order_line_id uuid not null references public.work_order_lines(id)
+    on delete cascade,
+  actor_user_id uuid not null references auth.users(id) on delete restrict,
+  operation_key text not null,
+  source_line_updated_at timestamptz not null,
+  state text not null,
+  lease_token uuid,
+  lease_expires_at timestamptz,
+  attempt_count integer not null default 1,
+  result jsonb not null default '{}'::jsonb,
+  completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (shop_id, work_order_line_id),
+  constraint completed_repair_learning_state_chk
+    check (state in ('running', 'retryable', 'completed')),
+  constraint completed_repair_learning_operation_key_chk
+    check (char_length(btrim(operation_key)) between 1 and 512),
+  constraint completed_repair_learning_attempt_count_chk
+    check (attempt_count > 0),
+  constraint completed_repair_learning_result_chk
+    check (jsonb_typeof(result) = 'object')
+);
+
+alter table copilot.completed_repair_learning_receipts enable row level security;
+revoke all on copilot.completed_repair_learning_receipts
+  from public, anon, authenticated, service_role;
+
+create or replace function public.claim_completed_repair_learning_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_lease_token uuid,
+  p_at timestamptz default now()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_actor_auth_user_id uuid;
+  v_line_updated_at public.work_order_lines.updated_at%type;
+  v_line_status text;
+  v_receipt copilot.completed_repair_learning_receipts%rowtype;
+  v_now timestamptz := coalesce(p_at, now());
+  v_inserted integer := 0;
+begin
+  if p_shop_id is null
+    or p_work_order_line_id is null
+    or p_actor_user_id is null
+    or p_lease_token is null
+    or nullif(btrim(p_operation_key), '') is null
+  then
+    raise exception 'completed_repair_learning_claim_invalid'
+      using errcode = '22023';
+  end if;
+
+  select coalesce(p.user_id, p.id)
+    into v_actor_auth_user_id
+  from public.profiles p
+  where p.shop_id = p_shop_id
+    and (p.id = p_actor_user_id or p.user_id = p_actor_user_id)
+  order by case when p.user_id = p_actor_user_id then 0 else 1 end
+  limit 1;
+
+  if not found
+    or not exists (
+      select 1 from auth.users u where u.id = v_actor_auth_user_id
+    )
+    or (
+      auth.uid() is not null
+      and auth.uid() is distinct from v_actor_auth_user_id
+    )
+  then
+    raise exception 'completed_repair_learning_actor_forbidden'
+      using errcode = '42501';
+  end if;
+
+  select coalesce(wol.updated_at, v_now), lower(coalesce(wol.status::text, ''))
+    into v_line_updated_at, v_line_status
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id
+    and wol.shop_id = p_shop_id
+  for share;
+
+  if not found then
+    raise exception 'completed_repair_learning_line_not_found'
+      using errcode = 'P0001';
+  end if;
+  if v_line_status not in ('completed', 'invoiced') then
+    raise exception 'completed_repair_learning_line_not_completed'
+      using errcode = '55000';
+  end if;
+
+  insert into copilot.completed_repair_learning_receipts (
+    shop_id,
+    work_order_line_id,
+    actor_user_id,
+    operation_key,
+    source_line_updated_at,
+    state,
+    lease_token,
+    lease_expires_at,
+    result,
+    updated_at
+  ) values (
+    p_shop_id,
+    p_work_order_line_id,
+    v_actor_auth_user_id,
+    btrim(p_operation_key),
+    v_line_updated_at,
+    'running',
+    p_lease_token,
+    v_now + interval '5 minutes',
+    '{}'::jsonb,
+    v_now
+  )
+  on conflict (shop_id, work_order_line_id) do nothing;
+  get diagnostics v_inserted = row_count;
+
+  if v_inserted = 1 then
+    return jsonb_build_object(
+      'claimed', true,
+      'completed', false,
+      'inProgress', false,
+      'replayed', false
+    );
+  end if;
+
+  select receipt.*
+    into v_receipt
+  from copilot.completed_repair_learning_receipts receipt
+  where receipt.shop_id = p_shop_id
+    and receipt.work_order_line_id = p_work_order_line_id
+  for update;
+
+  if v_receipt.state = 'completed'
+    and v_receipt.source_line_updated_at >= v_line_updated_at
+  then
+    return jsonb_build_object(
+      'claimed', false,
+      'completed', true,
+      'inProgress', false,
+      'replayed', true
+    );
+  end if;
+
+  if v_receipt.state = 'running'
+    and v_receipt.source_line_updated_at = v_line_updated_at
+    and v_receipt.lease_token = p_lease_token
+  then
+    return jsonb_build_object(
+      'claimed', true,
+      'completed', false,
+      'inProgress', false,
+      'replayed', true
+    );
+  end if;
+
+  if v_receipt.source_line_updated_at < v_line_updated_at
+    or v_receipt.state = 'retryable'
+    or v_receipt.lease_expires_at is null
+    or v_receipt.lease_expires_at <= v_now
+  then
+    update copilot.completed_repair_learning_receipts receipt
+    set actor_user_id = v_actor_auth_user_id,
+        operation_key = btrim(p_operation_key),
+        source_line_updated_at = v_line_updated_at,
+        state = 'running',
+        lease_token = p_lease_token,
+        lease_expires_at = v_now + interval '5 minutes',
+        attempt_count = receipt.attempt_count + 1,
+        result = '{}'::jsonb,
+        completed_at = null,
+        updated_at = v_now
+    where receipt.shop_id = p_shop_id
+      and receipt.work_order_line_id = p_work_order_line_id;
+
+    return jsonb_build_object(
+      'claimed', true,
+      'completed', false,
+      'inProgress', false,
+      'replayed', true
+    );
+  end if;
+
+  return jsonb_build_object(
+    'claimed', false,
+    'completed', false,
+    'inProgress', true,
+    'replayed', true
+  );
+end;
+$$;
+
+create or replace function public.finish_completed_repair_learning_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_actor_user_id uuid,
+  p_lease_token uuid,
+  p_succeeded boolean,
+  p_result jsonb default '{}'::jsonb,
+  p_at timestamptz default now()
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_actor_auth_user_id uuid;
+  v_receipt copilot.completed_repair_learning_receipts%rowtype;
+  v_now timestamptz := coalesce(p_at, now());
+  v_result jsonb := case
+    when jsonb_typeof(p_result) = 'object'
+      and octet_length(p_result::text) <= 16384
+    then p_result
+    else '{}'::jsonb
+  end;
+begin
+  if p_shop_id is null
+    or p_work_order_line_id is null
+    or p_actor_user_id is null
+    or p_lease_token is null
+    or p_succeeded is null
+  then
+    raise exception 'completed_repair_learning_finish_invalid'
+      using errcode = '22023';
+  end if;
+
+  select coalesce(p.user_id, p.id)
+    into v_actor_auth_user_id
+  from public.profiles p
+  where p.shop_id = p_shop_id
+    and (p.id = p_actor_user_id or p.user_id = p_actor_user_id)
+  order by case when p.user_id = p_actor_user_id then 0 else 1 end
+  limit 1;
+
+  if not found
+    or (
+      auth.uid() is not null
+      and auth.uid() is distinct from v_actor_auth_user_id
+    )
+  then
+    raise exception 'completed_repair_learning_actor_forbidden'
+      using errcode = '42501';
+  end if;
+
+  select receipt.*
+    into v_receipt
+  from copilot.completed_repair_learning_receipts receipt
+  where receipt.shop_id = p_shop_id
+    and receipt.work_order_line_id = p_work_order_line_id
+  for update;
+
+  if not found then
+    raise exception 'completed_repair_learning_receipt_not_found'
+      using errcode = 'P0001';
+  end if;
+  if v_receipt.state = 'completed' then
+    return jsonb_build_object('completed', true, 'replayed', true);
+  end if;
+  if v_receipt.actor_user_id is distinct from v_actor_auth_user_id
+    or v_receipt.lease_token is distinct from p_lease_token
+  then
+    raise exception 'completed_repair_learning_lease_conflict'
+      using errcode = '23505';
+  end if;
+
+  update copilot.completed_repair_learning_receipts receipt
+  set state = case when p_succeeded then 'completed' else 'retryable' end,
+      lease_token = case when p_succeeded then null else receipt.lease_token end,
+      lease_expires_at = case when p_succeeded then null else v_now end,
+      result = v_result,
+      completed_at = case when p_succeeded then v_now else null end,
+      updated_at = v_now
+  where receipt.shop_id = p_shop_id
+    and receipt.work_order_line_id = p_work_order_line_id;
+
+  return jsonb_build_object(
+    'completed', p_succeeded,
+    'retryable', not p_succeeded,
+    'replayed', false
+  );
+end;
+$$;
+
+revoke all on function public.claim_completed_repair_learning_atomic(
+  uuid,uuid,uuid,text,uuid,timestamptz
+) from public, anon;
+grant execute on function public.claim_completed_repair_learning_atomic(
+  uuid,uuid,uuid,text,uuid,timestamptz
+) to authenticated, service_role;
+
+revoke all on function public.finish_completed_repair_learning_atomic(
+  uuid,uuid,uuid,uuid,boolean,jsonb,timestamptz
+) from public, anon;
+grant execute on function public.finish_completed_repair_learning_atomic(
+  uuid,uuid,uuid,uuid,boolean,jsonb,timestamptz
+) to authenticated, service_role;
+
+create or replace function copilot.normalize_completion_receipt_actor()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, copilot, pg_temp
+as $$
+declare
+  v_auth_user_id uuid;
+begin
+  if new.operation_name = 'job_punch:finish'
+    and new.operation_key like 'technician-copilot:%'
+  then
+    select p.user_id
+      into v_auth_user_id
+    from public.profiles p
+    join auth.users u on u.id = p.user_id
+    where p.id = new.actor_user_id
+      and p.shop_id = new.shop_id
+      and p.user_id is not null
+      and p.user_id is distinct from p.id
+    limit 1;
+
+    if found then
+      new.actor_user_id := v_auth_user_id;
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function copilot.normalize_completion_receipt_actor()
+  from public, anon, authenticated, service_role;
+
+drop trigger if exists normalize_technician_copilot_completion_receipt_actor
+  on public.workforce_operation_keys;
+create trigger normalize_technician_copilot_completion_receipt_actor
+before insert or update of actor_user_id, operation_name, operation_key
+on public.workforce_operation_keys
+for each row execute function copilot.normalize_completion_receipt_actor();
+
+do $legacy_completion_receipt_backfill$
+declare
+  v_backfilled integer := 0;
+begin
+  update public.workforce_operation_keys receipt
+  set actor_user_id = profile.user_id
+  from public.profiles profile
+  join auth.users auth_user on auth_user.id = profile.user_id
+  where receipt.actor_user_id = profile.id
+    and receipt.shop_id = profile.shop_id
+    and receipt.operation_name = 'job_punch:finish'
+    and receipt.operation_key like 'technician-copilot:%'
+    and profile.user_id is not null
+    and profile.user_id is distinct from profile.id;
+  get diagnostics v_backfilled = row_count;
+  raise notice 'Normalized % legacy technician completion receipt actor(s)',
+    v_backfilled;
+end
+$legacy_completion_receipt_backfill$;
+
+-- The canonical job-punch function is replaced below so its inspection lock
+-- and completion gate ignore retained non-canonical evidence rows.
+
+create or replace function public.apply_job_punch_transition_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_action text,
+  p_technician_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_allow_concurrent boolean default false,
+  p_at timestamptz default now(),
+  p_start_source text default null,
+  p_hold_reason text default null,
+  p_notes text default null,
+  p_preserve_line_status boolean default false,
+  p_release_to_awaiting boolean default false,
+  p_cause text default null,
+  p_correction text default null,
+  p_event text default null,
+  p_details jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_shift public.tech_shifts%rowtype;
+  v_status text;
+  v_approval text;
+  v_action text := lower(trim(coalesce(p_action, '')));
+  v_now timestamptz := coalesce(p_at, now());
+  v_existing jsonb;
+  v_result jsonb;
+  v_final_cause text;
+  v_final_correction text;
+  v_segment_id uuid;
+  v_earliest timestamptz;
+  v_latest timestamptz;
+  v_has_open boolean;
+  v_closed_count integer := 0;
+  v_technician_profile_id uuid;
+  v_actor_profile_id uuid;
+  v_actor_auth_user_id uuid;
+  v_existing_actor_user_id uuid;
+  v_existing_line_id uuid;
+begin
+  if v_action not in ('start','resume','pause','finish') then
+    raise exception using errcode = 'P0001', message = 'Unsupported job punch action.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+
+  select p.id
+    into v_technician_profile_id
+  from public.profiles p
+  where p.shop_id = p_shop_id
+    and (p.id = p_technician_id or p.user_id = p_technician_id)
+  order by case when p.id = p_technician_id then 0 else 1 end
+  limit 1
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Technician is not available for this shop.';
+  end if;
+
+  select p.id, coalesce(p.user_id, p.id)
+    into v_actor_profile_id, v_actor_auth_user_id
+  from public.profiles p
+  where p.shop_id = p_shop_id
+    and (p.id = p_actor_user_id or p.user_id = p_actor_user_id)
+  order by case when p.id = p_actor_user_id then 0 else 1 end
+  limit 1;
+  if not found
+    or not exists (
+      select 1 from auth.users u where u.id = v_actor_auth_user_id
+    )
+    or (
+      auth.uid() is not null
+      and auth.uid() is distinct from v_actor_auth_user_id
+    )
+  then
+    raise exception using errcode = 'P0001', message = 'Actor is not available for this shop.';
+  end if;
+
+  select wok.result, wok.actor_user_id, wok.work_order_line_id
+    into v_existing, v_existing_actor_user_id, v_existing_line_id
+  from public.workforce_operation_keys wok
+  where wok.shop_id = p_shop_id
+    and wok.operation_name = 'job_punch:' || v_action
+    and wok.operation_key = p_operation_key;
+  if found then
+    if v_existing_actor_user_id is distinct from v_actor_auth_user_id
+      or v_existing_line_id is distinct from p_work_order_line_id
+    then
+      raise exception using errcode = '23505', message = 'JOB_PUNCH_OPERATION_CONFLICT';
+    end if;
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  select *
+    into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id
+    and wol.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work-order line not found for shop.';
+  end if;
+  if v_line.work_order_id is null then
+    raise exception using errcode = 'P0001', message = 'Work-order line is missing its work-order anchor.';
+  end if;
+  if coalesce(v_line.line_type::text, 'job') = 'info' then
+    raise exception using errcode = 'P0001', message = 'Info lines are non-actionable.';
+  end if;
+  if public.work_order_is_financially_locked(p_shop_id, v_line.work_order_id) then
+    raise exception using errcode = 'P0001', message = 'FINANCIALLY_LOCKED: job labor cannot change after invoice finalization.';
+  end if;
+
+  v_status := lower(coalesce(v_line.status::text, 'awaiting'));
+  v_approval := lower(coalesce(v_line.approval_state::text, ''));
+
+  perform 1
+  from public.work_order_line_technicians wolt
+  where wolt.work_order_line_id = p_work_order_line_id
+  for update;
+
+  perform 1
+  from public.work_order_line_labor_segments seg
+  where seg.shop_id = p_shop_id
+    and (
+      seg.work_order_line_id = p_work_order_line_id
+      or (seg.technician_id = v_technician_profile_id and seg.ended_at is null)
+    )
+  for update;
+
+  if v_action in ('start','resume') and p_release_to_awaiting then
+    if v_status in ('completed','invoiced') then
+      raise exception using errcode = 'P0001', message = 'Cannot release hold on a closed line.';
+    end if;
+
+    update public.work_order_lines
+    set status = 'awaiting',
+        hold_reason = null,
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+  elsif v_action in ('start','resume') then
+    if v_status in ('completed','invoiced') then
+      raise exception using errcode = 'P0001', message = 'Cannot start or resume a closed line.';
+    end if;
+    if v_status = 'awaiting_approval'
+       and v_approval <> 'approved'
+       and not coalesce(v_line.punchable, false) then
+      raise exception using errcode = 'P0001', message = 'Line is awaiting approval and cannot be started.';
+    end if;
+
+    select *
+      into v_shift
+    from public.tech_shifts ts
+    where ts.user_id = v_technician_profile_id
+      and ts.shop_id = p_shop_id
+      and ts.status::text = 'active'
+      and ts.end_time is null
+    order by ts.start_time desc, ts.id desc
+    limit 1
+    for update;
+    if not found then
+      if exists (
+        select 1
+        from public.tech_shifts ts
+        where ts.user_id = v_technician_profile_id
+          and ts.end_time is null
+          and (ts.shop_id is null or ts.shop_id <> p_shop_id)
+      ) then
+        raise exception using errcode = 'P0001', message = 'SHIFT_SHOP_MISMATCH: an open shift exists outside this shop and cannot authorize job labor.';
+      end if;
+      raise exception using errcode = 'P0001', message = 'You need an active shift in this shop before starting job labor.';
+    end if;
+
+    if exists (
+      select 1
+      from public.work_order_line_labor_segments seg
+      where seg.shop_id = p_shop_id
+        and seg.technician_id = v_technician_profile_id
+        and seg.work_order_line_id = p_work_order_line_id
+        and seg.ended_at is null
+    ) then
+      raise exception using errcode = 'P0001', message = 'Technician already has active labor on this line.';
+    end if;
+
+    if not p_allow_concurrent and exists (
+      select 1
+      from public.work_order_line_labor_segments seg
+      where seg.shop_id = p_shop_id
+        and seg.technician_id = v_technician_profile_id
+        and seg.work_order_line_id <> p_work_order_line_id
+        and seg.ended_at is null
+    ) then
+      raise exception using errcode = 'P0001', message = 'Technician already has an active job punch.';
+    end if;
+
+    insert into public.work_order_line_technicians(
+      work_order_line_id, technician_id, assigned_by
+    ) values (
+      p_work_order_line_id, v_technician_profile_id, v_actor_profile_id
+    )
+    on conflict (work_order_line_id, technician_id)
+    do update set assigned_by = excluded.assigned_by;
+
+    update public.work_order_lines
+    set assigned_tech_id = coalesce(assigned_tech_id, v_technician_profile_id),
+        status = 'in_progress',
+        hold_reason = null,
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+    insert into public.work_order_line_labor_segments(
+      shop_id, work_order_id, work_order_line_id, technician_id,
+      created_by, started_at, source
+    ) values (
+      p_shop_id, v_line.work_order_id, p_work_order_line_id, v_technician_profile_id,
+      v_actor_profile_id, v_now,
+      coalesce(nullif(trim(p_start_source), ''), case when v_action = 'start' then 'job_start' else 'job_resume' end)
+    ) returning id into v_segment_id;
+
+  elsif v_action = 'pause' then
+    if v_status in ('completed','invoiced') then
+      raise exception using errcode = 'P0001', message = 'Cannot pause a closed line.';
+    end if;
+
+    update public.work_order_line_labor_segments
+    set ended_at = v_now,
+        pause_reason = case
+          when p_preserve_line_status then coalesce(nullif(trim(p_hold_reason), ''), 'labor_pause')
+          when nullif(trim(p_hold_reason), '') is not null then 'hold:' || trim(p_hold_reason)
+          else 'hold'
+        end
+    where shop_id = p_shop_id
+      and work_order_line_id = p_work_order_line_id
+      and technician_id = v_technician_profile_id
+      and ended_at is null;
+    get diagnostics v_closed_count = row_count;
+
+    update public.work_order_lines
+    set status = case when p_preserve_line_status then status else 'on_hold' end,
+        hold_reason = case
+          when p_preserve_line_status then hold_reason
+          else coalesce(nullif(trim(p_hold_reason), ''), 'Paused by technician')
+        end,
+        notes = case when p_preserve_line_status then notes else coalesce(p_notes, notes) end,
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+  else
+    if v_status = 'invoiced' then
+      raise exception using errcode = 'P0001', message = 'Cannot finish an invoiced line.';
+    end if;
+
+    v_final_cause := coalesce(nullif(trim(p_cause), ''), nullif(trim(v_line.cause), ''));
+    v_final_correction := coalesce(nullif(trim(p_correction), ''), nullif(trim(v_line.correction), ''));
+    if v_final_cause is null then
+      raise exception using errcode = 'P0001', message = 'Cause is required before finishing this job.';
+    end if;
+    if v_final_correction is null then
+      raise exception using errcode = 'P0001', message = 'Correction is required before finishing this job.';
+    end if;
+    if coalesce(v_line.labor_time, 0) <= 0 then
+      raise exception using errcode = 'P0001', message = 'Labor time must be greater than 0 before finishing this job.';
+    end if;
+
+    perform 1
+    from public.inspections i
+    where i.work_order_line_id = p_work_order_line_id
+      and i.is_canonical
+    for update;
+
+    if exists (
+      select 1
+      from public.inspections i
+      where i.work_order_line_id = p_work_order_line_id
+        and i.is_canonical
+        and (
+          not coalesce(i.completed, false)
+          or coalesce(i.is_draft, true)
+          or not coalesce(i.locked, false)
+          or lower(coalesce(i.status, 'draft')) not in ('completed', 'finalized', 'signed')
+          or i.finalized_at is null
+          or i.finalized_by is null
+          or not exists (
+            select 1
+            from public.inspection_signatures s
+            where s.inspection_id = i.id
+              and s.signing_cycle = coalesce(i.signing_cycle, 0)
+          )
+        )
+    ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'INSPECTION_COMPLETION_REQUIRED: complete and sign the inspection before finishing this job.';
+    end if;
+
+    update public.work_order_line_labor_segments
+    set ended_at = v_now,
+        pause_reason = 'completed'
+    where shop_id = p_shop_id
+      and work_order_line_id = p_work_order_line_id
+      and technician_id = v_technician_profile_id
+      and ended_at is null;
+    get diagnostics v_closed_count = row_count;
+
+    -- The completed-line constraint is immediate. Persist the punch timeline in
+    -- the same row update that changes status so no invalid intermediate row
+    -- can be observed by PostgreSQL.
+    update public.work_order_lines
+    set status = 'completed',
+        cause = v_final_cause,
+        correction = v_final_correction,
+        hold_reason = null,
+        punched_in_at = coalesce(
+          (
+            select min(seg.started_at)
+            from public.work_order_line_labor_segments seg
+            where seg.work_order_line_id = p_work_order_line_id
+          ),
+          v_line.punched_in_at
+        ),
+        punched_out_at = coalesce(
+          (
+            select max(seg.ended_at)
+            from public.work_order_line_labor_segments seg
+            where seg.work_order_line_id = p_work_order_line_id
+              and seg.ended_at is not null
+          ),
+          v_line.punched_out_at,
+          v_now
+        ),
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+  end if;
+
+  select min(seg.started_at),
+         max(seg.ended_at) filter (where seg.ended_at is not null),
+         bool_or(seg.ended_at is null)
+    into v_earliest, v_latest, v_has_open
+  from public.work_order_line_labor_segments seg
+  where seg.work_order_line_id = p_work_order_line_id;
+
+  update public.work_order_lines
+  set punched_in_at = coalesce(v_earliest, punched_in_at),
+      punched_out_at = case
+        when v_action = 'finish' then coalesce(v_latest, punched_out_at, v_now)
+        when coalesce(v_has_open, false) then null
+        else v_latest
+      end,
+      updated_at = v_now
+  where id = p_work_order_line_id;
+
+  select jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'action', v_action,
+    'shop_id', p_shop_id,
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'technician_id', v_technician_profile_id,
+    'shift_id', v_shift.id,
+    'labor_segment_id', v_segment_id,
+    'closed_segment_count', v_closed_count,
+    'line', (
+      select to_jsonb(wol)
+      from public.work_order_lines wol
+      where wol.id = p_work_order_line_id
+    )
+  ) into v_result;
+
+  insert into public.activity_logs(action, user_id, timestamp, target_table, target_id, context)
+  values (
+    coalesce(nullif(trim(p_event), ''), v_action),
+    v_actor_auth_user_id,
+    v_now,
+    'work_order_line',
+    p_work_order_line_id,
+    coalesce(p_details, '{}'::jsonb) || jsonb_build_object(
+      'shop_id', p_shop_id,
+      'work_order_id', v_line.work_order_id,
+      'technician_id', v_technician_profile_id,
+      'shift_id', v_shift.id,
+      'operation_key', p_operation_key
+    )
+  );
+
+  insert into public.workforce_operation_keys(
+    shop_id, operation_name, operation_key, actor_user_id,
+    work_order_id, work_order_line_id, result
+  ) values (
+    p_shop_id, 'job_punch:' || v_action, p_operation_key, v_actor_auth_user_id,
+    v_line.work_order_id, p_work_order_line_id, v_result
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.apply_job_punch_transition_atomic(
+  uuid,uuid,text,uuid,uuid,text,boolean,timestamptz,text,text,text,
+  boolean,boolean,text,text,text,jsonb
+) from public, anon;
+grant execute on function public.apply_job_punch_transition_atomic(
+  uuid,uuid,text,uuid,uuid,text,boolean,timestamptz,text,text,text,
+  boolean,boolean,text,text,text,jsonb
+) to authenticated, service_role;
+
+comment on table copilot.completed_repair_learning_receipts is
+  'Private durable lease and completion receipt for exactly-once completed-repair learning.';
+comment on function public.claim_completed_repair_learning_atomic(
+  uuid,uuid,uuid,text,uuid,timestamptz
+) is
+  'Claims one serialized completed-repair learning attempt for the current line revision.';
+comment on function public.finish_completed_repair_learning_atomic(
+  uuid,uuid,uuid,uuid,boolean,jsonb,timestamptz
+) is
+  'Completes or releases a completed-repair learning lease without affecting job completion.';
+
+do $technician_completion_review_postcheck$
+declare
+  v_receipt_definition text;
+  v_finish_definition text;
+begin
+  select pg_get_functiondef(
+    'copilot.technician_has_bound_completion_receipt(uuid,uuid,text)'::regprocedure
+  ) into v_receipt_definition;
+  select pg_get_functiondef(
+    'public.apply_job_punch_transition_atomic(uuid,uuid,text,uuid,uuid,text,boolean,timestamp with time zone,text,text,text,boolean,boolean,text,text,text,jsonb)'::regprocedure
+  ) into v_finish_definition;
+
+  if position('active_work_order_line_id = wok.work_order_line_id'
+      in v_receipt_definition) = 0
+  then
+    raise exception 'Completion review postcheck failed: receipt recovery is not line-bound';
+  end if;
+  if (
+    length(v_finish_definition)
+    - length(replace(v_finish_definition, 'i.is_canonical', ''))
+  ) / length('i.is_canonical') < 2
+  then
+    raise exception 'Completion review postcheck failed: inspection completion is not canonical-only';
+  end if;
+  if not exists (
+    select 1
+    from pg_class relation
+    join pg_namespace namespace on namespace.oid = relation.relnamespace
+    where namespace.nspname = 'copilot'
+      and relation.relname = 'completed_repair_learning_receipts'
+      and relation.relrowsecurity
+  ) then
+    raise exception 'Completion review postcheck failed: learning receipts are not private/RLS protected';
+  end if;
+  if has_table_privilege(
+    'authenticated',
+    'copilot.completed_repair_learning_receipts',
+    'SELECT'
+  ) then
+    raise exception 'Completion review postcheck failed: learning receipts are directly readable';
+  end if;
+  if has_function_privilege(
+    'anon',
+    'public.claim_completed_repair_learning_atomic(uuid,uuid,uuid,text,uuid,timestamp with time zone)',
+    'EXECUTE'
+  ) or has_function_privilege(
+    'anon',
+    'public.finish_completed_repair_learning_atomic(uuid,uuid,uuid,uuid,boolean,jsonb,timestamp with time zone)',
+    'EXECUTE'
+  ) then
+    raise exception 'Completion review postcheck failed: anonymous repair-learning execution remains';
+  end if;
+  if not exists (
+    select 1
+    from pg_trigger trigger
+    where trigger.tgrelid = 'public.workforce_operation_keys'::regclass
+      and trigger.tgname =
+        'normalize_technician_copilot_completion_receipt_actor'
+      and not trigger.tgisinternal
+  ) then
+    raise exception 'Completion review postcheck failed: legacy receipt normalizer is missing';
+  end if;
+  if exists (
+    select 1
+    from public.workforce_operation_keys receipt
+    join public.profiles profile on profile.id = receipt.actor_user_id
+    where receipt.shop_id = profile.shop_id
+      and receipt.operation_name = 'job_punch:finish'
+      and receipt.operation_key like 'technician-copilot:%'
+      and profile.user_id is not null
+      and profile.user_id is distinct from profile.id
+  ) then
+    raise exception 'Completion review postcheck failed: legacy profile-owned receipt remains';
+  end if;
+end
+$technician_completion_review_postcheck$;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260816013256_technician_completion_review_hotfix.sql
+++ b/supabase/migrations/20260816013256_technician_completion_review_hotfix.sql
@@ -86,6 +86,20 @@ alter table copilot.completed_repair_learning_receipts enable row level security
 revoke all on copilot.completed_repair_learning_receipts
   from public, anon, authenticated, service_role;
 
+create index if not exists completed_repair_learning_receipts_line_idx
+  on copilot.completed_repair_learning_receipts (work_order_line_id);
+create index if not exists completed_repair_learning_receipts_actor_idx
+  on copilot.completed_repair_learning_receipts (actor_user_id);
+
+drop policy if exists completed_repair_learning_receipts_deny_direct_access
+  on copilot.completed_repair_learning_receipts;
+create policy completed_repair_learning_receipts_deny_direct_access
+  on copilot.completed_repair_learning_receipts
+  for all
+  to public
+  using (false)
+  with check (false);
+
 create or replace function public.claim_completed_repair_learning_atomic(
   p_shop_id uuid,
   p_work_order_line_id uuid,

--- a/supabase/migrations/20260816013256_technician_completion_review_hotfix.sql
+++ b/supabase/migrations/20260816013256_technician_completion_review_hotfix.sql
@@ -86,20 +86,6 @@ alter table copilot.completed_repair_learning_receipts enable row level security
 revoke all on copilot.completed_repair_learning_receipts
   from public, anon, authenticated, service_role;
 
-create index if not exists completed_repair_learning_receipts_line_idx
-  on copilot.completed_repair_learning_receipts (work_order_line_id);
-create index if not exists completed_repair_learning_receipts_actor_idx
-  on copilot.completed_repair_learning_receipts (actor_user_id);
-
-drop policy if exists completed_repair_learning_receipts_deny_direct_access
-  on copilot.completed_repair_learning_receipts;
-create policy completed_repair_learning_receipts_deny_direct_access
-  on copilot.completed_repair_learning_receipts
-  for all
-  to public
-  using (false)
-  with check (false);
-
 create or replace function public.claim_completed_repair_learning_atomic(
   p_shop_id uuid,
   p_work_order_line_id uuid,

--- a/supabase/migrations/20260816020500_completion_learning_receipt_advisor_hardening.sql
+++ b/supabase/migrations/20260816020500_completion_learning_receipt_advisor_hardening.sql
@@ -1,0 +1,47 @@
+-- Keep the private completion-learning receipt table free of avoidable advisor
+-- debt. This is separate from the hotfix migration because Supabase preview
+-- branches apply only newly added migration files after their first deploy.
+
+create index if not exists completed_repair_learning_receipts_line_idx
+  on copilot.completed_repair_learning_receipts (work_order_line_id);
+create index if not exists completed_repair_learning_receipts_actor_idx
+  on copilot.completed_repair_learning_receipts (actor_user_id);
+
+drop policy if exists completed_repair_learning_receipts_deny_direct_access
+  on copilot.completed_repair_learning_receipts;
+create policy completed_repair_learning_receipts_deny_direct_access
+  on copilot.completed_repair_learning_receipts
+  for all
+  to public
+  using (false)
+  with check (false);
+
+do $$
+begin
+  if to_regclass(
+    'copilot.completed_repair_learning_receipts_line_idx'
+  ) is null then
+    raise exception
+      'completion learning receipt line foreign-key index is missing';
+  end if;
+
+  if to_regclass(
+    'copilot.completed_repair_learning_receipts_actor_idx'
+  ) is null then
+    raise exception
+      'completion learning receipt actor foreign-key index is missing';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies policy
+    where policy.schemaname = 'copilot'
+      and policy.tablename = 'completed_repair_learning_receipts'
+      and policy.policyname =
+        'completed_repair_learning_receipts_deny_direct_access'
+  ) then
+    raise exception
+      'completion learning receipt deny-direct-access policy is missing';
+  end if;
+end;
+$$;

--- a/tests/security/technician-copilot-runtime-integrity.runtime.sql
+++ b/tests/security/technician-copilot-runtime-integrity.runtime.sql
@@ -765,7 +765,8 @@ begin
     completed,
     is_draft,
     locked,
-    signing_cycle
+    signing_cycle,
+    is_canonical
   ) values (
     'a1438000-0000-4000-8000-000000000220',
     'a1438000-0000-4000-8000-000000000010',
@@ -775,7 +776,8 @@ begin
     false,
     true,
     false,
-    0
+    0,
+    true
   );
 
   begin
@@ -843,6 +845,33 @@ begin
     'CoPilot Runtime Technician',
     0,
     now()
+  );
+
+  -- Retained non-canonical inspections are immutable evidence history. A
+  -- stale draft must not block completion once the canonical inspection is
+  -- explicitly complete and signed.
+  insert into public.inspections (
+    id,
+    shop_id,
+    work_order_id,
+    work_order_line_id,
+    status,
+    completed,
+    is_draft,
+    locked,
+    signing_cycle,
+    is_canonical
+  ) values (
+    'a1438000-0000-4000-8000-000000000222',
+    'a1438000-0000-4000-8000-000000000010',
+    'a1438000-0000-4000-8000-000000000102',
+    'a1438000-0000-4000-8000-000000000202',
+    'draft',
+    false,
+    true,
+    false,
+    0,
+    false
   );
 
   perform copilot.technician_event_append_internal(
@@ -983,6 +1012,24 @@ begin
   where id = 'a1438000-0000-4000-8000-000000000209'
   returning updated_at into v_line_updated_at;
 
+  perform copilot.technician_event_append_internal(
+    'a1438000-0000-4000-8000-000000000003',
+    v_session_id,
+    'action.pending',
+    'system',
+    'a1438000-0000-5000-a000-000000000423',
+    jsonb_build_object(
+      'action', 'job.complete',
+      'key', 'a1438000-0000-5000-a000-000000000422',
+      'turnId', 'runtime-split-complete-turn',
+      'request', jsonb_build_object('type', 'job.complete'),
+      'workOrderId', 'a1438000-0000-4000-8000-000000000104',
+      'workOrderLineId', 'a1438000-0000-4000-8000-000000000209',
+      'lineUpdatedAt', v_line_updated_at
+    ),
+    now()
+  );
+
   perform copilot.technician_job_action_internal(
     'a1438000-0000-4000-8000-000000000003',
     v_session_id,
@@ -1022,8 +1069,128 @@ begin
   ) then
     raise exception 'CoPilot split-identity assertion failed: auth/profile ownership was conflated';
   end if;
+
+  update public.work_order_lines
+  set assigned_tech_id = 'a1438000-0000-4000-8000-000000000004',
+      assigned_to = 'a1438000-0000-4000-8000-000000000004'
+  where id = 'a1438000-0000-4000-8000-000000000210';
+
+  perform copilot.technician_session_start_internal(
+    'a1438000-0000-4000-8000-000000000003',
+    'a1438000-0000-4000-8000-000000000104',
+    'a1438000-0000-4000-8000-000000000210',
+    'shop',
+    'a1438000-0000-5000-a000-000000000424'
+  );
+
+  update public.work_order_lines
+  set assigned_tech_id = null,
+      assigned_to = null
+  where id = 'a1438000-0000-4000-8000-000000000210';
+  delete from public.work_order_line_technicians
+  where work_order_line_id = 'a1438000-0000-4000-8000-000000000210'
+    and technician_id = 'a1438000-0000-4000-8000-000000000004';
+
+  begin
+    perform copilot.technician_session_read_internal(
+      'a1438000-0000-4000-8000-000000000003',
+      v_session_id
+    );
+    raise exception 'CoPilot receipt assertion failed: historical completion receipt survived re-anchor';
+  exception when sqlstate '42501' then
+    if sqlerrm <> 'copilot_work_order_assignment_required' then
+      raise;
+    end if;
+  end;
+
+  insert into public.workforce_operation_keys (
+    shop_id,
+    operation_name,
+    operation_key,
+    actor_user_id,
+    work_order_id,
+    work_order_line_id,
+    result
+  ) values (
+    'a1438000-0000-4000-8000-000000000010',
+    'job_punch:finish',
+    'technician-copilot:a1438000-0000-5000-a000-000000000425',
+    'a1438000-0000-4000-8000-000000000004',
+    'a1438000-0000-4000-8000-000000000104',
+    'a1438000-0000-4000-8000-000000000210',
+    '{}'::jsonb
+  );
+
+  if not exists (
+    select 1
+    from public.workforce_operation_keys receipt
+    where receipt.operation_key =
+      'technician-copilot:a1438000-0000-5000-a000-000000000425'
+      and receipt.actor_user_id =
+        'a1438000-0000-4000-8000-000000000003'
+  ) then
+    raise exception 'CoPilot split-identity assertion failed: legacy receipt actor was not normalized';
+  end if;
 end
 $technician_copilot_split_identity_completion$;
+
+do $technician_completion_learning_serialization$
+declare
+  v_first jsonb;
+  v_overlapping jsonb;
+  v_finished jsonb;
+  v_replay jsonb;
+begin
+  v_first := public.claim_completed_repair_learning_atomic(
+    'a1438000-0000-4000-8000-000000000010',
+    'a1438000-0000-4000-8000-000000000202',
+    'a1438000-0000-4000-8000-000000000002',
+    'runtime-learning-operation',
+    'a1438000-0000-5000-a000-000000000430'
+  );
+  v_overlapping := public.claim_completed_repair_learning_atomic(
+    'a1438000-0000-4000-8000-000000000010',
+    'a1438000-0000-4000-8000-000000000202',
+    'a1438000-0000-4000-8000-000000000002',
+    'runtime-learning-operation',
+    'a1438000-0000-5000-a000-000000000431'
+  );
+  v_finished := public.finish_completed_repair_learning_atomic(
+    'a1438000-0000-4000-8000-000000000010',
+    'a1438000-0000-4000-8000-000000000202',
+    'a1438000-0000-4000-8000-000000000002',
+    'a1438000-0000-5000-a000-000000000430',
+    true,
+    '{"ok":true}'::jsonb
+  );
+  v_replay := public.claim_completed_repair_learning_atomic(
+    'a1438000-0000-4000-8000-000000000010',
+    'a1438000-0000-4000-8000-000000000202',
+    'a1438000-0000-4000-8000-000000000002',
+    'runtime-learning-operation',
+    'a1438000-0000-5000-a000-000000000432'
+  );
+
+  if not coalesce((v_first ->> 'claimed')::boolean, false)
+    or not coalesce((v_overlapping ->> 'inProgress')::boolean, false)
+    or not coalesce((v_finished ->> 'completed')::boolean, false)
+    or not coalesce((v_replay ->> 'completed')::boolean, false)
+    or exists (
+      select 1
+      from copilot.completed_repair_learning_receipts receipt
+      where receipt.shop_id = 'a1438000-0000-4000-8000-000000000010'
+        and receipt.work_order_line_id =
+          'a1438000-0000-4000-8000-000000000202'
+        and (
+          receipt.state <> 'completed'
+          or receipt.attempt_count <> 1
+        )
+    )
+  then
+    raise exception 'Completed repair learning assertion failed: replay serialization is incoherent';
+  end if;
+end
+$technician_completion_learning_serialization$;
 
 do $technician_copilot_runtime_schema$
 begin

--- a/tests/technician-completion-review-hotfix.test.ts
+++ b/tests/technician-completion-review-hotfix.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260816013256_technician_completion_review_hotfix.sql",
+  "utf8",
+);
+const actions = readFileSync(
+  "features/copilot/technician/server/actions.ts",
+  "utf8",
+);
+const chat = readFileSync(
+  "features/copilot/technician/server/chat.ts",
+  "utf8",
+);
+const completionService = readFileSync(
+  "features/work-orders/server/completeWorkOrderLine.ts",
+  "utf8",
+);
+
+describe("technician completion post-merge review hotfix", () => {
+  it("expires completion-receipt authorization when a session re-anchors", () => {
+    expect(migration).toContain(
+      "rs.active_work_order_line_id = wok.work_order_line_id",
+    );
+    expect(migration).toContain(
+      "copilot.technician_has_bound_completion_receipt(",
+    );
+  });
+
+  it("serializes repair learning behind a private durable lease", () => {
+    expect(migration).toContain(
+      "copilot.completed_repair_learning_receipts",
+    );
+    expect(migration).toContain("on conflict (shop_id, work_order_line_id)");
+    expect(migration).toContain("for update");
+    expect(migration).toContain("interval '5 minutes'");
+    expect(completionService).toContain(
+      '"claim_completed_repair_learning_atomic"',
+    );
+    expect(completionService).toContain(
+      '"finish_completed_repair_learning_atomic"',
+    );
+    expect(completionService).toContain("operationKey: input.operationKey");
+  });
+
+  it("normalizes legacy split-identity completion receipts", () => {
+    expect(migration).toContain(
+      "normalize_technician_copilot_completion_receipt_actor",
+    );
+    expect(migration).toContain("set actor_user_id = profile.user_id");
+    expect(migration).toContain("receipt.actor_user_id = profile.id");
+  });
+
+  it("locks and validates only the canonical inspection", () => {
+    const canonicalPredicates = migration.match(/and i\.is_canonical/g) ?? [];
+    expect(canonicalPredicates).toHaveLength(2);
+    expect(migration).toContain("INSPECTION_COMPLETION_REQUIRED");
+  });
+
+  it("uses the shared next-work ordering when completion re-anchors", () => {
+    expect(actions).toContain("selectNextTechnicianWorkLine");
+    expect(actions).toContain("compareTechnicianWorkLines");
+    expect(chat).toContain(
+      "selectNextTechnicianWorkLine(\n      activeWorkOrder?.lines ?? [],",
+    );
+  });
+});

--- a/tests/technician-completion-review-hotfix.test.ts
+++ b/tests/technician-completion-review-hotfix.test.ts
@@ -35,6 +35,15 @@ describe("technician completion post-merge review hotfix", () => {
     expect(migration).toContain("on conflict (shop_id, work_order_line_id)");
     expect(migration).toContain("for update");
     expect(migration).toContain("interval '5 minutes'");
+    expect(migration).toContain(
+      "completed_repair_learning_receipts_line_idx",
+    );
+    expect(migration).toContain(
+      "completed_repair_learning_receipts_actor_idx",
+    );
+    expect(migration).toContain(
+      "completed_repair_learning_receipts_deny_direct_access",
+    );
     expect(completionService).toContain(
       '"claim_completed_repair_learning_atomic"',
     );

--- a/tests/technician-completion-review-hotfix.test.ts
+++ b/tests/technician-completion-review-hotfix.test.ts
@@ -5,6 +5,10 @@ const migration = readFileSync(
   "supabase/migrations/20260816013256_technician_completion_review_hotfix.sql",
   "utf8",
 );
+const advisorMigration = readFileSync(
+  "supabase/migrations/20260816020500_completion_learning_receipt_advisor_hardening.sql",
+  "utf8",
+);
 const actions = readFileSync(
   "features/copilot/technician/server/actions.ts",
   "utf8",
@@ -35,13 +39,13 @@ describe("technician completion post-merge review hotfix", () => {
     expect(migration).toContain("on conflict (shop_id, work_order_line_id)");
     expect(migration).toContain("for update");
     expect(migration).toContain("interval '5 minutes'");
-    expect(migration).toContain(
+    expect(advisorMigration).toContain(
       "completed_repair_learning_receipts_line_idx",
     );
-    expect(migration).toContain(
+    expect(advisorMigration).toContain(
       "completed_repair_learning_receipts_actor_idx",
     );
-    expect(migration).toContain(
+    expect(advisorMigration).toContain(
       "completed_repair_learning_receipts_deny_direct_access",
     );
     expect(completionService).toContain(

--- a/tests/technician-copilot-job-actions.test.ts
+++ b/tests/technician-copilot-job-actions.test.ts
@@ -19,6 +19,7 @@ import {
   describeNextTechnicianWork,
   executeTechnicianCopilotAction,
   prepareTechnicianCopilotAction,
+  selectNextTechnicianWorkLine,
 } from "@/features/copilot/technician/server/actions";
 
 const workOrder: TechnicianWorkCandidate = {
@@ -78,6 +79,17 @@ describe("Technician CoPilot canonical job actions", () => {
     expect(reply).toContain("already punched into Road test");
     expect(reply).toContain("WO #EL000005");
     expect(mocks.sendCopilotServerCommand).not.toHaveBeenCalled();
+  });
+
+  it("selects in-progress work before awaiting, held, or waiting-parts lines", () => {
+    const selected = selectNextTechnicianWorkLine([
+      { ...workOrder.lines[0], status: "waiting_parts", priority: 1 },
+      { ...workOrder.lines[0], id: "line-awaiting", status: "awaiting", priority: 1 },
+      { ...workOrder.lines[1], id: "line-running", status: "in_progress", priority: 9 },
+      { ...workOrder.lines[0], id: "line-held", status: "on_hold", priority: 0 },
+    ]);
+
+    expect(selected?.id).toBe("line-running");
   });
 
   it("uses the repair session's active line when natural language omits an ID", () => {
@@ -322,6 +334,7 @@ describe("Technician CoPilot canonical job actions", () => {
       supabase: expect.anything(),
       lineId: activeWorkOrder.lines[0].id,
       actorUserId: "00000000-0000-4000-8000-000000000011",
+      operationKey: "00000000-0000-5000-a000-000000000310",
     });
   });
 

--- a/tests/technician-copilot-text-runtime.test.ts
+++ b/tests/technician-copilot-text-runtime.test.ts
@@ -593,7 +593,7 @@ describe("Technician CoPilot persistent text runtime", () => {
       turnId: "turn-start-before-reanchor",
       inputSource: "voice",
     });
-    const remainingLine = {
+    const remainingAwaitingLine = {
       ...candidate.lines[0],
       id: "line-road-test",
       complaint: "Final road test",
@@ -601,9 +601,28 @@ describe("Technician CoPilot persistent text runtime", () => {
       cause: null,
       correction: null,
     };
+    const remainingHeldLine = {
+      ...remainingAwaitingLine,
+      id: "line-held",
+      complaint: "Repair on hold",
+      status: "on_hold",
+      priority: 1,
+    };
+    const remainingRunningLine = {
+      ...remainingAwaitingLine,
+      id: "line-running",
+      complaint: "Running repair",
+      status: "in_progress",
+      priority: 9,
+    };
     const beforeCompletion = {
       ...candidate,
-      lineIds: ["line-driveline", remainingLine.id],
+      lineIds: [
+        "line-driveline",
+        remainingHeldLine.id,
+        remainingAwaitingLine.id,
+        remainingRunningLine.id,
+      ],
       lines: [
         {
           ...candidate.lines[0],
@@ -611,13 +630,25 @@ describe("Technician CoPilot persistent text runtime", () => {
           cause: "Failed rear U-joint",
           correction: "Replaced rear U-joint",
         },
-        remainingLine,
+        remainingHeldLine,
+        remainingAwaitingLine,
+        remainingRunningLine,
       ],
     };
     const afterCompletion = {
       ...beforeCompletion,
-      lineIds: [remainingLine.id],
-      lines: [remainingLine],
+      lineIds: [
+        remainingHeldLine.id,
+        remainingAwaitingLine.id,
+        remainingRunningLine.id,
+      ],
+      // Deliberately unordered to prove completion disposition uses the same
+      // in-progress/status/priority ordering as "what's next".
+      lines: [
+        remainingHeldLine,
+        remainingAwaitingLine,
+        remainingRunningLine,
+      ],
     };
     let completionCommitted = false;
     mocks.listTechnicianWorkCandidates.mockResolvedValue([beforeCompletion]);
@@ -657,13 +688,13 @@ describe("Technician CoPilot persistent text runtime", () => {
     expect(completed.sessionId).toBe("session-ford");
     expect(completed.session).toMatchObject({
       status: "active",
-      activeWorkOrderLineId: remainingLine.id,
+      activeWorkOrderLineId: remainingRunningLine.id,
     });
     expect(
       mocks.sendCopilotServerCommand.mock.calls.some(
         ([call]) =>
           call.action === "session.start" &&
-          call.args.workOrderLineId === remainingLine.id,
+          call.args.workOrderLineId === remainingRunningLine.id,
       ),
     ).toBe(true);
     expect(

--- a/tests/work-order-completion-service.test.ts
+++ b/tests/work-order-completion-service.test.ts
@@ -17,7 +17,10 @@ vi.mock(
   }),
 );
 
-import { completeWorkOrderLine } from "@/features/work-orders/server/completeWorkOrderLine";
+import {
+  completeWorkOrderLine,
+  learnFromCompletedWorkOrderLine,
+} from "@/features/work-orders/server/completeWorkOrderLine";
 
 function completionClient() {
   const maybeSingle = vi.fn().mockResolvedValue({
@@ -27,7 +30,26 @@ function completionClient() {
   const eq = vi.fn(() => ({ maybeSingle }));
   const select = vi.fn(() => ({ eq }));
   const from = vi.fn(() => ({ select }));
-  return { client: { from } as never, from, select, eq, maybeSingle };
+  const rpc = vi.fn(async (name: string) => {
+    if (name === "claim_completed_repair_learning_atomic") {
+      return {
+        data: { claimed: true, completed: false, inProgress: false },
+        error: null,
+      };
+    }
+    if (name === "finish_completed_repair_learning_atomic") {
+      return { data: { completed: true }, error: null };
+    }
+    throw new Error(`Unexpected RPC: ${name}`);
+  });
+  return {
+    client: { from, rpc } as never,
+    from,
+    select,
+    eq,
+    maybeSingle,
+    rpc,
+  };
 }
 
 describe("canonical work-order line completion", () => {
@@ -41,7 +63,7 @@ describe("canonical work-order line completion", () => {
   });
 
   it("runs idempotent repair learning after the canonical finish succeeds", async () => {
-    const { client } = completionClient();
+    const { client, rpc } = completionClient();
     const result = await completeWorkOrderLine({
       supabase: client,
       lineId: "line-1",
@@ -71,6 +93,25 @@ describe("canonical work-order line completion", () => {
       workOrderLineId: "line-1",
       actorUserId: "auth-tech",
     });
+    expect(rpc).toHaveBeenNthCalledWith(
+      1,
+      "claim_completed_repair_learning_atomic",
+      expect.objectContaining({
+        p_shop_id: "shop-1",
+        p_work_order_line_id: "line-1",
+        p_actor_user_id: "auth-tech",
+        p_operation_key: "finish-key",
+        p_lease_token: expect.any(String),
+      }),
+    );
+    expect(rpc).toHaveBeenNthCalledWith(
+      2,
+      "finish_completed_repair_learning_atomic",
+      expect.objectContaining({
+        p_succeeded: true,
+        p_lease_token: expect.any(String),
+      }),
+    );
     expect(result).toMatchObject({
       ok: true,
       menuRepairLearning: { ok: true },
@@ -78,7 +119,7 @@ describe("canonical work-order line completion", () => {
   });
 
   it("keeps completion successful when repair learning fails", async () => {
-    const { client } = completionClient();
+    const { client, rpc } = completionClient();
     mocks.upsertMenuRepairItemFromCompletedLine.mockRejectedValue(
       new Error("learning unavailable"),
     );
@@ -97,6 +138,10 @@ describe("canonical work-order line completion", () => {
       ok: true,
       menuRepairLearning: { ok: false },
     });
+    expect(rpc).toHaveBeenLastCalledWith(
+      "finish_completed_repair_learning_atomic",
+      expect.objectContaining({ p_succeeded: false }),
+    );
   });
 
   it("does not learn from a completion that did not commit", async () => {
@@ -121,5 +166,55 @@ describe("canonical work-order line completion", () => {
       error: "INSPECTION_COMPLETION_REQUIRED",
     });
     expect(mocks.upsertMenuRepairItemFromCompletedLine).not.toHaveBeenCalled();
+  });
+
+  it("lets only one concurrent replay perform repair learning", async () => {
+    const { client, rpc } = completionClient();
+    let claimCount = 0;
+    rpc.mockImplementation(async (name: string) => {
+      if (name === "claim_completed_repair_learning_atomic") {
+        claimCount += 1;
+        return claimCount === 1
+          ? {
+              data: { claimed: true, completed: false, inProgress: false },
+              error: null,
+            }
+          : {
+              data: { claimed: false, completed: false, inProgress: true },
+              error: null,
+            };
+      }
+      return { data: { completed: true }, error: null };
+    });
+
+    let releaseLearning!: () => void;
+    mocks.upsertMenuRepairItemFromCompletedLine.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseLearning = resolve;
+        }),
+    );
+
+    const first = learnFromCompletedWorkOrderLine({
+      supabase: client,
+      lineId: "line-1",
+      actorUserId: "auth-tech",
+      operationKey: "finish-key",
+    });
+    await vi.waitFor(() => {
+      expect(mocks.upsertMenuRepairItemFromCompletedLine).toHaveBeenCalledTimes(1);
+    });
+    const replay = await learnFromCompletedWorkOrderLine({
+      supabase: client,
+      lineId: "line-1",
+      actorUserId: "auth-tech",
+      operationKey: "finish-key",
+    });
+    releaseLearning();
+    const completed = await first;
+
+    expect(replay).toEqual({ ok: true });
+    expect(completed).toEqual({ ok: true });
+    expect(mocks.upsertMenuRepairItemFromCompletedLine).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Scope

Forward-only hotfix for the five Codex findings submitted after #1445 merged.

- expire completion-receipt recovery authority when a repair session re-anchors to another line
- serialize completed-repair learning behind a private durable lease shared by screen and CoPilot completion
- backfill and normalize legacy profile-owned CoPilot completion receipts to auth ownership
- lock and validate only the canonical inspection when completing a job
- re-anchor to the highest-priority remaining line using the same ordering as “what’s next”

This branch starts from current `main` at merge commit `e364fad1dfc65e6c2da04a37ad2fbdf40c8759e2`.

## Database

Adds forward migrations:

- `20260816013256_technician_completion_review_hotfix.sql`
- `20260816020500_completion_learning_receipt_advisor_hardening.sql`

The second migration adds the private receipt table's foreign-key indexes and explicit deny-direct-access RLS policy. It is separate so an already-created Supabase preview applies the same final schema that Clean Replay and production would apply.

The already-applied `20260815232321` migration is unchanged. Neither new migration has been applied to production.

## Exact-head validation

Final head: `5910463c6bcd591223e8ed3bc11b4174210517fd`

- Agent PR Checks: pass (type-check, changed-file lint, complete test suite, production build)
- Phase 4 Technician Labor Validation: pass
- P0-006 Stripe Identity Validation: pass
- Supabase Clean Replay Validation: pass
- generated Supabase types match the replayed migration contract
- full migration reset/replay and Technician CoPilot runtime integration: pass
- Supabase preview: database, services, APIs, configurations, migrations, and seeding healthy
- preview assertions: line-bound receipt recovery, canonical-inspection completion, private RLS receipt storage, no direct authenticated read, no anonymous RPC execution, actor normalizer, foreign-key indexes, and deny-direct-access policy all present
- clean eleven-file task scope; five commits ahead and zero behind `main`

## Review findings addressed

- #1445 discussion `r3790659591`: historical receipt authorization after re-anchor
- #1445 discussion `r3790659593`: concurrent repair-learning replay
- #1445 discussion `r3790659595`: legacy split-identity receipts
- #1445 discussion `r3790659597`: non-canonical inspection completion block
- #1445 discussion `r3790659598`: unordered completion re-anchor

## Explicitly out of scope

- persistent voice shell
- new technician actions or permissions
- production migration
- merge
