### PR TITLE
Fix product sign-in review findings

### DIFF
--- a/app/api/auth/password-activation/route.ts
+++ b/app/api/auth/password-activation/route.ts
@@ -1,0 +1,46 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+
+import { clearCanonicalPasswordRequirement } from "@/features/auth/server/passwordActivation";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
+
+const NO_STORE_HEADERS = { "Cache-Control": "private, no-store" };
+
+export async function POST() {
+  const sessionClient = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error: userError,
+  } = await sessionClient.auth.getUser();
+
+  if (userError || !user) {
+    return NextResponse.json(
+      { ok: false, error: "Not authenticated." },
+      { status: 401, headers: NO_STORE_HEADERS },
+    );
+  }
+
+  const result = await clearCanonicalPasswordRequirement({
+    authUserId: user.id,
+    sessionClient,
+    adminClient: createAdminSupabase(),
+  });
+
+  if (!result.ok) {
+    console.error("[password-activation] canonical profile update failed", {
+      authUserId: user.id,
+      detail: result.detail,
+    });
+    return NextResponse.json(
+      { ok: false, error: "Account activation could not be completed." },
+      { status: 500, headers: NO_STORE_HEADERS },
+    );
+  }
+
+  return NextResponse.json({ ok: true }, { headers: NO_STORE_HEADERS });
+}

--- a/app/api/auth/sign-in/route.ts
+++ b/app/api/auth/sign-in/route.ts
@@ -7,6 +7,7 @@ import { enforceAuthRateLimit } from "@/features/auth/server/authRateLimit";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 import { getMobileFieldServiceAccess } from "@/features/mobile/service/server/access";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { resolveAuthenticatedStaffProfile } from "@/features/shared/lib/server/admin-access";
 import {
   createAdminSupabase,
   createServerSupabaseRoute,
@@ -199,13 +200,10 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: true, destination: "/portal/fleet" });
   }
 
-  const { data: profile } = await supabase
-    .from("profiles")
-    .select("id, shop_id, role, completed_onboarding, must_change_password, email, full_name")
-    .eq("id", signedInUser.id)
-    .maybeSingle();
+  const { profile, error: profileError } =
+    await resolveAuthenticatedStaffProfile(supabase, signedInUser.id);
 
-  if (!profile) return deny();
+  if (profileError || !profile) return deny();
 
   if (!profile.shop_id) {
     if (surface === "shop" && !profile.role) {
@@ -231,6 +229,7 @@ export async function POST(req: Request) {
           role: profile.role,
           shop_id: profile.shop_id,
           completed_onboarding: profile.completed_onboarding,
+          must_change_password: profile.must_change_password,
           email: profile.email,
           full_name: profile.full_name,
         },

--- a/app/api/mobile/field-service/access/route.ts
+++ b/app/api/mobile/field-service/access/route.ts
@@ -10,9 +10,14 @@ export async function GET() {
   if (!access.ok) return access.response;
 
   try {
-    return NextResponse.json(await getMobileFieldServiceAccess(access), {
-      headers: { "Cache-Control": "private, no-store" },
-    });
+    const fieldAccess = await getMobileFieldServiceAccess(access);
+    return NextResponse.json(
+      {
+        ...fieldAccess,
+        mustChangePassword: access.profile.must_change_password === true,
+      },
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
   } catch {
     return NextResponse.json(
       { error: "Unable to verify Field Service access." },

--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -72,7 +72,7 @@ export default function SetPasswordPage() {
   }, [isPortalActivation, supabase]);
 
   async function finishActivation(userId: string, role: string | null) {
-    const activation = await activatePasswordProfile(supabase, userId);
+    const activation = await activatePasswordProfile();
     if (!activation.ok) {
       console.error("[set-password] profile activation failed", {
         userId,

--- a/features/auth/components/FieldSignIn.tsx
+++ b/features/auth/components/FieldSignIn.tsx
@@ -7,21 +7,21 @@ import { Eye, EyeOff, Loader2, Truck, WifiOff } from "lucide-react";
 
 import AuthShell from "@/features/auth/components/AuthShell";
 import AuthStatus from "@/features/auth/components/AuthStatus";
-import { resolveFieldPostSignInHref } from "@/features/auth/lib/accessSurfaceRouting";
+import {
+  resolveFieldExistingSessionHref,
+  resolveFieldPostSignInHref,
+  type FieldExistingSessionAccess,
+} from "@/features/auth/lib/accessSurfaceRouting";
 import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
 import { signInWithIdentifier } from "@/features/auth/lib/signInClient";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 const FIELD_HOME = "/mobile/service";
-const FIELD_SETUP = "/mobile/service/setup";
 
 const inputClass =
   "w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3.5 py-3 text-base text-[color:var(--theme-input-text)] outline-none transition placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper)] focus:ring-4 focus:ring-[color:color-mix(in_srgb,var(--accent-copper)_16%,transparent)]";
 
-type FieldAccessResponse = {
-  canAccessFieldService?: boolean;
-  canConfigure?: boolean;
-};
+type FieldAccessResponse = FieldExistingSessionAccess;
 
 export default function FieldSignIn() {
   const router = useRouter();
@@ -69,12 +69,12 @@ export default function FieldSignIn() {
           | null;
         if (cancelled) return;
 
-        if (response.ok && access?.canAccessFieldService) {
-          router.replace(requestedDestination);
-          return;
-        }
-        if (response.ok && access?.canConfigure) {
-          router.replace(FIELD_SETUP);
+        const destination =
+          response.ok && access
+            ? resolveFieldExistingSessionHref(access, requestedDestination)
+            : null;
+        if (destination) {
+          router.replace(destination);
           return;
         }
 

--- a/features/auth/lib/accessSurfaceRouting.ts
+++ b/features/auth/lib/accessSurfaceRouting.ts
@@ -91,6 +91,12 @@ const FIELD_HOME = "/mobile/service";
 const FIELD_SETUP = "/mobile/service/setup";
 const PASSWORD_CHANGE = "/auth/set-password";
 
+export type FieldExistingSessionAccess = {
+  canAccessFieldService?: boolean;
+  canConfigure?: boolean;
+  mustChangePassword?: boolean;
+};
+
 /**
  * The API owns security-sensitive Field destinations. A requested Field
  * continuation is applied only after the API returns the normal Field home;
@@ -113,4 +119,31 @@ export function resolveFieldPostSignInHref(
   if (destination !== FIELD_HOME) return FIELD_HOME;
 
   return safeInternalRedirect(requestedDestination, FIELD_HOME, [FIELD_HOME]);
+}
+
+/**
+ * Existing sessions do not pass through the sign-in API, so the Field access
+ * endpoint must supply the password-change flag and this client-side routing
+ * decision must enforce it before entering either the workspace or setup.
+ */
+export function resolveFieldExistingSessionHref(
+  access: FieldExistingSessionAccess,
+  requestedDestination: string,
+): string | null {
+  const fieldDestination = access.canAccessFieldService
+    ? FIELD_HOME
+    : access.canConfigure
+      ? FIELD_SETUP
+      : null;
+
+  if (!fieldDestination) return null;
+
+  const apiEquivalentDestination = access.mustChangePassword
+    ? `${PASSWORD_CHANGE}?redirect=${encodeURIComponent(fieldDestination)}`
+    : fieldDestination;
+
+  return resolveFieldPostSignInHref(
+    apiEquivalentDestination,
+    requestedDestination,
+  );
 }

--- a/features/auth/lib/passwordActivation.ts
+++ b/features/auth/lib/passwordActivation.ts
@@ -1,27 +1,39 @@
-import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "@shared/types/types/supabase";
-
 export const PASSWORD_ACTIVATION_RETRY_MESSAGE =
   "Your password was updated, but account activation could not be completed. Retry activation or contact your shop administrator.";
 
 export async function activatePasswordProfile(
-  supabase: SupabaseClient<Database>,
-  userId: string,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<{ ok: true } | { ok: false; userMessage: string; detail: string }> {
-  const { error } = await supabase
-    .from("profiles")
-    .update({
-      must_change_password: false,
-      updated_at: new Date().toISOString(),
-    } as Database["public"]["Tables"]["profiles"]["Update"])
-    .eq("id", userId);
+  try {
+    const response = await fetchImpl("/api/auth/password-activation", {
+      method: "POST",
+      credentials: "same-origin",
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+    });
+    const body = (await response.json().catch(() => null)) as
+      | { ok?: boolean; error?: string }
+      | null;
 
-  if (error) {
+    if (response.ok && body?.ok === true) {
+      return { ok: true };
+    }
+
     return {
       ok: false,
       userMessage: PASSWORD_ACTIVATION_RETRY_MESSAGE,
-      detail: error.message,
+      detail:
+        body?.error ??
+        `Password activation request failed with status ${response.status}.`,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      userMessage: PASSWORD_ACTIVATION_RETRY_MESSAGE,
+      detail:
+        error instanceof Error
+          ? error.message
+          : "Password activation request failed.",
     };
   }
-  return { ok: true };
 }

--- a/features/auth/server/passwordActivation.ts
+++ b/features/auth/server/passwordActivation.ts
@@ -1,0 +1,74 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { resolveCanonicalStaffProfile } from "@/features/shared/lib/authenticated-profile";
+import type { Database } from "@shared/types/types/supabase";
+
+type ProfileActivationRow = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "id" | "must_change_password"
+>;
+
+type PasswordActivationClients = {
+  authUserId: string;
+  sessionClient: SupabaseClient<Database>;
+  adminClient: SupabaseClient<Database>;
+};
+
+export type PasswordActivationServerResult =
+  | { ok: true; profileUpdated: boolean }
+  | { ok: false; detail: string };
+
+/**
+ * Clear the first-login password requirement on the exact canonical profile
+ * linked to a server-verified auth subject. The service client is kept
+ * separate from the cookie-backed session client and the returned row is
+ * required so an RLS-style zero-row update can never be reported as success.
+ */
+export async function clearCanonicalPasswordRequirement({
+  authUserId,
+  sessionClient,
+  adminClient,
+}: PasswordActivationClients): Promise<PasswordActivationServerResult> {
+  const { profile, error: profileError } =
+    await resolveCanonicalStaffProfile(sessionClient, authUserId, {
+      linkedProfileClient: () => adminClient,
+    });
+
+  if (profileError) {
+    return { ok: false, detail: profileError };
+  }
+
+  // Portal-only and pre-profile accounts have no staff password flag to clear.
+  if (!profile) {
+    return { ok: true, profileUpdated: false };
+  }
+
+  const { data: updatedProfile, error: updateError } = await adminClient
+    .from("profiles")
+    .update({
+      must_change_password: false,
+      updated_at: new Date().toISOString(),
+    } as Database["public"]["Tables"]["profiles"]["Update"])
+    .eq("id", profile.id)
+    .select("id, must_change_password")
+    .maybeSingle<ProfileActivationRow>();
+
+  if (updateError) {
+    return { ok: false, detail: updateError.message };
+  }
+
+  if (
+    !updatedProfile ||
+    updatedProfile.id !== profile.id ||
+    updatedProfile.must_change_password !== false
+  ) {
+    return {
+      ok: false,
+      detail: "Canonical profile password activation was not persisted.",
+    };
+  }
+
+  return { ok: true, profileUpdated: true };
+}

--- a/features/mobile/service/MobileFieldServiceRouteGate.tsx
+++ b/features/mobile/service/MobileFieldServiceRouteGate.tsx
@@ -2,11 +2,10 @@
 
 import { useEffect, useState, type ReactNode } from "react";
 import { usePathname, useRouter } from "next/navigation";
-
-type FieldAccess = {
-  canAccessFieldService?: boolean;
-  canConfigure?: boolean;
-};
+import {
+  resolveFieldExistingSessionHref,
+  type FieldExistingSessionAccess,
+} from "@/features/auth/lib/accessSurfaceRouting";
 
 export default function MobileFieldServiceRouteGate({
   children,
@@ -25,19 +24,22 @@ export default function MobileFieldServiceRouteGate({
         credentials: "include",
         cache: "no-store",
       }).catch(() => null);
-      const access = (await response?.json().catch(() => null)) as FieldAccess | null;
+      const access = (await response?.json().catch(() => null)) as
+        | FieldExistingSessionAccess
+        | null;
       if (!active) return;
 
-      const setupRoute = pathname === "/mobile/service/setup";
-      if (
-        response?.ok &&
-        (access?.canAccessFieldService || (setupRoute && access?.canConfigure))
-      ) {
+      const destination =
+        response?.ok && access
+          ? resolveFieldExistingSessionHref(access, pathname)
+          : null;
+
+      if (destination === pathname) {
         setAllowed(true);
         return;
       }
 
-      router.replace(setupRoute && access?.canConfigure ? "/mobile/service/setup" : "/mobile");
+      router.replace(destination ?? "/mobile");
     })();
 
     return () => {

--- a/features/shared/components/LandingButtons.tsx
+++ b/features/shared/components/LandingButtons.tsx
@@ -33,7 +33,7 @@ export default function LandingHero() {
 
         <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
           <Link
-            href="/shop/sign-in?redirect=%2Fai"
+            href="/shop/sign-in?redirect=%2Fai%2Fassistant"
             className="rounded-lg bg-orange-500 px-5 py-3 font-bold text-[color:var(--theme-text-on-accent)] shadow hover:bg-orange-600"
           >
             Try the AI

--- a/features/shared/lib/authenticated-profile.ts
+++ b/features/shared/lib/authenticated-profile.ts
@@ -1,0 +1,65 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+
+export type AuthenticatedStaffProfile = Pick<
+  DB["public"]["Tables"]["profiles"]["Row"],
+  | "id"
+  | "role"
+  | "shop_id"
+  | "completed_onboarding"
+  | "must_change_password"
+  | "email"
+  | "full_name"
+>;
+
+type ProfileClient = SupabaseClient<Database>;
+
+type CanonicalProfileOptions = {
+  linkedProfileClient?: () => ProfileClient;
+};
+
+const PROFILE_SELECT =
+  "id, role, shop_id, completed_onboarding, must_change_password, email, full_name";
+
+/**
+ * Resolve the canonical profiles.id row for a verified Supabase auth subject.
+ * Imported staff can retain a different canonical profile id and link their
+ * auth identity through profiles.user_id, so both identity shapes are checked
+ * in a deterministic order.
+ */
+export async function resolveCanonicalStaffProfile(
+  supabase: ProfileClient,
+  authUserId: string,
+  options: CanonicalProfileOptions = {},
+): Promise<{
+  profile: AuthenticatedStaffProfile | null;
+  error: string | null;
+}> {
+  const byId = await supabase
+    .from("profiles")
+    .select(PROFILE_SELECT)
+    .eq("id", authUserId)
+    .maybeSingle<AuthenticatedStaffProfile>();
+
+  if (byId.error) {
+    return { profile: null, error: byId.error.message };
+  }
+  if (byId.data) {
+    return { profile: byId.data, error: null };
+  }
+
+  const linkedClient = options.linkedProfileClient?.() ?? supabase;
+  const byAuthUser = await linkedClient
+    .from("profiles")
+    .select(PROFILE_SELECT)
+    .eq("user_id", authUserId)
+    .maybeSingle<AuthenticatedStaffProfile>();
+
+  return {
+    profile: byAuthUser.data ?? null,
+    error: byAuthUser.error?.message ?? null,
+  };
+}

--- a/features/shared/lib/server/admin-access.ts
+++ b/features/shared/lib/server/admin-access.ts
@@ -1,7 +1,11 @@
 import "server-only";
 
 import { redirect } from "next/navigation";
-import type { Database } from "@shared/types/types/supabase";
+import { NextResponse } from "next/server";
+import {
+  resolveCanonicalStaffProfile,
+  type AuthenticatedStaffProfile,
+} from "@/features/shared/lib/authenticated-profile";
 import {
   createAdminSupabase,
   createServerSupabaseRSC,
@@ -17,19 +21,8 @@ import {
   type OwnerPinPurpose,
   requireOwnerPinVerified,
 } from "@/features/shared/lib/server/owner-pin";
-import { NextResponse } from "next/server";
 
-type DB = Database;
-type ProfileScope = Pick<
-  DB["public"]["Tables"]["profiles"]["Row"],
-  | "id"
-  | "role"
-  | "shop_id"
-  | "completed_onboarding"
-  | "must_change_password"
-  | "email"
-  | "full_name"
->;
+type ProfileScope = AuthenticatedStaffProfile;
 type ShopScopedProfile = Omit<ProfileScope, "shop_id"> & { shop_id: string };
 
 type CapabilityKey = keyof ActorCapabilities;
@@ -49,38 +42,13 @@ export async function resolveAuthenticatedStaffProfile(
   supabase: ServerSupabase,
   authUserId: string,
 ): Promise<{ profile: ProfileScope | null; error: string | null }> {
-  const byId = await supabase
-    .from("profiles")
-    .select(
-      "id, role, shop_id, completed_onboarding, must_change_password, email, full_name",
-    )
-    .eq("id", authUserId)
-    .maybeSingle<ProfileScope>();
-
-  if (byId.error) {
-    return { profile: null, error: byId.error.message };
-  }
-  if (byId.data) {
-    return { profile: byId.data, error: null };
-  }
-
   // profiles.self.read historically only matched profiles.id = auth.uid().
   // Imported staff can instead retain a canonical profile id while linking
-  // their Supabase account through profiles.user_id. The auth subject above is
-  // server-verified, and user_id is unique, so the service client is used only
-  // for this exact fallback lookup.
-  const byAuthUser = await createAdminSupabase()
-    .from("profiles")
-    .select(
-      "id, role, shop_id, completed_onboarding, must_change_password, email, full_name",
-    )
-    .eq("user_id", authUserId)
-    .maybeSingle<ProfileScope>();
-
-  return {
-    profile: byAuthUser.data ?? null,
-    error: byAuthUser.error?.message ?? null,
-  };
+  // their Supabase account through profiles.user_id. Keep an exact service
+  // fallback for deployments that have not yet installed linked self-read RLS.
+  return resolveCanonicalStaffProfile(supabase, authUserId, {
+    linkedProfileClient: createAdminSupabase,
+  });
 }
 
 type ShopPageAccessOptions = {

--- a/features/shared/lib/server/admin-access.ts
+++ b/features/shared/lib/server/admin-access.ts
@@ -22,7 +22,13 @@ import { NextResponse } from "next/server";
 type DB = Database;
 type ProfileScope = Pick<
   DB["public"]["Tables"]["profiles"]["Row"],
-  "id" | "role" | "shop_id" | "completed_onboarding" | "email" | "full_name"
+  | "id"
+  | "role"
+  | "shop_id"
+  | "completed_onboarding"
+  | "must_change_password"
+  | "email"
+  | "full_name"
 >;
 type ShopScopedProfile = Omit<ProfileScope, "shop_id"> & { shop_id: string };
 
@@ -45,7 +51,9 @@ export async function resolveAuthenticatedStaffProfile(
 ): Promise<{ profile: ProfileScope | null; error: string | null }> {
   const byId = await supabase
     .from("profiles")
-    .select("id, role, shop_id, completed_onboarding, email, full_name")
+    .select(
+      "id, role, shop_id, completed_onboarding, must_change_password, email, full_name",
+    )
     .eq("id", authUserId)
     .maybeSingle<ProfileScope>();
 
@@ -63,7 +71,9 @@ export async function resolveAuthenticatedStaffProfile(
   // for this exact fallback lookup.
   const byAuthUser = await createAdminSupabase()
     .from("profiles")
-    .select("id, role, shop_id, completed_onboarding, email, full_name")
+    .select(
+      "id, role, shop_id, completed_onboarding, must_change_password, email, full_name",
+    )
     .eq("user_id", authUserId)
     .maybeSingle<ProfileScope>();
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -21,6 +21,7 @@ import {
   toFleetPublicPath,
   resolveLegacyFleetRedirect,
 } from "@/features/fleet/lib/fleetProductRouting";
+import { resolveCanonicalStaffProfile } from "@/features/shared/lib/authenticated-profile";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   hasSupabasePublicEnv,
@@ -358,12 +359,10 @@ export async function middleware(req: NextRequest) {
 
   if (user && !isPortal) {
     try {
-      const { data: profile } = await supabase
-        .from("profiles")
-        .select("completed_onboarding, shop_id, role")
-        .eq("id", user.id)
-        .limit(1)
-        .maybeSingle();
+      const { profile } = await resolveCanonicalStaffProfile(
+        supabase,
+        user.id,
+      );
 
       const normalizedRole = String(profile?.role ?? "").trim().toLowerCase();
       const pendingOwnerBootstrap =

--- a/middleware.ts
+++ b/middleware.ts
@@ -427,11 +427,11 @@ export async function middleware(req: NextRequest) {
       const access = await resolvePortalAccessServer(supabase, user.id);
       if (!access.customer && !access.fleet) return res;
 
-      const target = productRequestUrl(
-        req,
-        access.customer ? "/portal" : "/portal/fleet",
-        fleetProductRequest,
-      );
+      const surface: PortalSurface = access.customer ? "customer" : "fleet";
+      const to = isPortalPathForSurface(redirectParam, surface)
+        ? redirectParam!
+        : PORTAL_HOME[surface];
+      const target = productRequestUrl(req, to, fleetProductRequest);
       return redirectWithResponseHeaders(target, res);
     }
 

--- a/tests/acquisition-auth-handoff.test.ts
+++ b/tests/acquisition-auth-handoff.test.ts
@@ -7,7 +7,7 @@ describe("acquisition auth handoff", () => {
   it("lets only a canonical unassigned shop owner continue to onboarding", () => {
     const route = read("app/api/auth/sign-in/route.ts");
 
-    expect(route).toContain("if (!profile) return deny();");
+    expect(route).toContain("if (profileError || !profile) return deny();");
     expect(route).toContain('if (surface === "shop" && !profile.role)');
     expect(route).toContain(
       'return NextResponse.json({ ok: true, destination: "/onboarding" });',

--- a/tests/codex-review-followup-hardening.test.ts
+++ b/tests/codex-review-followup-hardening.test.ts
@@ -14,15 +14,23 @@ const read = (path: string) => readFileSync(path, "utf8");
 
 describe("Codex review follow-up hardening", () => {
   it("keeps password activation retryable without exposing database details", async () => {
-    const eq = vi.fn().mockResolvedValue({ error: { message: "raw postgres policy detail" } });
-    const update = vi.fn(() => ({ eq }));
-    const from = vi.fn(() => ({ update }));
-    const result = await activatePasswordProfile({ from } as never, "user-id");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({
+        error: "Account activation could not be completed.",
+      }),
+    });
+    const result = await activatePasswordProfile(fetchMock as never);
     expect(result).toEqual({
       ok: false,
       userMessage: PASSWORD_ACTIVATION_RETRY_MESSAGE,
-      detail: "raw postgres policy detail",
+      detail: "Account activation could not be completed.",
     });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/password-activation",
+      expect.objectContaining({ method: "POST" }),
+    );
     expect(PASSWORD_ACTIVATION_RETRY_MESSAGE).not.toContain("postgres");
   });
 

--- a/tests/dashboard-server-context.test.ts
+++ b/tests/dashboard-server-context.test.ts
@@ -122,17 +122,21 @@ describe("dashboard server shop context", () => {
       "features/shared/lib/server/admin-access.ts",
       "utf8",
     );
+    const canonicalProfileSource = readFileSync(
+      "features/shared/lib/authenticated-profile.ts",
+      "utf8",
+    );
 
-    expect(middlewareSource).toContain('.from("profiles")');
-    expect(middlewareSource).toContain('.eq("id", user.id)');
-    expect(middlewareSource).toContain(".limit(1)");
-    expect(middlewareSource).toContain(".maybeSingle()");
+    expect(middlewareSource).toContain("resolveCanonicalStaffProfile");
 
     expect(resolverSource).toContain("resolveAuthenticatedStaffProfile");
-    expect(staffResolverSource).toContain('.from("profiles")');
-    expect(staffResolverSource).toContain('.eq("id", authUserId)');
-    expect(staffResolverSource).toContain('.eq("user_id", authUserId)');
-    expect(staffResolverSource).toContain(".maybeSingle<ProfileScope>()");
+    expect(staffResolverSource).toContain("resolveCanonicalStaffProfile");
+    expect(canonicalProfileSource).toContain('.from("profiles")');
+    expect(canonicalProfileSource).toContain('.eq("id", authUserId)');
+    expect(canonicalProfileSource).toContain('.eq("user_id", authUserId)');
+    expect(canonicalProfileSource).toContain(
+      ".maybeSingle<AuthenticatedStaffProfile>()",
+    );
     expect(resolverSource).not.toContain("createServer" + "ComponentClient");
     expect(resolverSource).not.toContain("@supabase/" + "auth-helpers-nextjs");
   });

--- a/tests/dashboard-server-context.test.ts
+++ b/tests/dashboard-server-context.test.ts
@@ -90,7 +90,8 @@ describe("dashboard server shop context", () => {
     expect(calls).toContainEqual({
       table: "profiles",
       method: "select",
-      columns: "id, role, shop_id, completed_onboarding, email, full_name",
+      columns:
+        "id, role, shop_id, completed_onboarding, must_change_password, email, full_name",
     });
     expect(calls).toContainEqual({
       table: "profiles",

--- a/tests/fleet-product-middleware-boundary.test.ts
+++ b/tests/fleet-product-middleware-boundary.test.ts
@@ -19,6 +19,7 @@ const authFixture = vi.hoisted(() => ({
     role: string;
     created_at: string;
   }>,
+  customerId: null as string | null,
 }));
 
 vi.mock("@supabase/ssr", () => ({
@@ -40,7 +41,12 @@ vi.mock("@supabase/ssr", () => ({
 
       async maybeSingle() {
         return {
-          data: this.table === "profiles" ? authFixture.profile : null,
+          data:
+            this.table === "profiles"
+              ? authFixture.profile
+              : this.table === "customers" && authFixture.customerId
+                ? { id: authFixture.customerId }
+                : null,
           error: null,
         };
       }
@@ -73,6 +79,7 @@ afterEach(() => {
   authFixture.user = null;
   authFixture.profile = null;
   authFixture.memberships = [];
+  authFixture.customerId = null;
 
   if (originalSupabaseUrl === undefined) {
     delete process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -226,6 +233,30 @@ describe("Product host middleware boundary", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("preserves a customer portal deep link for an active session", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
+    authFixture.user = { id: "customer-user-1", app_metadata: {} };
+    authFixture.profile = {
+      id: "customer-user-1",
+      role: "customer",
+      shop_id: null,
+      completed_onboarding: true,
+    };
+    authFixture.customerId = "customer-1";
+
+    const response = await middleware(
+      shopRequest(
+        "/customer/sign-in?redirect=%2Fportal%2Finvoices%2Finvoice-1",
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://profixiq.com/portal/invoices/invoice-1",
+    );
   });
 
   it("honors explicit Shop sign-in on a phone instead of switching products", async () => {

--- a/tests/fleet-product-middleware-boundary.test.ts
+++ b/tests/fleet-product-middleware-boundary.test.ts
@@ -9,6 +9,7 @@ const authFixture = vi.hoisted(() => ({
   },
   profile: null as null | {
     id: string;
+    user_id?: string | null;
     role: string | null;
     shop_id: string | null;
     completed_onboarding: boolean;
@@ -25,13 +26,16 @@ const authFixture = vi.hoisted(() => ({
 vi.mock("@supabase/ssr", () => ({
   createServerClient: () => {
     class MockQuery {
+      private readonly filters = new Map<string, unknown>();
+
       constructor(private readonly table: string) {}
 
       select() {
         return this;
       }
 
-      eq() {
+      eq(column: string, value: unknown) {
+        this.filters.set(column, value);
         return this;
       }
 
@@ -40,10 +44,18 @@ vi.mock("@supabase/ssr", () => ({
       }
 
       async maybeSingle() {
+        const profileMatches =
+          authFixture.profile &&
+          ((this.filters.has("id") &&
+            authFixture.profile.id === this.filters.get("id")) ||
+            (this.filters.has("user_id") &&
+              authFixture.profile.user_id === this.filters.get("user_id")));
         return {
           data:
             this.table === "profiles"
-              ? authFixture.profile
+              ? profileMatches
+                ? authFixture.profile
+                : null
               : this.table === "customers" && authFixture.customerId
                 ? { id: authFixture.customerId }
                 : null,
@@ -142,6 +154,24 @@ describe("Product host middleware boundary", () => {
     expect(response.headers.get("location")).toBe(
       "https://profixiq.com/onboarding",
     );
+  });
+
+  it("uses the canonical linked profile for imported staff in middleware", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
+    authFixture.user = { id: "auth-user-1", app_metadata: {} };
+    authFixture.profile = {
+      id: "canonical-profile-1",
+      user_id: "auth-user-1",
+      role: "technician",
+      shop_id: "shop-1",
+      completed_onboarding: true,
+    };
+
+    const response = await middleware(shopRequest("/mobile/service"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
   });
 
   it("moves legacy Fleet workspace URLs off the Shop hostname", async () => {

--- a/tests/password-activation-server.test.ts
+++ b/tests/password-activation-server.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { clearCanonicalPasswordRequirement } from "@/features/auth/server/passwordActivation";
+
+type Profile = {
+  id: string;
+  user_id?: string | null;
+  role: string;
+  shop_id: string;
+  completed_onboarding: boolean;
+  must_change_password: boolean;
+  email: string;
+  full_name: string;
+};
+
+function createReadClient(profile: Profile | null) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn((column: string, value: string) => ({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data:
+              profile &&
+              ((column === "id" && profile.id === value) ||
+                (column === "user_id" && profile.user_id === value))
+                ? profile
+                : null,
+            error: null,
+          }),
+        })),
+      })),
+    })),
+  };
+}
+
+function createAdminClient(profile: Profile | null, updated: Profile | null) {
+  const updateEq = vi.fn(() => ({
+    select: vi.fn(() => ({
+      maybeSingle: vi.fn().mockResolvedValue({ data: updated, error: null }),
+    })),
+  }));
+
+  return {
+    client: {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn((column: string, value: string) => ({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data:
+                profile && column === "user_id" && profile.user_id === value
+                  ? profile
+                  : null,
+              error: null,
+            }),
+          })),
+        })),
+        update: vi.fn(() => ({ eq: updateEq })),
+      })),
+    },
+    updateEq,
+  };
+}
+
+const linkedProfile: Profile = {
+  id: "canonical-profile-1",
+  user_id: "auth-user-1",
+  role: "technician",
+  shop_id: "shop-1",
+  completed_onboarding: true,
+  must_change_password: true,
+  email: "tech@example.com",
+  full_name: "Field Tech",
+};
+
+describe("canonical password activation", () => {
+  it("updates and verifies the exact linked canonical profile row", async () => {
+    const sessionClient = createReadClient(null);
+    const admin = createAdminClient(linkedProfile, {
+      ...linkedProfile,
+      must_change_password: false,
+    });
+
+    const result = await clearCanonicalPasswordRequirement({
+      authUserId: "auth-user-1",
+      sessionClient: sessionClient as never,
+      adminClient: admin.client as never,
+    });
+
+    expect(result).toEqual({ ok: true, profileUpdated: true });
+    expect(admin.updateEq).toHaveBeenCalledWith("id", "canonical-profile-1");
+  });
+
+  it("fails instead of reporting success when no updated row is returned", async () => {
+    const sessionClient = createReadClient(null);
+    const admin = createAdminClient(linkedProfile, null);
+
+    const result = await clearCanonicalPasswordRequirement({
+      authUserId: "auth-user-1",
+      sessionClient: sessionClient as never,
+      adminClient: admin.client as never,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      detail: "Canonical profile password activation was not persisted.",
+    });
+  });
+
+  it("keeps portal-only and pre-profile password changes as no-op success", async () => {
+    const sessionClient = createReadClient(null);
+    const admin = createAdminClient(null, null);
+
+    const result = await clearCanonicalPasswordRequirement({
+      authUserId: "portal-user-1",
+      sessionClient: sessionClient as never,
+      adminClient: admin.client as never,
+    });
+
+    expect(result).toEqual({ ok: true, profileUpdated: false });
+    expect(admin.updateEq).not.toHaveBeenCalled();
+  });
+});

--- a/tests/product-access-separation.test.ts
+++ b/tests/product-access-separation.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { resolveFieldExistingSessionHref } from "../features/auth/lib/accessSurfaceRouting";
 
 const read = (path: string) => readFileSync(path, "utf8");
 
@@ -32,6 +33,7 @@ describe("dedicated product access surfaces", () => {
   it("makes Field a first-class authentication surface", () => {
     const field = read("features/auth/components/FieldSignIn.tsx");
     const route = read("app/api/auth/sign-in/route.ts");
+    const accessRoute = read("app/api/mobile/field-service/access/route.ts");
 
     expect(field).toContain('surface: "field"');
     expect(field).toContain("Sign in to ProFixIQ Field");
@@ -40,13 +42,54 @@ describe("dedicated product access surfaces", () => {
     expect(route).toContain('fieldAccess.canAccessFieldService');
     expect(route).toContain('"/mobile/service/setup"');
     expect(field).toContain("resolveFieldPostSignInHref");
+    expect(field).toContain("resolveFieldExistingSessionHref");
     expect(field).toContain("We couldn't reach ProFixIQ");
-    expect(route).toContain(
-      'surface === "field" ? "local" : "global"',
-    );
+    expect(route).toContain("resolveAuthenticatedStaffProfile");
+    expect(accessRoute).toContain("mustChangePassword");
+    expect(route).toContain('surface === "field" ? "local" : "global"');
     expect(route).toContain(
       "supabase.auth.signOut({ scope: rejectedSessionScope })",
     );
+  });
+
+  it("forces existing Field sessions through password setup before routing", () => {
+    expect(
+      resolveFieldExistingSessionHref(
+        {
+          canAccessFieldService: true,
+          mustChangePassword: true,
+        },
+        "/mobile/service/work-orders/work-order-1",
+      ),
+    ).toBe("/auth/set-password?redirect=%2Fmobile%2Fservice");
+
+    expect(
+      resolveFieldExistingSessionHref(
+        {
+          canAccessFieldService: true,
+          mustChangePassword: false,
+        },
+        "/mobile/service/work-orders/work-order-1",
+      ),
+    ).toBe("/mobile/service/work-orders/work-order-1");
+
+    expect(
+      resolveFieldExistingSessionHref(
+        { canConfigure: true, mustChangePassword: true },
+        "/mobile/service",
+      ),
+    ).toBe("/auth/set-password?redirect=%2Fmobile%2Fservice%2Fsetup");
+
+    expect(resolveFieldExistingSessionHref({}, "/mobile/service")).toBeNull();
+  });
+
+  it("keeps the public AI CTA on the implemented assistant route", () => {
+    const buttons = read("features/shared/components/LandingButtons.tsx");
+
+    expect(buttons).toContain(
+      'href="/shop/sign-in?redirect=%2Fai%2Fassistant"',
+    );
+    expect(buttons).not.toContain('href="/shop/sign-in?redirect=%2Fai"');
   });
 
   it("removes Mobile companion from the public Shop sign-in hierarchy", () => {

--- a/tests/product-access-separation.test.ts
+++ b/tests/product-access-separation.test.ts
@@ -34,6 +34,9 @@ describe("dedicated product access surfaces", () => {
     const field = read("features/auth/components/FieldSignIn.tsx");
     const route = read("app/api/auth/sign-in/route.ts");
     const accessRoute = read("app/api/mobile/field-service/access/route.ts");
+    const routeGate = read(
+      "features/mobile/service/MobileFieldServiceRouteGate.tsx",
+    );
 
     expect(field).toContain('surface: "field"');
     expect(field).toContain("Sign in to ProFixIQ Field");
@@ -46,6 +49,8 @@ describe("dedicated product access surfaces", () => {
     expect(field).toContain("We couldn't reach ProFixIQ");
     expect(route).toContain("resolveAuthenticatedStaffProfile");
     expect(accessRoute).toContain("mustChangePassword");
+    expect(routeGate).toContain("resolveFieldExistingSessionHref");
+    expect(routeGate).toContain('router.replace(destination ?? "/mobile")');
     expect(route).toContain('surface === "field" ? "local" : "global"');
     expect(route).toContain(
       "supabase.auth.signOut({ scope: rejectedSessionScope })",

--- a/tests/set-password-shell-transition.test.ts
+++ b/tests/set-password-shell-transition.test.ts
@@ -26,23 +26,24 @@ describe("set-password shell transition", () => {
   });
 
   it("keeps database details internal and presents a safe retry message", async () => {
-    const eq = vi.fn().mockResolvedValue({
-      error: { message: "raw postgres policy detail" },
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({
+        error: "Account activation could not be completed.",
+      }),
     });
-    const update = vi.fn(() => ({ eq }));
-    const from = vi.fn(() => ({ update }));
-
-    const result = await activatePasswordProfile(
-      { from } as never,
-      "profile-id",
-    );
+    const result = await activatePasswordProfile(fetchMock as never);
 
     expect(result).toEqual({
       ok: false,
       userMessage: PASSWORD_ACTIVATION_RETRY_MESSAGE,
-      detail: "raw postgres policy detail",
+      detail: "Account activation could not be completed.",
     });
     expect(PASSWORD_ACTIVATION_RETRY_MESSAGE).not.toContain("postgres");
+    expect(readFileSync(helperPath, "utf8")).toContain(
+      "/api/auth/password-activation",
+    );
     expect(readFileSync(helperPath, "utf8")).toContain(
       "PASSWORD_ACTIVATION_RETRY_MESSAGE",
     );

--- a/tests/workforce-premier-cohesion.test.ts
+++ b/tests/workforce-premier-cohesion.test.ts
@@ -23,6 +23,7 @@ const scheduleOverrideMigration = read(
   "supabase/migrations/20260728213500_atomic_staff_schedule_overrides.sql",
 );
 const adminAccess = read("features/shared/lib/server/admin-access.ts");
+const canonicalProfile = read("features/shared/lib/authenticated-profile.ts");
 const selfRoute = read("app/api/workforce/me/route.ts");
 const mobileShiftRoute = read("app/api/mobile/shifts/route.ts");
 const selfCard = read("features/workforce/components/MyWorkforceCard.tsx");
@@ -97,7 +98,9 @@ const assignablesRoute = read("app/api/assignables/route.ts");
 describe("premier workforce cohesion", () => {
   it("resolves both historical and canonical profile identity shapes", () => {
     expect(adminAccess).toContain("resolveAuthenticatedStaffProfile");
-    expect(adminAccess).toContain('.eq("user_id", authUserId)');
+    expect(adminAccess).toContain("resolveCanonicalStaffProfile");
+    expect(canonicalProfile).toContain('.eq("id", authUserId)');
+    expect(canonicalProfile).toContain('.eq("user_id", authUserId)');
     expect(identityMigration).toContain(
       "create or replace function public.profixiq_workforce_profile_id()",
     );


### PR DESCRIPTION
## Summary

- enforce mandatory password changes in the Field route gate for direct or bookmarked workspace/setup access
- use one canonical staff-profile resolver in sign-in, middleware, and server access paths, including imported `profiles.user_id` identities
- clear `must_change_password` through an authenticated server endpoint that updates and verifies the exact canonical profile row
- preserve portal-only and pre-profile password changes as safe no-op activation success
- preserve validated Customer Portal deep links and the dedicated Shop, Field, Fleet, and Customer sign-in surfaces
- retain the merged Field Hub workspace and local-scope Field denial behavior

## Root cause

The Field access endpoint returned `mustChangePassword`, but the workspace route gate did not consume it, so a direct `/mobile/service` request could bypass password setup. The sign-in route resolved imported staff through `profiles.user_id`, while middleware still assumed `profiles.id = auth.uid()`. Finally, the browser attempted to clear `must_change_password` with an ID-based RLS update and treated a zero-row update as success.

## Fix

- route existing Field sessions through the same security-sensitive destination resolver used by Field sign-in
- centralize deterministic `profiles.id` then `profiles.user_id` lookup and reuse it from middleware and server access
- authenticate password activation with `auth.getUser()`, keep the cookie session client separate from the service client, update by canonical `profiles.id`, and require the returned row to contain `must_change_password = false`
- keep database failures server-side and preserve the retryable activation UI

## Validation

- focused auth, middleware, Field, dashboard, and workforce regression suites: 71 tests passed
- `tsc --noEmit`: passed
- ESLint on all changed TypeScript/TSX files: passed
- API route boundary audit: passed; the new authenticated endpoint is classified low risk
- local production bundle compiled successfully; local page-data collection then stopped only because `OPENAI_API_KEY` is absent
- final Agent PR Checks on `b436ed88a`: passed, including the complete Linux test suite, production build, and regression gate
- final Mobile Command Validation on `b436ed88a`: passed
- final Mobile Dispatch Validation on `b436ed88a`: passed
- final Mobile V1 Validation on `b436ed88a`: passed
- final Universal Scheduler Validation on `b436ed88a`: passed

## Database and deployment

- no migration or database change
- no new environment variables
- no deployment performed
