### PR TITLE
Add persistent technician CoPilot shell

### DIFF
--- a/app/copilot/technician/page.tsx
+++ b/app/copilot/technician/page.tsx
@@ -1,5 +1,7 @@
-import { TechnicianTextCopilot } from "@/features/copilot/technician/components/TechnicianTextCopilot";
-
 export default function TechnicianCopilotPage() {
-  return <TechnicianTextCopilot />;
+  return (
+    <div className="p-6 text-sm text-muted-foreground" aria-live="polite">
+      Opening your persistent Technician CoPilot…
+    </div>
+  );
 }

--- a/app/copilot/technician/page.tsx
+++ b/app/copilot/technician/page.tsx
@@ -1,7 +1,5 @@
+import { TechnicianCopilotCompatibilityRoute } from "@/features/copilot/technician/components/TechnicianCopilotCompatibilityRoute";
+
 export default function TechnicianCopilotPage() {
-  return (
-    <div className="p-6 text-sm text-muted-foreground" aria-live="polite">
-      Opening your persistent Technician CoPilot…
-    </div>
-  );
+  return <TechnicianCopilotCompatibilityRoute returnHref="/tech/queue" />;
 }

--- a/app/mobile/copilot/technician/page.tsx
+++ b/app/mobile/copilot/technician/page.tsx
@@ -1,7 +1,7 @@
+import { TechnicianCopilotCompatibilityRoute } from "@/features/copilot/technician/components/TechnicianCopilotCompatibilityRoute";
+
 export default function MobileTechnicianCopilotPage() {
   return (
-    <div className="p-6 text-sm text-muted-foreground" aria-live="polite">
-      Opening your persistent Technician CoPilot…
-    </div>
+    <TechnicianCopilotCompatibilityRoute returnHref="/mobile/tech/queue" />
   );
 }

--- a/app/mobile/copilot/technician/page.tsx
+++ b/app/mobile/copilot/technician/page.tsx
@@ -1,5 +1,7 @@
-import { TechnicianTextCopilot } from "@/features/copilot/technician/components/TechnicianTextCopilot";
-
 export default function MobileTechnicianCopilotPage() {
-  return <TechnicianTextCopilot />;
+  return (
+    <div className="p-6 text-sm text-muted-foreground" aria-live="polite">
+      Opening your persistent Technician CoPilot…
+    </div>
+  );
 }

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -10,6 +10,7 @@ import FieldWorkspaceShell, {
   FIELD_SURFACE_SESSION_KEY,
 } from "@/features/mobile/service/FieldWorkspaceShell";
 import { MobileBottomNav } from "./MobileBottomNav";
+import { TechnicianCopilotShell } from "@/features/copilot/technician/components/TechnicianCopilotShell";
 
 type Props = {
   children: ReactNode;
@@ -150,14 +151,22 @@ export function MobileShell({ children, title }: Props) {
 
   if (isImmersiveRoute(pathname)) {
     return (
-      <div className="profixiq-mobile-command min-h-screen overflow-x-hidden pt-[env(safe-area-inset-top,0px)]">
-        <main className="mobile-command-main min-w-0 overflow-x-hidden">{children}</main>
-      </div>
+      <>
+        <div className="profixiq-mobile-command min-h-screen overflow-x-hidden pt-[env(safe-area-inset-top,0px)]">
+          <main className="mobile-command-main min-w-0 overflow-x-hidden">{children}</main>
+        </div>
+        <TechnicianCopilotShell shouldCheck surface="mobile" />
+      </>
     );
   }
 
   if (fieldSurface) {
-    return <FieldWorkspaceShell>{children}</FieldWorkspaceShell>;
+    return (
+      <>
+        <FieldWorkspaceShell>{children}</FieldWorkspaceShell>
+        <TechnicianCopilotShell shouldCheck surface="mobile" />
+      </>
+    );
   }
 
   return (
@@ -190,6 +199,7 @@ export function MobileShell({ children, title }: Props) {
       <main className="mobile-command-main">{children}</main>
 
       <MobileBottomNav open={menuOpen} onClose={() => setMenuOpen(false)} />
+      <TechnicianCopilotShell shouldCheck surface="mobile" />
     </div>
   );
 }

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -5,12 +5,12 @@ import { usePathname, useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
+import { TechnicianCopilotShell } from "@/features/copilot/technician/components/TechnicianCopilotShell";
 import { resolveMobileHref } from "@/features/mobile/navigation/mobile-route-continuity";
 import FieldWorkspaceShell, {
   FIELD_SURFACE_SESSION_KEY,
 } from "@/features/mobile/service/FieldWorkspaceShell";
 import { MobileBottomNav } from "./MobileBottomNav";
-import { TechnicianCopilotShell } from "@/features/copilot/technician/components/TechnicianCopilotShell";
 
 type Props = {
   children: ReactNode;
@@ -149,58 +149,57 @@ export function MobileShell({ children, title }: Props) {
     return children;
   }
 
+  let mobileSurface: ReactNode;
   if (isImmersiveRoute(pathname)) {
-    return (
-      <>
-        <div className="profixiq-mobile-command min-h-screen overflow-x-hidden pt-[env(safe-area-inset-top,0px)]">
-          <main className="mobile-command-main min-w-0 overflow-x-hidden">{children}</main>
-        </div>
-        <TechnicianCopilotShell shouldCheck surface="mobile" />
-      </>
+    mobileSurface = (
+      <div className="profixiq-mobile-command min-h-screen overflow-x-hidden pt-[env(safe-area-inset-top,0px)]">
+        <main className="mobile-command-main min-w-0 overflow-x-hidden">
+          {children}
+        </main>
+      </div>
     );
-  }
+  } else if (fieldSurface) {
+    mobileSurface = <FieldWorkspaceShell>{children}</FieldWorkspaceShell>;
+  } else {
+    mobileSurface = (
+      <div className="profixiq-mobile-command min-h-screen overflow-x-hidden">
+        <header className="mobile-command-header">
+          <div className="mobile-command-header__inner">
+            <button
+              type="button"
+              onClick={() => setMenuOpen(true)}
+              aria-label="Open navigation menu"
+              aria-expanded={menuOpen}
+              className="mobile-command-header__menu"
+            >
+              <Menu aria-hidden className="h-5 w-5" strokeWidth={2.2} />
+            </button>
 
-  if (fieldSurface) {
-    return (
-      <>
-        <FieldWorkspaceShell>{children}</FieldWorkspaceShell>
-        <TechnicianCopilotShell shouldCheck surface="mobile" />
-      </>
+            <div className="mobile-command-header__title">{resolvedTitle}</div>
+
+            <button
+              type="button"
+              onClick={() => router.push("/mobile")}
+              aria-label="Go to mobile home"
+              className="mobile-command-header__mark"
+            >
+              PFIQ
+            </button>
+          </div>
+        </header>
+
+        <main className="mobile-command-main">{children}</main>
+
+        <MobileBottomNav open={menuOpen} onClose={() => setMenuOpen(false)} />
+      </div>
     );
   }
 
   return (
-    <div className="profixiq-mobile-command min-h-screen overflow-x-hidden">
-      <header className="mobile-command-header">
-        <div className="mobile-command-header__inner">
-          <button
-            type="button"
-            onClick={() => setMenuOpen(true)}
-            aria-label="Open navigation menu"
-            aria-expanded={menuOpen}
-            className="mobile-command-header__menu"
-          >
-            <Menu aria-hidden className="h-5 w-5" strokeWidth={2.2} />
-          </button>
-
-          <div className="mobile-command-header__title">{resolvedTitle}</div>
-
-          <button
-            type="button"
-            onClick={() => router.push("/mobile")}
-            aria-label="Go to mobile home"
-            className="mobile-command-header__mark"
-          >
-            PFIQ
-          </button>
-        </div>
-      </header>
-
-      <main className="mobile-command-main">{children}</main>
-
-      <MobileBottomNav open={menuOpen} onClose={() => setMenuOpen(false)} />
+    <>
+      {mobileSurface}
       <TechnicianCopilotShell shouldCheck surface="mobile" />
-    </div>
+    </>
   );
 }
 

--- a/docs/architecture/technician-copilot-v2-persistent-shell.md
+++ b/docs/architecture/technician-copilot-v2-persistent-shell.md
@@ -1,0 +1,74 @@
+# Technician CoPilot V2 — Persistent Technician Shell
+
+## Scope
+
+This phase moves the existing technician collaborator from a destination page
+into the authenticated application shells. It does not create another CoPilot
+runtime, voice provider, Repair Session, or mutation path.
+
+One `TechnicianTextCopilot` instance now remains mounted while an authorized
+technician moves through:
+
+- desktop shop routes;
+- standard Shop Mobile routes;
+- focused mobile job and inspection routes; and
+- the Field Service mobile surface when the same technician has access.
+
+The desktop shell presents the collaborator as a right-side panel. Shop Mobile
+uses a full-height overlay above the mobile navigation. Closing either surface
+keeps the Repair Session client mounted but stops active microphone capture.
+
+## Canonical runtime
+
+The persistent shell continues to use the existing boundaries:
+
+```text
+Application shell
+  -> technician capability access check
+  -> one mounted Technician CoPilot client
+  -> existing session and chat APIs
+  -> existing Technician Interaction Gateway
+  -> existing Repair Session event ledger
+  -> canonical technician actions and silent documentation
+```
+
+Legacy links remain compatible. Visiting `/copilot/technician` or
+`/mobile/copilot/technician` opens the shell-owned panel; it no longer mounts a
+second page-owned voice or conversation client.
+
+## Authorization and lifecycle
+
+- Desktop checks availability only for the canonical `mechanic` role.
+- Mobile relies on the same authenticated server access check, so other roles
+  receive no launcher or client runtime.
+- Capability removal unmounts the shell client.
+- Closing the panel stops Realtime capture and speech output.
+- Route changes do not unmount the collaborator, so text, voice state, and the
+  hydrated Repair Session remain available throughout the technician workflow.
+- Server-side authorization, tenant scope, assignment checks, action replay,
+  and mutation rules are unchanged.
+
+## Rollback
+
+The shell is still default-closed behind the existing
+`technician_copilot_text` capability. Disabling that capability removes the
+launcher and client without changing Repair Session or work-order data. The
+dedicated route URLs remain valid compatibility entry points.
+
+## Acceptance path
+
+1. Open CoPilot from the desktop or Shop Mobile launcher.
+2. Start or resume an assigned repair and exchange at least one turn.
+3. Navigate to the technician queue, focused job, work order, inspection, and
+   another shop route.
+4. Reopen the panel and confirm the same Repair Session context is present.
+5. Start voice, close the panel, and confirm microphone/speech output stops.
+6. Reopen the panel and explicitly restart voice.
+7. Disable technician CoPilot access and confirm the launcher disappears.
+
+## Next slice
+
+After live-device validation of this shell, the next voice slice can add true
+hands-free duplex behavior: acoustic barge-in, echo suppression, resumable
+long-running listening, and shop-floor latency/noise evaluation. Those changes
+must continue through the same shell-owned client and Repair Session runtime.

--- a/features/copilot/technician/client/useTechnicianCopilotAvailability.ts
+++ b/features/copilot/technician/client/useTechnicianCopilotAvailability.ts
@@ -2,14 +2,25 @@
 
 import { useEffect, useState } from "react";
 
-export function useTechnicianCopilotAvailability(
+export type TechnicianCopilotAvailabilityState =
+  | { status: "idle" | "checking" | "available"; message: null }
+  | { status: "unavailable" | "error"; message: string };
+
+export function useTechnicianCopilotAvailabilityState(
   shouldCheck: boolean,
-): boolean {
-  const [available, setAvailable] = useState(false);
+): TechnicianCopilotAvailabilityState {
+  const [availability, setAvailability] =
+    useState<TechnicianCopilotAvailabilityState>({
+      status: shouldCheck ? "checking" : "idle",
+      message: null,
+    });
 
   useEffect(() => {
     let active = true;
-    setAvailable(false);
+    setAvailability({
+      status: shouldCheck ? "checking" : "idle",
+      message: null,
+    });
     if (!shouldCheck) {
       return () => {
         active = false;
@@ -19,11 +30,35 @@ export function useTechnicianCopilotAvailability(
     void fetch("/api/copilot/technician/session?accessOnly=1", {
       cache: "no-store",
     })
-      .then((response) => {
-        if (active) setAvailable(response.ok);
+      .then(async (response) => {
+        if (!active) return;
+        if (response.ok) {
+          setAvailability({ status: "available", message: null });
+          return;
+        }
+
+        const body = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        setAvailability({
+          status:
+            response.status === 401 || response.status === 403
+              ? "unavailable"
+              : "error",
+          message:
+            body?.error ??
+            (response.status === 401 || response.status === 403
+              ? "Technician CoPilot is not enabled for this account."
+              : "Technician CoPilot availability could not be verified."),
+        });
       })
       .catch(() => {
-        if (active) setAvailable(false);
+        if (active) {
+          setAvailability({
+            status: "error",
+            message: "Technician CoPilot availability could not be verified.",
+          });
+        }
       });
 
     return () => {
@@ -31,5 +66,13 @@ export function useTechnicianCopilotAvailability(
     };
   }, [shouldCheck]);
 
-  return available;
+  return availability;
+}
+
+export function useTechnicianCopilotAvailability(
+  shouldCheck: boolean,
+): boolean {
+  return (
+    useTechnicianCopilotAvailabilityState(shouldCheck).status === "available"
+  );
 }

--- a/features/copilot/technician/components/TechnicianCopilotCompatibilityRoute.tsx
+++ b/features/copilot/technician/components/TechnicianCopilotCompatibilityRoute.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+
+import { useTechnicianCopilotAvailabilityState } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
+
+export function TechnicianCopilotCompatibilityRoute({
+  returnHref,
+}: {
+  returnHref: string;
+}) {
+  const availability = useTechnicianCopilotAvailabilityState(true);
+
+  if (
+    availability.status === "idle" ||
+    availability.status === "checking" ||
+    availability.status === "available"
+  ) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground" aria-live="polite">
+        Opening your persistent Technician CoPilot…
+      </div>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-xl p-6">
+      <div className="rounded-2xl border bg-card p-5 shadow-sm" role="alert">
+        <h1 className="text-lg font-semibold">Technician CoPilot unavailable</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {availability.message}
+        </p>
+        <Link
+          href={returnHref}
+          className="mt-4 inline-flex rounded-xl bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+        >
+          Return to my jobs
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/features/copilot/technician/components/TechnicianCopilotShell.tsx
+++ b/features/copilot/technician/components/TechnicianCopilotShell.tsx
@@ -2,9 +2,15 @@
 
 import { Bot, X } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-import { useTechnicianCopilotAvailability } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
+import { useTechnicianCopilotAvailabilityState } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/features/shared/components/ui/dialog";
 import { cn } from "@/features/shared/utils/cn";
 import { TechnicianTextCopilot } from "./TechnicianTextCopilot";
 
@@ -27,8 +33,15 @@ export function TechnicianCopilotShell({
 }) {
   const pathname = usePathname() ?? "/";
   const router = useRouter();
-  const available = useTechnicianCopilotAvailability(shouldCheck);
+  const availability = useTechnicianCopilotAvailabilityState(shouldCheck);
   const [open, setOpen] = useState(() => isCopilotRoute(pathname));
+
+  const close = useCallback(() => {
+    setOpen(false);
+    if (isCopilotRoute(pathname)) {
+      router.replace(surface === "mobile" ? "/mobile/tech/queue" : "/tech/queue");
+    }
+  }, [pathname, router, surface]);
 
   useEffect(() => {
     if (isCopilotRoute(pathname)) setOpen(true);
@@ -42,71 +55,92 @@ export function TechnicianCopilotShell({
   }, []);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || surface === "mobile") return;
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
+      if (event.key === "Escape") close();
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [open]);
+  }, [close, open, surface]);
 
-  if (!available) return null;
+  if (availability.status !== "available") return null;
 
-  const close = () => {
-    setOpen(false);
-    if (isCopilotRoute(pathname)) {
-      router.replace(surface === "mobile" ? "/mobile/tech/queue" : "/tech/queue");
-    }
-  };
+  const launcher = (
+    <button
+      type="button"
+      onClick={() => setOpen(true)}
+      aria-label="Open Technician CoPilot"
+      aria-expanded={open}
+      tabIndex={open ? -1 : 0}
+      className={cn(
+        "fixed z-30 inline-flex items-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold shadow-xl backdrop-blur transition hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-ring",
+        surface === "mobile"
+          ? "bottom-[calc(4.75rem+env(safe-area-inset-bottom))] right-4"
+          : "bottom-[calc(4rem+env(safe-area-inset-bottom))] right-4 md:bottom-6 md:right-6",
+        open && "pointer-events-none translate-y-2 opacity-0",
+      )}
+      style={{
+        borderColor: "var(--theme-border-soft)",
+        background: "var(--theme-gradient-panel)",
+        color: "var(--theme-text-primary)",
+      }}
+    >
+      <Bot className="h-5 w-5" aria-hidden />
+      <span>CoPilot</span>
+    </button>
+  );
+
+  if (surface === "mobile") {
+    return (
+      <>
+        {launcher}
+        <Dialog
+          open={open}
+          onOpenChange={(next) => (next ? setOpen(true) : close())}
+        >
+          <DialogContent
+            forceMount
+            className="!inset-0 !flex !h-[100dvh] !w-full !max-w-none !translate-x-0 !translate-y-0 !flex-col !overflow-hidden !rounded-none !p-0 data-[state=closed]:invisible data-[state=closed]:pointer-events-none"
+          >
+            <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">
+              <div>
+                <DialogTitle className="text-sm normal-case tracking-normal">
+                  Technician CoPilot
+                </DialogTitle>
+                <DialogDescription className="text-xs">
+                  Stays with you as you move through the app
+                </DialogDescription>
+              </div>
+              <button
+                type="button"
+                onClick={close}
+                aria-label="Close Technician CoPilot"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border bg-background"
+              >
+                <X className="h-5 w-5" aria-hidden />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1">
+              <TechnicianTextCopilot embedded active={open} />
+            </div>
+          </DialogContent>
+        </Dialog>
+      </>
+    );
+  }
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        aria-label="Open Technician CoPilot"
-        aria-expanded={open}
-        className={cn(
-          "fixed z-[70] inline-flex items-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold shadow-xl backdrop-blur transition hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-ring",
-          surface === "mobile"
-            ? "bottom-[calc(4.75rem+env(safe-area-inset-bottom))] right-4"
-            : "bottom-6 right-6",
-          open && "pointer-events-none translate-y-2 opacity-0",
-        )}
-        style={{
-          borderColor: "var(--theme-border-soft)",
-          background: "var(--theme-gradient-panel)",
-          color: "var(--theme-text-primary)",
-        }}
-      >
-        <Bot className="h-5 w-5" aria-hidden />
-        <span>CoPilot</span>
-      </button>
-
-      {surface === "mobile" && open ? (
-        <button
-          type="button"
-          aria-label="Close Technician CoPilot"
-          onClick={close}
-          className="fixed inset-0 z-[74] bg-black/50"
-        />
-      ) : null}
-
+      {launcher}
       <section
         role="dialog"
-        aria-modal={surface === "mobile"}
         aria-label="Technician CoPilot"
         aria-hidden={!open}
         className={cn(
-          "fixed z-[75] flex min-h-0 flex-col overflow-hidden border bg-background shadow-2xl transition duration-200",
-          surface === "mobile"
-            ? "inset-x-0 bottom-0 top-[env(safe-area-inset-top,0px)] rounded-t-3xl"
-            : "bottom-4 right-4 top-16 w-[min(32rem,calc(100vw-2rem))] rounded-2xl",
+          "fixed bottom-4 right-4 top-16 z-30 flex w-[min(32rem,calc(100vw-2rem))] min-h-0 flex-col overflow-hidden rounded-2xl border bg-background shadow-2xl transition duration-200",
           open
-            ? "translate-x-0 translate-y-0 opacity-100"
-            : surface === "mobile"
-              ? "invisible pointer-events-none translate-y-full opacity-0"
-              : "invisible pointer-events-none translate-x-[calc(100%+2rem)] opacity-0",
+            ? "translate-x-0 opacity-100"
+            : "invisible pointer-events-none translate-x-[calc(100%+2rem)] opacity-0",
         )}
       >
         <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">

--- a/features/copilot/technician/components/TechnicianCopilotShell.tsx
+++ b/features/copilot/technician/components/TechnicianCopilotShell.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { Bot, X } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { useTechnicianCopilotAvailability } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
+import { cn } from "@/features/shared/utils/cn";
+import { TechnicianTextCopilot } from "./TechnicianTextCopilot";
+
+export const OPEN_TECHNICIAN_COPILOT_EVENT =
+  "profixiq:technician-copilot-open";
+
+function isCopilotRoute(pathname: string): boolean {
+  return (
+    pathname === "/copilot/technician" ||
+    pathname === "/mobile/copilot/technician"
+  );
+}
+
+export function TechnicianCopilotShell({
+  shouldCheck,
+  surface,
+}: {
+  shouldCheck: boolean;
+  surface: "desktop" | "mobile";
+}) {
+  const pathname = usePathname() ?? "/";
+  const router = useRouter();
+  const available = useTechnicianCopilotAvailability(shouldCheck);
+  const [open, setOpen] = useState(() => isCopilotRoute(pathname));
+
+  useEffect(() => {
+    if (isCopilotRoute(pathname)) setOpen(true);
+  }, [pathname]);
+
+  useEffect(() => {
+    const handleOpen = () => setOpen(true);
+    window.addEventListener(OPEN_TECHNICIAN_COPILOT_EVENT, handleOpen);
+    return () =>
+      window.removeEventListener(OPEN_TECHNICIAN_COPILOT_EVENT, handleOpen);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  if (!available) return null;
+
+  const close = () => {
+    setOpen(false);
+    if (isCopilotRoute(pathname)) {
+      router.replace(surface === "mobile" ? "/mobile/tech/queue" : "/tech/queue");
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Open Technician CoPilot"
+        aria-expanded={open}
+        className={cn(
+          "fixed z-[70] inline-flex items-center gap-2 rounded-full border px-4 py-3 text-sm font-semibold shadow-xl backdrop-blur transition hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-ring",
+          surface === "mobile"
+            ? "bottom-[calc(4.75rem+env(safe-area-inset-bottom))] right-4"
+            : "bottom-6 right-6",
+          open && "pointer-events-none translate-y-2 opacity-0",
+        )}
+        style={{
+          borderColor: "var(--theme-border-soft)",
+          background: "var(--theme-gradient-panel)",
+          color: "var(--theme-text-primary)",
+        }}
+      >
+        <Bot className="h-5 w-5" aria-hidden />
+        <span>CoPilot</span>
+      </button>
+
+      {surface === "mobile" && open ? (
+        <button
+          type="button"
+          aria-label="Close Technician CoPilot"
+          onClick={close}
+          className="fixed inset-0 z-[74] bg-black/50"
+        />
+      ) : null}
+
+      <section
+        role="dialog"
+        aria-modal={surface === "mobile"}
+        aria-label="Technician CoPilot"
+        aria-hidden={!open}
+        className={cn(
+          "fixed z-[75] flex min-h-0 flex-col overflow-hidden border bg-background shadow-2xl transition duration-200",
+          surface === "mobile"
+            ? "inset-x-0 bottom-0 top-[env(safe-area-inset-top,0px)] rounded-t-3xl"
+            : "bottom-4 right-4 top-16 w-[min(32rem,calc(100vw-2rem))] rounded-2xl",
+          open
+            ? "translate-x-0 translate-y-0 opacity-100"
+            : surface === "mobile"
+              ? "invisible pointer-events-none translate-y-full opacity-0"
+              : "invisible pointer-events-none translate-x-[calc(100%+2rem)] opacity-0",
+        )}
+      >
+        <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">
+          <div>
+            <div className="text-sm font-semibold">Technician CoPilot</div>
+            <div className="text-xs text-muted-foreground">
+              Stays with you as you move through the app
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Close Technician CoPilot"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border bg-background"
+          >
+            <X className="h-5 w-5" aria-hidden />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1">
+          <TechnicianTextCopilot embedded active={open} />
+        </div>
+      </section>
+    </>
+  );
+}

--- a/features/copilot/technician/components/TechnicianTextCopilot.tsx
+++ b/features/copilot/technician/components/TechnicianTextCopilot.tsx
@@ -10,6 +10,7 @@ import {
 import { Mic, Square, VolumeX } from "lucide-react";
 
 import { useTechnicianInteractionGateway } from "@/features/copilot/technician/voice/useTechnicianInteractionGateway";
+import { cn } from "@/features/shared/utils/cn";
 
 type Turn = {
   eventId: string;
@@ -88,7 +89,13 @@ function voiceStatus(phase: ReturnType<typeof useTechnicianInteractionGateway>["
   return "Voice ready";
 }
 
-export function TechnicianTextCopilot() {
+export function TechnicianTextCopilot({
+  embedded = false,
+  active = true,
+}: {
+  embedded?: boolean;
+  active?: boolean;
+}) {
   const [snapshot, setSnapshot] = useState<Snapshot>({
     context: null,
     workOrder: null,
@@ -190,9 +197,13 @@ export function TechnicianTextCopilot() {
 
   const voice = useTechnicianInteractionGateway({
     enabled: voiceEnabled,
-    autoStart: true,
+    autoStart: active,
     onUtterance: handleVoiceUtterance,
   });
+
+  useEffect(() => {
+    if (!active && voice.active) voice.stop();
+  }, [active, voice]);
 
   const vehicleLabel = useMemo(() => {
     const workOrder = snapshot.workOrder;
@@ -224,7 +235,12 @@ export function TechnicianTextCopilot() {
 
   if (loading) {
     return (
-      <main className="mx-auto max-w-4xl p-4 text-sm text-muted-foreground">
+      <main
+        className={cn(
+          "mx-auto max-w-4xl p-4 text-sm text-muted-foreground",
+          embedded && "flex h-full items-center justify-center",
+        )}
+      >
         Loading Technician CoPilot…
       </main>
     );
@@ -233,10 +249,19 @@ export function TechnicianTextCopilot() {
   const recentTimeline = snapshot.context?.documentation.timeline.slice(-8) ?? [];
 
   return (
-    <main className="mx-auto flex min-h-[100dvh] max-w-4xl flex-col gap-4 p-4 pb-28">
+    <main
+      className={cn(
+        "mx-auto flex max-w-4xl flex-col gap-4 p-4",
+        embedded
+          ? "h-full min-h-0 overflow-y-auto pb-4"
+          : "min-h-[100dvh] pb-28",
+      )}
+    >
       <header className="rounded-2xl border bg-card p-4 shadow-sm">
         <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          Phase 4 Preview · Text + realtime voice + silent documentation
+          {embedded
+            ? "Persistent repair collaborator"
+            : "Phase 4 Preview · Text + realtime voice + silent documentation"}
         </div>
         <h1 className="mt-1 text-2xl font-semibold">Technician CoPilot</h1>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -414,7 +439,12 @@ export function TechnicianTextCopilot() {
 
       <form
         onSubmit={send}
-        className="fixed inset-x-0 bottom-0 z-20 border-t bg-background/95 p-3 backdrop-blur"
+        className={cn(
+          "border-t bg-background/95 p-3 backdrop-blur",
+          embedded
+            ? "sticky bottom-0 z-20 -mx-4 -mb-4 mt-auto"
+            : "fixed inset-x-0 bottom-0 z-20",
+        )}
       >
         <div className="mx-auto flex max-w-4xl gap-2">
           <input

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -27,6 +27,7 @@ import OpsNotificationsBell from "@/features/shared/components/OpsNotificationsB
 import { isDefaultOpsOperatorEmail } from "@/features/ops/lib/operatorAccess";
 import { TechnicianCopilotShell } from "@/features/copilot/technician/components/TechnicianCopilotShell";
 import { canonicalizeRole } from "@/features/shared/lib/rbac";
+import { resolveCanonicalStaffProfile } from "@/features/shared/lib/authenticated-profile";
 
 const HEADER_OFFSET_DESKTOP = "pt-14";
 
@@ -53,11 +54,6 @@ const ActionButton = ({
     {children}
   </button>
 );
-
-type ProfileScope = Pick<
-  Database["public"]["Tables"]["profiles"]["Row"],
-  "email" | "role" | "must_change_password" | "shop_id"
->;
 
 type ShopBillingScope = Pick<
   Database["public"]["Tables"]["shops"]["Row"],
@@ -182,15 +178,11 @@ export default function AppShell({
       if (!uid) return;
 
       try {
-        const { data: profile } = await supabase
-          .from("profiles")
-          .select("email, role, must_change_password, shop_id")
-          .eq("id", uid)
-          .single<ProfileScope>();
+        const { profile } = await resolveCanonicalStaffProfile(supabase, uid);
 
         setUserEmail(profile?.email ?? session?.user?.email ?? null);
         setMustChangePassword(!!profile?.must_change_password);
-        setRole(profile?.role ?? null);
+        if (profile) setRole(profile.role);
 
         const sid = (profile?.shop_id as string | null) ?? null;
         setShopId(sid);

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -25,6 +25,8 @@ import { isBillingAttentionStatus } from "@/features/stripe/lib/stripe/subscript
 import { isOutsideDesktopAppShell } from "@/features/shared/lib/routes/shellBoundaries";
 import OpsNotificationsBell from "@/features/shared/components/OpsNotificationsBell";
 import { isDefaultOpsOperatorEmail } from "@/features/ops/lib/operatorAccess";
+import { TechnicianCopilotShell } from "@/features/copilot/technician/components/TechnicianCopilotShell";
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
 
 const HEADER_OFFSET_DESKTOP = "pt-14";
 
@@ -104,6 +106,9 @@ export default function AppShell({
     initialIdentity?.email ?? null,
   );
   const [mustChangePassword, setMustChangePassword] = useState(false);
+  const [role, setRole] = useState<string | null>(
+    initialIdentity?.role ?? null,
+  );
   const [, setShopId] = useState<string | null>(
     initialIdentity?.shopId ?? null,
   );
@@ -185,6 +190,7 @@ export default function AppShell({
 
         setUserEmail(profile?.email ?? session?.user?.email ?? null);
         setMustChangePassword(!!profile?.must_change_password);
+        setRole(profile?.role ?? null);
 
         const sid = (profile?.shop_id as string | null) ?? null;
         setShopId(sid);
@@ -673,6 +679,11 @@ export default function AppShell({
           <AskAssistantEntry mobile />
         </div>
       ) : null}
+
+      <TechnicianCopilotShell
+        shouldCheck={canonicalizeRole(role) === "mechanic"}
+        surface="desktop"
+      />
     </>
   );
 }

--- a/features/shared/components/ui/dialog.tsx
+++ b/features/shared/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ export const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-40 bg-[color:var(--theme-surface-overlay)] backdrop-blur-sm transition-opacity data-[state=open]:opacity-100 data-[state=closed]:opacity-0",
+      "fixed inset-0 z-40 bg-[color:var(--theme-surface-overlay)] backdrop-blur-sm transition-opacity data-[state=open]:opacity-100 data-[state=closed]:invisible data-[state=closed]:pointer-events-none data-[state=closed]:opacity-0",
       className,
     )}
     {...props}
@@ -33,8 +33,8 @@ export const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
+  <DialogPortal forceMount={props.forceMount}>
+    <DialogOverlay forceMount={props.forceMount} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(

--- a/tests/technician-copilot-persistent-shell.test.tsx
+++ b/tests/technician-copilot-persistent-shell.test.tsx
@@ -5,6 +5,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const replace = vi.fn();
 let pathname = "/dashboard";
+const availability = vi.hoisted(() => ({
+  state: {
+    status: "available" as "available" | "unavailable",
+    message: null as string | null,
+  },
+}));
 
 vi.mock("next/navigation", () => ({
   usePathname: () => pathname,
@@ -13,7 +19,11 @@ vi.mock("next/navigation", () => ({
 
 vi.mock(
   "@/features/copilot/technician/client/useTechnicianCopilotAvailability",
-  () => ({ useTechnicianCopilotAvailability: () => true }),
+  () => ({
+    useTechnicianCopilotAvailability: () =>
+      availability.state.status === "available",
+    useTechnicianCopilotAvailabilityState: () => availability.state,
+  }),
 );
 
 vi.mock(
@@ -26,6 +36,7 @@ vi.mock(
 );
 
 import { TechnicianCopilotShell } from "@/features/copilot/technician/components/TechnicianCopilotShell";
+import { TechnicianCopilotCompatibilityRoute } from "@/features/copilot/technician/components/TechnicianCopilotCompatibilityRoute";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
@@ -33,6 +44,7 @@ describe("persistent Technician CoPilot shell", () => {
   beforeEach(() => {
     pathname = "/dashboard";
     replace.mockReset();
+    availability.state = { status: "available", message: null };
   });
 
   it("keeps one collaborator runtime mounted while the panel opens and closes", () => {
@@ -43,15 +55,21 @@ describe("persistent Technician CoPilot shell", () => {
       "false",
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Open Technician CoPilot" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Technician CoPilot" }),
+    );
 
-    expect(screen.getByRole("dialog", { name: "Technician CoPilot" })).toBeVisible();
+    expect(
+      screen.getByRole("dialog", { name: "Technician CoPilot" }),
+    ).toBeVisible();
     expect(screen.getByTestId("copilot-runtime")).toHaveAttribute(
       "data-active",
       "true",
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Close Technician CoPilot" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Close Technician CoPilot" }),
+    );
 
     expect(screen.getByTestId("copilot-runtime")).toHaveAttribute(
       "data-active",
@@ -64,7 +82,9 @@ describe("persistent Technician CoPilot shell", () => {
     pathname = "/mobile/copilot/technician";
     render(<TechnicianCopilotShell shouldCheck surface="mobile" />);
 
-    expect(screen.getByRole("dialog", { name: "Technician CoPilot" })).toBeVisible();
+    expect(
+      screen.getByRole("dialog", { name: "Technician CoPilot" }),
+    ).toBeVisible();
     const closeButtons = screen.getAllByRole("button", {
       name: "Close Technician CoPilot",
     });
@@ -94,8 +114,43 @@ describe("persistent Technician CoPilot shell", () => {
     expect(desktopShell).toContain(
       'shouldCheck={canonicalizeRole(role) === "mechanic"}',
     );
-    expect(mobileShell.match(/<TechnicianCopilotShell/g)).toHaveLength(3);
+    expect(mobileShell.match(/<TechnicianCopilotShell/g)).toHaveLength(1);
+    expect(desktopShell).toContain(
+      "resolveCanonicalStaffProfile(supabase, uid)",
+    );
+    expect(desktopShell).toContain("if (profile) setRole(profile.role)");
     expect(desktopRoute).not.toContain("<TechnicianTextCopilot");
     expect(mobileRoute).not.toContain("<TechnicianTextCopilot");
+  });
+
+  it("provides a terminal recovery state when a compatibility route is unavailable", () => {
+    availability.state = {
+      status: "unavailable",
+      message: "Technician CoPilot is not enabled for this account.",
+    };
+
+    render(<TechnicianCopilotCompatibilityRoute returnHref="/tech/queue" />);
+
+    expect(
+      screen.getByRole("heading", { name: "Technician CoPilot unavailable" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: "Return to my jobs" }),
+    ).toHaveAttribute("href", "/tech/queue");
+  });
+
+  it("keeps force-mounted dialogs inert while closed", () => {
+    const sharedDialog = readFileSync(
+      "features/shared/components/ui/dialog.tsx",
+      "utf8",
+    );
+
+    expect(sharedDialog).toContain(
+      "<DialogPortal forceMount={props.forceMount}>",
+    );
+    expect(sharedDialog).toContain(
+      "<DialogOverlay forceMount={props.forceMount} />",
+    );
+    expect(sharedDialog).toContain("data-[state=closed]:pointer-events-none");
   });
 });

--- a/tests/technician-copilot-persistent-shell.test.tsx
+++ b/tests/technician-copilot-persistent-shell.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { readFileSync } from "node:fs";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const replace = vi.fn();
+let pathname = "/dashboard";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+  useRouter: () => ({ replace }),
+}));
+
+vi.mock(
+  "@/features/copilot/technician/client/useTechnicianCopilotAvailability",
+  () => ({ useTechnicianCopilotAvailability: () => true }),
+);
+
+vi.mock(
+  "@/features/copilot/technician/components/TechnicianTextCopilot",
+  () => ({
+    TechnicianTextCopilot: ({ active }: { active?: boolean }) => (
+      <div data-testid="copilot-runtime" data-active={String(active)} />
+    ),
+  }),
+);
+
+import { TechnicianCopilotShell } from "@/features/copilot/technician/components/TechnicianCopilotShell";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+describe("persistent Technician CoPilot shell", () => {
+  beforeEach(() => {
+    pathname = "/dashboard";
+    replace.mockReset();
+  });
+
+  it("keeps one collaborator runtime mounted while the panel opens and closes", () => {
+    render(<TechnicianCopilotShell shouldCheck surface="desktop" />);
+
+    expect(screen.getByTestId("copilot-runtime")).toHaveAttribute(
+      "data-active",
+      "false",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Technician CoPilot" }));
+
+    expect(screen.getByRole("dialog", { name: "Technician CoPilot" })).toBeVisible();
+    expect(screen.getByTestId("copilot-runtime")).toHaveAttribute(
+      "data-active",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close Technician CoPilot" }));
+
+    expect(screen.getByTestId("copilot-runtime")).toHaveAttribute(
+      "data-active",
+      "false",
+    );
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("opens from the legacy mobile destination and returns to the job queue on close", () => {
+    pathname = "/mobile/copilot/technician";
+    render(<TechnicianCopilotShell shouldCheck surface="mobile" />);
+
+    expect(screen.getByRole("dialog", { name: "Technician CoPilot" })).toBeVisible();
+    const closeButtons = screen.getAllByRole("button", {
+      name: "Close Technician CoPilot",
+    });
+    fireEvent.click(closeButtons.at(-1)!);
+
+    expect(replace).toHaveBeenCalledWith("/mobile/tech/queue");
+  });
+
+  it("mounts one role-gated collaborator in each authenticated application shell", () => {
+    const desktopShell = readFileSync(
+      "features/shared/components/AppShell.tsx",
+      "utf8",
+    );
+    const mobileShell = readFileSync(
+      "components/layout/MobileShell.tsx",
+      "utf8",
+    );
+    const desktopRoute = readFileSync(
+      "app/copilot/technician/page.tsx",
+      "utf8",
+    );
+    const mobileRoute = readFileSync(
+      "app/mobile/copilot/technician/page.tsx",
+      "utf8",
+    );
+
+    expect(desktopShell).toContain(
+      'shouldCheck={canonicalizeRole(role) === "mechanic"}',
+    );
+    expect(mobileShell.match(/<TechnicianCopilotShell/g)).toHaveLength(3);
+    expect(desktopRoute).not.toContain("<TechnicianTextCopilot");
+    expect(mobileRoute).not.toContain("<TechnicianTextCopilot");
+  });
+});


### PR DESCRIPTION
## Summary

Move the existing technician collaborator from a destination page into the authenticated desktop and Shop Mobile application shells.

- keep one Technician CoPilot client mounted while the technician navigates between shop routes
- add a desktop side panel and mobile full-height collaborator surface
- preserve the shell across focused jobs, inspections, work orders, and Field Service mobile routes
- stop active microphone and speech output whenever the panel closes
- keep the existing desktop/mobile CoPilot URLs as compatibility entry points without mounting a second runtime
- retain the existing Repair Session, chat API, Realtime gateway, capability gates, canonical actions, and silent-documentation path

## User impact

An enabled technician can open CoPilot from anywhere, move between the queue, focused work, inspections, work orders, and other technician surfaces, then reopen the same mounted collaborator without returning to a separate page.

## Safety

- desktop mounting is limited to the canonical mechanic role and still requires the server capability gate
- mobile also uses the authenticated server access gate; unauthorized roles receive no launcher or runtime
- closing the panel invalidates the active voice generation and stops microphone/speech output
- no database, RLS, work-order mutation, labor, inspection, parts, billing, or customer workflow changes
- disabling the existing `technician_copilot_text` capability removes the shell client

## Exact-head validation

Head: `24833b0dd3a316785dbdd82b4ec1502546fbda4f`

All ready-for-review workflows passed:

- Agent PR Checks: regression inventory, TypeScript, changed-file ESLint, complete Vitest suite, production Next.js build
- Mobile Command Validation
- Mobile Dispatch Validation
- Universal Scheduler Validation
- GitGuardian Security Checks

`git diff --check` also passed locally. Supabase Preview was skipped because this branch has no associated Supabase preview branch.

## Live preview

No deployment was emitted for the repaired exact head. The earlier Vercel attempt was intentionally cancelled through the project's configured ignored-build step, so authenticated live UI testing remains pending a deployable preview or merge.

## Reviews

Codex submitted six findings on the first head. The repair commit addresses all six:

- stable mobile shell position
- canonical linked-profile role hydration
- terminal compatibility-route failure states
- shared dialog layer precedence
- responsive launcher clearance
- shared Radix modal focus/inert behavior on mobile

Five threads are automatically outdated. The remaining thread overlaps the replaced mobile modal lines and is implemented with the shared dialog primitive in the repaired head.

## Database

None. No migration or production schema change.