### PR TITLE
Field Hub: add mobile purchase orders

### DIFF
--- a/app/api/parts/_lib/lifecycleCommand.ts
+++ b/app/api/parts/_lib/lifecycleCommand.ts
@@ -77,6 +77,7 @@ export async function runPartsLifecycleRpcWithAccess(
         /^Receipt quantity .*$/i,
         /^Requested .* quantity .*$/i,
         /^No outstanding .*$/i,
+        /^Purchase order supplier is inactive\.?$/i,
         /^Cannot .*$/i,
       ],
     });

--- a/app/api/parts/purchase-orders/[poId]/place/route.ts
+++ b/app/api/parts/purchase-orders/[poId]/place/route.ts
@@ -1,0 +1,184 @@
+import { NextResponse } from "next/server";
+
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { toSafeDatabaseError } from "@/features/shared/lib/server/safeDatabaseError";
+
+type Body = {
+  idempotencyKey?: unknown;
+};
+
+function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value.trim(),
+    )
+  );
+}
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+const PLACED_STATUSES = new Set([
+  "open",
+  "ordered",
+  "sent",
+  "receiving",
+  "received",
+]);
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ poId: string }> },
+) {
+  const { poId } = await context.params;
+  const body = (await request.json().catch(() => null)) as Body | null;
+  const idempotencyKey =
+    clean(request.headers.get("Idempotency-Key")) ||
+    clean(body?.idempotencyKey);
+
+  if (!isUuid(poId) || !idempotencyKey || idempotencyKey.length > 300) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          "A valid purchase order and stable idempotency key are required.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageParts",
+  });
+  if (!access.ok) return access.response;
+
+  const shopId = access.profile.shop_id;
+  const { data: purchaseOrder, error: purchaseOrderError } =
+    await access.supabase
+      .from("purchase_orders")
+      .select("id,status,ordered_at")
+      .eq("id", poId)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+
+  if (purchaseOrderError) {
+    const safeError = toSafeDatabaseError(purchaseOrderError, {
+      context: "parts/po/place-context",
+      fallback: "The purchase order could not be loaded.",
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: safeError.message,
+        correlationId: safeError.correlationId,
+      },
+      { status: 500 },
+    );
+  }
+  if (!purchaseOrder) {
+    return NextResponse.json(
+      { ok: false, error: "Purchase order not found." },
+      { status: 404 },
+    );
+  }
+
+  const currentStatus = clean(purchaseOrder.status).toLowerCase();
+  if (PLACED_STATUSES.has(currentStatus)) {
+    return NextResponse.json({
+      ok: true,
+      idempotent: true,
+      result: purchaseOrder,
+    });
+  }
+  if (currentStatus !== "draft") {
+    return NextResponse.json(
+      { ok: false, error: "Only a draft purchase order can be placed." },
+      { status: 409 },
+    );
+  }
+
+  const { data: lines, error: linesError } = await access.supabase
+    .from("purchase_order_lines")
+    .select("id,qty,cancelled_qty")
+    .eq("po_id", poId);
+  if (linesError) {
+    const safeError = toSafeDatabaseError(linesError, {
+      context: "parts/po/place-lines",
+      fallback: "The purchase-order lines could not be verified.",
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: safeError.message,
+        correlationId: safeError.correlationId,
+      },
+      { status: 500 },
+    );
+  }
+  const hasActiveLine = (lines ?? []).some(
+    (line) => Number(line.qty ?? 0) - Number(line.cancelled_qty ?? 0) > 0,
+  );
+  if (!hasActiveLine) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Add at least one active line before placing this PO.",
+      },
+      { status: 409 },
+    );
+  }
+
+  const orderedAt = purchaseOrder.ordered_at || new Date().toISOString();
+  const { data: updated, error: updateError } = await access.supabase
+    .from("purchase_orders")
+    .update({ status: "open", ordered_at: orderedAt })
+    .eq("id", poId)
+    .eq("shop_id", shopId)
+    .eq("status", "draft")
+    .select("id,status,ordered_at")
+    .maybeSingle();
+
+  if (updateError) {
+    const safeError = toSafeDatabaseError(updateError, {
+      context: "parts/po/place",
+      fallback: "The purchase order could not be placed.",
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: safeError.message,
+        correlationId: safeError.correlationId,
+      },
+      { status: 500 },
+    );
+  }
+  if (updated) {
+    return NextResponse.json({ ok: true, idempotent: false, result: updated });
+  }
+
+  const { data: raced, error: racedError } = await access.supabase
+    .from("purchase_orders")
+    .select("id,status,ordered_at")
+    .eq("id", poId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+  if (racedError) {
+    return NextResponse.json(
+      { ok: false, error: "The purchase-order state could not be confirmed." },
+      { status: 500 },
+    );
+  }
+  if (raced && PLACED_STATUSES.has(clean(raced.status).toLowerCase())) {
+    return NextResponse.json({ ok: true, idempotent: true, result: raced });
+  }
+
+  return NextResponse.json(
+    {
+      ok: false,
+      error: "The purchase order changed before it could be placed.",
+    },
+    { status: 409 },
+  );
+}

--- a/app/api/parts/purchase-orders/[poId]/place/route.ts
+++ b/app/api/parts/purchase-orders/[poId]/place/route.ts
@@ -4,7 +4,23 @@ import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-a
 import { toSafeDatabaseError } from "@/features/shared/lib/server/safeDatabaseError";
 
 type Body = {
+  contactChannel?: unknown;
   idempotencyKey?: unknown;
+};
+
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{
+    data: Record<string, unknown> | null;
+    error: {
+      message?: string | null;
+      details?: string | null;
+      hint?: string | null;
+      code?: string | null;
+    } | null;
+  }>;
 };
 
 function isUuid(value: unknown): value is string {
@@ -20,14 +36,6 @@ function clean(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-const PLACED_STATUSES = new Set([
-  "open",
-  "ordered",
-  "sent",
-  "receiving",
-  "received",
-]);
-
 export async function POST(
   request: Request,
   context: { params: Promise<{ poId: string }> },
@@ -37,13 +45,19 @@ export async function POST(
   const idempotencyKey =
     clean(request.headers.get("Idempotency-Key")) ||
     clean(body?.idempotencyKey);
+  const contactChannel = clean(body?.contactChannel).toLowerCase();
 
-  if (!isUuid(poId) || !idempotencyKey || idempotencyKey.length > 300) {
+  if (
+    !isUuid(poId) ||
+    !idempotencyKey ||
+    idempotencyKey.length > 200 ||
+    (contactChannel && contactChannel !== "email" && contactChannel !== "phone")
+  ) {
     return NextResponse.json(
       {
         ok: false,
         error:
-          "A valid purchase order and stable idempotency key are required.",
+          "A valid purchase order, contact method, and stable idempotency key are required.",
       },
       { status: 400 },
     );
@@ -54,96 +68,28 @@ export async function POST(
   });
   if (!access.ok) return access.response;
 
-  const shopId = access.profile.shop_id;
-  const { data: purchaseOrder, error: purchaseOrderError } =
-    await access.supabase
-      .from("purchase_orders")
-      .select("id,status,ordered_at")
-      .eq("id", poId)
-      .eq("shop_id", shopId)
-      .maybeSingle();
-
-  if (purchaseOrderError) {
-    const safeError = toSafeDatabaseError(purchaseOrderError, {
-      context: "parts/po/place-context",
-      fallback: "The purchase order could not be loaded.",
-    });
-    return NextResponse.json(
-      {
-        ok: false,
-        error: safeError.message,
-        correlationId: safeError.correlationId,
-      },
-      { status: 500 },
-    );
-  }
-  if (!purchaseOrder) {
-    return NextResponse.json(
-      { ok: false, error: "Purchase order not found." },
-      { status: 404 },
-    );
-  }
-
-  const currentStatus = clean(purchaseOrder.status).toLowerCase();
-  if (PLACED_STATUSES.has(currentStatus)) {
-    return NextResponse.json({
-      ok: true,
-      idempotent: true,
-      result: purchaseOrder,
-    });
-  }
-  if (currentStatus !== "draft") {
-    return NextResponse.json(
-      { ok: false, error: "Only a draft purchase order can be placed." },
-      { status: 409 },
-    );
-  }
-
-  const { data: lines, error: linesError } = await access.supabase
-    .from("purchase_order_lines")
-    .select("id,qty,cancelled_qty")
-    .eq("po_id", poId);
-  if (linesError) {
-    const safeError = toSafeDatabaseError(linesError, {
-      context: "parts/po/place-lines",
-      fallback: "The purchase-order lines could not be verified.",
-    });
-    return NextResponse.json(
-      {
-        ok: false,
-        error: safeError.message,
-        correlationId: safeError.correlationId,
-      },
-      { status: 500 },
-    );
-  }
-  const hasActiveLine = (lines ?? []).some(
-    (line) => Number(line.qty ?? 0) - Number(line.cancelled_qty ?? 0) > 0,
+  const scopedKey = `${access.profile.shop_id}:parts_place_purchase_order:${idempotencyKey}`;
+  const { data, error } = await (access.supabase as unknown as RpcClient).rpc(
+    "parts_place_purchase_order",
+    {
+      p_po_id: poId,
+      p_idempotency_key: scopedKey,
+      p_contact_channel: contactChannel || null,
+    },
   );
-  if (!hasActiveLine) {
-    return NextResponse.json(
-      {
-        ok: false,
-        error: "Add at least one active line before placing this PO.",
-      },
-      { status: 409 },
-    );
-  }
 
-  const orderedAt = purchaseOrder.ordered_at || new Date().toISOString();
-  const { data: updated, error: updateError } = await access.supabase
-    .from("purchase_orders")
-    .update({ status: "open", ordered_at: orderedAt })
-    .eq("id", poId)
-    .eq("shop_id", shopId)
-    .eq("status", "draft")
-    .select("id,status,ordered_at")
-    .maybeSingle();
-
-  if (updateError) {
-    const safeError = toSafeDatabaseError(updateError, {
+  if (error) {
+    const safeError = toSafeDatabaseError(error, {
       context: "parts/po/place",
       fallback: "The purchase order could not be placed.",
+      publicMessagePatterns: [
+        /^Purchase order not found/i,
+        /^Only a draft purchase order/i,
+        /^Add at least one active line/i,
+        /^A supplier contact method is required/i,
+        /^Purchase order supplier was not found/i,
+        /^The selected supplier does not have/i,
+      ],
     });
     return NextResponse.json(
       {
@@ -151,34 +97,16 @@ export async function POST(
         error: safeError.message,
         correlationId: safeError.correlationId,
       },
-      { status: 500 },
+      {
+        status:
+          safeError.isPublicMessage && error.code === "P0002"
+            ? 404
+            : safeError.isPublicMessage
+              ? 409
+              : 500,
+      },
     );
   }
-  if (updated) {
-    return NextResponse.json({ ok: true, idempotent: false, result: updated });
-  }
 
-  const { data: raced, error: racedError } = await access.supabase
-    .from("purchase_orders")
-    .select("id,status,ordered_at")
-    .eq("id", poId)
-    .eq("shop_id", shopId)
-    .maybeSingle();
-  if (racedError) {
-    return NextResponse.json(
-      { ok: false, error: "The purchase-order state could not be confirmed." },
-      { status: 500 },
-    );
-  }
-  if (raced && PLACED_STATUSES.has(clean(raced.status).toLowerCase())) {
-    return NextResponse.json({ ok: true, idempotent: true, result: raced });
-  }
-
-  return NextResponse.json(
-    {
-      ok: false,
-      error: "The purchase order changed before it could be placed.",
-    },
-    { status: 409 },
-  );
+  return NextResponse.json({ ok: true, result: data });
 }

--- a/app/api/parts/requests/items/[itemId]/po-line/route.ts
+++ b/app/api/parts/requests/items/[itemId]/po-line/route.ts
@@ -27,8 +27,10 @@ export async function POST(req: Request, ctx: { params: Promise<{ itemId: string
     !isUuid(itemId) ||
     (!isUuid(poId) && !isUuid(supplierId)) ||
     qty == null ||
+    Math.round(qty * 100) / 100 !== qty ||
     (locationId != null && !isUuid(locationId)) ||
-    (unitCost != null && (!Number.isFinite(unitCost) || unitCost < 0))
+    (unitCost != null && (!Number.isFinite(unitCost) || unitCost < 0)) ||
+    (notes != null && notes.length > 2000)
   )
     return NextResponse.json(
       {

--- a/app/api/parts/vendors/route.ts
+++ b/app/api/parts/vendors/route.ts
@@ -91,10 +91,10 @@ async function findNormalizedDuplicate(args: {
   shopId: string;
   name: string;
   excludeId?: string;
-}): Promise<{ id: string; name: string } | null> {
+}): Promise<{ id: string; name: string; is_active: boolean } | null> {
   const { data, error } = await args.supabase
     .from("suppliers")
-    .select("id, name")
+    .select("id, name, is_active")
     .eq("shop_id", args.shopId)
     .limit(1000);
   if (error) throw error;
@@ -132,6 +132,7 @@ export async function POST(request: Request) {
         {
           error: `A vendor named “${duplicate.name}” already exists.`,
           vendorId: duplicate.id,
+          vendorIsActive: duplicate.is_active,
         },
         { status: 409 },
       );
@@ -195,6 +196,7 @@ export async function PATCH(request: Request) {
         {
           error: `A vendor named “${duplicate.name}” already exists.`,
           vendorId: duplicate.id,
+          vendorIsActive: duplicate.is_active,
         },
         { status: 409 },
       );

--- a/app/mobile/service/purchase-orders/page.tsx
+++ b/app/mobile/service/purchase-orders/page.tsx
@@ -1,0 +1,37 @@
+import { PackagePlus } from "lucide-react";
+
+import MobilePurchaseOrders from "@/features/parts/mobile/MobilePurchaseOrders";
+import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export const dynamic = "force-dynamic";
+
+export default async function FieldPurchaseOrdersPage() {
+  const { profile } = await requireShopPageAccess({
+    requiredCapability: "canManageParts",
+    redirectTo: "/mobile/service",
+  });
+
+  return (
+    <main className="mx-auto w-full max-w-5xl space-y-3 px-3 py-3 sm:px-4">
+      <section className="mobile-dashboard-hero">
+        <div className="flex items-start gap-3">
+          <span className="inline-grid h-11 w-11 shrink-0 place-items-center rounded-2xl border border-white/15 bg-white/10 text-[#8ed4ff]">
+            <PackagePlus aria-hidden className="h-5 w-5" />
+          </span>
+          <div className="min-w-0">
+            <div className="mobile-dashboard-hero__eyebrow">
+              Field purchasing
+            </div>
+            <h1 className="mobile-dashboard-hero__title">Purchase orders</h1>
+            <p className="mobile-dashboard-hero__subtitle">
+              Turn approved parts into supplier orders, then receive them into
+              the exact Field inventory location.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <MobilePurchaseOrders shopId={profile.shop_id} />
+    </main>
+  );
+}

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -30,9 +30,8 @@ import {
 type FieldModule = {
   title: string;
   description: string;
-  href?: string;
+  href: string;
   icon: LucideIcon;
-  status: "ready" | "next";
   requiredCapability?: keyof FieldWorkspaceCapabilities;
 };
 
@@ -42,7 +41,6 @@ const FIELD_MODULES: FieldModule[] = [
     description: "Accept, create and manage digital bookings.",
     href: "/mobile/appointments",
     icon: CalendarDays,
-    status: "ready",
     requiredCapability: "canManageScheduling",
   },
   {
@@ -50,28 +48,24 @@ const FIELD_MODULES: FieldModule[] = [
     description: "Build the repair, labor and job record.",
     href: "/mobile/work-orders",
     icon: BriefcaseBusiness,
-    status: "ready",
   },
   {
     title: "Inspections",
     description: "Run forms, capture evidence and findings.",
     href: "/mobile/inspections",
     icon: ClipboardCheck,
-    status: "ready",
   },
   {
     title: "Customer intake",
     description: "Find or create the customer as you book the call.",
     href: "/mobile/service/new",
     icon: UserRound,
-    status: "ready",
   },
   {
     title: "Parts & truck stock",
     description: "Request, receive, allocate and consume parts.",
     href: "/mobile/parts",
     icon: Boxes,
-    status: "ready",
     requiredCapability: "canManageParts",
   },
   {
@@ -79,21 +73,20 @@ const FIELD_MODULES: FieldModule[] = [
     description: "Finish the invoice and collect in the field.",
     href: "/mobile/work-orders?status=ready_to_invoice&mode=field_closeout",
     icon: FileText,
-    status: "ready",
   },
   {
     title: "Fleet connections",
     description: "Work with units, inspections and service requests.",
     href: "/mobile/fleet",
     icon: Truck,
-    status: "ready",
     requiredCapability: "canAccessFleet",
   },
   {
     title: "Purchase orders",
-    description: "Mobile-first PO authoring and receiving is the next build slice.",
+    description: "Author supplier orders and receive parts into Field stock.",
+    href: "/mobile/service/purchase-orders",
     icon: PackagePlus,
-    status: "next",
+    requiredCapability: "canManageParts",
   },
 ];
 
@@ -107,30 +100,17 @@ function FieldModuleCard({ module }: { module: FieldModule }) {
       <span className="min-w-0 flex-1">
         <span className="flex items-center gap-2">
           <span className="field-hub-module__title">{module.title}</span>
-          {module.status === "next" ? (
-            <span className="field-hub-module__badge">Next</span>
-          ) : null}
         </span>
         <span className="field-hub-module__description">
           {module.description}
         </span>
       </span>
-      {module.href ? (
-        <ArrowRight
-          aria-hidden
-          className="h-4 w-4 shrink-0 text-[color:var(--accent-copper)]"
-        />
-      ) : null}
+      <ArrowRight
+        aria-hidden
+        className="h-4 w-4 shrink-0 text-[color:var(--accent-copper)]"
+      />
     </>
   );
-
-  if (!module.href) {
-    return (
-      <div className="field-hub-module" data-available="false">
-        {content}
-      </div>
-    );
-  }
 
   return (
     <Link className="field-hub-module" href={module.href}>

--- a/features/mobile/service/FieldWorkspaceShell.tsx
+++ b/features/mobile/service/FieldWorkspaceShell.tsx
@@ -9,6 +9,7 @@ import {
   LogOut,
   Menu,
   PackageOpen,
+  PackagePlus,
   Plus,
   Settings2,
   Truck,
@@ -68,6 +69,13 @@ const OPERATIONS_NAV: FieldNavItem[] = [
     label: "Parts",
     href: "/mobile/parts",
     icon: Boxes,
+    exact: true,
+    requiredCapability: "canManageParts",
+  },
+  {
+    label: "Purchase orders",
+    href: "/mobile/service/purchase-orders",
+    icon: PackagePlus,
     requiredCapability: "canManageParts",
   },
   {
@@ -91,6 +99,9 @@ function isActive(pathname: string, item: FieldNavItem): boolean {
 
 function pageTitle(pathname: string): string {
   if (pathname === "/mobile/service") return "Field Hub";
+  if (pathname.startsWith("/mobile/service/purchase-orders")) {
+    return "Purchase orders";
+  }
   if (pathname.startsWith("/mobile/service/new")) return "New service call";
   if (pathname.startsWith("/mobile/service/truck-inventory")) {
     return "Truck inventory";

--- a/features/parts/mobile/MobilePurchaseOrders.tsx
+++ b/features/parts/mobile/MobilePurchaseOrders.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { purchaseOrderIdentity } from "@/features/parts/lib/purchaseOrderIdentity";
+import { isOpenPartsObligation } from "@/features/parts/lib/open-parts-obligations";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
   purchaseOrderCanReceive,
@@ -70,6 +71,7 @@ type PurchaseOrder = {
   ordered_at: string | null;
   expected_at: string | null;
   work_order_id: string | null;
+  supplier_quote_request_id: string | null;
   total: number | null;
 };
 
@@ -114,27 +116,30 @@ type JsonResult = {
   ok?: boolean;
   error?: string;
   vendorId?: string;
+  vendorIsActive?: boolean;
   vendor?: Supplier;
   result?: Record<string, unknown>;
 };
 
-const RELEASED_REQUEST_STATUSES = [
+const ORDERABLE_REQUEST_STATUSES = [
   "approved",
   "partially_ordered",
   "partially_consumed",
   "partially_returned",
-  "fulfilled",
-  "returned",
 ] as const;
 
-const CANCELLED_ITEM_STATUSES = new Set([
-  "cancelled",
-  "canceled",
-  "declined",
-  "rejected",
-]);
-
 const CLOSED_PO_STATUSES = new Set(["received", "cancelled", "canceled"]);
+const ACTIVE_PURCHASE_ORDER_STATUSES = [
+  "draft",
+  "open",
+  "ordered",
+  "partially_ordered",
+  "sent",
+  "receiving",
+  "partially_received",
+] as const;
+const QUERY_PAGE_SIZE = 200;
+const QUERY_ID_BATCH_SIZE = 100;
 
 const actionClass =
   "inline-flex min-h-11 items-center justify-center rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-3 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--accent-copper)] disabled:cursor-not-allowed disabled:opacity-50";
@@ -230,15 +235,46 @@ export default function MobilePurchaseOrders({
     setError(null);
 
     try {
-      const [requestResult, supplierResult, locationResult, poResult] =
-        await Promise.all([
-          supabase
+      const requestPromise = (async (): Promise<PartRequest[]> => {
+        const rows: PartRequest[] = [];
+        for (let offset = 0; ; offset += QUERY_PAGE_SIZE) {
+          const result = await supabase
             .from("part_requests")
             .select("id,work_order_id,status")
             .eq("shop_id", shopId)
-            .in("status", [...RELEASED_REQUEST_STATUSES])
+            .in("status", [...ORDERABLE_REQUEST_STATUSES])
             .order("created_at", { ascending: false })
-            .limit(200),
+            .order("id", { ascending: false })
+            .range(offset, offset + QUERY_PAGE_SIZE - 1);
+          if (result.error) throw result.error;
+          const page = (result.data ?? []) as PartRequest[];
+          rows.push(...page);
+          if (page.length < QUERY_PAGE_SIZE) return rows;
+        }
+      })();
+      const purchaseOrderPromise = (async (): Promise<PurchaseOrder[]> => {
+        const rows: PurchaseOrder[] = [];
+        for (let offset = 0; ; offset += QUERY_PAGE_SIZE) {
+          const result = await supabase
+            .from("purchase_orders")
+            .select(
+              "id,po_number,supplier_id,status,created_at,ordered_at,expected_at,work_order_id,supplier_quote_request_id,total",
+            )
+            .eq("shop_id", shopId)
+            .in("status", [...ACTIVE_PURCHASE_ORDER_STATUSES])
+            .order("created_at", { ascending: false })
+            .order("id", { ascending: false })
+            .range(offset, offset + QUERY_PAGE_SIZE - 1);
+          if (result.error) throw result.error;
+          const page = (result.data ?? []) as PurchaseOrder[];
+          rows.push(...page);
+          if (page.length < QUERY_PAGE_SIZE) return rows;
+        }
+      })();
+
+      const [nextRequests, supplierResult, locationResult, nextPurchaseOrders] =
+        await Promise.all([
+          requestPromise,
           supabase
             .from("suppliers")
             .select("id,name,email,phone,is_active")
@@ -250,53 +286,61 @@ export default function MobilePurchaseOrders({
             .select("id,code,name")
             .eq("shop_id", shopId)
             .order("code", { ascending: true }),
-          supabase
-            .from("purchase_orders")
-            .select(
-              "id,po_number,supplier_id,status,created_at,ordered_at,expected_at,work_order_id,total",
-            )
-            .eq("shop_id", shopId)
-            .order("created_at", { ascending: false })
-            .limit(150),
+          purchaseOrderPromise,
         ]);
 
-      const firstError =
-        requestResult.error ||
-        supplierResult.error ||
-        locationResult.error ||
-        poResult.error;
+      const firstError = supplierResult.error || locationResult.error;
       if (firstError) throw firstError;
 
-      const nextRequests = (requestResult.data ?? []) as PartRequest[];
-      const nextPurchaseOrders = (poResult.data ?? []) as PurchaseOrder[];
       const requestIds = nextRequests.map((request) => request.id);
       const poIds = nextPurchaseOrders.map((purchaseOrder) => purchaseOrder.id);
 
-      let nextItems: PartRequestItem[] = [];
-      if (requestIds.length > 0) {
-        const itemResult = await supabase
-          .from("part_request_items")
-          .select(
-            "id,request_id,work_order_id,work_order_line_id,part_id,description,status,qty,qty_requested,qty_approved,qty_ordered,qty_received,unit_cost,location_id,vendor_id,updated_at",
-          )
-          .eq("shop_id", shopId)
-          .in("request_id", requestIds)
-          .order("updated_at", { ascending: false });
-        if (itemResult.error) throw itemResult.error;
-        nextItems = (itemResult.data ?? []) as PartRequestItem[];
+      const nextItems: PartRequestItem[] = [];
+      for (
+        let start = 0;
+        start < requestIds.length;
+        start += QUERY_ID_BATCH_SIZE
+      ) {
+        const requestIdBatch = requestIds.slice(
+          start,
+          start + QUERY_ID_BATCH_SIZE,
+        );
+        for (let offset = 0; ; offset += QUERY_PAGE_SIZE) {
+          const itemResult = await supabase
+            .from("part_request_items")
+            .select(
+              "id,request_id,work_order_id,work_order_line_id,part_id,description,status,qty,qty_requested,qty_approved,qty_ordered,qty_received,unit_cost,location_id,vendor_id,updated_at",
+            )
+            .eq("shop_id", shopId)
+            .in("request_id", requestIdBatch)
+            .order("updated_at", { ascending: false })
+            .order("id", { ascending: false })
+            .range(offset, offset + QUERY_PAGE_SIZE - 1);
+          if (itemResult.error) throw itemResult.error;
+          const page = (itemResult.data ?? []) as PartRequestItem[];
+          nextItems.push(...page);
+          if (page.length < QUERY_PAGE_SIZE) break;
+        }
       }
 
-      let nextLines: PurchaseOrderLine[] = [];
-      if (poIds.length > 0) {
-        const lineResult = await supabase
-          .from("purchase_order_lines")
-          .select(
-            "id,po_id,part_request_item_id,part_id,description,sku,qty,cancelled_qty,received_qty,unit_cost,location_id,created_at",
-          )
-          .in("po_id", poIds)
-          .order("created_at", { ascending: true });
-        if (lineResult.error) throw lineResult.error;
-        nextLines = (lineResult.data ?? []) as PurchaseOrderLine[];
+      const nextLines: PurchaseOrderLine[] = [];
+      for (let start = 0; start < poIds.length; start += QUERY_ID_BATCH_SIZE) {
+        const poIdBatch = poIds.slice(start, start + QUERY_ID_BATCH_SIZE);
+        for (let offset = 0; ; offset += QUERY_PAGE_SIZE) {
+          const lineResult = await supabase
+            .from("purchase_order_lines")
+            .select(
+              "id,po_id,part_request_item_id,part_id,description,sku,qty,cancelled_qty,received_qty,unit_cost,location_id,created_at",
+            )
+            .in("po_id", poIdBatch)
+            .order("created_at", { ascending: true })
+            .order("id", { ascending: true })
+            .range(offset, offset + QUERY_PAGE_SIZE - 1);
+          if (lineResult.error) throw lineResult.error;
+          const page = (lineResult.data ?? []) as PurchaseOrderLine[];
+          nextLines.push(...page);
+          if (page.length < QUERY_PAGE_SIZE) break;
+        }
       }
 
       const workOrderIds = Array.from(
@@ -310,15 +354,23 @@ export default function MobilePurchaseOrders({
           ].filter((id): id is string => Boolean(id)),
         ),
       );
-      let nextWorkOrders: WorkOrder[] = [];
-      if (workOrderIds.length > 0) {
+      const nextWorkOrders: WorkOrder[] = [];
+      for (
+        let start = 0;
+        start < workOrderIds.length;
+        start += QUERY_ID_BATCH_SIZE
+      ) {
+        const workOrderIdBatch = workOrderIds.slice(
+          start,
+          start + QUERY_ID_BATCH_SIZE,
+        );
         const workOrderResult = await supabase
           .from("work_orders")
           .select("id,custom_id")
           .eq("shop_id", shopId)
-          .in("id", workOrderIds);
+          .in("id", workOrderIdBatch);
         if (workOrderResult.error) throw workOrderResult.error;
-        nextWorkOrders = (workOrderResult.data ?? []) as WorkOrder[];
+        nextWorkOrders.push(...((workOrderResult.data ?? []) as WorkOrder[]));
       }
 
       setRequests(nextRequests);
@@ -377,11 +429,16 @@ export default function MobilePurchaseOrders({
   const needsOrdering = useMemo(
     () =>
       items.filter(
-        (item) =>
-          !CANCELLED_ITEM_STATUSES.has(clean(item.status).toLowerCase()) &&
-          requestRemainingToOrder(item) > 0,
+        (item) => {
+          const request = requestById.get(item.request_id);
+          return (
+            Boolean(request) &&
+            isOpenPartsObligation(request?.status, item) &&
+            requestRemainingToOrder(item) > 0
+          );
+        },
       ),
-    [items],
+    [items, requestById],
   );
   const activePurchaseOrders = useMemo(
     () =>
@@ -443,6 +500,20 @@ export default function MobilePurchaseOrders({
 
   const placePurchaseOrder = async (purchaseOrder: PurchaseOrder) => {
     if (placingPoId) return;
+    const supplier = supplierById.get(purchaseOrder.supplier_id);
+    const contactChannel = purchaseOrder.supplier_quote_request_id
+      ? clean(supplier?.email)
+        ? "email"
+        : clean(supplier?.phone)
+          ? "phone"
+          : null
+      : null;
+    if (purchaseOrder.supplier_quote_request_id && !contactChannel) {
+      toast.error(
+        "Add an email address or phone number for this supplier before placing the quoted PO.",
+      );
+      return;
+    }
     const key =
       placeOperationKeys.current.get(purchaseOrder.id) ?? operationId();
     placeOperationKeys.current.set(purchaseOrder.id, key);
@@ -460,7 +531,10 @@ export default function MobilePurchaseOrders({
             "Content-Type": "application/json",
             "Idempotency-Key": key,
           },
-          body: JSON.stringify({ idempotencyKey: key }),
+          body: JSON.stringify({
+            idempotencyKey: key,
+            contactChannel,
+          }),
         },
       );
       const payload = await readJson(response);
@@ -501,6 +575,18 @@ export default function MobilePurchaseOrders({
     if ((!response.ok && response.status !== 409) || !supplierId) {
       throw new Error(payload?.error || "Unable to create the supplier.");
     }
+    if (response.status === 409) {
+      const duplicate = suppliers.find(
+        (supplier) => supplier.id === supplierId,
+      );
+      const duplicateIsActive =
+        payload?.vendorIsActive ?? duplicate?.is_active ?? false;
+      if (!duplicateIsActive) {
+        throw new Error(
+          "A supplier with this name is inactive. Reactivate it before creating a purchase order.",
+        );
+      }
+    }
     if (payload?.vendor) {
       setSuppliers((current) =>
         [
@@ -517,6 +603,10 @@ export default function MobilePurchaseOrders({
     const remaining = requestRemainingToOrder(orderDraft.item);
     if (!Number.isFinite(orderDraft.qty) || orderDraft.qty <= 0) {
       toast.error("Order quantity must be greater than zero.");
+      return;
+    }
+    if (Math.round(orderDraft.qty * 100) / 100 !== orderDraft.qty) {
+      toast.error("Order quantity supports at most two decimal places.");
       return;
     }
     if (orderDraft.qty > remaining) {
@@ -645,9 +735,7 @@ export default function MobilePurchaseOrders({
       toast.error(`Only ${formatQuantity(remaining)} remains on this line.`);
       return;
     }
-    const needsLocation = Boolean(
-      receiveDraft.line.part_request_item_id || receiveDraft.line.part_id,
-    );
+    const needsLocation = Boolean(receiveDraft.line.part_id);
     if (needsLocation && !receiveDraft.locationId) {
       toast.error("Select the receiving location.");
       return;
@@ -670,7 +758,10 @@ export default function MobilePurchaseOrders({
     setSubmitting(true);
     try {
       let response: Response;
-      if (receiveDraft.line.part_request_item_id) {
+      if (
+        receiveDraft.line.part_request_item_id &&
+        receiveDraft.line.part_id
+      ) {
         response = await fetch(
           `/api/parts/requests/items/${encodeURIComponent(
             receiveDraft.line.part_request_item_id,
@@ -1060,9 +1151,7 @@ export default function MobilePurchaseOrders({
                                 className={`${primaryActionClass} mt-3 w-full`}
                                 onClick={() => openReceive(purchaseOrder, line)}
                                 disabled={
-                                  Boolean(
-                                    line.part_request_item_id || line.part_id,
-                                  ) && locations.length === 0
+                                  Boolean(line.part_id) && locations.length === 0
                                 }
                               >
                                 Receive {formatQuantity(remaining)}
@@ -1346,8 +1435,7 @@ export default function MobilePurchaseOrders({
               {formatQuantity(purchaseOrderLineRemaining(receiveDraft.line))}
             </div>
 
-            {receiveDraft.line.part_request_item_id ||
-            receiveDraft.line.part_id ? (
+            {receiveDraft.line.part_id ? (
               <label className="mt-3 block text-sm text-[color:var(--theme-text-secondary)]">
                 Receiving location
                 <select

--- a/features/parts/mobile/MobilePurchaseOrders.tsx
+++ b/features/parts/mobile/MobilePurchaseOrders.tsx
@@ -1,0 +1,1421 @@
+"use client";
+
+import {
+  ChevronDown,
+  PackageCheck,
+  PackagePlus,
+  RefreshCw,
+  X,
+} from "lucide-react";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+
+import { purchaseOrderIdentity } from "@/features/parts/lib/purchaseOrderIdentity";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import {
+  purchaseOrderCanReceive,
+  purchaseOrderLineRemaining,
+  requestRemainingToOrder,
+  requestTargetQuantity,
+} from "./mobilePurchaseOrderQuantities";
+
+type View = "needs-ordering" | "purchase-orders";
+
+type PartRequest = {
+  id: string;
+  work_order_id: string | null;
+  status: string | null;
+};
+
+type PartRequestItem = {
+  id: string;
+  request_id: string;
+  work_order_id: string | null;
+  work_order_line_id: string | null;
+  part_id: string | null;
+  description: string;
+  status: string | null;
+  qty: number | null;
+  qty_requested: number | null;
+  qty_approved: number | null;
+  qty_ordered: number | null;
+  qty_received: number | null;
+  unit_cost: number | null;
+  location_id: string | null;
+  vendor_id: string | null;
+  updated_at: string | null;
+};
+
+type Supplier = {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  is_active: boolean;
+};
+
+type StockLocation = {
+  id: string;
+  code: string;
+  name: string;
+};
+
+type PurchaseOrder = {
+  id: string;
+  po_number: string | null;
+  supplier_id: string;
+  status: string;
+  created_at: string;
+  ordered_at: string | null;
+  expected_at: string | null;
+  work_order_id: string | null;
+  total: number | null;
+};
+
+type PurchaseOrderLine = {
+  id: string;
+  po_id: string;
+  part_request_item_id: string | null;
+  part_id: string | null;
+  description: string | null;
+  sku: string | null;
+  qty: number;
+  cancelled_qty: number;
+  received_qty: number;
+  unit_cost: number | null;
+  location_id: string | null;
+  created_at: string;
+};
+
+type WorkOrder = {
+  id: string;
+  custom_id: string | null;
+};
+
+type OrderDraft = {
+  item: PartRequestItem;
+  supplierId: string;
+  newSupplierName: string;
+  locationId: string;
+  qty: number;
+  unitCost: number | "";
+  notes: string;
+};
+
+type ReceiveDraft = {
+  purchaseOrder: PurchaseOrder;
+  line: PurchaseOrderLine;
+  locationId: string;
+  qty: number;
+};
+
+type JsonResult = {
+  ok?: boolean;
+  error?: string;
+  vendorId?: string;
+  vendor?: Supplier;
+  result?: Record<string, unknown>;
+};
+
+const RELEASED_REQUEST_STATUSES = [
+  "approved",
+  "partially_ordered",
+  "partially_consumed",
+  "partially_returned",
+  "fulfilled",
+  "returned",
+] as const;
+
+const CANCELLED_ITEM_STATUSES = new Set([
+  "cancelled",
+  "canceled",
+  "declined",
+  "rejected",
+]);
+
+const CLOSED_PO_STATUSES = new Set(["received", "cancelled", "canceled"]);
+
+const actionClass =
+  "inline-flex min-h-11 items-center justify-center rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-3 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--accent-copper)] disabled:cursor-not-allowed disabled:opacity-50";
+const primaryActionClass = `${actionClass} border-[color:var(--accent-copper)] bg-[color:var(--accent-copper)] text-white`;
+const fieldClass =
+  "mt-1 min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-[color:var(--theme-text-primary)] outline-none focus:border-[color:var(--accent-copper)]";
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function numeric(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatQuantity(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(0) : value.toFixed(2);
+}
+
+function formatMoney(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(Number(value))) return "Not set";
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+  }).format(Number(value));
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "No date";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "No date"
+    : new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+      }).format(date);
+}
+
+function statusTone(status: string): string {
+  const normalized = status.toLowerCase();
+  if (normalized === "received") {
+    return "border-emerald-500/35 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200";
+  }
+  if (normalized === "ordered" || normalized === "receiving") {
+    return "border-sky-500/35 bg-sky-500/10 text-sky-700 dark:text-sky-200";
+  }
+  if (normalized === "cancelled" || normalized === "canceled") {
+    return "border-rose-500/35 bg-rose-500/10 text-rose-700 dark:text-rose-200";
+  }
+  return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-secondary)]";
+}
+
+function operationId(): string {
+  return globalThis.crypto.randomUUID();
+}
+
+async function readJson(response: Response): Promise<JsonResult | null> {
+  return (await response.json().catch(() => null)) as JsonResult | null;
+}
+
+export default function MobilePurchaseOrders({
+  shopId,
+}: {
+  shopId: string;
+}): JSX.Element {
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const [view, setView] = useState<View>("needs-ordering");
+  const [requests, setRequests] = useState<PartRequest[]>([]);
+  const [items, setItems] = useState<PartRequestItem[]>([]);
+  const [suppliers, setSuppliers] = useState<Supplier[]>([]);
+  const [locations, setLocations] = useState<StockLocation[]>([]);
+  const [purchaseOrders, setPurchaseOrders] = useState<PurchaseOrder[]>([]);
+  const [lines, setLines] = useState<PurchaseOrderLine[]>([]);
+  const [workOrders, setWorkOrders] = useState<WorkOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [orderDraft, setOrderDraft] = useState<OrderDraft | null>(null);
+  const [receiveDraft, setReceiveDraft] = useState<ReceiveDraft | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [placingPoId, setPlacingPoId] = useState<string | null>(null);
+  const orderOperationRef = useRef<{ signature: string; key: string } | null>(
+    null,
+  );
+  const receiveOperationRef = useRef<{
+    signature: string;
+    key: string;
+  } | null>(null);
+  const placeOperationKeys = useRef(new Map<string, string>());
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const [requestResult, supplierResult, locationResult, poResult] =
+        await Promise.all([
+          supabase
+            .from("part_requests")
+            .select("id,work_order_id,status")
+            .eq("shop_id", shopId)
+            .in("status", [...RELEASED_REQUEST_STATUSES])
+            .order("created_at", { ascending: false })
+            .limit(200),
+          supabase
+            .from("suppliers")
+            .select("id,name,email,phone,is_active")
+            .eq("shop_id", shopId)
+            .order("name", { ascending: true })
+            .limit(1000),
+          supabase
+            .from("stock_locations")
+            .select("id,code,name")
+            .eq("shop_id", shopId)
+            .order("code", { ascending: true }),
+          supabase
+            .from("purchase_orders")
+            .select(
+              "id,po_number,supplier_id,status,created_at,ordered_at,expected_at,work_order_id,total",
+            )
+            .eq("shop_id", shopId)
+            .order("created_at", { ascending: false })
+            .limit(150),
+        ]);
+
+      const firstError =
+        requestResult.error ||
+        supplierResult.error ||
+        locationResult.error ||
+        poResult.error;
+      if (firstError) throw firstError;
+
+      const nextRequests = (requestResult.data ?? []) as PartRequest[];
+      const nextPurchaseOrders = (poResult.data ?? []) as PurchaseOrder[];
+      const requestIds = nextRequests.map((request) => request.id);
+      const poIds = nextPurchaseOrders.map((purchaseOrder) => purchaseOrder.id);
+
+      let nextItems: PartRequestItem[] = [];
+      if (requestIds.length > 0) {
+        const itemResult = await supabase
+          .from("part_request_items")
+          .select(
+            "id,request_id,work_order_id,work_order_line_id,part_id,description,status,qty,qty_requested,qty_approved,qty_ordered,qty_received,unit_cost,location_id,vendor_id,updated_at",
+          )
+          .eq("shop_id", shopId)
+          .in("request_id", requestIds)
+          .order("updated_at", { ascending: false });
+        if (itemResult.error) throw itemResult.error;
+        nextItems = (itemResult.data ?? []) as PartRequestItem[];
+      }
+
+      let nextLines: PurchaseOrderLine[] = [];
+      if (poIds.length > 0) {
+        const lineResult = await supabase
+          .from("purchase_order_lines")
+          .select(
+            "id,po_id,part_request_item_id,part_id,description,sku,qty,cancelled_qty,received_qty,unit_cost,location_id,created_at",
+          )
+          .in("po_id", poIds)
+          .order("created_at", { ascending: true });
+        if (lineResult.error) throw lineResult.error;
+        nextLines = (lineResult.data ?? []) as PurchaseOrderLine[];
+      }
+
+      const workOrderIds = Array.from(
+        new Set(
+          [
+            ...nextRequests.map((request) => request.work_order_id),
+            ...nextItems.map((item) => item.work_order_id),
+            ...nextPurchaseOrders.map(
+              (purchaseOrder) => purchaseOrder.work_order_id,
+            ),
+          ].filter((id): id is string => Boolean(id)),
+        ),
+      );
+      let nextWorkOrders: WorkOrder[] = [];
+      if (workOrderIds.length > 0) {
+        const workOrderResult = await supabase
+          .from("work_orders")
+          .select("id,custom_id")
+          .eq("shop_id", shopId)
+          .in("id", workOrderIds);
+        if (workOrderResult.error) throw workOrderResult.error;
+        nextWorkOrders = (workOrderResult.data ?? []) as WorkOrder[];
+      }
+
+      setRequests(nextRequests);
+      setItems(nextItems);
+      setSuppliers((supplierResult.data ?? []) as Supplier[]);
+      setLocations((locationResult.data ?? []) as StockLocation[]);
+      setPurchaseOrders(nextPurchaseOrders);
+      setLines(nextLines);
+      setWorkOrders(nextWorkOrders);
+    } catch (loadError) {
+      const message =
+        loadError instanceof Error
+          ? loadError.message
+          : "Unable to load purchase orders.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [shopId, supabase]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const requestById = useMemo(
+    () => new Map(requests.map((request) => [request.id, request])),
+    [requests],
+  );
+  const itemById = useMemo(
+    () => new Map(items.map((item) => [item.id, item])),
+    [items],
+  );
+  const supplierById = useMemo(
+    () => new Map(suppliers.map((supplier) => [supplier.id, supplier])),
+    [suppliers],
+  );
+  const activeSuppliers = useMemo(
+    () => suppliers.filter((supplier) => supplier.is_active),
+    [suppliers],
+  );
+  const workOrderById = useMemo(
+    () => new Map(workOrders.map((workOrder) => [workOrder.id, workOrder])),
+    [workOrders],
+  );
+  const linesByPoId = useMemo(() => {
+    const result = new Map<string, PurchaseOrderLine[]>();
+    for (const line of lines) {
+      const current = result.get(line.po_id) ?? [];
+      current.push(line);
+      result.set(line.po_id, current);
+    }
+    return result;
+  }, [lines]);
+
+  const needsOrdering = useMemo(
+    () =>
+      items.filter(
+        (item) =>
+          !CANCELLED_ITEM_STATUSES.has(clean(item.status).toLowerCase()) &&
+          requestRemainingToOrder(item) > 0,
+      ),
+    [items],
+  );
+  const activePurchaseOrders = useMemo(
+    () =>
+      purchaseOrders.filter(
+        (purchaseOrder) =>
+          !CLOSED_PO_STATUSES.has(clean(purchaseOrder.status).toLowerCase()),
+      ),
+    [purchaseOrders],
+  );
+  const receivingLineCount = useMemo(() => {
+    const receivablePoIds = new Set(
+      activePurchaseOrders
+        .filter((purchaseOrder) =>
+          purchaseOrderCanReceive(purchaseOrder.status),
+        )
+        .map((purchaseOrder) => purchaseOrder.id),
+    );
+    return lines.filter(
+      (line) =>
+        receivablePoIds.has(line.po_id) && purchaseOrderLineRemaining(line) > 0,
+    ).length;
+  }, [activePurchaseOrders, lines]);
+  const defaultLocationId = useMemo(() => {
+    const main = locations.find(
+      (location) => clean(location.code).toUpperCase() === "MAIN",
+    );
+    return main?.id ?? locations[0]?.id ?? "";
+  }, [locations]);
+
+  const workOrderLabel = useCallback(
+    (workOrderId: string | null | undefined): string => {
+      if (!workOrderId) return "Stock purchase";
+      const workOrder = workOrderById.get(workOrderId);
+      return clean(workOrder?.custom_id) || `WO ${workOrderId.slice(0, 8)}`;
+    },
+    [workOrderById],
+  );
+
+  const openOrder = (item: PartRequestItem) => {
+    const preferredSupplier = item.vendor_id
+      ? suppliers.find((supplier) => supplier.id === item.vendor_id)
+      : null;
+    const preferredLocation = locations.some(
+      (location) => location.id === item.location_id,
+    )
+      ? (item.location_id ?? "")
+      : defaultLocationId;
+    setOrderDraft({
+      item,
+      supplierId: preferredSupplier?.id ?? activeSuppliers[0]?.id ?? "",
+      newSupplierName: "",
+      locationId: preferredLocation,
+      qty: requestRemainingToOrder(item),
+      unitCost: item.unit_cost == null ? "" : numeric(item.unit_cost),
+      notes: "",
+    });
+    orderOperationRef.current = null;
+  };
+
+  const placePurchaseOrder = async (purchaseOrder: PurchaseOrder) => {
+    if (placingPoId) return;
+    const key =
+      placeOperationKeys.current.get(purchaseOrder.id) ?? operationId();
+    placeOperationKeys.current.set(purchaseOrder.id, key);
+    setPlacingPoId(purchaseOrder.id);
+
+    try {
+      const response = await fetch(
+        `/api/parts/purchase-orders/${encodeURIComponent(
+          purchaseOrder.id,
+        )}/place`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": key,
+          },
+          body: JSON.stringify({ idempotencyKey: key }),
+        },
+      );
+      const payload = await readJson(response);
+      if (!response.ok || payload?.ok === false || payload?.error) {
+        throw new Error(
+          payload?.error || "Unable to place the purchase order.",
+        );
+      }
+
+      placeOperationKeys.current.delete(purchaseOrder.id);
+      toast.success("Purchase order marked as placed.");
+      await load();
+    } catch (placeError) {
+      toast.error(
+        placeError instanceof Error
+          ? placeError.message
+          : "Unable to place the purchase order.",
+      );
+    } finally {
+      setPlacingPoId(null);
+    }
+  };
+
+  const ensureSupplier = async (draft: OrderDraft): Promise<string> => {
+    if (draft.supplierId) return draft.supplierId;
+    const name = clean(draft.newSupplierName);
+    if (!name)
+      throw new Error("Select a supplier or enter a new supplier name.");
+
+    const response = await fetch("/api/parts/vendors", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, isActive: true }),
+    });
+    const payload = await readJson(response);
+    const supplierId = clean(payload?.vendor?.id || payload?.vendorId);
+    if ((!response.ok && response.status !== 409) || !supplierId) {
+      throw new Error(payload?.error || "Unable to create the supplier.");
+    }
+    if (payload?.vendor) {
+      setSuppliers((current) =>
+        [
+          ...current.filter((supplier) => supplier.id !== supplierId),
+          payload.vendor!,
+        ].sort((left, right) => left.name.localeCompare(right.name)),
+      );
+    }
+    return supplierId;
+  };
+
+  const submitOrder = async () => {
+    if (!orderDraft || submitting) return;
+    const remaining = requestRemainingToOrder(orderDraft.item);
+    if (!Number.isFinite(orderDraft.qty) || orderDraft.qty <= 0) {
+      toast.error("Order quantity must be greater than zero.");
+      return;
+    }
+    if (orderDraft.qty > remaining) {
+      toast.error(
+        `Only ${formatQuantity(remaining)} remains approved to order.`,
+      );
+      return;
+    }
+    if (!orderDraft.locationId) {
+      toast.error("Select the receiving location.");
+      return;
+    }
+    if (orderDraft.unitCost !== "" && orderDraft.unitCost < 0) {
+      toast.error("Acquisition cost cannot be negative.");
+      return;
+    }
+    if (!orderDraft.item.part_id && orderDraft.unitCost === "") {
+      toast.error(
+        "Enter the supplier acquisition cost for this free-text part.",
+      );
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const supplierId = await ensureSupplier(orderDraft);
+      if (
+        orderDraft.item.vendor_id &&
+        supplierId !== orderDraft.item.vendor_id
+      ) {
+        throw new Error(
+          "This approved request is assigned to a different supplier.",
+        );
+      }
+      const signature = JSON.stringify({
+        itemId: orderDraft.item.id,
+        supplierId,
+        locationId: orderDraft.locationId,
+        qty: orderDraft.qty,
+        unitCost: orderDraft.unitCost === "" ? null : orderDraft.unitCost,
+        notes: clean(orderDraft.notes) || null,
+      });
+      const existing = orderOperationRef.current;
+      const key =
+        existing?.signature === signature ? existing.key : operationId();
+      orderOperationRef.current = { signature, key };
+
+      const response = await fetch(
+        `/api/parts/requests/items/${encodeURIComponent(
+          orderDraft.item.id,
+        )}/po-line`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": key,
+          },
+          body: JSON.stringify({
+            supplierId,
+            locationId: orderDraft.locationId,
+            qty: orderDraft.qty,
+            unitCost: orderDraft.unitCost === "" ? null : orderDraft.unitCost,
+            notes: clean(orderDraft.notes) || null,
+            idempotencyKey: key,
+          }),
+        },
+      );
+      const payload = await readJson(response);
+      if (!response.ok || payload?.ok === false || payload?.error) {
+        throw new Error(
+          payload?.error || "Unable to add this part to a purchase order.",
+        );
+      }
+
+      orderOperationRef.current = null;
+      setOrderDraft(null);
+      toast.success(
+        payload?.result?.po_created
+          ? "Purchase order created."
+          : "Part added to the supplier purchase order.",
+      );
+      await load();
+      setView("purchase-orders");
+    } catch (submitError) {
+      toast.error(
+        submitError instanceof Error
+          ? submitError.message
+          : "Unable to create the purchase order.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const openReceive = (
+    purchaseOrder: PurchaseOrder,
+    line: PurchaseOrderLine,
+  ) => {
+    const preferredLocation = locations.some(
+      (location) => location.id === line.location_id,
+    )
+      ? (line.location_id ?? "")
+      : defaultLocationId;
+    setReceiveDraft({
+      purchaseOrder,
+      line,
+      locationId: preferredLocation,
+      qty: purchaseOrderLineRemaining(line),
+    });
+    receiveOperationRef.current = null;
+  };
+
+  const submitReceive = async () => {
+    if (!receiveDraft || submitting) return;
+    const remaining = purchaseOrderLineRemaining(receiveDraft.line);
+    if (!Number.isFinite(receiveDraft.qty) || receiveDraft.qty <= 0) {
+      toast.error("Receipt quantity must be greater than zero.");
+      return;
+    }
+    if (Math.round(receiveDraft.qty * 100) / 100 !== receiveDraft.qty) {
+      toast.error("Receipt quantity supports at most two decimal places.");
+      return;
+    }
+    if (receiveDraft.qty > remaining) {
+      toast.error(`Only ${formatQuantity(remaining)} remains on this line.`);
+      return;
+    }
+    const needsLocation = Boolean(
+      receiveDraft.line.part_request_item_id || receiveDraft.line.part_id,
+    );
+    if (needsLocation && !receiveDraft.locationId) {
+      toast.error("Select the receiving location.");
+      return;
+    }
+
+    const signature = JSON.stringify({
+      poId: receiveDraft.purchaseOrder.id,
+      lineId: receiveDraft.line.id,
+      requestItemId: receiveDraft.line.part_request_item_id,
+      partId: receiveDraft.line.part_id,
+      locationId: receiveDraft.locationId,
+      qty: receiveDraft.qty,
+      alreadyReceived: receiveDraft.line.received_qty,
+    });
+    const existing = receiveOperationRef.current;
+    const key =
+      existing?.signature === signature ? existing.key : operationId();
+    receiveOperationRef.current = { signature, key };
+
+    setSubmitting(true);
+    try {
+      let response: Response;
+      if (receiveDraft.line.part_request_item_id) {
+        response = await fetch(
+          `/api/parts/requests/items/${encodeURIComponent(
+            receiveDraft.line.part_request_item_id,
+          )}/receive`,
+          {
+            method: "POST",
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+              "Idempotency-Key": key,
+            },
+            body: JSON.stringify({
+              location_id: receiveDraft.locationId,
+              qty: receiveDraft.qty,
+              po_id: receiveDraft.purchaseOrder.id,
+              idempotencyKey: key,
+            }),
+          },
+        );
+      } else if (receiveDraft.line.part_id) {
+        response = await fetch("/api/receive-scan", {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": key,
+          },
+          body: JSON.stringify({
+            part_id: receiveDraft.line.part_id,
+            location_id: receiveDraft.locationId,
+            qty: receiveDraft.qty,
+            po_id: receiveDraft.purchaseOrder.id,
+            operation_id: key,
+          }),
+        });
+      } else {
+        response = await fetch(
+          `/api/parts/purchase-orders/${encodeURIComponent(
+            receiveDraft.purchaseOrder.id,
+          )}/lines/${encodeURIComponent(
+            receiveDraft.line.id,
+          )}/receive-free-text`,
+          {
+            method: "POST",
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+              "Idempotency-Key": key,
+            },
+            body: JSON.stringify({
+              qty: receiveDraft.qty,
+              idempotencyKey: key,
+            }),
+          },
+        );
+      }
+
+      const payload = await readJson(response);
+      if (!response.ok || payload?.ok === false || payload?.error) {
+        throw new Error(
+          payload?.error || "Unable to receive this purchase-order line.",
+        );
+      }
+
+      receiveOperationRef.current = null;
+      setReceiveDraft(null);
+      toast.success("Purchase-order receipt recorded.");
+      window.dispatchEvent(new Event("parts:received"));
+      await load();
+    } catch (receiveError) {
+      toast.error(
+        receiveError instanceof Error
+          ? receiveError.message
+          : "Unable to receive this purchase-order line.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <section className="grid grid-cols-3 gap-2">
+        {[
+          ["Needs ordering", needsOrdering.length],
+          ["Open POs", activePurchaseOrders.length],
+          ["Lines to receive", receivingLineCount],
+        ].map(([label, value]) => (
+          <div
+            key={String(label)}
+            className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3"
+          >
+            <span className="block text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--theme-text-secondary)]">
+              {label}
+            </span>
+            <strong className="mt-1 block text-2xl text-[color:var(--theme-text-primary)]">
+              {loading ? "..." : value}
+            </strong>
+          </div>
+        ))}
+      </section>
+
+      <section className="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          onClick={() => setView("needs-ordering")}
+          data-active={view === "needs-ordering" ? "true" : "false"}
+          className="min-h-14 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-3 text-left text-sm font-semibold text-[color:var(--theme-text-primary)] data-[active=true]:border-[color:var(--accent-copper)]"
+        >
+          Author POs
+        </button>
+        <button
+          type="button"
+          onClick={() => setView("purchase-orders")}
+          data-active={view === "purchase-orders" ? "true" : "false"}
+          className="min-h-14 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-3 text-left text-sm font-semibold text-[color:var(--theme-text-primary)] data-[active=true]:border-[color:var(--accent-copper)]"
+        >
+          Receive POs
+        </button>
+      </section>
+
+      {error ? (
+        <div className="rounded-2xl border border-red-500/35 bg-red-500/10 p-4 text-sm text-red-700 dark:text-red-200">
+          {error}
+        </div>
+      ) : null}
+
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">
+              {view === "needs-ordering"
+                ? "Approved demand"
+                : "Supplier orders"}
+            </div>
+            <h2 className="mt-1 text-xl font-semibold text-[color:var(--theme-text-primary)]">
+              {view === "needs-ordering"
+                ? "Create or extend a draft PO"
+                : "Receive against the exact PO"}
+            </h2>
+          </div>
+          <button
+            type="button"
+            className={actionClass}
+            onClick={() => void load()}
+            disabled={loading}
+          >
+            <RefreshCw
+              aria-hidden
+              className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`}
+            />
+            Refresh
+          </button>
+        </div>
+
+        {view === "needs-ordering" ? (
+          <div className="mt-4 grid gap-3">
+            {!loading && !error && needsOrdering.length === 0 ? (
+              <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 text-sm text-[color:var(--theme-text-secondary)]">
+                Every approved request is fully ordered.
+              </div>
+            ) : null}
+
+            {needsOrdering.map((item) => {
+              const request = requestById.get(item.request_id);
+              const orderRemaining = requestRemainingToOrder(item);
+              const supplier = item.vendor_id
+                ? supplierById.get(item.vendor_id)
+                : null;
+              return (
+                <article
+                  key={item.id}
+                  className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--theme-text-secondary)]">
+                        {workOrderLabel(
+                          item.work_order_id || request?.work_order_id,
+                        )}
+                      </div>
+                      <h3 className="mt-1 text-base font-semibold text-[color:var(--theme-text-primary)]">
+                        {item.description}
+                      </h3>
+                      <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                        {supplier
+                          ? `Assigned supplier: ${supplier.name}`
+                          : "Choose the supplier when ordering"}
+                      </p>
+                    </div>
+                    <PackagePlus
+                      aria-hidden
+                      className="h-5 w-5 shrink-0 text-[color:var(--accent-copper)]"
+                    />
+                  </div>
+
+                  <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+                    {[
+                      ["Approved", requestTargetQuantity(item)],
+                      ["Ordered", numeric(item.qty_ordered)],
+                      ["Remaining", orderRemaining],
+                    ].map(([label, value]) => (
+                      <div
+                        key={String(label)}
+                        className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2"
+                      >
+                        <span className="block text-[10px] text-[color:var(--theme-text-secondary)]">
+                          {label}
+                        </span>
+                        <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
+                          {formatQuantity(Number(value))}
+                        </strong>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-xs text-[color:var(--theme-text-secondary)]">
+                      Cost: {formatMoney(item.unit_cost)}
+                    </span>
+                    <button
+                      type="button"
+                      className={primaryActionClass}
+                      onClick={() => openOrder(item)}
+                      disabled={locations.length === 0}
+                    >
+                      Order {formatQuantity(orderRemaining)}
+                    </button>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="mt-4 grid gap-3">
+            {!loading && !error && purchaseOrders.length === 0 ? (
+              <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 text-sm text-[color:var(--theme-text-secondary)]">
+                No purchase orders have been created yet.
+              </div>
+            ) : null}
+
+            {purchaseOrders.map((purchaseOrder) => {
+              const supplier = supplierById.get(purchaseOrder.supplier_id);
+              const poLines = linesByPoId.get(purchaseOrder.id) ?? [];
+              const identity = purchaseOrderIdentity({
+                id: purchaseOrder.id,
+                poNumber: purchaseOrder.po_number,
+                workOrderNumber: (() => {
+                  if (purchaseOrder.work_order_id) {
+                    return workOrderLabel(purchaseOrder.work_order_id);
+                  }
+                  const linkedWorkOrderIds = Array.from(
+                    new Set(
+                      poLines
+                        .map((line) =>
+                          line.part_request_item_id
+                            ? itemById.get(line.part_request_item_id)
+                                ?.work_order_id
+                            : null,
+                        )
+                        .filter((id): id is string => Boolean(id)),
+                    ),
+                  );
+                  if (linkedWorkOrderIds.length === 1) {
+                    return workOrderLabel(linkedWorkOrderIds[0]);
+                  }
+                  return linkedWorkOrderIds.length > 1
+                    ? "Multiple work orders"
+                    : "Stock purchase";
+                })(),
+              });
+              const ordered = poLines.reduce(
+                (sum, line) =>
+                  sum +
+                  Math.max(0, numeric(line.qty) - numeric(line.cancelled_qty)),
+                0,
+              );
+              const received = poLines.reduce(
+                (sum, line) => sum + numeric(line.received_qty),
+                0,
+              );
+
+              return (
+                <article
+                  key={purchaseOrder.id}
+                  className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--theme-text-secondary)]">
+                        {identity.secondary}
+                      </div>
+                      <h3 className="mt-1 text-base font-semibold text-[color:var(--theme-text-primary)]">
+                        {supplier?.name || "Unknown supplier"}
+                      </h3>
+                      <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                        {identity.primary} · Created{" "}
+                        {formatDate(purchaseOrder.created_at)}
+                        {purchaseOrder.expected_at
+                          ? ` · Expected ${formatDate(purchaseOrder.expected_at)}`
+                          : ""}
+                      </p>
+                    </div>
+                    <span
+                      className={`shrink-0 rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] ${statusTone(
+                        purchaseOrder.status,
+                      )}`}
+                    >
+                      {purchaseOrder.status}
+                    </span>
+                  </div>
+
+                  <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+                    {[
+                      ["Lines", poLines.length],
+                      ["Ordered", ordered],
+                      ["Received", received],
+                    ].map(([label, value]) => (
+                      <div
+                        key={String(label)}
+                        className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2"
+                      >
+                        <span className="block text-[10px] text-[color:var(--theme-text-secondary)]">
+                          {label}
+                        </span>
+                        <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
+                          {formatQuantity(Number(value))}
+                        </strong>
+                      </div>
+                    ))}
+                  </div>
+
+                  <details className="mt-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]">
+                    <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between px-3 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                      PO lines
+                      <ChevronDown aria-hidden className="h-4 w-4" />
+                    </summary>
+                    <div className="grid gap-2 border-t border-[color:var(--theme-border-soft)] p-2">
+                      {poLines.length === 0 ? (
+                        <div className="p-2 text-xs text-[color:var(--theme-text-secondary)]">
+                          This PO has no lines yet.
+                        </div>
+                      ) : null}
+                      {poLines.map((line) => {
+                        const remaining = purchaseOrderLineRemaining(line);
+                        const requestItem = line.part_request_item_id
+                          ? itemById.get(line.part_request_item_id)
+                          : null;
+                        return (
+                          <div
+                            key={line.id}
+                            className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0">
+                                <div className="font-semibold text-[color:var(--theme-text-primary)]">
+                                  {requestItem?.description ||
+                                    clean(line.description) ||
+                                    clean(line.sku) ||
+                                    "Purchase-order line"}
+                                </div>
+                                <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                                  Ordered{" "}
+                                  {formatQuantity(
+                                    Math.max(
+                                      0,
+                                      numeric(line.qty) -
+                                        numeric(line.cancelled_qty),
+                                    ),
+                                  )}{" "}
+                                  · Received{" "}
+                                  {formatQuantity(numeric(line.received_qty))} ·
+                                  Remaining {formatQuantity(remaining)}
+                                </div>
+                              </div>
+                              {remaining <= 0 ? (
+                                <PackageCheck
+                                  aria-label="Fully received"
+                                  className="h-5 w-5 shrink-0 text-emerald-500"
+                                />
+                              ) : null}
+                            </div>
+                            {remaining > 0 &&
+                            purchaseOrderCanReceive(purchaseOrder.status) ? (
+                              <button
+                                type="button"
+                                className={`${primaryActionClass} mt-3 w-full`}
+                                onClick={() => openReceive(purchaseOrder, line)}
+                                disabled={
+                                  Boolean(
+                                    line.part_request_item_id || line.part_id,
+                                  ) && locations.length === 0
+                                }
+                              >
+                                Receive {formatQuantity(remaining)}
+                              </button>
+                            ) : null}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </details>
+
+                  <div className="mt-3 flex justify-end">
+                    {clean(purchaseOrder.status).toLowerCase() === "draft" &&
+                    poLines.some(
+                      (line) =>
+                        numeric(line.qty) - numeric(line.cancelled_qty) > 0,
+                    ) ? (
+                      <button
+                        type="button"
+                        className={`${primaryActionClass} mr-2`}
+                        onClick={() => void placePurchaseOrder(purchaseOrder)}
+                        disabled={Boolean(placingPoId)}
+                      >
+                        {placingPoId === purchaseOrder.id
+                          ? "Placing..."
+                          : "Mark placed"}
+                      </button>
+                    ) : null}
+                    {supplier?.email ? (
+                      <a
+                        href={`mailto:${encodeURIComponent(supplier.email)}`}
+                        className={`${actionClass} mr-2`}
+                      >
+                        Email supplier
+                      </a>
+                    ) : supplier?.phone ? (
+                      <a
+                        href={`tel:${encodeURIComponent(supplier.phone)}`}
+                        className={`${actionClass} mr-2`}
+                      >
+                        Call supplier
+                      </a>
+                    ) : null}
+                    <Link
+                      href={`/parts/po/${encodeURIComponent(purchaseOrder.id)}`}
+                      className={actionClass}
+                    >
+                      Full PO record
+                    </Link>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {orderDraft ? (
+        <div className="fixed inset-0 z-[700] flex items-end justify-center bg-black/55 p-3 backdrop-blur-sm sm:items-center">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Add approved part to purchase order"
+            className="max-h-[92vh] w-full max-w-lg overflow-y-auto rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-5 shadow-[var(--theme-shadow-medium)]"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">
+                  Author purchase order
+                </div>
+                <h3 className="mt-1 text-xl font-semibold text-[color:var(--theme-text-primary)]">
+                  {orderDraft.item.description}
+                </h3>
+              </div>
+              <button
+                type="button"
+                className={actionClass}
+                aria-label="Close purchase-order authoring"
+                onClick={() => setOrderDraft(null)}
+                disabled={submitting}
+              >
+                <X aria-hidden className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="mt-4 grid gap-3">
+              <label className="text-sm text-[color:var(--theme-text-secondary)]">
+                Supplier
+                <select
+                  className={fieldClass}
+                  value={orderDraft.supplierId}
+                  disabled={Boolean(orderDraft.item.vendor_id)}
+                  onChange={(event) =>
+                    setOrderDraft((current) =>
+                      current
+                        ? {
+                            ...current,
+                            supplierId: event.target.value,
+                            newSupplierName: "",
+                          }
+                        : current,
+                    )
+                  }
+                >
+                  <option value="">Create a new supplier</option>
+                  {(orderDraft.item.vendor_id
+                    ? suppliers.filter(
+                        (supplier) => supplier.id === orderDraft.item.vendor_id,
+                      )
+                    : activeSuppliers
+                  ).map((supplier) => (
+                    <option key={supplier.id} value={supplier.id}>
+                      {supplier.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {!orderDraft.supplierId ? (
+                <label className="text-sm text-[color:var(--theme-text-secondary)]">
+                  New supplier name
+                  <input
+                    className={fieldClass}
+                    value={orderDraft.newSupplierName}
+                    maxLength={160}
+                    onChange={(event) =>
+                      setOrderDraft((current) =>
+                        current
+                          ? { ...current, newSupplierName: event.target.value }
+                          : current,
+                      )
+                    }
+                  />
+                </label>
+              ) : null}
+
+              <label className="text-sm text-[color:var(--theme-text-secondary)]">
+                Receiving location
+                <select
+                  className={fieldClass}
+                  value={orderDraft.locationId}
+                  onChange={(event) =>
+                    setOrderDraft((current) =>
+                      current
+                        ? { ...current, locationId: event.target.value }
+                        : current,
+                    )
+                  }
+                >
+                  <option value="">Select a location</option>
+                  {locations.map((location) => (
+                    <option key={location.id} value={location.id}>
+                      {location.code} — {location.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <div className="grid grid-cols-2 gap-3">
+                <label className="text-sm text-[color:var(--theme-text-secondary)]">
+                  Quantity
+                  <input
+                    className={fieldClass}
+                    type="number"
+                    min="0.01"
+                    step="0.01"
+                    max={requestRemainingToOrder(orderDraft.item)}
+                    value={orderDraft.qty}
+                    onChange={(event) =>
+                      setOrderDraft((current) =>
+                        current
+                          ? { ...current, qty: numeric(event.target.value) }
+                          : current,
+                      )
+                    }
+                  />
+                </label>
+                <label className="text-sm text-[color:var(--theme-text-secondary)]">
+                  Unit cost
+                  <input
+                    className={fieldClass}
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={orderDraft.unitCost}
+                    placeholder={
+                      orderDraft.item.part_id ? "Optional" : "Required"
+                    }
+                    onChange={(event) =>
+                      setOrderDraft((current) =>
+                        current
+                          ? {
+                              ...current,
+                              unitCost:
+                                event.target.value === ""
+                                  ? ""
+                                  : numeric(event.target.value),
+                            }
+                          : current,
+                      )
+                    }
+                  />
+                </label>
+              </div>
+
+              <label className="text-sm text-[color:var(--theme-text-secondary)]">
+                PO note
+                <textarea
+                  className={`${fieldClass} min-h-20 py-2`}
+                  value={orderDraft.notes}
+                  maxLength={2000}
+                  onChange={(event) =>
+                    setOrderDraft((current) =>
+                      current
+                        ? { ...current, notes: event.target.value }
+                        : current,
+                    )
+                  }
+                />
+              </label>
+            </div>
+
+            <p className="mt-3 text-xs text-[color:var(--theme-text-secondary)]">
+              The approved quantity is the ceiling. Matching draft POs for this
+              supplier are reused automatically.
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                className={actionClass}
+                onClick={() => setOrderDraft(null)}
+                disabled={submitting}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={primaryActionClass}
+                onClick={() => void submitOrder()}
+                disabled={submitting}
+              >
+                {submitting ? "Saving..." : "Create / add to PO"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {receiveDraft ? (
+        <div className="fixed inset-0 z-[700] flex items-end justify-center bg-black/55 p-3 backdrop-blur-sm sm:items-center">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Receive purchase-order line"
+            className="w-full max-w-lg rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-5 shadow-[var(--theme-shadow-medium)]"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">
+                  Receive purchase order
+                </div>
+                <h3 className="mt-1 text-xl font-semibold text-[color:var(--theme-text-primary)]">
+                  {clean(receiveDraft.line.description) ||
+                    clean(receiveDraft.line.sku) ||
+                    "Purchase-order line"}
+                </h3>
+              </div>
+              <button
+                type="button"
+                className={actionClass}
+                aria-label="Close purchase-order receipt"
+                onClick={() => setReceiveDraft(null)}
+                disabled={submitting}
+              >
+                <X aria-hidden className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3 text-sm text-[color:var(--theme-text-secondary)]">
+              Remaining on this line:{" "}
+              {formatQuantity(purchaseOrderLineRemaining(receiveDraft.line))}
+            </div>
+
+            {receiveDraft.line.part_request_item_id ||
+            receiveDraft.line.part_id ? (
+              <label className="mt-3 block text-sm text-[color:var(--theme-text-secondary)]">
+                Receiving location
+                <select
+                  className={fieldClass}
+                  value={receiveDraft.locationId}
+                  onChange={(event) =>
+                    setReceiveDraft((current) =>
+                      current
+                        ? { ...current, locationId: event.target.value }
+                        : current,
+                    )
+                  }
+                >
+                  <option value="">Select a location</option>
+                  {locations.map((location) => (
+                    <option key={location.id} value={location.id}>
+                      {location.code} — {location.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : (
+              <p className="mt-3 text-xs text-[color:var(--theme-text-secondary)]">
+                This free-text receipt updates the PO only and does not create
+                inventory stock.
+              </p>
+            )}
+
+            <label className="mt-3 block text-sm text-[color:var(--theme-text-secondary)]">
+              Quantity received
+              <input
+                className={fieldClass}
+                type="number"
+                min="0.01"
+                step="0.01"
+                max={purchaseOrderLineRemaining(receiveDraft.line)}
+                value={receiveDraft.qty}
+                onChange={(event) =>
+                  setReceiveDraft((current) =>
+                    current
+                      ? { ...current, qty: numeric(event.target.value) }
+                      : current,
+                  )
+                }
+              />
+            </label>
+
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                className={actionClass}
+                onClick={() => setReceiveDraft(null)}
+                disabled={submitting}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={primaryActionClass}
+                onClick={() => void submitReceive()}
+                disabled={submitting}
+              >
+                {submitting ? "Receiving..." : "Receive against PO"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/features/parts/mobile/mobilePurchaseOrderQuantities.ts
+++ b/features/parts/mobile/mobilePurchaseOrderQuantities.ts
@@ -1,0 +1,58 @@
+type RequestQuantitySnapshot = {
+  qty?: number | null;
+  qty_requested?: number | null;
+  qty_approved?: number | null;
+  qty_ordered?: number | null;
+};
+
+type PurchaseOrderLineQuantitySnapshot = {
+  qty?: number | null;
+  cancelled_qty?: number | null;
+  received_qty?: number | null;
+};
+
+const RECEIVABLE_PURCHASE_ORDER_STATUSES = new Set([
+  "open",
+  "ordered",
+  "sent",
+  "receiving",
+  "partially_received",
+]);
+
+function finiteQuantity(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+export function requestTargetQuantity(item: RequestQuantitySnapshot): number {
+  return Math.max(
+    finiteQuantity(item.qty),
+    finiteQuantity(item.qty_requested),
+    finiteQuantity(item.qty_approved),
+  );
+}
+
+export function requestRemainingToOrder(item: RequestQuantitySnapshot): number {
+  return Math.max(
+    0,
+    requestTargetQuantity(item) - finiteQuantity(item.qty_ordered),
+  );
+}
+
+export function purchaseOrderLineRemaining(
+  line: PurchaseOrderLineQuantitySnapshot,
+): number {
+  const activeOrdered = Math.max(
+    0,
+    finiteQuantity(line.qty) - finiteQuantity(line.cancelled_qty),
+  );
+  return Math.max(0, activeOrdered - finiteQuantity(line.received_qty));
+}
+
+export function purchaseOrderCanReceive(
+  status: string | null | undefined,
+): boolean {
+  return RECEIVABLE_PURCHASE_ORDER_STATUSES.has(
+    typeof status === "string" ? status.trim().toLowerCase() : "",
+  );
+}

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -28926,6 +28926,14 @@ export type Database = {
         Args: { p_channel: string; p_idempotency_key: string; p_po_id: string }
         Returns: Json
       }
+      parts_place_purchase_order: {
+        Args: {
+          p_contact_channel?: string
+          p_idempotency_key: string
+          p_po_id: string
+        }
+        Returns: Json
+      }
       parts_on_hand: {
         Args: { p_location_id?: string; p_part_id: string; p_shop_id: string }
         Returns: number

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -28926,6 +28926,10 @@ export type Database = {
         Args: { p_channel: string; p_idempotency_key: string; p_po_id: string }
         Returns: Json
       }
+      parts_on_hand: {
+        Args: { p_location_id?: string; p_part_id: string; p_shop_id: string }
+        Returns: number
+      }
       parts_place_purchase_order: {
         Args: {
           p_contact_channel?: string
@@ -28933,10 +28937,6 @@ export type Database = {
           p_po_id: string
         }
         Returns: Json
-      }
-      parts_on_hand: {
-        Args: { p_location_id?: string; p_part_id: string; p_shop_id: string }
-        Returns: number
       }
       parts_publish_request_notification: {
         Args: { p_request_id: string; p_stage: string }

--- a/supabase/migrations/20260816192840_field_purchase_order_review_fixes.sql
+++ b/supabase/migrations/20260816192840_field_purchase_order_review_fixes.sql
@@ -1,0 +1,289 @@
+-- Address the Field purchase-order review findings without reopening deployed
+-- history: keep order quantities and notes canonical, and make PO placement a
+-- single tenant-authorized transaction that composes the quote-contact command.
+
+begin;
+
+set local lock_timeout = '10s';
+set local statement_timeout = '120s';
+
+do $migration$
+declare
+  v_definition text;
+  v_updated text;
+  v_validation_anchor constant text := $anchor$  if nullif(trim(p_idempotency_key), '') is null then$anchor$;
+  v_validation_replacement constant text := $replacement$  if p_qty <> round(p_qty, 2) then
+    raise exception using
+      errcode = '22023',
+      message = 'PO quantity cannot use more than two decimal places.';
+  end if;
+  if length(coalesce(p_notes, '')) > 2000 then
+    raise exception using
+      errcode = '22023',
+      message = 'Purchase order notes must be 2000 characters or fewer.';
+  end if;
+  if nullif(trim(p_idempotency_key), '') is null then$replacement$;
+  v_supplier_anchor constant text := $anchor$    if not found then
+      raise exception using
+        errcode = '42501',
+        message = 'Supplier not found for this shop.';
+    end if;
+  end if;$anchor$;
+  v_supplier_replacement constant text := $replacement$    if not found then
+      raise exception using
+        errcode = '42501',
+        message = 'Supplier not found for this shop.';
+    end if;
+    if not coalesce(v_supplier.is_active, true) then
+      raise exception using
+        errcode = '55000',
+        message = 'Purchase order supplier is inactive.';
+    end if;
+  end if;$replacement$;
+  v_notes_anchor constant text := $anchor$  v_result := public.parts_create_po_line_for_request($anchor$;
+  v_notes_replacement constant text := $replacement$  if not v_created and nullif(trim(p_notes), '') is not null then
+    update public.purchase_orders
+    set notes = concat_ws(
+      E'\n',
+      nullif(trim(notes), ''),
+      nullif(trim(p_notes), '')
+    )
+    where id = v_po_id
+    returning * into v_po;
+  end if;
+
+  v_result := public.parts_create_po_line_for_request($replacement$;
+begin
+  select pg_get_functiondef(
+    'public.parts_create_or_reuse_po_line_for_request(uuid,numeric,text,uuid,uuid,numeric,uuid,text)'::regprocedure
+  )
+    into v_definition;
+
+  if v_definition is null then
+    raise exception 'parts_create_or_reuse_po_line_for_request is missing';
+  end if;
+
+  v_updated := v_definition;
+  if position('PO quantity cannot use more than two decimal places.' in v_updated) = 0 then
+    if position(v_validation_anchor in v_updated) = 0 then
+      raise exception 'PO quantity validation patch anchor is missing';
+    end if;
+    if (
+      length(v_updated) - length(replace(v_updated, v_validation_anchor, ''))
+    ) / length(v_validation_anchor) <> 1 then
+      raise exception 'PO quantity validation patch anchor is ambiguous';
+    end if;
+    v_updated := replace(
+      v_updated,
+      v_validation_anchor,
+      v_validation_replacement
+    );
+  end if;
+
+  if position('Purchase order supplier is inactive.' in v_updated) = 0 then
+    if position(v_supplier_anchor in v_updated) = 0 then
+      raise exception 'PO supplier activity patch anchor is missing';
+    end if;
+    if (
+      length(v_updated) - length(replace(v_updated, v_supplier_anchor, ''))
+    ) / length(v_supplier_anchor) <> 1 then
+      raise exception 'PO supplier activity patch anchor is ambiguous';
+    end if;
+    v_updated := replace(v_updated, v_supplier_anchor, v_supplier_replacement);
+  end if;
+
+  if position('concat_ws(' in v_updated) = 0 then
+    if position(v_notes_anchor in v_updated) = 0 then
+      raise exception 'PO reuse notes patch anchor is missing';
+    end if;
+    if (
+      length(v_updated) - length(replace(v_updated, v_notes_anchor, ''))
+    ) / length(v_notes_anchor) <> 1 then
+      raise exception 'PO reuse notes patch anchor is ambiguous';
+    end if;
+    v_updated := replace(v_updated, v_notes_anchor, v_notes_replacement);
+  end if;
+
+  if v_updated = v_definition then
+    raise exception 'parts_create_or_reuse_po_line_for_request was already patched';
+  end if;
+  execute v_updated;
+end;
+$migration$;
+
+comment on function public.parts_create_or_reuse_po_line_for_request(
+  uuid, numeric, text, uuid, uuid, numeric, uuid, text
+) is
+  'Creates or reuses a supplier PO for approved demand with two-decimal quantities, durable notes, tenant authorization, locking, and idempotency.';
+
+create or replace function public.parts_place_purchase_order(
+  p_po_id uuid,
+  p_idempotency_key text,
+  p_contact_channel text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_po public.purchase_orders%rowtype;
+  v_status text;
+  v_contact_channel text := lower(nullif(trim(p_contact_channel), ''));
+  v_contact_result jsonb;
+begin
+  if p_po_id is null then
+    raise exception using
+      errcode = '22023',
+      message = 'A purchase order is required.';
+  end if;
+  if nullif(trim(p_idempotency_key), '') is null
+     or length(p_idempotency_key) > 300 then
+    raise exception using
+      errcode = '22023',
+      message = 'A stable PO placement idempotency key is required.';
+  end if;
+  if v_contact_channel is not null
+     and v_contact_channel not in ('email', 'phone') then
+    raise exception using
+      errcode = '22023',
+      message = 'A valid supplier contact method is required.';
+  end if;
+
+  -- Canonical lock order is PO header, then PO lines by durable identity.
+  select purchase_order.*
+    into v_po
+  from public.purchase_orders purchase_order
+  where purchase_order.id = p_po_id
+  for update;
+
+  if not found or v_po.shop_id is null then
+    raise exception using
+      errcode = 'P0002',
+      message = 'Purchase order not found.';
+  end if;
+
+  perform public.parts_lifecycle_assert_shop_access(v_po.shop_id);
+  if coalesce(auth.jwt() ->> 'role', '') <> 'service_role'
+     and not exists (
+       select 1
+       from public.profiles profile
+       where profile.shop_id = v_po.shop_id
+         and (profile.id = auth.uid() or profile.user_id = auth.uid())
+         and public.canonical_shop_membership_role(profile.role::text) in (
+           'owner', 'admin', 'manager', 'parts', 'lead_hand', 'foreman'
+         )
+     ) then
+    raise exception using
+      errcode = '42501',
+      message = 'Parts ordering actor is not authorized for this shop.';
+  end if;
+
+  v_status := lower(coalesce(v_po.status, ''));
+  if v_status in (
+    'open', 'ordered', 'sent', 'receiving', 'partially_received', 'received'
+  ) then
+    -- Repair legacy quote-backed rows that were opened by the old route before
+    -- it recorded the supplier/quote contact audit.
+    if v_po.supplier_quote_request_id is not null
+       and v_po.supplier_contacted_at is null then
+      if v_status <> 'open' then
+        raise exception using
+          errcode = '55000',
+          message = 'Only an open quoted purchase order can repair missing supplier contact.';
+      end if;
+      if v_contact_channel is null then
+        raise exception using
+          errcode = '22023',
+          message = 'A supplier contact method is required for this quoted purchase order.';
+      end if;
+      v_contact_result := public.parts_mark_purchase_order_contacted(
+        v_po.id,
+        v_contact_channel,
+        p_idempotency_key
+      );
+      return v_contact_result || jsonb_build_object(
+        'placed', true,
+        'idempotent', true,
+        'repaired_contact_audit', true
+      );
+    end if;
+
+    return jsonb_build_object(
+      'ok', true,
+      'placed', true,
+      'idempotent', true,
+      'po_id', v_po.id,
+      'status', v_po.status,
+      'ordered_at', v_po.ordered_at,
+      'contacted_at', v_po.supplier_contacted_at
+    );
+  end if;
+
+  if v_status <> 'draft' then
+    raise exception using
+      errcode = '55000',
+      message = 'Only a draft purchase order can be placed.';
+  end if;
+
+  perform line.id
+  from public.purchase_order_lines line
+  where line.po_id = v_po.id
+  order by line.created_at, line.id
+  for update;
+
+  if not exists (
+    select 1
+    from public.purchase_order_lines line
+    where line.po_id = v_po.id
+      and greatest(
+        coalesce(line.qty, 0) - coalesce(line.cancelled_qty, 0),
+        0
+      ) > 0
+  ) then
+    raise exception using
+      errcode = '23514',
+      message = 'Add at least one active line before placing this PO.';
+  end if;
+
+  if v_po.supplier_quote_request_id is not null then
+    if v_contact_channel is null then
+      raise exception using
+        errcode = '22023',
+        message = 'A supplier contact method is required for this quoted purchase order.';
+    end if;
+    v_contact_result := public.parts_mark_purchase_order_contacted(
+      v_po.id,
+      v_contact_channel,
+      p_idempotency_key
+    );
+    return v_contact_result || jsonb_build_object('placed', true);
+  end if;
+
+  update public.purchase_orders
+  set status = 'open',
+      ordered_at = coalesce(ordered_at, now())
+  where id = v_po.id
+  returning * into v_po;
+
+  return jsonb_build_object(
+    'ok', true,
+    'placed', true,
+    'idempotent', false,
+    'po_id', v_po.id,
+    'status', v_po.status,
+    'ordered_at', v_po.ordered_at
+  );
+end;
+$$;
+
+comment on function public.parts_place_purchase_order(uuid, text, text) is
+  'Atomically places a non-empty PO and composes canonical supplier-contact auditing for quote-backed orders.';
+
+revoke all on function public.parts_place_purchase_order(uuid, text, text)
+  from public, anon;
+grant execute on function public.parts_place_purchase_order(uuid, text, text)
+  to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/field-hub-shell.test.ts
+++ b/tests/field-hub-shell.test.ts
@@ -31,6 +31,7 @@ describe("Field Hub workspace", () => {
       "/mobile/work-orders",
       "/mobile/inspections",
       "/mobile/parts",
+      "/mobile/service/purchase-orders",
       "/mobile/fleet",
       "/mobile/service/followups",
     ]) {
@@ -66,9 +67,11 @@ describe("Field Hub workspace", () => {
     expect(fieldHub).toContain("canUseFieldWorkspaceCapability");
   });
 
-  it("treats purchase orders as an explicit next slice until a field-safe surface exists", () => {
+  it("exposes the field-safe purchase-order surface only to parts-capable operators", () => {
     expect(fieldHub).toContain('title: "Purchase orders"');
-    expect(fieldHub).toContain('status: "next"');
+    expect(fieldHub).toContain('href: "/mobile/service/purchase-orders"');
+    expect(fieldHub).toContain('requiredCapability: "canManageParts"');
+    expect(fieldShell).toContain('label: "Purchase orders"');
     expect(fieldHub).not.toContain('href: "/parts/po"');
   });
 

--- a/tests/field-purchase-orders.test.ts
+++ b/tests/field-purchase-orders.test.ts
@@ -7,6 +7,7 @@ import {
   requestRemainingToOrder,
   requestTargetQuantity,
 } from "@/features/parts/mobile/mobilePurchaseOrderQuantities";
+import { isOpenPartsObligation } from "@/features/parts/lib/open-parts-obligations";
 
 const read = (path: string) => readFileSync(path, "utf8");
 const page = read("app/mobile/service/purchase-orders/page.tsx");
@@ -76,5 +77,31 @@ describe("Field purchase orders", () => {
     expect(workflow).toContain("/receive-free-text`");
     expect(workflow).not.toContain('.from("stock_moves")');
     expect(workflow).not.toContain('.from("purchase_order_lines").update');
+  });
+
+  it("keeps terminal requests out of ordering and routes request-backed free text by inventory identity", () => {
+    expect(
+      isOpenPartsObligation("fulfilled", {
+        request_id: "request-1",
+        status: "approved",
+        qty_approved: 1,
+        qty_ordered: 0,
+      }),
+    ).toBe(false);
+    expect(workflow).toMatch(
+      /receiveDraft\.line\.part_request_item_id\s*&&\s*receiveDraft\.line\.part_id/,
+    );
+    expect(workflow).toContain(
+      "const needsLocation = Boolean(receiveDraft.line.part_id)",
+    );
+  });
+
+  it("loads every operational PO before rendering the receive queue", () => {
+    expect(workflow).toContain("ACTIVE_PURCHASE_ORDER_STATUSES");
+    expect(workflow).toContain("offset += QUERY_PAGE_SIZE");
+    expect(workflow).toContain(
+      '.range(offset, offset + QUERY_PAGE_SIZE - 1)',
+    );
+    expect(workflow).not.toContain(".limit(150)");
   });
 });

--- a/tests/field-purchase-orders.test.ts
+++ b/tests/field-purchase-orders.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  purchaseOrderCanReceive,
+  purchaseOrderLineRemaining,
+  requestRemainingToOrder,
+  requestTargetQuantity,
+} from "@/features/parts/mobile/mobilePurchaseOrderQuantities";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const page = read("app/mobile/service/purchase-orders/page.tsx");
+const workflow = read("features/parts/mobile/MobilePurchaseOrders.tsx");
+
+describe("Field purchase orders", () => {
+  it("derives the approved ordering ceiling without conflating requested and ordered quantities", () => {
+    const item = {
+      qty: 2,
+      qty_requested: 3,
+      qty_approved: 5,
+      qty_ordered: 1.5,
+    };
+
+    expect(requestTargetQuantity(item)).toBe(5);
+    expect(requestRemainingToOrder(item)).toBe(3.5);
+    expect(requestRemainingToOrder({ ...item, qty_ordered: 7 })).toBe(0);
+  });
+
+  it("subtracts cancelled and received quantities from the active PO line", () => {
+    expect(
+      purchaseOrderLineRemaining({
+        qty: 10,
+        cancelled_qty: 2,
+        received_qty: 3.5,
+      }),
+    ).toBe(4.5);
+    expect(
+      purchaseOrderLineRemaining({
+        qty: 4,
+        cancelled_qty: 1,
+        received_qty: 8,
+      }),
+    ).toBe(0);
+  });
+
+  it("requires placement before a purchase order can be received", () => {
+    expect(purchaseOrderCanReceive("draft")).toBe(false);
+    expect(purchaseOrderCanReceive("open")).toBe(true);
+    expect(purchaseOrderCanReceive("sent")).toBe(true);
+    expect(purchaseOrderCanReceive("received")).toBe(false);
+    expect(workflow).toContain("purchaseOrderCanReceive(purchaseOrder.status)");
+  });
+
+  it("requires parts capability at the Field page boundary", () => {
+    expect(page).toContain('requiredCapability: "canManageParts"');
+    expect(page).toContain('redirectTo: "/mobile/service"');
+    expect(page).toContain("shopId={profile.shop_id}");
+    expect(workflow).toContain('.eq("shop_id", shopId)');
+  });
+
+  it("authors approved demand through the canonical idempotent PO command", () => {
+    expect(workflow).toContain(
+      "/api/parts/requests/items/${encodeURIComponent(",
+    );
+    expect(workflow).toContain("/po-line`");
+    expect(workflow).toContain('"Idempotency-Key": key');
+    expect(workflow).toContain("requestRemainingToOrder(orderDraft.item)");
+    expect(workflow).toContain('fetch("/api/parts/vendors"');
+    expect(workflow).toContain("/place`");
+    expect(workflow).toContain("Mark placed");
+  });
+
+  it("uses each canonical receipt path without inventing a second inventory ledger", () => {
+    expect(workflow).toContain("/receive`");
+    expect(workflow).toContain('fetch("/api/receive-scan"');
+    expect(workflow).toContain("/receive-free-text`");
+    expect(workflow).not.toContain('.from("stock_moves")');
+    expect(workflow).not.toContain('.from("purchase_order_lines").update');
+  });
+});

--- a/tests/parts/field-purchase-order-place-route.test.ts
+++ b/tests/parts/field-purchase-order-place-route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const PO_ID = "11111111-1111-4111-8111-111111111111";
+const SHOP_ID = "22222222-2222-4222-8222-222222222222";
+
+const mocks = vi.hoisted(() => ({
+  requireShopScopedApiAccess: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireShopScopedApiAccess,
+}));
+
+function request(body: Record<string, unknown>): Request {
+  return new Request(
+    `http://localhost/api/parts/purchase-orders/${PO_ID}/place`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "Idempotency-Key": "place-po-1",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+async function callRoute(body: Record<string, unknown>) {
+  const { POST } =
+    await import("../../app/api/parts/purchase-orders/[poId]/place/route");
+  return POST(request(body), { params: Promise.resolve({ poId: PO_ID }) });
+}
+
+describe("Field purchase-order placement route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("places through the atomic lifecycle command with quote contact context", async () => {
+    const rpc = vi.fn(async () => ({
+      data: { ok: true, po_id: PO_ID, status: "open" },
+      error: null,
+    }));
+    mocks.requireShopScopedApiAccess.mockResolvedValue({
+      ok: true,
+      profile: { shop_id: SHOP_ID },
+      supabase: { rpc },
+    });
+
+    const response = await callRoute({ contactChannel: "email" });
+
+    expect(response.status).toBe(200);
+    expect(mocks.requireShopScopedApiAccess).toHaveBeenCalledWith({
+      requiredCapability: "canManageParts",
+    });
+    expect(rpc).toHaveBeenCalledWith("parts_place_purchase_order", {
+      p_po_id: PO_ID,
+      p_idempotency_key: `${SHOP_ID}:parts_place_purchase_order:place-po-1`,
+      p_contact_channel: "email",
+    });
+  });
+
+  it("returns a retryable conflict when no active line can be placed", async () => {
+    const rpc = vi.fn(async () => ({
+      data: null,
+      error: {
+        code: "23514",
+        message: "Add at least one active line before placing this PO.",
+      },
+    }));
+    mocks.requireShopScopedApiAccess.mockResolvedValue({
+      ok: true,
+      profile: { shop_id: SHOP_ID },
+      supabase: { rpc },
+    });
+
+    const response = await callRoute({ contactChannel: null });
+    const payload = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(payload).toMatchObject({
+      ok: false,
+      error: "Add at least one active line before placing this PO.",
+    });
+  });
+});

--- a/tests/parts/field-purchase-order-review-contract.test.ts
+++ b/tests/parts/field-purchase-order-review-contract.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260816192840_field_purchase_order_review_fixes.sql",
+  "utf8",
+);
+const placeRoute = readFileSync(
+  "app/api/parts/purchase-orders/[poId]/place/route.ts",
+  "utf8",
+);
+const workflow = readFileSync(
+  "features/parts/mobile/MobilePurchaseOrders.tsx",
+  "utf8",
+);
+
+describe("Field purchase-order review contract", () => {
+  it("places a non-empty PO under one PO-first database transaction", () => {
+    const poLock = migration.indexOf("from public.purchase_orders purchase_order");
+    const lineLock = migration.indexOf("from public.purchase_order_lines line");
+    expect(migration).toContain(
+      "create or replace function public.parts_place_purchase_order",
+    );
+    expect(poLock).toBeGreaterThan(-1);
+    expect(lineLock).toBeGreaterThan(poLock);
+    expect(migration).toContain("order by line.created_at, line.id");
+    expect(migration).toContain("for update;");
+    expect(migration).toContain("Add at least one active line before placing this PO.");
+    expect(placeRoute).toContain('"parts_place_purchase_order"');
+    expect(placeRoute).not.toContain('.from("purchase_order_lines")');
+  });
+
+  it("composes canonical quote contact auditing during placement", () => {
+    expect(migration).toContain(
+      "public.parts_mark_purchase_order_contacted(",
+    );
+    expect(migration).toContain("v_po.supplier_quote_request_id is not null");
+    expect(workflow).toContain("supplier_quote_request_id");
+    expect(workflow).toContain("contactChannel");
+  });
+
+  it("hardens PO-line precision and preserves notes when a draft is reused", () => {
+    expect(migration).toContain("p_qty <> round(p_qty, 2)");
+    expect(migration).toContain("Purchase order supplier is inactive.");
+    expect(migration).toContain("if not v_created");
+    expect(migration).toContain("set notes = concat_ws(");
+    expect(migration).toContain("nullif(trim(p_notes), '')");
+  });
+
+  it("keeps the new lifecycle command tenant-authorized and least-privileged", () => {
+    expect(migration).toContain("parts_lifecycle_assert_shop_access(v_po.shop_id)");
+    expect(migration).toContain("profile.shop_id = v_po.shop_id");
+    expect(migration).toContain("profile.id = auth.uid()");
+    expect(migration).toContain("profile.user_id = auth.uid()");
+    expect(migration).toContain(
+      "revoke all on function public.parts_place_purchase_order",
+    );
+    expect(migration).toContain("to authenticated, service_role");
+  });
+});

--- a/tests/parts/parts-request-purchase-order-route.test.ts
+++ b/tests/parts/parts-request-purchase-order-route.test.ts
@@ -134,4 +134,23 @@ describe("parts request purchase-order route", () => {
       }),
     );
   });
+
+  it("rejects order quantities with more than two decimal places", async () => {
+    const supabase = createSupabase();
+    mocks.requireShopScopedApiAccess.mockResolvedValue({
+      ok: true,
+      profile: { id: "actor-id", shop_id: SHOP_ID },
+      supabase,
+    });
+
+    const response = await callRoute({
+      supplierId: SUPPLIER_ID,
+      qty: 1.001,
+      unitCost: 40,
+      idempotencyKey: "over-precision-order",
+    });
+
+    expect(response.status).toBe(400);
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
 });

--- a/tests/parts/purchase-order-place-route.test.ts
+++ b/tests/parts/purchase-order-place-route.test.ts
@@ -16,70 +16,36 @@ function createSupabase(options: {
   found?: boolean;
   lines?: Array<{ id: string; qty: number; cancelled_qty: number }>;
 }) {
-  const filters: Array<[string, unknown]> = [];
-  const updates: Array<Record<string, unknown>> = [];
-  const purchaseOrder = {
-    id: PO_ID,
-    status: options.status,
-    ordered_at: options.status === "draft" ? null : "2026-08-16T12:00:00Z",
-  };
-
-  const purchaseOrderSelect = {
-    eq(field: string, value: unknown) {
-      filters.push([field, value]);
-      return purchaseOrderSelect;
-    },
-    maybeSingle: vi.fn(async () => ({
-      data: options.found === false ? null : purchaseOrder,
-      error: null,
-    })),
-  };
-  type PurchaseOrderUpdateChain = {
-    eq: (field: string, value: unknown) => PurchaseOrderUpdateChain;
-    select: ReturnType<typeof vi.fn>;
-    maybeSingle: ReturnType<typeof vi.fn>;
-  };
-  const purchaseOrderUpdate: PurchaseOrderUpdateChain = {
-    eq(field: string, value: unknown) {
-      filters.push([field, value]);
-      return purchaseOrderUpdate;
-    },
-    select: vi.fn(() => purchaseOrderUpdate),
-    maybeSingle: vi.fn(async () => ({
+  const hasActiveLine = (
+    options.lines ?? [{ id: "line-1", qty: 2, cancelled_qty: 0 }]
+  ).some((line) => line.qty - line.cancelled_qty > 0);
+  const rpc = vi.fn(async () => {
+    if (options.found === false) {
+      return {
+        data: null,
+        error: { code: "P0002", message: "Purchase order not found." },
+      };
+    }
+    if (!hasActiveLine) {
+      return {
+        data: null,
+        error: {
+          code: "23514",
+          message: "Add at least one active line before placing this PO.",
+        },
+      };
+    }
+    return {
       data: {
-        ...purchaseOrder,
+        idempotent: options.status !== "draft",
+        po_id: PO_ID,
         status: "open",
-        ordered_at: "2026-08-16T12:00:00Z",
       },
       error: null,
-    })),
-  };
-  const lineSelect = {
-    eq: vi.fn(async () => ({
-      data: options.lines ?? [{ id: "line-1", qty: 2, cancelled_qty: 0 }],
-      error: null,
-    })),
-  };
+    };
+  });
 
-  return {
-    filters,
-    updates,
-    from: vi.fn((table: string) => {
-      if (table === "purchase_order_lines") {
-        return { select: vi.fn(() => lineSelect) };
-      }
-      if (table === "purchase_orders") {
-        return {
-          select: vi.fn(() => purchaseOrderSelect),
-          update: vi.fn((payload: Record<string, unknown>) => {
-            updates.push(payload);
-            return purchaseOrderUpdate;
-          }),
-        };
-      }
-      throw new Error(`Unexpected table ${table}`);
-    }),
-  };
+  return { rpc };
 }
 
 async function callRoute(supabase: ReturnType<typeof createSupabase>) {
@@ -114,20 +80,18 @@ describe("purchase-order place route", () => {
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(payload).toMatchObject({ ok: true, idempotent: false });
+    expect(payload).toMatchObject({
+      ok: true,
+      result: { idempotent: false, po_id: PO_ID, status: "open" },
+    });
     expect(mocks.requireShopScopedApiAccess).toHaveBeenCalledWith({
       requiredCapability: "canManageParts",
     });
-    expect(supabase.updates).toEqual([
-      expect.objectContaining({ status: "open" }),
-    ]);
-    expect(supabase.filters).toEqual(
-      expect.arrayContaining([
-        ["id", PO_ID],
-        ["shop_id", SHOP_ID],
-        ["status", "draft"],
-      ]),
-    );
+    expect(supabase.rpc).toHaveBeenCalledWith("parts_place_purchase_order", {
+      p_po_id: PO_ID,
+      p_idempotency_key: `${SHOP_ID}:parts_place_purchase_order:place-po-1`,
+      p_contact_channel: null,
+    });
   });
 
   it("treats a retry against an already placed PO as idempotent", async () => {
@@ -136,8 +100,10 @@ describe("purchase-order place route", () => {
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(payload).toMatchObject({ ok: true, idempotent: true });
-    expect(supabase.updates).toHaveLength(0);
+    expect(payload).toMatchObject({
+      ok: true,
+      result: { idempotent: true, po_id: PO_ID, status: "open" },
+    });
   });
 
   it("refuses to place a header without an active line", async () => {
@@ -152,7 +118,7 @@ describe("purchase-order place route", () => {
       ok: false,
       error: expect.stringContaining("active line"),
     });
-    expect(supabase.updates).toHaveLength(0);
+    expect(supabase.rpc).toHaveBeenCalledTimes(1);
   });
 
   it("does not expose a purchase order outside the authorized shop", async () => {
@@ -164,12 +130,6 @@ describe("purchase-order place route", () => {
       ok: false,
       error: "Purchase order not found.",
     });
-    expect(supabase.filters).toEqual(
-      expect.arrayContaining([
-        ["id", PO_ID],
-        ["shop_id", SHOP_ID],
-      ]),
-    );
-    expect(supabase.updates).toHaveLength(0);
+    expect(supabase.rpc).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/parts/purchase-order-place-route.test.ts
+++ b/tests/parts/purchase-order-place-route.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const PO_ID = "11111111-1111-4111-8111-111111111111";
+const SHOP_ID = "22222222-2222-4222-8222-222222222222";
+
+const mocks = vi.hoisted(() => ({
+  requireShopScopedApiAccess: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireShopScopedApiAccess,
+}));
+
+function createSupabase(options: {
+  status: string;
+  found?: boolean;
+  lines?: Array<{ id: string; qty: number; cancelled_qty: number }>;
+}) {
+  const filters: Array<[string, unknown]> = [];
+  const updates: Array<Record<string, unknown>> = [];
+  const purchaseOrder = {
+    id: PO_ID,
+    status: options.status,
+    ordered_at: options.status === "draft" ? null : "2026-08-16T12:00:00Z",
+  };
+
+  const purchaseOrderSelect = {
+    eq(field: string, value: unknown) {
+      filters.push([field, value]);
+      return purchaseOrderSelect;
+    },
+    maybeSingle: vi.fn(async () => ({
+      data: options.found === false ? null : purchaseOrder,
+      error: null,
+    })),
+  };
+  type PurchaseOrderUpdateChain = {
+    eq: (field: string, value: unknown) => PurchaseOrderUpdateChain;
+    select: ReturnType<typeof vi.fn>;
+    maybeSingle: ReturnType<typeof vi.fn>;
+  };
+  const purchaseOrderUpdate: PurchaseOrderUpdateChain = {
+    eq(field: string, value: unknown) {
+      filters.push([field, value]);
+      return purchaseOrderUpdate;
+    },
+    select: vi.fn(() => purchaseOrderUpdate),
+    maybeSingle: vi.fn(async () => ({
+      data: {
+        ...purchaseOrder,
+        status: "open",
+        ordered_at: "2026-08-16T12:00:00Z",
+      },
+      error: null,
+    })),
+  };
+  const lineSelect = {
+    eq: vi.fn(async () => ({
+      data: options.lines ?? [{ id: "line-1", qty: 2, cancelled_qty: 0 }],
+      error: null,
+    })),
+  };
+
+  return {
+    filters,
+    updates,
+    from: vi.fn((table: string) => {
+      if (table === "purchase_order_lines") {
+        return { select: vi.fn(() => lineSelect) };
+      }
+      if (table === "purchase_orders") {
+        return {
+          select: vi.fn(() => purchaseOrderSelect),
+          update: vi.fn((payload: Record<string, unknown>) => {
+            updates.push(payload);
+            return purchaseOrderUpdate;
+          }),
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    }),
+  };
+}
+
+async function callRoute(supabase: ReturnType<typeof createSupabase>) {
+  mocks.requireShopScopedApiAccess.mockResolvedValue({
+    ok: true,
+    profile: { id: "actor-1", shop_id: SHOP_ID },
+    supabase,
+  });
+  const { POST } =
+    await import("../../app/api/parts/purchase-orders/[poId]/place/route");
+  return POST(
+    new Request(`http://localhost/api/parts/purchase-orders/${PO_ID}/place`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "idempotency-key": "place-po-1",
+      },
+      body: JSON.stringify({ idempotencyKey: "place-po-1" }),
+    }),
+    { params: Promise.resolve({ poId: PO_ID }) },
+  );
+}
+
+describe("purchase-order place route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("places a non-empty draft within the authorized shop scope", async () => {
+    const supabase = createSupabase({ status: "draft" });
+    const response = await callRoute(supabase);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({ ok: true, idempotent: false });
+    expect(mocks.requireShopScopedApiAccess).toHaveBeenCalledWith({
+      requiredCapability: "canManageParts",
+    });
+    expect(supabase.updates).toEqual([
+      expect.objectContaining({ status: "open" }),
+    ]);
+    expect(supabase.filters).toEqual(
+      expect.arrayContaining([
+        ["id", PO_ID],
+        ["shop_id", SHOP_ID],
+        ["status", "draft"],
+      ]),
+    );
+  });
+
+  it("treats a retry against an already placed PO as idempotent", async () => {
+    const supabase = createSupabase({ status: "open" });
+    const response = await callRoute(supabase);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({ ok: true, idempotent: true });
+    expect(supabase.updates).toHaveLength(0);
+  });
+
+  it("refuses to place a header without an active line", async () => {
+    const supabase = createSupabase({
+      status: "draft",
+      lines: [{ id: "line-1", qty: 2, cancelled_qty: 2 }],
+    });
+    const response = await callRoute(supabase);
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("active line"),
+    });
+    expect(supabase.updates).toHaveLength(0);
+  });
+
+  it("does not expose a purchase order outside the authorized shop", async () => {
+    const supabase = createSupabase({ status: "draft", found: false });
+    const response = await callRoute(supabase);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: "Purchase order not found.",
+    });
+    expect(supabase.filters).toEqual(
+      expect.arrayContaining([
+        ["id", PO_ID],
+        ["shop_id", SHOP_ID],
+      ]),
+    );
+    expect(supabase.updates).toHaveLength(0);
+  });
+});

--- a/tests/parts/vendor-management-route.test.ts
+++ b/tests/parts/vendor-management-route.test.ts
@@ -10,7 +10,9 @@ vi.mock("@/features/shared/lib/server/admin-access", () => ({
 
 const vendorId = "11111111-1111-4111-8111-111111111111";
 
-function createSupabase(existing: Array<{ id: string; name: string }> = []) {
+function createSupabase(
+  existing: Array<{ id: string; name: string; is_active: boolean }> = [],
+) {
   const inserted: Array<Record<string, unknown>> = [];
   const updated: Array<Record<string, unknown>> = [];
   const filters: Array<[string, unknown]> = [];
@@ -118,7 +120,7 @@ describe("parts vendor management route", () => {
 
   it("rejects normalized duplicate names before inserting", async () => {
     const supabase = createSupabase([
-      { id: vendorId, name: "North-Star Parts" },
+      { id: vendorId, name: "North-Star Parts", is_active: false },
     ]);
     authorize(supabase);
     const { POST } = await import("../../app/api/parts/vendors/route");
@@ -131,6 +133,10 @@ describe("parts vendor management route", () => {
     );
 
     expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      vendorId,
+      vendorIsActive: false,
+    });
     expect(supabase.supplierTable.insert).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- adds a mobile-first Field Hub purchase-order workspace for approved parts demand
- reuses the canonical idempotent PO-line and receipt APIs for request-linked, inventory, and free-text lines
- makes draft placement atomic and composes canonical supplier-contact auditing for quote-backed POs
- pages all operational requests, purchase orders, and lines so older open work remains reachable
- rejects inactive supplier reuse and over-precision quantities at both UI and server boundaries
- routes every non-inventory PO line through the free-text receipt command
- filters ordering work through canonical open-obligation rules
- preserves PO notes when an existing supplier draft is reused
- exposes the workflow in the Field Hub and mobile workspace navigation

## Why

Field Hub identified purchase orders as the next incomplete operational slice. Parts-capable field operators could request and receive parts elsewhere, but they could not author supplier POs and complete the receiving loop from the Field workspace.

This follow-up also addresses all eight Codex review findings on the initial implementation.

## Validation

- `tsc --noEmit` — passed
- changed-file ESLint — passed
- focused Vitest — 32 passed across 7 suites
- `next build` with CI placeholder environment — passed
- regression inventory — passed; 0 new errors
- migration anchors verified against the linked production schema
- local clean replay unavailable on this Windows host because Docker/Podman is not installed; Supabase Clean Replay CI is the authoritative migration/typegen check

## Database and deployment

- adds forward migration `20260816192840_field_purchase_order_review_fixes.sql`
- migration was not manually applied to production; it remains deployment-managed and is validated in isolated clean-replay CI
- no new environment variables
- no manual provider configuration required
