### PR TITLE
Fix mobile pointer lock and restore mobile sign-in

### DIFF
--- a/app/sign-in/page.tsx
+++ b/app/sign-in/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import {
   Building2,
   ChevronRight,
+  Smartphone,
   Truck,
   UserRound,
   Wrench,
@@ -18,7 +19,7 @@ import {
 
 export const metadata: Metadata = {
   title: "Choose your ProFixIQ app",
-  description: "Sign in to ProFixIQ Shop, Field, Fleet, or Customer Portal.",
+  description: "Sign in to ProFixIQ Shop, Shop Mobile, Field, Fleet, or Customer Portal.",
 };
 
 type SignInChooserProps = {
@@ -26,31 +27,43 @@ type SignInChooserProps = {
 };
 
 const accessCards: Array<{
-  surface: ProductAccessSurface;
+  surface: ProductAccessSurface | "mobile";
+  href: string;
   title: string;
   description: string;
   icon: typeof Wrench;
 }> = [
   {
     surface: "shop",
+    href: PRODUCT_SIGN_IN.shop,
     title: "ProFixIQ Shop",
     description: "Run a repair shop from intake and approvals through parts, labor, and invoicing.",
     icon: Wrench,
   },
   {
+    surface: "mobile",
+    href: "/mobile/sign-in",
+    title: "Shop Mobile",
+    description: "Use the role-specific shop workspace from a phone or tablet for jobs, inspections, shifts, evidence, and team communication.",
+    icon: Smartphone,
+  },
+  {
     surface: "field",
+    href: PRODUCT_SIGN_IN.field,
     title: "ProFixIQ Field",
     description: "Operate a mobile service business from the truck, tablet, phone, or laptop.",
     icon: Truck,
   },
   {
     surface: "fleet",
+    href: PRODUCT_SIGN_IN.fleet,
     title: "ProFixIQ Fleet",
     description: "Manage assets, maintenance programs, defects, approvals, and service history.",
     icon: Building2,
   },
   {
     surface: "customer",
+    href: PRODUCT_SIGN_IN.customer,
     title: "Customer Portal",
     description: "Request service, approve work, follow progress, pay invoices, and view records.",
     icon: UserRound,
@@ -79,7 +92,7 @@ export default async function SignInChooser({ searchParams }: SignInChooserProps
   return (
     <AuthShell
       productLabel="Product access"
-      heroTitle="Four clear doors into one connected platform."
+      heroTitle="Five clear doors into one connected platform."
       heroDescription="Choose the workspace that matches the work you are here to do. Your account stays secure and shared while each product keeps its own operating boundary."
       highlights={["Dedicated sign-in", "Shared identity", "Product-scoped access"]}
       cardClassName="sm:p-7"
@@ -97,10 +110,10 @@ export default async function SignInChooser({ searchParams }: SignInChooserProps
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
-        {accessCards.map(({ surface, title, description, icon: Icon }) => (
+        {accessCards.map(({ surface, href, title, description, icon: Icon }) => (
           <Link
             key={surface}
-            href={PRODUCT_SIGN_IN[surface]}
+            href={href}
             className="group flex min-h-40 flex-col rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4 transition hover:-translate-y-0.5 hover:border-[var(--accent-copper)] hover:bg-[color:var(--theme-surface-overlay)] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[color:color-mix(in_srgb,var(--accent-copper)_20%,transparent)]"
           >
             <div className="flex items-start justify-between gap-3">

--- a/features/copilot/technician/components/TechnicianCopilotShell.tsx
+++ b/features/copilot/technician/components/TechnicianCopilotShell.tsx
@@ -5,12 +5,6 @@ import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 import { useTechnicianCopilotAvailabilityState } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from "@/features/shared/components/ui/dialog";
 import { cn } from "@/features/shared/utils/cn";
 import { TechnicianTextCopilot } from "./TechnicianTextCopilot";
 
@@ -55,13 +49,13 @@ export function TechnicianCopilotShell({
   }, []);
 
   useEffect(() => {
-    if (!open || surface === "mobile") return;
+    if (!open) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") close();
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [close, open, surface]);
+  }, [close, open]);
 
   if (availability.status !== "available") return null;
 
@@ -94,36 +88,38 @@ export function TechnicianCopilotShell({
     return (
       <>
         {launcher}
-        <Dialog
-          open={open}
-          onOpenChange={(next) => (next ? setOpen(true) : close())}
+        <section
+          role="dialog"
+          aria-modal="true"
+          aria-label="Technician CoPilot"
+          aria-hidden={!open}
+          className={cn(
+            "fixed inset-0 z-50 flex h-[100dvh] w-full flex-col overflow-hidden overscroll-contain bg-background transition-opacity duration-200",
+            open
+              ? "visible pointer-events-auto opacity-100"
+              : "invisible pointer-events-none opacity-0",
+          )}
         >
-          <DialogContent
-            className="!inset-0 !flex !h-[100dvh] !w-full !max-w-none !translate-x-0 !translate-y-0 !flex-col !overflow-hidden !rounded-none !p-0 data-[state=closed]:invisible data-[state=closed]:pointer-events-none"
-          >
-            <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">
-              <div>
-                <DialogTitle className="text-sm normal-case tracking-normal">
-                  Technician CoPilot
-                </DialogTitle>
-                <DialogDescription className="text-xs">
-                  Stays with you as you move through the app
-                </DialogDescription>
+          <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">
+            <div>
+              <div className="text-sm font-semibold">Technician CoPilot</div>
+              <div className="text-xs text-muted-foreground">
+                Stays with you as you move through the app
               </div>
-              <button
-                type="button"
-                onClick={close}
-                aria-label="Close Technician CoPilot"
-                className="inline-flex h-10 w-10 items-center justify-center rounded-full border bg-background"
-              >
-                <X className="h-5 w-5" aria-hidden />
-              </button>
             </div>
-            <div className="min-h-0 flex-1">
-              <TechnicianTextCopilot embedded active={open} />
-            </div>
-          </DialogContent>
-        </Dialog>
+            <button
+              type="button"
+              onClick={close}
+              aria-label="Close Technician CoPilot"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full border bg-background"
+            >
+              <X className="h-5 w-5" aria-hidden />
+            </button>
+          </div>
+          <div className="min-h-0 flex-1">
+            <TechnicianTextCopilot embedded active={open} />
+          </div>
+        </section>
       </>
     );
   }

--- a/features/copilot/technician/components/TechnicianCopilotShell.tsx
+++ b/features/copilot/technician/components/TechnicianCopilotShell.tsx
@@ -99,7 +99,6 @@ export function TechnicianCopilotShell({
           onOpenChange={(next) => (next ? setOpen(true) : close())}
         >
           <DialogContent
-            forceMount
             className="!inset-0 !flex !h-[100dvh] !w-full !max-w-none !translate-x-0 !translate-y-0 !flex-col !overflow-hidden !rounded-none !p-0 data-[state=closed]:invisible data-[state=closed]:pointer-events-none"
           >
             <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">

--- a/tests/mobile-entry-regressions.test.ts
+++ b/tests/mobile-entry-regressions.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const technicianCopilotShell = readFileSync(
+  "features/copilot/technician/components/TechnicianCopilotShell.tsx",
+  "utf8",
+);
+const signInChooser = readFileSync("app/sign-in/page.tsx", "utf8");
+
+describe("mobile entry regressions", () => {
+  it("does not force-mount the closed mobile CoPilot modal", () => {
+    expect(technicianCopilotShell).toContain("<DialogContent");
+    expect(technicianCopilotShell).not.toContain("forceMount");
+  });
+
+  it("offers a dedicated Shop Mobile sign-in choice", () => {
+    expect(signInChooser).toContain('surface: "mobile"');
+    expect(signInChooser).toContain('href: "/mobile/sign-in"');
+    expect(signInChooser).toContain('title: "Shop Mobile"');
+  });
+});

--- a/tests/mobile-entry-regressions.test.ts
+++ b/tests/mobile-entry-regressions.test.ts
@@ -1,18 +1,9 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const technicianCopilotShell = readFileSync(
-  "features/copilot/technician/components/TechnicianCopilotShell.tsx",
-  "utf8",
-);
 const signInChooser = readFileSync("app/sign-in/page.tsx", "utf8");
 
 describe("mobile entry regressions", () => {
-  it("does not force-mount the closed mobile CoPilot modal", () => {
-    expect(technicianCopilotShell).toContain("<DialogContent");
-    expect(technicianCopilotShell).not.toContain("forceMount");
-  });
-
   it("offers a dedicated Shop Mobile sign-in choice", () => {
     expect(signInChooser).toContain('surface: "mobile"');
     expect(signInChooser).toContain('href: "/mobile/sign-in"');

--- a/tests/product-access-separation.test.ts
+++ b/tests/product-access-separation.test.ts
@@ -5,11 +5,12 @@ import { resolveFieldExistingSessionHref } from "../features/auth/lib/accessSurf
 const read = (path: string) => readFileSync(path, "utf8");
 
 describe("dedicated product access surfaces", () => {
-  it("presents four equal product choices instead of a Shop-owned login page", () => {
+  it("presents five equal product choices instead of a Shop-owned login page", () => {
     const chooser = read("app/sign-in/page.tsx");
 
     for (const label of [
       "ProFixIQ Shop",
+      "Shop Mobile",
       "ProFixIQ Field",
       "ProFixIQ Fleet",
       "Customer Portal",
@@ -18,7 +19,7 @@ describe("dedicated product access surfaces", () => {
     }
 
     expect(chooser).toContain("Where do you work?");
-    expect(chooser).toContain("PRODUCT_SIGN_IN[surface]");
+    expect(chooser).toContain('href: "/mobile/sign-in"');
     expect(chooser).not.toContain("<AuthPage");
   });
 

--- a/tests/technician-copilot-persistent-shell.test.tsx
+++ b/tests/technician-copilot-persistent-shell.test.tsx
@@ -45,6 +45,8 @@ describe("persistent Technician CoPilot shell", () => {
     pathname = "/dashboard";
     replace.mockReset();
     availability.state = { status: "available", message: null };
+    document.body.style.pointerEvents = "";
+    document.body.removeAttribute("data-scroll-locked");
   });
 
   it("keeps one collaborator runtime mounted while the panel opens and closes", () => {
@@ -76,6 +78,40 @@ describe("persistent Technician CoPilot shell", () => {
       "false",
     );
     expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("keeps the mobile collaborator mounted without retaining modal locks", () => {
+    pathname = "/mobile/tech/queue";
+    render(<TechnicianCopilotShell shouldCheck surface="mobile" />);
+
+    const runtime = screen.getByTestId("copilot-runtime");
+    expect(runtime).toHaveAttribute("data-active", "false");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Technician CoPilot" }),
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Technician CoPilot" });
+    expect(dialog).toBeVisible();
+    expect(screen.getByTestId("copilot-runtime")).toBe(runtime);
+    expect(runtime).toHaveAttribute("data-active", "true");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Close Technician CoPilot" }),
+    );
+
+    expect(dialog).not.toBeVisible();
+    expect(screen.getByTestId("copilot-runtime")).toBe(runtime);
+    expect(runtime).toHaveAttribute("data-active", "false");
+    expect(document.body.style.pointerEvents).not.toBe("none");
+    expect(document.body).not.toHaveAttribute("data-scroll-locked");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Technician CoPilot" }),
+    );
+
+    expect(screen.getByTestId("copilot-runtime")).toBe(runtime);
+    expect(runtime).toHaveAttribute("data-active", "true");
   });
 
   it("opens from the legacy mobile destination and returns to the job queue on close", () => {

--- a/tests/technician-copilot-persistent-shell.test.tsx
+++ b/tests/technician-copilot-persistent-shell.test.tsx
@@ -92,7 +92,12 @@ describe("persistent Technician CoPilot shell", () => {
     );
 
     const dialog = screen.getByRole("dialog", { name: "Technician CoPilot" });
-    expect(dialog).toBeVisible();
+    expect(dialog).toHaveAttribute("aria-hidden", "false");
+    expect(dialog).toHaveClass(
+      "visible",
+      "pointer-events-auto",
+      "opacity-100",
+    );
     expect(screen.getByTestId("copilot-runtime")).toBe(runtime);
     expect(runtime).toHaveAttribute("data-active", "true");
 
@@ -100,7 +105,12 @@ describe("persistent Technician CoPilot shell", () => {
       screen.getByRole("button", { name: "Close Technician CoPilot" }),
     );
 
-    expect(dialog).not.toBeVisible();
+    expect(dialog).toHaveAttribute("aria-hidden", "true");
+    expect(dialog).toHaveClass(
+      "invisible",
+      "pointer-events-none",
+      "opacity-0",
+    );
     expect(screen.getByTestId("copilot-runtime")).toBe(runtime);
     expect(runtime).toHaveAttribute("data-active", "false");
     expect(document.body.style.pointerEvents).not.toBe("none");


### PR DESCRIPTION
## What changed

- replace the mobile Technician CoPilot's force-mounted Radix modal with a persistent full-screen dialog layer
- keep the collaborator runtime mounted across close/reopen while closed UI remains invisible and non-interactive
- restore a dedicated Shop Mobile card on the product sign-in chooser
- add runtime coverage for CoPilot persistence/body-lock behavior and focused coverage for the mobile sign-in entry point

## Root cause

The mobile CoPilot used Radix `DialogContent forceMount`. Even with `data-state="closed"`, the mounted modal kept Radix scroll/pointer locking active on `body` (`data-scroll-locked="1"` and `pointer-events: none`). The page rendered normally but all touch, click, and scroll input was blocked in Safari and Chrome.

Simply unmounting the dialog removed the lock but also destroyed local draft, loading, error, and in-flight response state. The mobile shell now follows the persistent desktop collaborator pattern: its runtime remains mounted, while the closed full-screen layer uses only visibility and pointer-event guards and never activates Radix modal side effects.

The product chooser separately omitted the still-supported `/mobile/sign-in` entry point, which made the correct mobile workspace hard to reach.

## User impact

Closing CoPilot no longer disables the mobile workspace or discards the active collaborator state, and shop staff can explicitly choose Shop Mobile during sign-in.

## Validation

- runtime regression verifies the same CoPilot instance survives close/reopen and `body` is not pointer/scroll locked
- product access regression requires the Shop Mobile chooser card and `/mobile/sign-in` route
- Agent PR Checks validate type-check, changed-file lint, the complete test suite, and the production build for the published branch
