### PR TITLE
Build responsive Field Hub foundation

### DIFF
--- a/app/api/mobile/field-service/access/route.ts
+++ b/app/api/mobile/field-service/access/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import {
-  getMobileFieldServiceAccess,
+  getMobileFieldServiceWorkspaceAccess,
 } from "@/features/mobile/service/server/access";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
@@ -10,7 +10,7 @@ export async function GET() {
   if (!access.ok) return access.response;
 
   try {
-    return NextResponse.json(await getMobileFieldServiceAccess(access), {
+    return NextResponse.json(await getMobileFieldServiceWorkspaceAccess(access), {
       headers: { "Cache-Control": "private, no-store" },
     });
   } catch {

--- a/app/mobile/field-hub.css
+++ b/app/mobile/field-hub.css
@@ -131,6 +131,18 @@
   font-weight: 700;
 }
 
+.field-workspace-sign-out {
+  width: 100%;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.field-workspace-sign-out:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
 .field-workspace-header {
   position: sticky;
   top: 0;

--- a/app/mobile/field-hub.css
+++ b/app/mobile/field-hub.css
@@ -1,0 +1,690 @@
+.field-workspace {
+  --field-chrome: #061329;
+  --field-chrome-deep: #030a18;
+  --field-blue: #29b6f6;
+  --field-copper: var(--accent-copper, #c66a2b);
+  min-height: 100dvh;
+  background:
+    radial-gradient(circle at 80% 0%, rgba(41, 182, 246, 0.08), transparent 30rem),
+    var(--theme-surface-page);
+  color: var(--theme-text-primary);
+}
+
+.field-workspace-sidebar {
+  display: none;
+}
+
+.field-workspace-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 4.75rem;
+  border-bottom: 1px solid rgba(147, 185, 239, 0.16);
+  padding: 0.85rem 1rem;
+  color: white;
+}
+
+.field-workspace-brand__mark {
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid rgba(123, 211, 255, 0.35);
+  border-radius: 0.85rem;
+  background: linear-gradient(145deg, #1747ff, #19b7ff);
+  box-shadow: 0 10px 25px rgba(23, 71, 255, 0.35);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+.field-workspace-brand strong,
+.field-workspace-brand small {
+  display: block;
+}
+
+.field-workspace-brand strong {
+  font-size: 0.98rem;
+  letter-spacing: 0.02em;
+}
+
+.field-workspace-brand small {
+  margin-top: 0.1rem;
+  color: #8ed7ff;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.field-workspace-new-call {
+  display: flex;
+  min-height: 3rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 0.85rem;
+  border-radius: 0.85rem;
+  background: linear-gradient(135deg, #1747ff, #159ee7);
+  color: white;
+  box-shadow: 0 12px 28px rgba(23, 71, 255, 0.28);
+  font-size: 0.86rem;
+  font-weight: 800;
+}
+
+.field-workspace-sidebar__scroll {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.25rem 0.7rem 1rem;
+}
+
+.field-workspace-nav__section + .field-workspace-nav__section {
+  margin-top: 1.15rem;
+}
+
+.field-workspace-nav__label {
+  padding: 0 0.65rem 0.4rem;
+  color: rgba(199, 218, 246, 0.55);
+  font-size: 0.61rem;
+  font-weight: 850;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+.field-workspace-nav__link {
+  display: flex;
+  min-height: 2.85rem;
+  align-items: center;
+  gap: 0.7rem;
+  border: 1px solid transparent;
+  border-radius: 0.78rem;
+  padding: 0.55rem 0.7rem;
+  color: rgba(232, 241, 255, 0.78);
+  font-size: 0.84rem;
+  font-weight: 680;
+  transition: 140ms ease;
+}
+
+.field-workspace-nav__link:hover,
+.field-workspace-nav__link[data-active="true"] {
+  border-color: rgba(93, 166, 255, 0.28);
+  background: rgba(255, 255, 255, 0.075);
+  color: white;
+}
+
+.field-workspace-nav__link[data-active="true"] {
+  box-shadow: inset 3px 0 0 var(--field-blue);
+}
+
+.field-workspace-sidebar__footer {
+  border-top: 1px solid rgba(147, 185, 239, 0.15);
+  padding: 0.65rem 0.7rem 0.85rem;
+}
+
+.field-workspace-exit {
+  display: block;
+  margin: 0.45rem 0.7rem 0;
+  color: rgba(199, 218, 246, 0.68);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.field-workspace-header {
+  position: sticky;
+  top: 0;
+  z-index: 35;
+  display: grid;
+  grid-template-columns: 2.7rem minmax(0, 1fr) 2.7rem;
+  min-height: calc(4rem + env(safe-area-inset-top, 0px));
+  align-items: center;
+  gap: 0.7rem;
+  border-bottom: 1px solid rgba(137, 178, 234, 0.2);
+  padding: env(safe-area-inset-top, 0px) 0.75rem 0;
+  background:
+    radial-gradient(circle at 88% -55%, rgba(41, 182, 246, 0.28), transparent 12rem),
+    linear-gradient(145deg, var(--field-chrome), var(--field-chrome-deep));
+  color: white;
+  box-shadow: 0 12px 28px rgba(3, 13, 32, 0.18);
+}
+
+.field-workspace-header__menu,
+.field-workspace-header__add {
+  display: grid;
+  width: 2.7rem;
+  height: 2.7rem;
+  place-items: center;
+  border: 1px solid rgba(155, 193, 245, 0.22);
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.07);
+  color: white;
+}
+
+.field-workspace-header__add {
+  border-color: transparent;
+  background: #1747ff;
+}
+
+.field-workspace-header__eyebrow {
+  color: #86d5ff;
+  font-size: 0.59rem;
+  font-weight: 850;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.field-workspace-header__title {
+  overflow: hidden;
+  margin-top: 0.08rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.field-workspace-main {
+  min-width: 0;
+  overflow-x: clip;
+  padding-bottom: calc(5.75rem + env(safe-area-inset-bottom, 0px));
+}
+
+.field-workspace-bottom {
+  position: fixed;
+  inset: auto 0 0;
+  z-index: 35;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  min-height: calc(4.55rem + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid rgba(124, 166, 235, 0.2);
+  padding: 0.35rem 0.3rem env(safe-area-inset-bottom, 0px);
+  background: rgba(4, 13, 32, 0.96);
+  box-shadow: 0 -15px 38px rgba(3, 13, 32, 0.24);
+  backdrop-filter: blur(22px);
+}
+
+.field-workspace-bottom > a,
+.field-workspace-bottom > button {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  border-radius: 0.75rem;
+  color: rgba(210, 224, 246, 0.66);
+  font-size: 0.6rem;
+  font-weight: 750;
+}
+
+.field-workspace-bottom > [data-active="true"] {
+  color: #8bd8ff;
+}
+
+.field-workspace-bottom .field-workspace-bottom__new {
+  width: 3.7rem;
+  min-height: 3.7rem;
+  align-self: start;
+  justify-self: center;
+  margin-top: -1rem;
+  border: 4px solid var(--field-chrome-deep);
+  border-radius: 1.3rem;
+  background: linear-gradient(145deg, #1747ff, #19b7ff);
+  color: white;
+  box-shadow: 0 12px 26px rgba(23, 71, 255, 0.38);
+}
+
+.field-workspace-drawer__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  pointer-events: none;
+  background: rgba(1, 7, 19, 0.62);
+  opacity: 0;
+  backdrop-filter: blur(7px);
+  transition: opacity 180ms ease;
+}
+
+.field-workspace-drawer__backdrop[data-open="true"] {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.field-workspace-drawer {
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 55;
+  display: flex;
+  width: min(88vw, 22rem);
+  transform: translateX(-105%);
+  flex-direction: column;
+  border-right: 1px solid rgba(124, 166, 235, 0.22);
+  background:
+    radial-gradient(circle at 0 0, rgba(23, 71, 255, 0.22), transparent 20rem),
+    linear-gradient(180deg, var(--field-chrome), var(--field-chrome-deep));
+  color: white;
+  box-shadow: 28px 0 70px rgba(0, 0, 0, 0.36);
+  transition: transform 180ms ease;
+}
+
+.field-workspace-drawer[data-open="true"] {
+  transform: translateX(0);
+}
+
+.field-workspace-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(124, 166, 235, 0.18);
+  padding: calc(1rem + env(safe-area-inset-top, 0px)) 1rem 1rem;
+}
+
+.field-workspace-drawer__header strong,
+.field-workspace-drawer__header small {
+  display: block;
+}
+
+.field-workspace-drawer__header small {
+  margin-top: 0.15rem;
+  color: rgba(203, 220, 247, 0.65);
+  font-size: 0.7rem;
+}
+
+.field-workspace-drawer__header button {
+  display: grid;
+  width: 2.7rem;
+  height: 2.7rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 0.8rem;
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.field-workspace-drawer__scroll {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.2rem 0.7rem 1rem;
+}
+
+.field-workspace-drawer__footer {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.55rem;
+  border-top: 1px solid rgba(124, 166, 235, 0.16);
+  padding: 0.85rem 0.85rem calc(0.85rem + env(safe-area-inset-bottom, 0px));
+}
+
+.field-workspace-drawer__footer a,
+.field-workspace-drawer__footer button {
+  display: flex;
+  min-height: 2.8rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(238, 245, 255, 0.85);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+/* Field Hub dashboard */
+.field-hub {
+  width: min(100%, 96rem);
+  margin-inline: auto;
+  padding: 0.8rem 0.75rem 2rem;
+}
+
+.field-hub-hero {
+  position: relative;
+  display: flex;
+  overflow: hidden;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid rgba(123, 180, 240, 0.16);
+  border-radius: 1.5rem;
+  padding: 1.2rem;
+  background:
+    radial-gradient(circle at 88% 8%, rgba(41, 182, 246, 0.26), transparent 18rem),
+    radial-gradient(circle at 12% 140%, rgba(23, 71, 255, 0.33), transparent 20rem),
+    linear-gradient(145deg, #07172f, #030b1c);
+  color: white;
+  box-shadow: 0 22px 55px rgba(3, 13, 32, 0.22);
+}
+
+.field-hub-hero__eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #86d5ff;
+  font-size: 0.64rem;
+  font-weight: 850;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.field-hub-hero__title {
+  margin-top: 0.45rem;
+  font-size: clamp(1.75rem, 5vw, 3.15rem);
+  font-weight: 850;
+  letter-spacing: -0.045em;
+  line-height: 1.02;
+}
+
+.field-hub-hero__subtitle {
+  max-width: 42rem;
+  margin-top: 0.55rem;
+  color: rgba(220, 232, 250, 0.76);
+  font-size: 0.84rem;
+  line-height: 1.45;
+}
+
+.field-hub-hero__actions {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.55rem;
+}
+
+.field-hub-primary-action,
+.field-hub-secondary-action {
+  display: inline-flex;
+  min-height: 3rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.85rem;
+  padding: 0.65rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.field-hub-primary-action {
+  background: linear-gradient(135deg, #1747ff, #159ee7);
+  color: white;
+  box-shadow: 0 12px 28px rgba(23, 71, 255, 0.3);
+}
+
+.field-hub-secondary-action {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.075);
+  color: white;
+}
+
+.field-hub-signals {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.55rem;
+  margin-top: 0.7rem;
+}
+
+.field-hub-signal {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.7rem;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 1rem;
+  padding: 0.7rem 0.8rem;
+  background: var(--theme-surface-panel);
+  box-shadow: 0 10px 28px rgba(3, 13, 32, 0.07);
+}
+
+.field-hub-signal__icon {
+  display: grid;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 0.72rem;
+  background: rgba(41, 182, 246, 0.12);
+  color: #1585bd;
+}
+
+.field-hub-signal__icon[data-tone="green"] {
+  background: rgba(16, 185, 129, 0.12);
+  color: #0d956a;
+}
+
+.field-hub-signal__icon[data-tone="amber"] {
+  background: rgba(245, 158, 11, 0.13);
+  color: #b66b05;
+}
+
+.field-hub-signal strong,
+.field-hub-signal small {
+  display: block;
+}
+
+.field-hub-signal strong {
+  color: var(--theme-text-primary);
+  font-size: 0.78rem;
+}
+
+.field-hub-signal small {
+  overflow: hidden;
+  margin-top: 0.08rem;
+  color: var(--theme-text-secondary);
+  font-size: 0.66rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.field-hub-grid {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 0.8rem;
+}
+
+.field-hub-today,
+.field-hub-operations {
+  min-width: 0;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 1.35rem;
+  padding: 0.9rem;
+  background: color-mix(in srgb, var(--theme-surface-panel) 96%, transparent);
+  box-shadow: 0 16px 42px rgba(3, 13, 32, 0.08);
+}
+
+.field-hub-section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  padding-inline: 0.15rem;
+}
+
+.field-hub-section-heading__eyebrow {
+  color: var(--accent-copper);
+  font-size: 0.59rem;
+  font-weight: 850;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+.field-hub-section-heading h2 {
+  margin-top: 0.12rem;
+  color: var(--theme-text-primary);
+  font-size: 1.02rem;
+  font-weight: 820;
+  letter-spacing: -0.025em;
+}
+
+.field-hub-text-link {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--theme-text-secondary);
+  font-size: 0.68rem;
+  font-weight: 750;
+}
+
+.field-hub-module-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+}
+
+.field-hub-module {
+  display: flex;
+  min-height: 4.75rem;
+  align-items: center;
+  gap: 0.75rem;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 1rem;
+  padding: 0.7rem;
+  background: var(--theme-surface-page);
+  color: var(--theme-text-primary);
+  transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
+}
+
+a.field-hub-module:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent-copper) 55%, var(--theme-border-soft));
+  box-shadow: 0 12px 28px rgba(3, 13, 32, 0.09);
+}
+
+.field-hub-module[data-available="false"] {
+  border-style: dashed;
+  opacity: 0.74;
+}
+
+.field-hub-module__icon {
+  display: grid;
+  width: 2.55rem;
+  height: 2.55rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 0.82rem;
+  background: color-mix(in srgb, var(--accent-copper) 11%, transparent);
+  color: var(--accent-copper);
+}
+
+.field-hub-module__title,
+.field-hub-module__description {
+  display: block;
+}
+
+.field-hub-module__title {
+  font-size: 0.78rem;
+  font-weight: 780;
+}
+
+.field-hub-module__description {
+  margin-top: 0.18rem;
+  color: var(--theme-text-secondary);
+  font-size: 0.66rem;
+  line-height: 1.35;
+}
+
+.field-hub-module__badge {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent-copper) 12%, transparent);
+  padding: 0.12rem 0.38rem;
+  color: var(--accent-copper);
+  font-size: 0.55rem;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@media (min-width: 36rem) {
+  .field-hub {
+    padding: 1rem 1rem 2.5rem;
+  }
+
+  .field-hub-hero {
+    padding: 1.5rem;
+  }
+
+  .field-hub-hero__actions {
+    grid-template-columns: auto auto;
+    justify-content: start;
+  }
+
+  .field-hub-signals {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .field-hub-module-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 64rem) {
+  .field-workspace {
+    display: grid;
+    grid-template-columns: 16rem minmax(0, 1fr);
+  }
+
+  .field-workspace-sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    height: 100dvh;
+    flex-direction: column;
+    border-right: 1px solid rgba(124, 166, 235, 0.18);
+    background:
+      radial-gradient(circle at 0 0, rgba(23, 71, 255, 0.19), transparent 20rem),
+      linear-gradient(180deg, var(--field-chrome), var(--field-chrome-deep));
+    box-shadow: 16px 0 45px rgba(3, 13, 32, 0.11);
+  }
+
+  .field-workspace-header,
+  .field-workspace-bottom,
+  .field-workspace-drawer,
+  .field-workspace-drawer__backdrop {
+    display: none;
+  }
+
+  .field-workspace-main {
+    grid-column: 2;
+    min-height: 100dvh;
+    padding-bottom: 0;
+  }
+
+  .field-hub {
+    padding: 1.25rem 1.5rem 3rem;
+  }
+
+  .field-hub-hero {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.75rem 2rem;
+  }
+
+  .field-hub-hero__actions {
+    flex: 0 0 auto;
+  }
+
+  .field-hub-grid {
+    grid-template-columns: minmax(0, 1.7fr) minmax(23rem, 1fr);
+    align-items: start;
+  }
+
+  .field-hub-today,
+  .field-hub-operations {
+    padding: 1rem;
+  }
+
+  .field-hub-module-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 86rem) {
+  .field-workspace {
+    grid-template-columns: 17rem minmax(0, 1fr);
+  }
+
+  .field-hub-module-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/app/mobile/layout.tsx
+++ b/app/mobile/layout.tsx
@@ -11,6 +11,7 @@ import "./mobile-command.css";
 import "./mobile-command-overrides.css";
 import "./mobile-route-surfaces.css";
 import "./mobile-work-command.css";
+import "./field-hub.css";
 
 export default function MobileLayout({
   children,

--- a/app/mobile/work-orders/page.tsx
+++ b/app/mobile/work-orders/page.tsx
@@ -1,5 +1,25 @@
 import MobileWorkOrderQueue from "@/features/mobile/work-orders/MobileWorkOrderQueue";
 
-export default function MobileWorkOrdersListPage() {
-  return <MobileWorkOrderQueue />;
+const SUPPORTED_STATUSES = new Set([
+  "queued",
+  "in_progress",
+  "on_hold",
+  "awaiting_approval",
+  "completed",
+  "ready_to_invoice",
+  "invoiced",
+]);
+
+export default async function MobileWorkOrdersListPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string | string[] }>;
+}) {
+  const requested = (await searchParams).status;
+  const status =
+    typeof requested === "string" && SUPPORTED_STATUSES.has(requested)
+      ? requested
+      : "";
+
+  return <MobileWorkOrderQueue initialStatus={status} />;
 }

--- a/app/mobile/work-orders/page.tsx
+++ b/app/mobile/work-orders/page.tsx
@@ -13,13 +13,26 @@ const SUPPORTED_STATUSES = new Set([
 export default async function MobileWorkOrdersListPage({
   searchParams,
 }: {
-  searchParams: Promise<{ status?: string | string[] }>;
+  searchParams: Promise<{
+    status?: string | string[];
+    mode?: string | string[];
+  }>;
 }) {
-  const requested = (await searchParams).status;
+  const requestedParams = await searchParams;
+  const requested = requestedParams.status;
   const status =
     typeof requested === "string" && SUPPORTED_STATUSES.has(requested)
       ? requested
       : "";
+  const readyToInvoiceCloseout =
+    status === "ready_to_invoice" &&
+    requestedParams.mode === "field_closeout";
 
-  return <MobileWorkOrderQueue initialStatus={status} />;
+  return (
+    <MobileWorkOrderQueue
+      key={`${status || "active"}:${readyToInvoiceCloseout ? "closeout" : "detail"}`}
+      initialStatus={status}
+      readyToInvoiceCloseout={readyToInvoiceCloseout}
+    />
+  );
 }

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -6,6 +6,9 @@ import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
 import { resolveMobileHref } from "@/features/mobile/navigation/mobile-route-continuity";
+import FieldWorkspaceShell, {
+  FIELD_SURFACE_SESSION_KEY,
+} from "@/features/mobile/service/FieldWorkspaceShell";
 import { MobileBottomNav } from "./MobileBottomNav";
 
 type Props = {
@@ -74,7 +77,36 @@ export function MobileShell({ children, title }: Props) {
   const pathname = usePathname();
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [fieldSurface, setFieldSurface] = useState(
+    pathname.startsWith("/mobile/service"),
+  );
   const resolvedTitle = title ?? getTitleFromPath(pathname);
+
+  useEffect(() => {
+    try {
+      if (
+        pathname === "/mobile" ||
+        pathname === "/mobile/sign-in" ||
+        pathname.startsWith("/mobile/sign-in/")
+      ) {
+        window.sessionStorage.removeItem(FIELD_SURFACE_SESSION_KEY);
+        setFieldSurface(false);
+        return;
+      }
+
+      if (pathname.startsWith("/mobile/service")) {
+        window.sessionStorage.setItem(FIELD_SURFACE_SESSION_KEY, "true");
+        setFieldSurface(true);
+        return;
+      }
+
+      setFieldSurface(
+        window.sessionStorage.getItem(FIELD_SURFACE_SESSION_KEY) === "true",
+      );
+    } catch {
+      setFieldSurface(pathname.startsWith("/mobile/service"));
+    }
+  }, [pathname]);
 
   useEffect(() => {
     const openMenu = () => setMenuOpen(true);
@@ -122,6 +154,10 @@ export function MobileShell({ children, title }: Props) {
         <main className="mobile-command-main min-w-0 overflow-x-hidden">{children}</main>
       </div>
     );
+  }
+
+  if (fieldSurface) {
+    return <FieldWorkspaceShell>{children}</FieldWorkspaceShell>;
   }
 
   return (

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -22,6 +22,10 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import MobileServiceShell from "./MobileServiceShell";
+import {
+  canUseFieldWorkspaceCapability,
+  type FieldWorkspaceCapabilities,
+} from "./fieldWorkspaceCapabilities";
 
 type FieldModule = {
   title: string;
@@ -29,6 +33,7 @@ type FieldModule = {
   href?: string;
   icon: LucideIcon;
   status: "ready" | "next";
+  requiredCapability?: keyof FieldWorkspaceCapabilities;
 };
 
 const FIELD_MODULES: FieldModule[] = [
@@ -38,6 +43,7 @@ const FIELD_MODULES: FieldModule[] = [
     href: "/mobile/appointments",
     icon: CalendarDays,
     status: "ready",
+    requiredCapability: "canManageScheduling",
   },
   {
     title: "Work orders",
@@ -66,11 +72,12 @@ const FIELD_MODULES: FieldModule[] = [
     href: "/mobile/parts",
     icon: Boxes,
     status: "ready",
+    requiredCapability: "canManageParts",
   },
   {
     title: "Invoices & payment",
     description: "Finish the invoice and collect in the field.",
-    href: "/mobile/work-orders?status=ready_to_invoice",
+    href: "/mobile/work-orders?status=ready_to_invoice&mode=field_closeout",
     icon: FileText,
     status: "ready",
   },
@@ -80,6 +87,7 @@ const FIELD_MODULES: FieldModule[] = [
     href: "/mobile/fleet",
     icon: Truck,
     status: "ready",
+    requiredCapability: "canAccessFleet",
   },
   {
     title: "Purchase orders",
@@ -131,7 +139,11 @@ function FieldModuleCard({ module }: { module: FieldModule }) {
   );
 }
 
-export default function FieldHub() {
+export default function FieldHub({
+  capabilities,
+}: {
+  capabilities: FieldWorkspaceCapabilities;
+}) {
   const [online, setOnline] = useState(true);
   const [dateLabel, setDateLabel] = useState("Today");
 
@@ -169,12 +181,14 @@ export default function FieldHub() {
           <Link href="/mobile/service/new" className="field-hub-primary-action">
             <Plus aria-hidden className="h-5 w-5" /> New service call
           </Link>
-          <Link
-            href="/mobile/appointments"
-            className="field-hub-secondary-action"
-          >
-            <CalendarDays aria-hidden className="h-4 w-4" /> Book appointment
-          </Link>
+          {capabilities.canManageScheduling ? (
+            <Link
+              href="/mobile/appointments"
+              className="field-hub-secondary-action"
+            >
+              <CalendarDays aria-hidden className="h-4 w-4" /> Book appointment
+            </Link>
+          ) : null}
         </div>
       </section>
 
@@ -236,7 +250,12 @@ export default function FieldHub() {
             </div>
           </div>
           <div className="field-hub-module-grid">
-            {FIELD_MODULES.map((module) => (
+            {FIELD_MODULES.filter((module) =>
+              canUseFieldWorkspaceCapability(
+                capabilities,
+                module.requiredCapability,
+              ),
+            ).map((module) => (
               <FieldModuleCard key={module.title} module={module} />
             ))}
           </div>

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import {
+  ArrowRight,
+  Boxes,
+  BriefcaseBusiness,
+  CalendarDays,
+  CheckCircle2,
+  ClipboardCheck,
+  Clock3,
+  FileText,
+  PackagePlus,
+  Plus,
+  RadioTower,
+  Truck,
+  UserRound,
+  Wifi,
+  WifiOff,
+  type LucideIcon,
+} from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import MobileServiceShell from "./MobileServiceShell";
+
+type FieldModule = {
+  title: string;
+  description: string;
+  href?: string;
+  icon: LucideIcon;
+  status: "ready" | "next";
+};
+
+const FIELD_MODULES: FieldModule[] = [
+  {
+    title: "Appointments",
+    description: "Accept, create and manage digital bookings.",
+    href: "/mobile/appointments",
+    icon: CalendarDays,
+    status: "ready",
+  },
+  {
+    title: "Work orders",
+    description: "Build the repair, labor and job record.",
+    href: "/mobile/work-orders",
+    icon: BriefcaseBusiness,
+    status: "ready",
+  },
+  {
+    title: "Inspections",
+    description: "Run forms, capture evidence and findings.",
+    href: "/mobile/inspections",
+    icon: ClipboardCheck,
+    status: "ready",
+  },
+  {
+    title: "Customer intake",
+    description: "Find or create the customer as you book the call.",
+    href: "/mobile/service/new",
+    icon: UserRound,
+    status: "ready",
+  },
+  {
+    title: "Parts & truck stock",
+    description: "Request, receive, allocate and consume parts.",
+    href: "/mobile/parts",
+    icon: Boxes,
+    status: "ready",
+  },
+  {
+    title: "Invoices & payment",
+    description: "Finish the invoice and collect in the field.",
+    href: "/mobile/work-orders?status=ready_to_invoice",
+    icon: FileText,
+    status: "ready",
+  },
+  {
+    title: "Fleet connections",
+    description: "Work with units, inspections and service requests.",
+    href: "/mobile/fleet",
+    icon: Truck,
+    status: "ready",
+  },
+  {
+    title: "Purchase orders",
+    description: "Mobile-first PO authoring and receiving is the next build slice.",
+    icon: PackagePlus,
+    status: "next",
+  },
+];
+
+function FieldModuleCard({ module }: { module: FieldModule }) {
+  const Icon = module.icon;
+  const content = (
+    <>
+      <span className="field-hub-module__icon">
+        <Icon aria-hidden className="h-5 w-5" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2">
+          <span className="field-hub-module__title">{module.title}</span>
+          {module.status === "next" ? (
+            <span className="field-hub-module__badge">Next</span>
+          ) : null}
+        </span>
+        <span className="field-hub-module__description">
+          {module.description}
+        </span>
+      </span>
+      {module.href ? (
+        <ArrowRight
+          aria-hidden
+          className="h-4 w-4 shrink-0 text-[color:var(--accent-copper)]"
+        />
+      ) : null}
+    </>
+  );
+
+  if (!module.href) {
+    return (
+      <div className="field-hub-module" data-available="false">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <Link className="field-hub-module" href={module.href}>
+      {content}
+    </Link>
+  );
+}
+
+export default function FieldHub() {
+  const [online, setOnline] = useState(true);
+  const [dateLabel, setDateLabel] = useState("Today");
+
+  useEffect(() => {
+    const update = () => setOnline(navigator.onLine);
+    update();
+    setDateLabel(
+      new Intl.DateTimeFormat(undefined, {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+      }).format(new Date()),
+    );
+    window.addEventListener("online", update);
+    window.addEventListener("offline", update);
+    return () => {
+      window.removeEventListener("online", update);
+      window.removeEventListener("offline", update);
+    };
+  }, []);
+
+  return (
+    <main className="field-hub">
+      <section className="field-hub-hero">
+        <div className="min-w-0">
+          <div className="field-hub-hero__eyebrow">
+            <RadioTower aria-hidden className="h-3.5 w-3.5" /> Field command
+          </div>
+          <h1 className="field-hub-hero__title">Run the day from here.</h1>
+          <p className="field-hub-hero__subtitle">
+            {dateLabel}. One workspace for the call, repair, customer and money.
+          </p>
+        </div>
+        <div className="field-hub-hero__actions">
+          <Link href="/mobile/service/new" className="field-hub-primary-action">
+            <Plus aria-hidden className="h-5 w-5" /> New service call
+          </Link>
+          <Link
+            href="/mobile/appointments"
+            className="field-hub-secondary-action"
+          >
+            <CalendarDays aria-hidden className="h-4 w-4" /> Book appointment
+          </Link>
+        </div>
+      </section>
+
+      <section className="field-hub-signals" aria-label="Field workspace status">
+        <div className="field-hub-signal">
+          <span className="field-hub-signal__icon" data-tone="blue">
+            {online ? (
+              <Wifi aria-hidden className="h-4 w-4" />
+            ) : (
+              <WifiOff aria-hidden className="h-4 w-4" />
+            )}
+          </span>
+          <span>
+            <strong>{online ? "Online" : "Working offline"}</strong>
+            <small>
+              {online ? "Field data can refresh" : "Saved work remains available"}
+            </small>
+          </span>
+        </div>
+        <div className="field-hub-signal">
+          <span className="field-hub-signal__icon" data-tone="green">
+            <CheckCircle2 aria-hidden className="h-4 w-4" />
+          </span>
+          <span>
+            <strong>Full closeout</strong>
+            <small>Invoice, payment and receipt</small>
+          </span>
+        </div>
+        <div className="field-hub-signal">
+          <span className="field-hub-signal__icon" data-tone="amber">
+            <Clock3 aria-hidden className="h-4 w-4" />
+          </span>
+          <span>
+            <strong>All-day workspace</strong>
+            <small>Phone, tablet or laptop</small>
+          </span>
+        </div>
+      </section>
+
+      <div className="field-hub-grid">
+        <section className="field-hub-today" aria-labelledby="field-today-heading">
+          <div className="field-hub-section-heading">
+            <div>
+              <div className="field-hub-section-heading__eyebrow">Today</div>
+              <h2 id="field-today-heading">Your field work</h2>
+            </div>
+            <Link href="/mobile/work-orders" className="field-hub-text-link">
+              All work orders <ArrowRight aria-hidden className="h-4 w-4" />
+            </Link>
+          </div>
+          <MobileServiceShell embedded />
+        </section>
+
+        <aside className="field-hub-operations" aria-labelledby="field-operations-heading">
+          <div className="field-hub-section-heading">
+            <div>
+              <div className="field-hub-section-heading__eyebrow">Operations</div>
+              <h2 id="field-operations-heading">Run the business</h2>
+            </div>
+          </div>
+          <div className="field-hub-module-grid">
+            {FIELD_MODULES.map((module) => (
+              <FieldModuleCard key={module.title} module={module} />
+            ))}
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/features/mobile/service/FieldWorkspaceShell.tsx
+++ b/features/mobile/service/FieldWorkspaceShell.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import {
+  Boxes,
+  BriefcaseBusiness,
+  CalendarDays,
+  ClipboardCheck,
+  Home,
+  LogOut,
+  Menu,
+  PackageOpen,
+  Plus,
+  Settings2,
+  Truck,
+  Wrench,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState, type ReactNode } from "react";
+
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+
+export const FIELD_SURFACE_SESSION_KEY = "profixiq:field-surface:v1";
+
+type FieldNavItem = {
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  exact?: boolean;
+};
+
+const WORK_NAV: FieldNavItem[] = [
+  {
+    label: "Today",
+    href: "/mobile/service",
+    icon: Home,
+    exact: true,
+  },
+  {
+    label: "Appointments",
+    href: "/mobile/appointments",
+    icon: CalendarDays,
+  },
+  {
+    label: "Work orders",
+    href: "/mobile/work-orders",
+    icon: BriefcaseBusiness,
+  },
+  {
+    label: "Inspections",
+    href: "/mobile/inspections",
+    icon: ClipboardCheck,
+  },
+];
+
+const OPERATIONS_NAV: FieldNavItem[] = [
+  { label: "Parts", href: "/mobile/parts", icon: Boxes },
+  { label: "Fleet", href: "/mobile/fleet", icon: Truck },
+  {
+    label: "Follow-ups",
+    href: "/mobile/service/followups",
+    icon: Wrench,
+  },
+];
+
+function isActive(pathname: string, item: FieldNavItem): boolean {
+  return item.exact
+    ? pathname === item.href
+    : pathname === item.href || pathname.startsWith(`${item.href}/`);
+}
+
+function pageTitle(pathname: string): string {
+  if (pathname === "/mobile/service") return "Field Hub";
+  if (pathname.startsWith("/mobile/service/new")) return "New service call";
+  if (pathname.startsWith("/mobile/service/truck-inventory")) {
+    return "Truck inventory";
+  }
+  if (pathname.startsWith("/mobile/service/followup")) return "Follow-ups";
+  if (pathname.startsWith("/mobile/service/closeout")) return "Field closeout";
+  if (pathname.startsWith("/mobile/appointments")) return "Appointments";
+  if (pathname.startsWith("/mobile/work-orders")) return "Work orders";
+  if (pathname.startsWith("/mobile/inspections")) return "Inspections";
+  if (pathname.startsWith("/mobile/parts")) return "Parts";
+  if (pathname.startsWith("/mobile/fleet")) return "Fleet";
+  return "Field";
+}
+
+function FieldNavLink({
+  item,
+  pathname,
+  onNavigate,
+}: {
+  item: FieldNavItem;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const Icon = item.icon;
+  return (
+    <Link
+      href={item.href}
+      onClick={onNavigate}
+      className="field-workspace-nav__link"
+      data-active={isActive(pathname, item) ? "true" : "false"}
+    >
+      <Icon aria-hidden className="h-[1.1rem] w-[1.1rem]" />
+      <span>{item.label}</span>
+    </Link>
+  );
+}
+
+function FieldNavigation({
+  pathname,
+  onNavigate,
+}: {
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  return (
+    <nav aria-label="Field workspace">
+      <div className="field-workspace-nav__section">
+        <div className="field-workspace-nav__label">Work</div>
+        {WORK_NAV.map((item) => (
+          <FieldNavLink
+            key={item.href}
+            item={item}
+            pathname={pathname}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </div>
+      <div className="field-workspace-nav__section">
+        <div className="field-workspace-nav__label">Operations</div>
+        {OPERATIONS_NAV.map((item) => (
+          <FieldNavLink
+            key={item.href}
+            item={item}
+            pathname={pathname}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </div>
+    </nav>
+  );
+}
+
+export default function FieldWorkspaceShell({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
+
+  useEffect(() => setMenuOpen(false), [pathname]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMenuOpen(false);
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [menuOpen]);
+
+  const exitField = () => {
+    window.sessionStorage.removeItem(FIELD_SURFACE_SESSION_KEY);
+    setMenuOpen(false);
+  };
+
+  const signOut = async () => {
+    if (signingOut) return;
+    setSigningOut(true);
+    try {
+      const supabase = createBrowserSupabase();
+      await supabase.auth.signOut({ scope: "local" });
+      window.sessionStorage.removeItem(FIELD_SURFACE_SESSION_KEY);
+      router.replace("/field/sign-in");
+      router.refresh();
+    } finally {
+      setSigningOut(false);
+    }
+  };
+
+  return (
+    <div className="profixiq-mobile-command field-workspace">
+      <aside className="field-workspace-sidebar">
+        <Link href="/mobile/service" className="field-workspace-brand">
+          <span className="field-workspace-brand__mark">PF</span>
+          <span>
+            <strong>ProFixIQ</strong>
+            <small>Field</small>
+          </span>
+        </Link>
+
+        <Link href="/mobile/service/new" className="field-workspace-new-call">
+          <Plus aria-hidden className="h-5 w-5" /> New service call
+        </Link>
+
+        <div className="field-workspace-sidebar__scroll">
+          <FieldNavigation pathname={pathname} />
+        </div>
+
+        <div className="field-workspace-sidebar__footer">
+          <Link
+            href="/mobile/service/truck-inventory"
+            className="field-workspace-nav__link"
+          >
+            <PackageOpen aria-hidden className="h-[1.1rem] w-[1.1rem]" />
+            <span>Truck inventory</span>
+          </Link>
+          <Link
+            href="/mobile/service/setup"
+            className="field-workspace-nav__link"
+          >
+            <Settings2 aria-hidden className="h-[1.1rem] w-[1.1rem]" />
+            <span>Field setup</span>
+          </Link>
+          <Link href="/mobile" onClick={exitField} className="field-workspace-exit">
+            Switch workspace
+          </Link>
+        </div>
+      </aside>
+
+      <header className="field-workspace-header">
+        <button
+          type="button"
+          onClick={() => setMenuOpen(true)}
+          aria-label="Open Field navigation"
+          aria-expanded={menuOpen}
+          className="field-workspace-header__menu"
+        >
+          <Menu aria-hidden className="h-5 w-5" />
+        </button>
+        <div className="min-w-0">
+          <div className="field-workspace-header__eyebrow">ProFixIQ Field</div>
+          <div className="field-workspace-header__title">{pageTitle(pathname)}</div>
+        </div>
+        <Link
+          href="/mobile/service/new"
+          aria-label="Create service call"
+          className="field-workspace-header__add"
+        >
+          <Plus aria-hidden className="h-5 w-5" />
+        </Link>
+      </header>
+
+      <main className="field-workspace-main">{children}</main>
+
+      <nav className="field-workspace-bottom" aria-label="Field quick navigation">
+        <Link
+          href="/mobile/service"
+          data-active={pathname === "/mobile/service" ? "true" : "false"}
+        >
+          <Home aria-hidden className="h-5 w-5" />
+          <span>Today</span>
+        </Link>
+        <Link
+          href="/mobile/appointments"
+          data-active={pathname.startsWith("/mobile/appointments") ? "true" : "false"}
+        >
+          <CalendarDays aria-hidden className="h-5 w-5" />
+          <span>Schedule</span>
+        </Link>
+        <Link href="/mobile/service/new" className="field-workspace-bottom__new">
+          <Plus aria-hidden className="h-6 w-6" />
+          <span>New</span>
+        </Link>
+        <Link
+          href="/mobile/work-orders"
+          data-active={pathname.startsWith("/mobile/work-orders") ? "true" : "false"}
+        >
+          <BriefcaseBusiness aria-hidden className="h-5 w-5" />
+          <span>Work</span>
+        </Link>
+        <button
+          type="button"
+          onClick={() => setMenuOpen(true)}
+          aria-label="Open more Field tools"
+        >
+          <Menu aria-hidden className="h-5 w-5" />
+          <span>More</span>
+        </button>
+      </nav>
+
+      <button
+        type="button"
+        aria-label="Close Field navigation"
+        onClick={() => setMenuOpen(false)}
+        className="field-workspace-drawer__backdrop"
+        data-open={menuOpen ? "true" : "false"}
+      />
+      <aside
+        className="field-workspace-drawer"
+        data-open={menuOpen ? "true" : "false"}
+        aria-hidden={!menuOpen}
+        aria-label="Field navigation"
+        aria-modal="true"
+        inert={menuOpen ? undefined : true}
+        role="dialog"
+      >
+        <div className="field-workspace-drawer__header">
+          <div>
+            <strong>ProFixIQ Field</strong>
+            <small>Full operations workspace</small>
+          </div>
+          <button
+            type="button"
+            onClick={() => setMenuOpen(false)}
+            aria-label="Close Field navigation"
+          >
+            <X aria-hidden className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="field-workspace-drawer__scroll">
+          <Link
+            href="/mobile/service/new"
+            onClick={() => setMenuOpen(false)}
+            className="field-workspace-new-call"
+          >
+            <Plus aria-hidden className="h-5 w-5" /> New service call
+          </Link>
+          <FieldNavigation pathname={pathname} onNavigate={() => setMenuOpen(false)} />
+          <div className="field-workspace-nav__section">
+            <div className="field-workspace-nav__label">Workspace</div>
+            <FieldNavLink
+              item={{
+                label: "Truck inventory",
+                href: "/mobile/service/truck-inventory",
+                icon: PackageOpen,
+              }}
+              pathname={pathname}
+              onNavigate={() => setMenuOpen(false)}
+            />
+            <FieldNavLink
+              item={{
+                label: "Field setup",
+                href: "/mobile/service/setup",
+                icon: Settings2,
+              }}
+              pathname={pathname}
+              onNavigate={() => setMenuOpen(false)}
+            />
+          </div>
+        </div>
+        <div className="field-workspace-drawer__footer">
+          <Link href="/mobile" onClick={exitField}>
+            Switch workspace
+          </Link>
+          <button type="button" onClick={() => void signOut()} disabled={signingOut}>
+            <LogOut aria-hidden className="h-4 w-4" />
+            {signingOut ? "Signing out…" : "Sign out"}
+          </button>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/features/mobile/service/FieldWorkspaceShell.tsx
+++ b/features/mobile/service/FieldWorkspaceShell.tsx
@@ -21,6 +21,12 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState, type ReactNode } from "react";
 
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import {
+  canUseFieldWorkspaceCapability,
+  EMPTY_FIELD_WORKSPACE_CAPABILITIES,
+  normalizeFieldWorkspaceCapabilities,
+  type FieldWorkspaceCapabilities,
+} from "./fieldWorkspaceCapabilities";
 
 export const FIELD_SURFACE_SESSION_KEY = "profixiq:field-surface:v1";
 
@@ -29,6 +35,7 @@ type FieldNavItem = {
   href: string;
   icon: LucideIcon;
   exact?: boolean;
+  requiredCapability?: keyof FieldWorkspaceCapabilities;
 };
 
 const WORK_NAV: FieldNavItem[] = [
@@ -42,6 +49,7 @@ const WORK_NAV: FieldNavItem[] = [
     label: "Appointments",
     href: "/mobile/appointments",
     icon: CalendarDays,
+    requiredCapability: "canManageScheduling",
   },
   {
     label: "Work orders",
@@ -56,8 +64,18 @@ const WORK_NAV: FieldNavItem[] = [
 ];
 
 const OPERATIONS_NAV: FieldNavItem[] = [
-  { label: "Parts", href: "/mobile/parts", icon: Boxes },
-  { label: "Fleet", href: "/mobile/fleet", icon: Truck },
+  {
+    label: "Parts",
+    href: "/mobile/parts",
+    icon: Boxes,
+    requiredCapability: "canManageParts",
+  },
+  {
+    label: "Fleet",
+    href: "/mobile/fleet",
+    icon: Truck,
+    requiredCapability: "canAccessFleet",
+  },
   {
     label: "Follow-ups",
     href: "/mobile/service/followups",
@@ -112,16 +130,23 @@ function FieldNavLink({
 
 function FieldNavigation({
   pathname,
+  capabilities,
   onNavigate,
 }: {
   pathname: string;
+  capabilities: FieldWorkspaceCapabilities;
   onNavigate?: () => void;
 }) {
   return (
     <nav aria-label="Field workspace">
       <div className="field-workspace-nav__section">
         <div className="field-workspace-nav__label">Work</div>
-        {WORK_NAV.map((item) => (
+        {WORK_NAV.filter((item) =>
+          canUseFieldWorkspaceCapability(
+            capabilities,
+            item.requiredCapability,
+          ),
+        ).map((item) => (
           <FieldNavLink
             key={item.href}
             item={item}
@@ -132,7 +157,12 @@ function FieldNavigation({
       </div>
       <div className="field-workspace-nav__section">
         <div className="field-workspace-nav__label">Operations</div>
-        {OPERATIONS_NAV.map((item) => (
+        {OPERATIONS_NAV.filter((item) =>
+          canUseFieldWorkspaceCapability(
+            capabilities,
+            item.requiredCapability,
+          ),
+        ).map((item) => (
           <FieldNavLink
             key={item.href}
             item={item}
@@ -150,6 +180,8 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
+  const [workspaceCapabilities, setWorkspaceCapabilities] =
+    useState<FieldWorkspaceCapabilities>(EMPTY_FIELD_WORKSPACE_CAPABILITIES);
 
   useEffect(() => setMenuOpen(false), [pathname]);
 
@@ -161,6 +193,34 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
     window.addEventListener("keydown", closeOnEscape);
     return () => window.removeEventListener("keydown", closeOnEscape);
   }, [menuOpen]);
+
+  useEffect(() => {
+    let active = true;
+
+    void fetch("/api/mobile/field-service/access", {
+      credentials: "include",
+      cache: "no-store",
+    })
+      .then(async (response) => {
+        const body = (await response.json().catch(() => null)) as
+          | {
+              canAccessFieldService?: boolean;
+              workspaceCapabilities?: unknown;
+            }
+          | null;
+        if (!active || !response.ok || !body?.canAccessFieldService) return;
+        setWorkspaceCapabilities(
+          normalizeFieldWorkspaceCapabilities(body.workspaceCapabilities),
+        );
+      })
+      .catch(() => {
+        // Keep optional navigation hidden when capabilities cannot be verified.
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const exitField = () => {
     window.sessionStorage.removeItem(FIELD_SURFACE_SESSION_KEY);
@@ -197,7 +257,10 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
         </Link>
 
         <div className="field-workspace-sidebar__scroll">
-          <FieldNavigation pathname={pathname} />
+          <FieldNavigation
+            pathname={pathname}
+            capabilities={workspaceCapabilities}
+          />
         </div>
 
         <div className="field-workspace-sidebar__footer">
@@ -208,16 +271,27 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
             <PackageOpen aria-hidden className="h-[1.1rem] w-[1.1rem]" />
             <span>Truck inventory</span>
           </Link>
-          <Link
-            href="/mobile/service/setup"
-            className="field-workspace-nav__link"
-          >
-            <Settings2 aria-hidden className="h-[1.1rem] w-[1.1rem]" />
-            <span>Field setup</span>
-          </Link>
+          {workspaceCapabilities.canConfigureFieldService ? (
+            <Link
+              href="/mobile/service/setup"
+              className="field-workspace-nav__link"
+            >
+              <Settings2 aria-hidden className="h-[1.1rem] w-[1.1rem]" />
+              <span>Field setup</span>
+            </Link>
+          ) : null}
           <Link href="/mobile" onClick={exitField} className="field-workspace-exit">
             Switch workspace
           </Link>
+          <button
+            type="button"
+            onClick={() => void signOut()}
+            disabled={signingOut}
+            className="field-workspace-nav__link field-workspace-sign-out"
+          >
+            <LogOut aria-hidden className="h-[1.1rem] w-[1.1rem]" />
+            <span>{signingOut ? "Signing out…" : "Sign out"}</span>
+          </button>
         </div>
       </aside>
 
@@ -254,13 +328,27 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
           <Home aria-hidden className="h-5 w-5" />
           <span>Today</span>
         </Link>
-        <Link
-          href="/mobile/appointments"
-          data-active={pathname.startsWith("/mobile/appointments") ? "true" : "false"}
-        >
-          <CalendarDays aria-hidden className="h-5 w-5" />
-          <span>Schedule</span>
-        </Link>
+        {workspaceCapabilities.canManageScheduling ? (
+          <Link
+            href="/mobile/appointments"
+            data-active={
+              pathname.startsWith("/mobile/appointments") ? "true" : "false"
+            }
+          >
+            <CalendarDays aria-hidden className="h-5 w-5" />
+            <span>Schedule</span>
+          </Link>
+        ) : (
+          <Link
+            href="/mobile/inspections"
+            data-active={
+              pathname.startsWith("/mobile/inspections") ? "true" : "false"
+            }
+          >
+            <ClipboardCheck aria-hidden className="h-5 w-5" />
+            <span>Inspect</span>
+          </Link>
+        )}
         <Link href="/mobile/service/new" className="field-workspace-bottom__new">
           <Plus aria-hidden className="h-6 w-6" />
           <span>New</span>
@@ -319,7 +407,11 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
           >
             <Plus aria-hidden className="h-5 w-5" /> New service call
           </Link>
-          <FieldNavigation pathname={pathname} onNavigate={() => setMenuOpen(false)} />
+          <FieldNavigation
+            pathname={pathname}
+            capabilities={workspaceCapabilities}
+            onNavigate={() => setMenuOpen(false)}
+          />
           <div className="field-workspace-nav__section">
             <div className="field-workspace-nav__label">Workspace</div>
             <FieldNavLink
@@ -331,15 +423,17 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
               pathname={pathname}
               onNavigate={() => setMenuOpen(false)}
             />
-            <FieldNavLink
-              item={{
-                label: "Field setup",
-                href: "/mobile/service/setup",
-                icon: Settings2,
-              }}
-              pathname={pathname}
-              onNavigate={() => setMenuOpen(false)}
-            />
+            {workspaceCapabilities.canConfigureFieldService ? (
+              <FieldNavLink
+                item={{
+                  label: "Field setup",
+                  href: "/mobile/service/setup",
+                  icon: Settings2,
+                }}
+                pathname={pathname}
+                onNavigate={() => setMenuOpen(false)}
+              />
+            ) : null}
           </div>
         </div>
         <div className="field-workspace-drawer__footer">

--- a/features/mobile/service/MobileServiceScopeGate.tsx
+++ b/features/mobile/service/MobileServiceScopeGate.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Boxes } from "lucide-react";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
@@ -12,7 +10,7 @@ import {
   type OfflineMutationScope,
 } from "@/features/shared/lib/offline/mutations";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-import MobileServiceShell from "./MobileServiceShell";
+import FieldHub from "./FieldHub";
 
 const SNAPSHOT_CACHE_KEY = "profixiq:mobile-service:active:v1";
 const SNAPSHOT_SCOPE_KEY = "profixiq:mobile-service:active-scope:v1";
@@ -127,23 +125,5 @@ export default function MobileServiceScopeGate() {
     );
   }
 
-  return (
-    <>
-      <div className="mx-auto w-full max-w-3xl px-3 pt-3 sm:px-4">
-        <Link
-          href="/mobile/service/truck-inventory"
-          className="flex min-h-12 items-center justify-between rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-4 text-sm font-extrabold text-[color:var(--theme-text-primary)] shadow-card"
-        >
-          <span className="inline-flex items-center gap-2">
-            <Boxes className="h-4 w-4 text-[color:var(--accent-copper)]" />
-            Truck inventory
-          </span>
-          <span className="text-xs text-[color:var(--theme-text-muted)]">
-            Receive · transfer · scan/use
-          </span>
-        </Link>
-      </div>
-      <MobileServiceShell />
-    </>
-  );
+  return <FieldHub />;
 }

--- a/features/mobile/service/MobileServiceScopeGate.tsx
+++ b/features/mobile/service/MobileServiceScopeGate.tsx
@@ -11,6 +11,11 @@ import {
 } from "@/features/shared/lib/offline/mutations";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import FieldHub from "./FieldHub";
+import {
+  EMPTY_FIELD_WORKSPACE_CAPABILITIES,
+  normalizeFieldWorkspaceCapabilities,
+  type FieldWorkspaceCapabilities,
+} from "./fieldWorkspaceCapabilities";
 
 const SNAPSHOT_CACHE_KEY = "profixiq:mobile-service:active:v1";
 const SNAPSHOT_SCOPE_KEY = "profixiq:mobile-service:active-scope:v1";
@@ -57,6 +62,8 @@ function protectSnapshot(scope: OfflineMutationScope | null): void {
 
 export default function MobileServiceScopeGate() {
   const [ready, setReady] = useState(false);
+  const [workspaceCapabilities, setWorkspaceCapabilities] =
+    useState<FieldWorkspaceCapabilities>(EMPTY_FIELD_WORKSPACE_CAPABILITIES);
   const router = useRouter();
 
   useEffect(() => {
@@ -81,7 +88,11 @@ export default function MobileServiceScopeGate() {
         cache: "no-store",
       });
       const fieldAccess = (await fieldAccessResponse.json().catch(() => null)) as
-        | { canAccessFieldService?: boolean; canConfigure?: boolean }
+        | {
+            canAccessFieldService?: boolean;
+            canConfigure?: boolean;
+            workspaceCapabilities?: unknown;
+          }
         | null;
       if (!active) return;
       if (!fieldAccessResponse.ok || !fieldAccess?.canAccessFieldService) {
@@ -89,6 +100,9 @@ export default function MobileServiceScopeGate() {
         router.replace(fieldAccess?.canConfigure ? "/mobile/service/setup" : "/mobile");
         return;
       }
+      setWorkspaceCapabilities(
+        normalizeFieldWorkspaceCapabilities(fieldAccess.workspaceCapabilities),
+      );
 
       const cached = getOfflineMutationScope();
       let scope: OfflineMutationScope | null =
@@ -125,5 +139,5 @@ export default function MobileServiceScopeGate() {
     );
   }
 
-  return <FieldHub />;
+  return <FieldHub capabilities={workspaceCapabilities} />;
 }

--- a/features/mobile/service/MobileServiceShell.tsx
+++ b/features/mobile/service/MobileServiceShell.tsx
@@ -520,7 +520,11 @@ function VisitCard({
   );
 }
 
-export default function MobileServiceShell() {
+export default function MobileServiceShell({
+  embedded = false,
+}: {
+  embedded?: boolean;
+}) {
   const router = useRouter();
   const [snapshot, setSnapshot] = useState<MobileActiveJobContract | null>(null);
   const [loading, setLoading] = useState(true);
@@ -529,9 +533,7 @@ export default function MobileServiceShell() {
   const [stale, setStale] = useState(false);
   const [busyVisitId, setBusyVisitId] = useState<string | null>(null);
   const [queuedNotice, setQueuedNotice] = useState<string | null>(null);
-  const [online, setOnline] = useState(
-    () => typeof navigator === "undefined" || navigator.onLine,
-  );
+  const [online, setOnline] = useState(true);
 
   const applyVisit = useCallback((updated: DispatchVisit) => {
     setSnapshot((previous) => {
@@ -676,6 +678,7 @@ export default function MobileServiceShell() {
         void load(true);
       }
     }, REFRESH_INTERVAL_MS);
+    setOnline(navigator.onLine);
     window.addEventListener("online", updateOnline);
     window.addEventListener("offline", updateOnline);
     document.addEventListener("visibilitychange", refreshOnFocus);
@@ -832,8 +835,15 @@ export default function MobileServiceShell() {
   );
 
   return (
-    <main className="mx-auto w-full max-w-3xl space-y-4 px-3 pb-8 pt-3 text-[color:var(--theme-text-primary)] sm:px-4">
-      <section className="overflow-hidden rounded-3xl border border-white/10 bg-slate-950 px-4 py-4 text-white shadow-card">
+    <main
+      className={`${
+        embedded
+          ? "w-full space-y-4 text-[color:var(--theme-text-primary)]"
+          : "mx-auto w-full max-w-3xl space-y-4 px-3 pb-8 pt-3 text-[color:var(--theme-text-primary)] sm:px-4"
+      }`}
+    >
+      {!embedded ? (
+        <section className="overflow-hidden rounded-3xl border border-white/10 bg-slate-950 px-4 py-4 text-white shadow-card">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="text-[0.62rem] font-extrabold uppercase tracking-[0.2em] text-sky-300">
@@ -879,7 +889,8 @@ export default function MobileServiceShell() {
             <Settings2 className="h-4 w-4" /> Setup
           </Link>
         </div>
-      </section>
+        </section>
+      ) : null}
 
       {!online || stale ? (
         <section className="rounded-2xl border border-amber-400/30 bg-amber-500/10 px-3.5 py-3 text-sm text-amber-100">

--- a/features/mobile/service/fieldWorkspaceCapabilities.ts
+++ b/features/mobile/service/fieldWorkspaceCapabilities.ts
@@ -1,0 +1,36 @@
+export type FieldWorkspaceCapabilities = {
+  canManageScheduling: boolean;
+  canManageParts: boolean;
+  canAccessFleet: boolean;
+  canConfigureFieldService: boolean;
+};
+
+export const EMPTY_FIELD_WORKSPACE_CAPABILITIES: FieldWorkspaceCapabilities = {
+  canManageScheduling: false,
+  canManageParts: false,
+  canAccessFleet: false,
+  canConfigureFieldService: false,
+};
+
+export function normalizeFieldWorkspaceCapabilities(
+  value: unknown,
+): FieldWorkspaceCapabilities {
+  const capabilities =
+    value && typeof value === "object"
+      ? (value as Partial<FieldWorkspaceCapabilities>)
+      : null;
+
+  return {
+    canManageScheduling: capabilities?.canManageScheduling === true,
+    canManageParts: capabilities?.canManageParts === true,
+    canAccessFleet: capabilities?.canAccessFleet === true,
+    canConfigureFieldService: capabilities?.canConfigureFieldService === true,
+  };
+}
+
+export function canUseFieldWorkspaceCapability(
+  capabilities: FieldWorkspaceCapabilities,
+  requiredCapability?: keyof FieldWorkspaceCapabilities,
+): boolean {
+  return requiredCapability ? capabilities[requiredCapability] : true;
+}

--- a/features/mobile/service/server/access.test.ts
+++ b/features/mobile/service/server/access.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveMobileFieldServiceAccess } from "./access";
+import {
+  resolveFieldWorkspaceCapabilities,
+  resolveMobileFieldServiceAccess,
+} from "./access";
 
 describe("resolveMobileFieldServiceAccess", () => {
   it("does not grant Field Service to a standard shop mechanic", () => {
@@ -49,5 +52,36 @@ describe("resolveMobileFieldServiceAccess", () => {
         productEntitled: false,
       }).canAccessFieldService,
     ).toBe(false);
+  });
+});
+
+describe("resolveFieldWorkspaceCapabilities", () => {
+  it("does not advertise scheduling, parts, or fleet tools to a mechanic", () => {
+    expect(
+      resolveFieldWorkspaceCapabilities({
+        role: "mechanic",
+        canAccessFleet: false,
+        canConfigureFieldService: false,
+      }),
+    ).toEqual({
+      canManageScheduling: false,
+      canManageParts: false,
+      canAccessFleet: false,
+      canConfigureFieldService: false,
+    });
+  });
+
+  it("keeps fleet visibility tied to the canonical fleet scope", () => {
+    expect(
+      resolveFieldWorkspaceCapabilities({
+        role: "manager",
+        canAccessFleet: false,
+        canConfigureFieldService: false,
+      }),
+    ).toMatchObject({
+      canManageScheduling: true,
+      canManageParts: true,
+      canAccessFleet: false,
+    });
   });
 });

--- a/features/mobile/service/server/access.ts
+++ b/features/mobile/service/server/access.ts
@@ -2,6 +2,11 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 
+import {
+  resolveFleetActorContext,
+  resolveFleetActorScope,
+} from "@/features/fleet/lib/resolveFleetActorContext";
+import type { FieldWorkspaceCapabilities } from "@/features/mobile/service/fieldWorkspaceCapabilities";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
@@ -16,6 +21,24 @@ export type MobileFieldServiceAccess = {
   canConfigure: boolean;
   canAccessFieldService: boolean;
 };
+
+export type MobileFieldServiceWorkspaceAccess = MobileFieldServiceAccess & {
+  workspaceCapabilities: FieldWorkspaceCapabilities;
+};
+
+export function resolveFieldWorkspaceCapabilities(input: {
+  role: string | null | undefined;
+  canAccessFleet: boolean;
+  canConfigureFieldService: boolean;
+}): FieldWorkspaceCapabilities {
+  const actor = getActorCapabilities({ role: input.role });
+  return {
+    canManageScheduling: actor.canManageScheduling,
+    canManageParts: actor.canManageParts,
+    canAccessFleet: input.canAccessFleet,
+    canConfigureFieldService: input.canConfigureFieldService,
+  };
+}
 
 export function resolveMobileFieldServiceAccess(input: {
   serviceModel: string | null | undefined;
@@ -74,6 +97,36 @@ export async function getMobileFieldServiceAccess(
     canonicalRole: access.canonicalRole,
     productEntitled: entitlementResult.data === true,
   });
+}
+
+export async function getMobileFieldServiceWorkspaceAccess(
+  access: ShopAccess,
+): Promise<MobileFieldServiceWorkspaceAccess> {
+  const fieldAccess = await getMobileFieldServiceAccess(access);
+  let canAccessFleet = false;
+
+  if (fieldAccess.canAccessFieldService) {
+    try {
+      const fleetActor = await resolveFleetActorContext(access.supabase, {
+        userId: access.authUserId,
+      });
+      const fleetScope = resolveFleetActorScope(fleetActor, {
+        preferMembershipFleet: !fleetActor.isInternal,
+      });
+      canAccessFleet = fleetScope?.shopId === access.profile.shop_id;
+    } catch {
+      // Fleet navigation is optional; its own route remains authoritative.
+    }
+  }
+
+  return {
+    ...fieldAccess,
+    workspaceCapabilities: resolveFieldWorkspaceCapabilities({
+      role: access.profile.role,
+      canAccessFleet,
+      canConfigureFieldService: fieldAccess.canConfigure,
+    }),
+  };
 }
 
 export async function isExplicitMobileFieldOperator(

--- a/features/mobile/work-orders/MobileWorkOrderQueue.tsx
+++ b/features/mobile/work-orders/MobileWorkOrderQueue.tsx
@@ -164,14 +164,18 @@ function primarySignal(signal: WorkOrderSignal): string | null {
   return null;
 }
 
-export default function MobileWorkOrderQueue() {
+export default function MobileWorkOrderQueue({
+  initialStatus = "",
+}: {
+  initialStatus?: string;
+}) {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [queryText, setQueryText] = useState("");
-  const [status, setStatus] = useState<string>("");
+  const [status, setStatus] = useState<string>(initialStatus);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [forbidden, setForbidden] = useState(false);
   const [assignedOnly, setAssignedOnly] = useState(false);

--- a/features/mobile/work-orders/MobileWorkOrderQueue.tsx
+++ b/features/mobile/work-orders/MobileWorkOrderQueue.tsx
@@ -23,6 +23,7 @@ import {
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
+import { resolveMobileWorkOrderHref } from "./mobileWorkOrderRouting";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -166,8 +167,10 @@ function primarySignal(signal: WorkOrderSignal): string | null {
 
 export default function MobileWorkOrderQueue({
   initialStatus = "",
+  readyToInvoiceCloseout = false,
 }: {
   initialStatus?: string;
+  readyToInvoiceCloseout?: boolean;
 }) {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<Row[]>([]);
@@ -535,7 +538,11 @@ export default function MobileWorkOrderQueue({
             return (
               <Link
                 key={workOrder.id}
-                href={`/mobile/work-orders/${workOrder.id}`}
+                href={resolveMobileWorkOrderHref({
+                  workOrderId: workOrder.id,
+                  status: key,
+                  readyToInvoiceCloseout,
+                })}
                 className="mobile-command-row relative block overflow-hidden border p-4 pl-5 active:scale-[0.992]"
               >
                 <span

--- a/features/mobile/work-orders/mobileWorkOrderRouting.ts
+++ b/features/mobile/work-orders/mobileWorkOrderRouting.ts
@@ -1,0 +1,10 @@
+export function resolveMobileWorkOrderHref(input: {
+  workOrderId: string;
+  status: string;
+  readyToInvoiceCloseout: boolean;
+}): string {
+  const workOrderId = encodeURIComponent(input.workOrderId);
+  return input.readyToInvoiceCloseout && input.status === "ready_to_invoice"
+    ? `/mobile/service/closeout/${workOrderId}`
+    : `/mobile/work-orders/${workOrderId}`;
+}

--- a/tests/field-hub-shell.test.ts
+++ b/tests/field-hub-shell.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const mobileShell = read("components/layout/MobileShell.tsx");
+const fieldShell = read("features/mobile/service/FieldWorkspaceShell.tsx");
+const fieldHub = read("features/mobile/service/FieldHub.tsx");
+const workOrderPage = read("app/mobile/work-orders/page.tsx");
+
+describe("Field Hub workspace", () => {
+  it("keeps the Field shell active while an operator moves through shared mobile workflows", () => {
+    expect(mobileShell).toContain('pathname.startsWith("/mobile/service")');
+    expect(mobileShell).toContain("FIELD_SURFACE_SESSION_KEY");
+    expect(mobileShell).toContain("<FieldWorkspaceShell>{children}</FieldWorkspaceShell>");
+    expect(mobileShell).toContain('pathname === "/mobile"');
+    expect(fieldShell).toContain("Switch workspace");
+  });
+
+  it("links the Hub to canonical mobile operations instead of duplicating their data flows", () => {
+    for (const href of [
+      "/mobile/appointments",
+      "/mobile/work-orders",
+      "/mobile/inspections",
+      "/mobile/parts",
+      "/mobile/fleet",
+      "/mobile/service/followups",
+    ]) {
+      expect(`${fieldShell}\n${fieldHub}`).toContain(href);
+    }
+
+    expect(fieldHub).toContain("<MobileServiceShell embedded />");
+    expect(fieldHub).not.toContain('.from("');
+  });
+
+  it("treats purchase orders as an explicit next slice until a field-safe surface exists", () => {
+    expect(fieldHub).toContain('title: "Purchase orders"');
+    expect(fieldHub).toContain('status: "next"');
+    expect(fieldHub).not.toContain('href: "/parts/po"');
+  });
+
+  it("accepts only known work-order status filters from the URL", () => {
+    expect(workOrderPage).toContain("SUPPORTED_STATUSES");
+    expect(workOrderPage).toContain("SUPPORTED_STATUSES.has(requested)");
+    expect(workOrderPage).toContain('<MobileWorkOrderQueue initialStatus={status} />');
+  });
+
+  it("signs out the Field session locally before returning to its dedicated sign-in", () => {
+    expect(fieldShell).toContain('signOut({ scope: "local" })');
+    expect(fieldShell).toContain('router.replace("/field/sign-in")');
+  });
+});

--- a/tests/field-hub-shell.test.ts
+++ b/tests/field-hub-shell.test.ts
@@ -1,11 +1,20 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
+import {
+  canUseFieldWorkspaceCapability,
+  normalizeFieldWorkspaceCapabilities,
+} from "@/features/mobile/service/fieldWorkspaceCapabilities";
+import { resolveMobileWorkOrderHref } from "@/features/mobile/work-orders/mobileWorkOrderRouting";
+
 const read = (path: string) => readFileSync(path, "utf8");
 const mobileShell = read("components/layout/MobileShell.tsx");
 const fieldShell = read("features/mobile/service/FieldWorkspaceShell.tsx");
 const fieldHub = read("features/mobile/service/FieldHub.tsx");
 const workOrderPage = read("app/mobile/work-orders/page.tsx");
+const workOrderQueue = read(
+  "features/mobile/work-orders/MobileWorkOrderQueue.tsx",
+);
 
 describe("Field Hub workspace", () => {
   it("keeps the Field shell active while an operator moves through shared mobile workflows", () => {
@@ -32,6 +41,31 @@ describe("Field Hub workspace", () => {
     expect(fieldHub).not.toContain('.from("');
   });
 
+  it("shows optional modules only when the authenticated access response grants them", () => {
+    const mechanicCapabilities = normalizeFieldWorkspaceCapabilities({
+      canManageScheduling: false,
+      canManageParts: false,
+      canAccessFleet: false,
+      canConfigureFieldService: false,
+    });
+
+    expect(
+      canUseFieldWorkspaceCapability(
+        mechanicCapabilities,
+        "canManageScheduling",
+      ),
+    ).toBe(false);
+    expect(
+      canUseFieldWorkspaceCapability(mechanicCapabilities, "canManageParts"),
+    ).toBe(false);
+    expect(
+      canUseFieldWorkspaceCapability(mechanicCapabilities, "canAccessFleet"),
+    ).toBe(false);
+    expect(canUseFieldWorkspaceCapability(mechanicCapabilities)).toBe(true);
+    expect(fieldShell).toContain("normalizeFieldWorkspaceCapabilities");
+    expect(fieldHub).toContain("canUseFieldWorkspaceCapability");
+  });
+
   it("treats purchase orders as an explicit next slice until a field-safe surface exists", () => {
     expect(fieldHub).toContain('title: "Purchase orders"');
     expect(fieldHub).toContain('status: "next"');
@@ -41,11 +75,33 @@ describe("Field Hub workspace", () => {
   it("accepts only known work-order status filters from the URL", () => {
     expect(workOrderPage).toContain("SUPPORTED_STATUSES");
     expect(workOrderPage).toContain("SUPPORTED_STATUSES.has(requested)");
-    expect(workOrderPage).toContain('<MobileWorkOrderQueue initialStatus={status} />');
+    expect(workOrderPage).toContain('key={`${status || "active"}');
+    expect(workOrderPage).toContain('requestedParams.mode === "field_closeout"');
+  });
+
+  it("routes only opted-in ready-to-invoice rows to canonical Field closeout", () => {
+    expect(
+      resolveMobileWorkOrderHref({
+        workOrderId: "wo/123",
+        status: "ready_to_invoice",
+        readyToInvoiceCloseout: true,
+      }),
+    ).toBe("/mobile/service/closeout/wo%2F123");
+    expect(
+      resolveMobileWorkOrderHref({
+        workOrderId: "wo-123",
+        status: "in_progress",
+        readyToInvoiceCloseout: true,
+      }),
+    ).toBe("/mobile/work-orders/wo-123");
+    expect(workOrderQueue).toContain("resolveMobileWorkOrderHref");
   });
 
   it("signs out the Field session locally before returning to its dedicated sign-in", () => {
     expect(fieldShell).toContain('signOut({ scope: "local" })');
     expect(fieldShell).toContain('router.replace("/field/sign-in")');
+    expect(fieldShell.match(/onClick=\{\(\) => void signOut\(\)\}/g)).toHaveLength(
+      2,
+    );
   });
 });

--- a/tests/mobile-service-shell.test.ts
+++ b/tests/mobile-service-shell.test.ts
@@ -5,6 +5,7 @@ const read = (path: string) => readFileSync(path, "utf8");
 const page = read("app/mobile/service/page.tsx");
 const shell = read("features/mobile/service/MobileServiceShell.tsx");
 const scopeGate = read("features/mobile/service/MobileServiceScopeGate.tsx");
+const fieldHub = read("features/mobile/service/FieldHub.tsx");
 const tiles = read("features/mobile/config/mobile-tiles.ts");
 const activeRoute = read("app/api/mobile/service-visits/active/route.ts");
 const dispatchRoute = read("app/api/dispatch/visits/[id]/route.ts");
@@ -12,7 +13,8 @@ const dispatchRoute = read("app/api/dispatch/visits/[id]/route.ts");
 describe("Mobile Service shell", () => {
   it("uses the merged Dispatch contracts instead of duplicating service-visit state", () => {
     expect(page).toContain("MobileServiceScopeGate");
-    expect(scopeGate).toContain("MobileServiceShell");
+    expect(scopeGate).toContain("FieldHub");
+    expect(fieldHub).toContain("MobileServiceShell embedded");
     expect(shell).toContain("/api/mobile/service-visits/active");
     expect(shell).toContain("/api/dispatch/visits/${visit.id}");
     expect(shell).not.toContain('.from("service_visits")');


### PR DESCRIPTION
## Summary

- adds a dedicated, persistent ProFixIQ Field workspace with tablet/laptop sidebar navigation and phone header, drawer, and bottom navigation
- replaces the narrow Field landing page with a responsive Field Hub that keeps today's service-call workflow and connects appointments, work orders, inspections, parts/truck stock, invoices/payment, fleet work, and follow-ups
- keeps shared mobile workflows canonical while preserving the Field surface across navigation; immersive inspection/job routes retain their focused presentation
- gates Appointments, Parts, Fleet, and Field setup links from the authenticated server-derived capability response
- routes ready-to-invoice selections into the canonical Field closeout flow and remounts the queue when validated URL filters change
- keeps local-scope sign-out available in both the mobile drawer and visible desktop sidebar
- keeps purchase orders as an honest next-slice state and fixes the existing service-call online-state hydration mismatch

## Why

Field needs to operate as a standalone all-day workspace for a single mobile business, with an iPad or laptop as the command center and the same flow available on a phone.

## User impact

A Field operator now lands in a full dashboard instead of a single mobile companion screen. Existing operational workflows remain the source of truth, so this foundation does not fork appointments, work orders, inspections, parts, fleet, or invoice state.

Operators no longer see Appointments, Parts, Fleet, or Field setup destinations that their role cannot use. Ready invoices open the implemented payment/receipt closeout, URL filter changes reset the queue correctly, and desktop operators can end the local Field session without leaving the workspace.

Purchase-order authoring is intentionally labeled as the next build slice because the repository does not yet have a field-safe mobile PO surface.

## Validation

- `tsc --noEmit` — passed
- changed-file ESLint — passed
- focused Field tests — 17 passed
- production `next build` — passed using placeholder-only build-time integration variables
- API route boundary audit — passed
- regression inventory — 0 new errors
- responsive browser QA — passed at 1440×900, 1024×768, 768×1024, and 390×844; no horizontal overflow or runtime overlay
- full repository Vitest — reaches the known 39 Windows CRLF/static-contract failures; focused Field tests remain green
- full repository ESLint — blocked by 6 pre-existing unrelated errors in AI analysis, customer import, quote viewer, and DecisionEventFeed

## Deployment notes

- no database migration
- no new environment variables
- no manual deployment action required