### PR TITLE
Fix trial signup handoff and shorten trial to 7 days

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -120,8 +120,8 @@ function getShopDisplayName(shop: ShopScope): string {
 }
 
 function configuredTrialDays(): number {
-  const parsed = Math.trunc(Number(process.env.STRIPE_TRIAL_DAYS ?? "14"));
-  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 60 ? parsed : 14;
+  const parsed = Math.trunc(Number(process.env.STRIPE_TRIAL_DAYS ?? "7"));
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 60 ? parsed : 7;
 }
 
 function automaticTaxEnabled(): boolean {

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -15,6 +15,8 @@ import { createStripeClient } from "@/features/stripe/lib/stripe/client";
 import {
   PRODUCT_PACKAGE_BILLING_MODEL,
   PRODUCT_PACKAGE_KEYS,
+  productAcquisitionSurface,
+  type ProductAcquisitionSurface,
   type ProductPackageKey,
 } from "@/features/stripe/lib/stripe/product-packages";
 import { resolveProductPackagePriceId } from "@/features/stripe/lib/server/product-package-price-contract";
@@ -69,12 +71,14 @@ type CheckoutSelection =
       packageKey: ProductPackageKey;
       legacyPlanKey: null;
       acquisitionPlanKey: PlanKey;
+      acquisitionSurface: ProductAcquisitionSurface;
       pricingModel: typeof PRODUCT_PACKAGE_BILLING_MODEL;
     }
   | {
       packageKey: null;
       legacyPlanKey: PlanKey;
       acquisitionPlanKey: PlanKey;
+      acquisitionSurface: ProductAcquisitionSurface;
       pricingModel: "base_plus_seats_v2";
     };
 
@@ -192,6 +196,7 @@ function acquisitionMetadata(input: {
     acquisition_intent_id: input.intentId,
     acquisition_nonce: input.nonce,
     plan_key: input.selection.acquisitionPlanKey,
+    acquisition_surface: input.selection.acquisitionSurface,
     ...(input.selection.packageKey
       ? { package_key: input.selection.packageKey }
       : {}),
@@ -213,6 +218,7 @@ function resolveCheckoutSelection(input: {
       // The acquisition ledger keeps the historical canonical plan alias while
       // package_key carries the new commercial entitlement.
       acquisitionPlanKey: "starter",
+      acquisitionSurface: productAcquisitionSurface(input.packageKey),
       pricingModel: PRODUCT_PACKAGE_BILLING_MODEL,
     };
   }
@@ -221,6 +227,7 @@ function resolveCheckoutSelection(input: {
     packageKey: null,
     legacyPlanKey: input.planKey ?? "starter",
     acquisitionPlanKey: input.planKey ?? "starter",
+    acquisitionSurface: "shop",
     pricingModel: "base_plus_seats_v2",
   };
 }
@@ -251,8 +258,7 @@ function buildCheckoutParams(input: {
     success_url: input.successUrl,
     cancel_url: input.cancelUrl,
     allow_promotion_codes: true,
-    payment_method_collection:
-      input.trialDays > 0 ? "if_required" : "always",
+    payment_method_collection: input.trialDays > 0 ? "if_required" : "always",
     ...(input.clientReferenceId
       ? { client_reference_id: input.clientReferenceId }
       : {}),
@@ -317,7 +323,7 @@ export async function POST(req: Request) {
         foundingDiscountApplied: false,
       });
 
-      const successUrl = `${baseUrl}/auth/callback?flow=acquisition&session_id={CHECKOUT_SESSION_ID}`;
+      const successUrl = `${baseUrl}/auth/callback?flow=acquisition&session_id={CHECKOUT_SESSION_ID}&surface=${selection.acquisitionSurface}`;
       if (intent.status === "expired" || intent.status === "failed") {
         return noStoreJson({ error: "Checkout attempt expired" }, 409);
       }

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -4,8 +4,15 @@ import { useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { EmailOtpType } from "@supabase/supabase-js";
+import {
+  acquisitionHomeHref,
+  acquisitionOnboardingHref,
+} from "@/features/auth/lib/acquisitionSurfaceRouting";
 import { resolvePostAuthDestination } from "@/features/auth/lib/postAuthRouting";
-import { resolveLegacySignInHref } from "@/features/auth/lib/accessSurfaceRouting";
+import {
+  resolveAcquisitionSignupHref,
+  resolveLegacySignInHref,
+} from "@/features/auth/lib/accessSurfaceRouting";
 import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
 import { claimStripeAcquisitionAfterAuth } from "@/features/stripe/lib/client/claim-acquisition";
 
@@ -66,10 +73,13 @@ export default function AuthCallbackPage() {
         if (flow) passthrough.set("flow", flow);
         if (demoId) passthrough.set("demoId", demoId);
         if (intakeId) passthrough.set("intakeId", intakeId);
-        if (activationContext) passthrough.set("activationContext", activationContext);
+        if (activationContext)
+          passthrough.set("activationContext", activationContext);
         if (surface) passthrough.set("surface", surface);
         const signInHref =
-          resolveLegacySignInHref(passthrough) ?? "/sign-in";
+          resolveAcquisitionSignupHref(passthrough) ??
+          resolveLegacySignInHref(passthrough) ??
+          "/sign-in";
 
         router.replace(signInHref);
         setTimeout(() => {
@@ -92,7 +102,11 @@ export default function AuthCallbackPage() {
         if (sessionId) retry.set("session_id", sessionId);
         retry.set("flow", "acquisition");
         retry.set("billing_link_error", "1");
-        router.replace(`/shop/sign-in?${retry.toString()}`);
+        const surface = sp.get("surface")?.trim();
+        if (surface) retry.set("surface", surface);
+        router.replace(
+          resolveAcquisitionSignupHref(retry) ?? `/signup?${retry.toString()}`,
+        );
         return;
       }
 
@@ -104,6 +118,12 @@ export default function AuthCallbackPage() {
         supabase,
         searchParams: sp,
         isMobileMode,
+        ...(claim.surface
+          ? {
+              defaultDashboardHref: acquisitionHomeHref(claim.surface),
+              unassignedAccountHref: acquisitionOnboardingHref(claim.surface),
+            }
+          : {}),
       });
 
       router.replace(destination);
@@ -125,7 +145,9 @@ export default function AuthCallbackPage() {
     <div className="min-h-[60vh] grid place-items-center text-[color:var(--theme-text-primary)]">
       <div className="text-center">
         <h1 className="text-2xl font-bold">Finishing sign-in...</h1>
-        <p className="text-sm text-[color:var(--theme-text-secondary)]">One moment while we set things up.</p>
+        <p className="text-sm text-[color:var(--theme-text-secondary)]">
+          One moment while we set things up.
+        </p>
       </div>
     </div>
   );

--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import {
+  acquisitionHomeHref,
+  acquisitionOnboardingHref,
+} from "@/features/auth/lib/acquisitionSurfaceRouting";
 import { resolvePostAuthDestination } from "@/features/auth/lib/postAuthRouting";
 import { activatePasswordProfile } from "@/features/auth/lib/passwordActivation";
 import { claimStripeAcquisitionAfterAuth } from "@/features/stripe/lib/client/claim-acquisition";
@@ -12,7 +16,9 @@ import { Input } from "@shared/components/ui/input";
 type StatusTone = "neutral" | "error" | "success";
 
 function getReturnPath(role: string | null | undefined): string {
-  const normalized = String(role ?? "").trim().toLowerCase();
+  const normalized = String(role ?? "")
+    .trim()
+    .toLowerCase();
   if (!normalized) return "/dashboard";
   if (normalized === "customer") return "/portal";
   if (normalized === "fleet_manager") return "/fleet";
@@ -42,12 +48,17 @@ export default function SetPasswordPage() {
   useEffect(() => {
     let cancelled = false;
     async function checkSession() {
-      const { data: { session }, error } = await supabase.auth.getSession();
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
       if (cancelled) return;
       if (error) {
         setHasSession(false);
         setStatusTone("error");
-        setStatusMessage("Unable to validate your session. Request a new link and try again.");
+        setStatusMessage(
+          "Unable to validate your session. Request a new link and try again.",
+        );
         setCheckingSession(false);
         return;
       }
@@ -68,7 +79,9 @@ export default function SetPasswordPage() {
       setCheckingSession(false);
     }
     void checkSession();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [isPortalActivation, supabase]);
 
   async function finishActivation(userId: string, role: string | null) {
@@ -97,13 +110,20 @@ export default function SetPasswordPage() {
       isPortalActivation
         ? "Portal password created. Opening your portal..."
         : claim.required
-          ? "Password updated. Opening shop setup..."
+          ? "Password updated. Opening your product setup..."
           : "Password updated. Redirecting...",
     );
     const redirect = await resolvePostAuthDestination({
       supabase,
       searchParams,
-      defaultDashboardHref: claim.required ? "/onboarding" : getReturnPath(role),
+      defaultDashboardHref: claim.surface
+        ? acquisitionHomeHref(claim.surface)
+        : getReturnPath(role),
+      ...(claim.surface
+        ? {
+            unassignedAccountHref: acquisitionOnboardingHref(claim.surface),
+          }
+        : {}),
     });
     window.setTimeout(() => window.location.replace(redirect), 700);
     return true;
@@ -146,7 +166,9 @@ export default function SetPasswordPage() {
       }
 
       setStatusMessage("Saving your new password...");
-      const { data, error } = await supabase.auth.updateUser({ password: trimmedPassword });
+      const { data, error } = await supabase.auth.updateUser({
+        password: trimmedPassword,
+      });
       if (error) {
         setStatusTone("error");
         setStatusMessage(error.message || "Failed to update password.");
@@ -154,10 +176,13 @@ export default function SetPasswordPage() {
       }
 
       const userId = data.user?.id ?? null;
-      const role = (data.user?.user_metadata?.role as string | undefined) ?? null;
+      const role =
+        (data.user?.user_metadata?.role as string | undefined) ?? null;
       if (!userId) {
         setStatusTone("error");
-        setStatusMessage("Password updated, but the account could not be identified. Contact support.");
+        setStatusMessage(
+          "Password updated, but the account could not be identified. Contact support.",
+        );
         return;
       }
 
@@ -171,7 +196,9 @@ export default function SetPasswordPage() {
     } catch (error) {
       console.error("[set-password] unexpected activation error", error);
       setStatusTone("error");
-      setStatusMessage("Unable to finish account setup. Retry activation or contact support.");
+      setStatusMessage(
+        "Unable to finish account setup. Retry activation or contact support.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -188,29 +215,53 @@ export default function SetPasswordPage() {
     <main className="flex min-h-screen items-center justify-center bg-[color:var(--theme-surface-page)] px-6 py-10 text-[color:var(--theme-text-primary)]">
       <div className="w-full max-w-md rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-6 shadow-2xl">
         <h1 className="text-2xl font-semibold text-[color:var(--theme-text-primary)]">
-          {isPortalActivation ? "Create your portal password" : "Set new password"}
+          {isPortalActivation
+            ? "Create your portal password"
+            : "Set new password"}
         </h1>
         <p className={`mt-3 text-sm ${statusClass}`}>{statusMessage}</p>
 
         <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
           <div className="space-y-2">
-            <label className="text-xs text-[color:var(--theme-text-secondary)]">New password</label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              New password
+            </label>
             <Input
               type="password"
               value={password}
               onChange={(event) => setPassword(event.target.value)}
-              placeholder={passwordCommitted ? "Password already updated" : "Enter new password"}
-              disabled={checkingSession || submitting || !hasSession || passwordCommitted}
+              placeholder={
+                passwordCommitted
+                  ? "Password already updated"
+                  : "Enter new password"
+              }
+              disabled={
+                checkingSession ||
+                submitting ||
+                !hasSession ||
+                passwordCommitted
+              }
             />
           </div>
           <div className="space-y-2">
-            <label className="text-xs text-[color:var(--theme-text-secondary)]">Confirm password</label>
+            <label className="text-xs text-[color:var(--theme-text-secondary)]">
+              Confirm password
+            </label>
             <Input
               type="password"
               value={confirmPassword}
               onChange={(event) => setConfirmPassword(event.target.value)}
-              placeholder={passwordCommitted ? "Password already updated" : "Confirm new password"}
-              disabled={checkingSession || submitting || !hasSession || passwordCommitted}
+              placeholder={
+                passwordCommitted
+                  ? "Password already updated"
+                  : "Confirm new password"
+              }
+              disabled={
+                checkingSession ||
+                submitting ||
+                !hasSession ||
+                passwordCommitted
+              }
             />
           </div>
           <Button

--- a/app/field-service/page.tsx
+++ b/app/field-service/page.tsx
@@ -25,7 +25,7 @@ export default function FieldServiceMarketingPage() {
         outcomes: [
           "1 truck included",
           "No per-user charge",
-          "14-day free trial",
+          "7-day free trial",
         ],
         features: [
           {

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -57,22 +57,22 @@ export default function ForgotPasswordPage() {
     const params = buildContinuationParams(sp, email);
     const redirect = params.get("redirect");
     const signInPath =
-      surface === "field"
-        ? "/field/sign-in"
-        : surface === "customer"
-          ? "/customer/sign-in"
-          : surface === "fleet"
-            ? "/sign-in"
-            : surface === "shop"
-              ? "/shop/sign-in"
-              : redirect?.startsWith("/mobile/service")
-                ? "/field/sign-in"
-                : redirect?.startsWith("/mobile")
-                  ? "/mobile/sign-in"
-                  : "/sign-in";
-    router.push(
-      `${signInPath}${params.size ? `?${params.toString()}` : ""}`,
-    );
+      params.get("flow") === "acquisition" && params.has("session_id")
+        ? "/signup"
+        : surface === "field"
+          ? "/field/sign-in"
+          : surface === "customer"
+            ? "/customer/sign-in"
+            : surface === "fleet"
+              ? "/sign-in"
+              : surface === "shop"
+                ? "/shop/sign-in"
+                : redirect?.startsWith("/mobile/service")
+                  ? "/field/sign-in"
+                  : redirect?.startsWith("/mobile")
+                    ? "/mobile/sign-in"
+                    : "/sign-in";
+    router.push(`${signInPath}${params.size ? `?${params.toString()}` : ""}`);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -114,7 +114,9 @@ export default function ForgotPasswordPage() {
       setNotice(data.message || "Reset email sent. Check your inbox.");
       setStatus("sent");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Unable to send reset email.");
+      setError(
+        err instanceof Error ? err.message : "Unable to send reset email.",
+      );
       setStatus("error");
     }
   };
@@ -151,7 +153,9 @@ export default function ForgotPasswordPage() {
                 disabled:cursor-not-allowed disabled:opacity-60
               "
             >
-              <span aria-hidden className="text-base leading-none">←</span>
+              <span aria-hidden className="text-base leading-none">
+                ←
+              </span>
               Back
             </button>
 

--- a/app/onboarding/OwnerOnboardingForm.tsx
+++ b/app/onboarding/OwnerOnboardingForm.tsx
@@ -12,6 +12,7 @@ import {
   shopCountryForTimezone,
   type ShopCountryCode,
 } from "@/features/shared/lib/timezones/shopTimezones";
+import type { ProductAcquisitionSurface } from "@/features/stripe/lib/stripe/product-packages";
 
 const COUNTRIES = [
   { value: "US", label: "United States" },
@@ -24,7 +25,55 @@ type BootstrapResponse = {
   destination?: string;
 };
 
-export default function OwnerOnboardingForm() {
+const ONBOARDING_COPY: Record<
+  ProductAcquisitionSurface,
+  {
+    eyebrow: string;
+    title: string;
+    description: string;
+    businessLabel: string;
+    locationLabel: string;
+    submitLabel: string;
+    destination: string | null;
+  }
+> = {
+  shop: {
+    eyebrow: "ProFixIQ Shop setup",
+    title: "Create your shop workspace",
+    description:
+      "Add the shop details your team and customers will see. You can change these settings later.",
+    businessLabel: "Shop details",
+    locationLabel: "Primary shop location",
+    submitLabel: "Create shop and continue",
+    destination: null,
+  },
+  field: {
+    eyebrow: "ProFixIQ Field setup",
+    title: "Create your Field Service workspace",
+    description:
+      "Add the business and primary service location behind this Field Service trial. You will configure trucks and operators next.",
+    businessLabel: "Field Service business",
+    locationLabel: "Primary service location",
+    submitLabel: "Create Field workspace and continue",
+    destination: "/mobile/service/setup",
+  },
+  fleet: {
+    eyebrow: "ProFixIQ Fleet setup",
+    title: "Create your Fleet workspace",
+    description:
+      "Add the organization and primary location behind this Fleet Maintenance trial. You will create the first fleet relationship next.",
+    businessLabel: "Fleet organization",
+    locationLabel: "Primary fleet location",
+    submitLabel: "Create Fleet workspace and continue",
+    destination: "/dashboard/owner/fleet-access",
+  },
+};
+
+export default function OwnerOnboardingForm({
+  acquisitionSurface,
+}: {
+  acquisitionSurface: ProductAcquisitionSurface;
+}) {
   const [country, setCountry] = useState<ShopCountryCode>("US");
   const [timezone, setTimezone] = useState<string>(defaultShopTimezone("US"));
   const [error, setError] = useState<string | null>(null);
@@ -33,6 +82,7 @@ export default function OwnerOnboardingForm() {
     () => getSupportedShopTimezones(country),
     [country],
   );
+  const copy = ONBOARDING_COPY[acquisitionSurface];
 
   useEffect(() => {
     const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -83,10 +133,15 @@ export default function OwnerOnboardingForm() {
           pin,
         }),
       });
-      const payload = (await response.json().catch(() => ({}))) as BootstrapResponse;
+      const payload = (await response
+        .json()
+        .catch(() => ({}))) as BootstrapResponse;
 
       if (!response.ok || !payload.ok) {
-        setError(payload.error || "We could not create your shop. Please try again.");
+        setError(
+          payload.error ||
+            "We could not create your workspace. Please try again.",
+        );
         return;
       }
 
@@ -103,10 +158,12 @@ export default function OwnerOnboardingForm() {
             "/onboarding/shop-boost",
             activationContext,
           )
-        : payload.destination || "/dashboard/onboarding-v2";
+        : copy.destination || payload.destination || "/dashboard/onboarding-v2";
       window.location.assign(destination);
     } catch {
-      setError("We could not create your shop. Check your connection and try again.");
+      setError(
+        "We could not create your workspace. Check your connection and try again.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -120,11 +177,11 @@ export default function OwnerOnboardingForm() {
       <div className="mx-auto max-w-3xl">
         <header className="mb-6">
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
-            ProFixIQ shop setup
+            {copy.eyebrow}
           </p>
-          <h1 className="mt-2 text-3xl font-semibold">Create your shop workspace</h1>
+          <h1 className="mt-2 text-3xl font-semibold">{copy.title}</h1>
           <p className="mt-2 max-w-2xl text-sm text-[color:var(--theme-text-secondary)]">
-            Add the shop details your team and customers will see. You can change these settings later.
+            {copy.description}
           </p>
         </header>
 
@@ -134,51 +191,111 @@ export default function OwnerOnboardingForm() {
         >
           <section aria-labelledby="shop-details-heading">
             <h2 id="shop-details-heading" className="text-lg font-semibold">
-              Shop details
+              {copy.businessLabel}
             </h2>
             <div className="mt-4 grid gap-4 sm:grid-cols-2">
               <label className="space-y-1.5 text-sm font-medium">
                 <span>Business name</span>
-                <input name="businessName" type="text" autoComplete="organization" required maxLength={120} className={fieldClassName} />
+                <input
+                  name="businessName"
+                  type="text"
+                  autoComplete="organization"
+                  required
+                  maxLength={120}
+                  className={fieldClassName}
+                />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>Shop name</span>
-                <input name="shopName" type="text" maxLength={120} placeholder="Defaults to business name" className={fieldClassName} />
+                <input
+                  name="shopName"
+                  type="text"
+                  maxLength={120}
+                  placeholder="Defaults to business name"
+                  className={fieldClassName}
+                />
               </label>
             </div>
           </section>
 
           <section aria-labelledby="location-heading">
-            <h2 id="location-heading" className="text-lg font-semibold">Primary location</h2>
+            <h2 id="location-heading" className="text-lg font-semibold">
+              {copy.locationLabel}
+            </h2>
             <div className="mt-4 grid gap-4 sm:grid-cols-2">
               <label className="space-y-1.5 text-sm font-medium sm:col-span-2">
                 <span>Street address</span>
-                <input name="street" type="text" autoComplete="street-address" required maxLength={200} className={fieldClassName} />
+                <input
+                  name="street"
+                  type="text"
+                  autoComplete="street-address"
+                  required
+                  maxLength={200}
+                  className={fieldClassName}
+                />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>City</span>
-                <input name="city" type="text" autoComplete="address-level2" required maxLength={100} className={fieldClassName} />
+                <input
+                  name="city"
+                  type="text"
+                  autoComplete="address-level2"
+                  required
+                  maxLength={100}
+                  className={fieldClassName}
+                />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>{country === "CA" ? "Province" : "State"}</span>
-                <input name="province" type="text" autoComplete="address-level1" required maxLength={80} className={fieldClassName} />
+                <input
+                  name="province"
+                  type="text"
+                  autoComplete="address-level1"
+                  required
+                  maxLength={80}
+                  className={fieldClassName}
+                />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>{country === "CA" ? "Postal code" : "ZIP code"}</span>
-                <input name="postalCode" type="text" autoComplete="postal-code" required maxLength={16} className={fieldClassName} />
+                <input
+                  name="postalCode"
+                  type="text"
+                  autoComplete="postal-code"
+                  required
+                  maxLength={16}
+                  className={fieldClassName}
+                />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>Country</span>
-                <select value={country} onChange={(event) => changeCountry(event.target.value as ShopCountryCode)} className={fieldClassName}>
-                  {COUNTRIES.map((item) => <option key={item.value} value={item.value}>{item.label}</option>)}
+                <select
+                  value={country}
+                  onChange={(event) =>
+                    changeCountry(event.target.value as ShopCountryCode)
+                  }
+                  className={fieldClassName}
+                >
+                  {COUNTRIES.map((item) => (
+                    <option key={item.value} value={item.value}>
+                      {item.label}
+                    </option>
+                  ))}
                 </select>
               </label>
               <label className="space-y-1.5 text-sm font-medium sm:col-span-2">
                 <span>Timezone</span>
-                <select value={timezone} onChange={(event) => setTimezone(event.target.value)} className={fieldClassName}>
+                <select
+                  value={timezone}
+                  onChange={(event) => setTimezone(event.target.value)}
+                  className={fieldClassName}
+                >
                   {timezoneOptions.map((item) => (
                     <option key={item} value={item}>
-                      {item.replace("America/", "").replace("Pacific/", "").replaceAll("_", " ")}
+                      {item
+                        .replace("America/", "")
+                        .replace("Pacific/", "")
+                        .replaceAll("_", " ")}
                     </option>
                   ))}
                 </select>
@@ -187,24 +304,56 @@ export default function OwnerOnboardingForm() {
           </section>
 
           <section aria-labelledby="owner-pin-heading">
-            <h2 id="owner-pin-heading" className="text-lg font-semibold">Owner PIN</h2>
-            <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">Use 4 to 8 digits. This protects sensitive owner actions inside the shop.</p>
+            <h2 id="owner-pin-heading" className="text-lg font-semibold">
+              Owner PIN
+            </h2>
+            <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+              Use 4 to 8 digits. This protects sensitive owner actions inside
+              the shop.
+            </p>
             <div className="mt-4 grid gap-4 sm:grid-cols-2">
               <label className="space-y-1.5 text-sm font-medium">
                 <span>Owner PIN</span>
-                <input name="pin" type="password" inputMode="numeric" autoComplete="new-password" pattern="[0-9]{4,8}" required className={fieldClassName} />
+                <input
+                  name="pin"
+                  type="password"
+                  inputMode="numeric"
+                  autoComplete="new-password"
+                  pattern="[0-9]{4,8}"
+                  required
+                  className={fieldClassName}
+                />
               </label>
               <label className="space-y-1.5 text-sm font-medium">
                 <span>Confirm owner PIN</span>
-                <input name="pinConfirmation" type="password" inputMode="numeric" autoComplete="new-password" pattern="[0-9]{4,8}" required className={fieldClassName} />
+                <input
+                  name="pinConfirmation"
+                  type="password"
+                  inputMode="numeric"
+                  autoComplete="new-password"
+                  pattern="[0-9]{4,8}"
+                  required
+                  className={fieldClassName}
+                />
               </label>
             </div>
           </section>
 
-          {error ? <p role="alert" className="rounded-xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">{error}</p> : null}
+          {error ? (
+            <p
+              role="alert"
+              className="rounded-xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-200"
+            >
+              {error}
+            </p>
+          ) : null}
 
-          <button type="submit" disabled={submitting} className="inline-flex min-h-11 w-full items-center justify-center rounded-xl bg-[var(--accent-copper)] px-5 py-3 text-sm font-semibold text-[color:var(--theme-text-on-accent)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto">
-            {submitting ? "Creating shop…" : "Create shop and continue"}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex min-h-11 w-full items-center justify-center rounded-xl bg-[var(--accent-copper)] px-5 py-3 text-sm font-semibold text-[color:var(--theme-text-on-accent)] transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+          >
+            {submitting ? "Creating workspace…" : copy.submitLabel}
           </button>
         </form>
       </div>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 
+import { acquisitionHomeHref } from "@/features/auth/lib/acquisitionSurfaceRouting";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { normalizeProductAcquisitionSurface } from "@/features/stripe/lib/stripe/product-packages";
 import OwnerOnboardingForm from "./OwnerOnboardingForm";
 
 export const dynamic = "force-dynamic";
@@ -13,6 +15,11 @@ export default async function OwnerOnboardingPage() {
 
   if (!user) redirect("/sign-in");
 
+  const acquisitionSurface =
+    normalizeProductAcquisitionSurface(
+      user.app_metadata?.profixiq_acquisition_surface,
+    ) ?? "shop";
+
   const { data: profile } = await supabase
     .from("profiles")
     .select("shop_id, role, completed_onboarding")
@@ -23,8 +30,8 @@ export default async function OwnerOnboardingPage() {
   // pending. Only the explicit completion marker may release an owner from the
   // setup surface; the bootstrap API's pending-owner branch handles retries.
   if (profile?.completed_onboarding) {
-    redirect("/dashboard");
+    redirect(acquisitionHomeHref(acquisitionSurface));
   }
 
-  return <OwnerOnboardingForm />;
+  return <OwnerOnboardingForm acquisitionSurface={acquisitionSurface} />;
 }

--- a/docs/stripe-billing-v2-activation.md
+++ b/docs/stripe-billing-v2-activation.md
@@ -51,7 +51,7 @@ Lifetime coupons must be assigned to a specific approved customer or subscriptio
 ## Required production environment variables
 
 ```text
-STRIPE_TRIAL_DAYS=14
+STRIPE_TRIAL_DAYS=7
 STRIPE_AUTOMATIC_TAX_ENABLED=true
 STRIPE_CONNECT_WEBHOOK_SECRET=<secret from the connected-account webhook endpoint>
 STRIPE_BILLING_RECONCILE_TOKEN=<random server-only secret>

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -454,7 +454,7 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         </h1>
         <p className="mt-2 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
           {isAwaitingConfirmation
-            ? `We created the owner account for ${pendingConfirmationEmail}. Open the verification link to securely attach this 14-day trial and continue ${productCopy.label} setup.`
+            ? `We created the owner account for ${pendingConfirmationEmail}. Open the verification link to securely attach this 7-day trial and continue ${productCopy.label} setup.`
             : isSignIn
               ? `Use your ${productCopy.label} username or account email.`
               : productCopy.accountDescription}

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -6,11 +6,19 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
 import AuthShell from "@/features/auth/components/AuthShell";
 import AuthStatus from "@/features/auth/components/AuthStatus";
+import {
+  acquisitionHomeHref,
+  acquisitionOnboardingHref,
+} from "@/features/auth/lib/acquisitionSurfaceRouting";
 import { resolvePostAuthDestination } from "@/features/auth/lib/postAuthRouting";
 import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
 import { signInWithIdentifier } from "@/features/auth/lib/signInClient";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { claimStripeAcquisitionAfterAuth } from "@/features/stripe/lib/client/claim-acquisition";
+import {
+  normalizeProductAcquisitionSurface,
+  type ProductAcquisitionSurface,
+} from "@/features/stripe/lib/stripe/product-packages";
 
 type Mode = "sign-in" | "sign-up";
 type AcquisitionContextStatus = "idle" | "loading" | "ready" | "error";
@@ -22,6 +30,75 @@ type AuthPageProps = {
 const inputClass =
   "w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3.5 py-3 text-sm text-[color:var(--theme-input-text)] outline-none transition placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper)] focus:ring-4 focus:ring-[color:color-mix(in_srgb,var(--accent-copper)_16%,transparent)]";
 
+const PRODUCT_AUTH_COPY: Record<
+  ProductAcquisitionSurface,
+  {
+    label: string;
+    heroTitle: string;
+    heroDescription: string;
+    highlights: [string, string, string];
+    accountTitle: string;
+    accountDescription: string;
+  }
+> = {
+  shop: {
+    label: "ProFixIQ Shop",
+    heroTitle: "The operating system for modern repair shops.",
+    heroDescription:
+      "Move from intake to invoice with every role, approval, and service record connected to the right shop.",
+    highlights: [
+      "Role-aware access",
+      "Live work visibility",
+      "Secure approvals",
+    ],
+    accountTitle: "Create your shop account",
+    accountDescription:
+      "Start with the owner account; invite the rest of your team after setup.",
+  },
+  field: {
+    label: "ProFixIQ Field",
+    heroTitle: "Your mobile service business, fully operational.",
+    heroDescription:
+      "Dispatch and complete off-site work with the right service-truck, operator, inventory, and evidence context.",
+    highlights: [
+      "Field Hub ready",
+      "Multi-device workflow",
+      "Offline-resilient work",
+    ],
+    accountTitle: "Create your Field owner account",
+    accountDescription:
+      "Verify the owner account, then configure the service operation covered by this trial.",
+  },
+  fleet: {
+    label: "ProFixIQ Fleet",
+    heroTitle: "Keep every unit moving.",
+    heroDescription:
+      "Asset readiness, preventive maintenance, service decisions, and repair history in one dedicated Fleet workspace.",
+    highlights: [
+      "Fleet control tower",
+      "Maintenance planning",
+      "Connected repair history",
+    ],
+    accountTitle: "Create your Fleet owner account",
+    accountDescription:
+      "Verify the owner account, then configure the fleet operation covered by this trial.",
+  },
+};
+
+const VERIFYING_TRIAL_COPY = {
+  label: "ProFixIQ trial setup",
+  heroTitle: "Connecting your trial to the right workspace.",
+  heroDescription:
+    "We verify the completed Checkout Session before choosing the Shop, Field, or Fleet account path.",
+  highlights: [
+    "Verified checkout",
+    "Product-scoped setup",
+    "Secure account claim",
+  ] as [string, string, string],
+  accountTitle: "Create your owner account",
+  accountDescription: "One moment while we verify your trial workspace.",
+};
+
 export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -31,18 +108,45 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
     const value = searchParams.get("session_id")?.trim() ?? "";
     return isAcquisitionFlow && /^cs_[A-Za-z0-9_]+$/.test(value) ? value : null;
   }, [isAcquisitionFlow, searchParams]);
-  const [mode, setMode] = useState<Mode>(() => (isAcquisitionFlow ? "sign-up" : initialMode));
-  const [identifier, setIdentifier] = useState(() => searchParams.get("email")?.trim().toLowerCase() ?? "");
+  const [mode, setMode] = useState<Mode>(() =>
+    isAcquisitionFlow ? "sign-up" : initialMode,
+  );
+  const [identifier, setIdentifier] = useState(
+    () => searchParams.get("email")?.trim().toLowerCase() ?? "",
+  );
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
-  const [error, setError] = useState(() => (searchParams.get("billing_link_error") === "1" ? "We couldn't securely link that checkout. Retry from the same checkout confirmation link." : ""));
+  const [error, setError] = useState(() =>
+    searchParams.get("billing_link_error") === "1"
+      ? "We couldn't securely link that checkout. Retry from the same checkout confirmation link."
+      : "",
+  );
   const [notice, setNotice] = useState("");
   const [loading, setLoading] = useState(false);
   const [resendLoading, setResendLoading] = useState(false);
-  const [pendingConfirmationEmail, setPendingConfirmationEmail] = useState<string | null>(null);
-  const [acquisitionContextStatus, setAcquisitionContextStatus] = useState<AcquisitionContextStatus>(isAcquisitionFlow ? "loading" : "idle");
+  const [pendingConfirmationEmail, setPendingConfirmationEmail] = useState<
+    string | null
+  >(null);
+  const [acquisitionContextStatus, setAcquisitionContextStatus] =
+    useState<AcquisitionContextStatus>(isAcquisitionFlow ? "loading" : "idle");
+  const [acquisitionSurface, setAcquisitionSurface] =
+    useState<ProductAcquisitionSurface | null>(null);
 
-  const origin = useMemo(() => (typeof window !== "undefined" ? window.location.origin : process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") || "https://profixiq.com"), []);
+  const productSurface: ProductAcquisitionSurface | null = isAcquisitionFlow
+    ? acquisitionSurface
+    : "shop";
+  const productCopy = productSurface
+    ? PRODUCT_AUTH_COPY[productSurface]
+    : VERIFYING_TRIAL_COPY;
+
+  const origin = useMemo(
+    () =>
+      typeof window !== "undefined"
+        ? window.location.origin
+        : process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") ||
+          "https://profixiq.com",
+    [],
+  );
 
   const emailRedirectTo = useMemo(() => {
     const params = new URLSearchParams();
@@ -58,9 +162,9 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
     if (demoId) params.set("demoId", demoId);
     if (intakeId) params.set("intakeId", intakeId);
     if (activationContext) params.set("activationContext", activationContext);
-    params.set("surface", "shop");
+    params.set("surface", acquisitionSurface ?? "shop");
     return `${origin}/auth/callback${params.size ? `?${params.toString()}` : ""}`;
-  }, [origin, searchParams]);
+  }, [acquisitionSurface, origin, searchParams]);
 
   const forgotPasswordHref = useMemo(() => {
     const params = new URLSearchParams();
@@ -79,37 +183,51 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
     if (demoId) params.set("demoId", demoId);
     if (intakeId) params.set("intakeId", intakeId);
     if (activationContext) params.set("activationContext", activationContext);
-    params.set("surface", "shop");
+    params.set("surface", acquisitionSurface ?? "shop");
 
     return `/forgot-password${params.size ? `?${params.toString()}` : ""}`;
-  }, [identifier, searchParams]);
+  }, [acquisitionSurface, identifier, searchParams]);
 
-  const isOpsSignIn = useMemo(() => safeInternalRedirect(searchParams.get("redirect"), "") === "/ops", [searchParams]);
+  const isOpsSignIn = useMemo(
+    () => safeInternalRedirect(searchParams.get("redirect"), "") === "/ops",
+    [searchParams],
+  );
 
   useEffect(() => {
     if (!isAcquisitionFlow) return;
     if (!acquisitionSessionId) {
       setAcquisitionContextStatus("error");
-      setError("This trial checkout link is invalid. Return to pricing and start a new trial.");
+      setError(
+        "This trial checkout link is invalid. Return to pricing and start a new trial.",
+      );
       return;
     }
 
     const controller = new AbortController();
     setAcquisitionContextStatus("loading");
-    void fetch(`/api/stripe/checkout/acquisition-context?session_id=${encodeURIComponent(acquisitionSessionId)}`, {
-      cache: "no-store",
-      headers: { Accept: "application/json" },
-      signal: controller.signal,
-    })
+    void fetch(
+      `/api/stripe/checkout/acquisition-context?session_id=${encodeURIComponent(acquisitionSessionId)}`,
+      {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      },
+    )
       .then(async (response) => {
         const body = (await response.json().catch(() => null)) as {
           email?: unknown;
+          surface?: unknown;
         } | null;
-        const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : "";
-        if (!response.ok || !email.includes("@")) {
+        const email =
+          typeof body?.email === "string"
+            ? body.email.trim().toLowerCase()
+            : "";
+        const surface = normalizeProductAcquisitionSurface(body?.surface);
+        if (!response.ok || !email.includes("@") || !surface) {
           throw new Error("checkout_not_eligible");
         }
         setIdentifier(email);
+        setAcquisitionSurface(surface);
         setAcquisitionContextStatus("ready");
       })
       .catch((fetchError: unknown) => {
@@ -117,8 +235,11 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         console.warn("stripe acquisition context unavailable", {
           name: fetchError instanceof Error ? fetchError.name : "UnknownError",
         });
+        setAcquisitionSurface(null);
         setAcquisitionContextStatus("error");
-        setError("We couldn't verify this trial checkout. Return to the checkout confirmation page and try again.");
+        setError(
+          "We couldn't verify this trial checkout. Return to the checkout confirmation page and try again.",
+        );
       });
 
     return () => controller.abort();
@@ -132,12 +253,20 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
       const claim = await claimStripeAcquisitionAfterAuth(searchParams);
       if (cancelled) return;
       if (!claim.linked) {
-        setError("We couldn't securely link that checkout to this account. Retry from the checkout confirmation link.");
+        setError(
+          "We couldn't securely link that checkout to this account. Retry from the checkout confirmation link.",
+        );
         return;
       }
       const destination = await resolvePostAuthDestination({
         supabase,
         searchParams,
+        ...(claim.surface
+          ? {
+              defaultDashboardHref: acquisitionHomeHref(claim.surface),
+              unassignedAccountHref: acquisitionOnboardingHref(claim.surface),
+            }
+          : {}),
       });
       router.replace(destination);
     })();
@@ -155,7 +284,9 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
 
     try {
       if (isAcquisitionFlow && acquisitionContextStatus !== "ready") {
-        setError("Wait for us to verify your trial checkout before continuing.");
+        setError(
+          "Wait for us to verify your trial checkout before continuing.",
+        );
         return;
       }
 
@@ -172,10 +303,26 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         }
         const claim = await claimStripeAcquisitionAfterAuth(searchParams);
         if (!claim.linked) {
-          setError("We couldn't securely link that checkout to this account. Retry from the checkout confirmation link.");
+          setError(
+            "We couldn't securely link that checkout to this account. Retry from the checkout confirmation link.",
+          );
           return;
         }
-        const requested = safeInternalRedirect(searchParams.get("redirect"), result.destination);
+        if (claim.surface) {
+          const destination = await resolvePostAuthDestination({
+            supabase,
+            searchParams,
+            defaultDashboardHref: acquisitionHomeHref(claim.surface),
+            unassignedAccountHref: acquisitionOnboardingHref(claim.surface),
+          });
+          router.replace(destination);
+          router.refresh();
+          return;
+        }
+        const requested = safeInternalRedirect(
+          searchParams.get("redirect"),
+          result.destination,
+        );
         router.replace(requested);
         router.refresh();
         return;
@@ -183,7 +330,7 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
 
       const email = identifier.trim().toLowerCase();
       if (!email.includes("@")) {
-        setError("Use a valid email address to create a shop account.");
+        setError("Use a valid email address to create an owner account.");
         return;
       }
       if (password.length < 12) {
@@ -197,24 +344,38 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         options: { emailRedirectTo },
       });
       if (signUpError) {
-        setError("We couldn't create the account. Check your details and try again.");
+        setError(
+          "We couldn't create the account. Check your details and try again.",
+        );
         return;
       }
       if (!data.session) {
         setPassword("");
         setPendingConfirmationEmail(email);
-        setNotice("Check your inbox for the verification link. If it doesn't arrive, resend it below or choose Sign in if this account already exists.");
+        setNotice(
+          "Check your inbox for the verification link. If it doesn't arrive, resend it below or choose Sign in if this account already exists.",
+        );
         return;
       }
       const claim = await claimStripeAcquisitionAfterAuth(searchParams);
       if (!claim.linked) {
-        setError("Your account was created, but checkout could not be securely linked. Retry from the checkout confirmation link.");
+        setError(
+          "Your account was created, but checkout could not be securely linked. Retry from the checkout confirmation link.",
+        );
         return;
       }
       const destination = await resolvePostAuthDestination({
         supabase,
         searchParams,
-        defaultDashboardHref: "/onboarding",
+        ...(claim.surface
+          ? {
+              defaultDashboardHref: acquisitionHomeHref(claim.surface),
+              unassignedAccountHref: acquisitionOnboardingHref(claim.surface),
+            }
+          : {
+              defaultDashboardHref: "/onboarding",
+              unassignedAccountHref: "/onboarding",
+            }),
       });
       router.replace(destination);
     } finally {
@@ -235,10 +396,14 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         options: { emailRedirectTo },
       });
       if (resendError) {
-        setError("We couldn't resend the verification email. Wait a minute and try again, or choose Sign in if this account is already verified.");
+        setError(
+          "We couldn't resend the verification email. Wait a minute and try again, or choose Sign in if this account is already verified.",
+        );
         return;
       }
-      setNotice("Verification email resent. Check your inbox and spam folder for the newest link.");
+      setNotice(
+        "Verification email resent. Check your inbox and spam folder for the newest link.",
+      );
     } finally {
       setResendLoading(false);
     }
@@ -256,7 +421,9 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         options: { redirectTo: emailRedirectTo },
       });
       if (oauthError) {
-        setError("Google sign-in is not available yet. Use email and password for now.");
+        setError(
+          "Google sign-in is not available yet. Use email and password for now.",
+        );
       }
     } finally {
       setLoading(false);
@@ -264,50 +431,65 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
   }
 
   const isSignIn = mode === "sign-in";
+  const isAwaitingConfirmation = !isSignIn && Boolean(pendingConfirmationEmail);
 
   return (
     <AuthShell
-      productLabel="ProFixIQ Shop"
-      heroTitle="The operating system for modern repair shops."
-      heroDescription="Move from intake to invoice with every role, approval, and service record connected to the right shop."
-      highlights={["Role-aware access", "Live work visibility", "Secure approvals"]}
+      productLabel={productCopy.label}
+      heroTitle={productCopy.heroTitle}
+      heroDescription={productCopy.heroDescription}
+      highlights={productCopy.highlights}
       backHref="/sign-in"
     >
       <div className="mb-6">
-        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">ProFixIQ Shop</div>
-        <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em] text-[color:var(--theme-text-primary)] sm:text-4xl">{isSignIn ? "Welcome back" : "Create your shop account"}</h1>
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          {productCopy.label}
+        </div>
+        <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em] text-[color:var(--theme-text-primary)] sm:text-4xl">
+          {isAwaitingConfirmation
+            ? "Verify your email"
+            : isSignIn
+              ? "Welcome back"
+              : productCopy.accountTitle}
+        </h1>
         <p className="mt-2 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
-          {isSignIn ? "Use your shop username or account email." : "Start with the owner account; invite the rest of your team after setup."}
+          {isAwaitingConfirmation
+            ? `We created the owner account for ${pendingConfirmationEmail}. Open the verification link to securely attach this 14-day trial and continue ${productCopy.label} setup.`
+            : isSignIn
+              ? `Use your ${productCopy.label} username or account email.`
+              : productCopy.accountDescription}
         </p>
       </div>
 
-      <div className="mb-6 grid grid-cols-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-1">
-        {(["sign-in", "sign-up"] as const).map((value) => (
-          <button
-            key={value}
-            type="button"
-            onClick={() => {
-              setMode(value);
-              setError("");
-              setNotice("");
-            }}
-            className={`rounded-lg px-3 py-2 text-xs font-semibold transition ${
-              mode === value
-                ? "bg-[color:var(--theme-surface-overlay)] text-[color:var(--theme-text-primary)] shadow-sm"
-                : "text-[color:var(--theme-text-muted)] hover:text-[color:var(--theme-text-primary)]"
-            }`}
-          >
-            {value === "sign-in" ? "Sign in" : "Create owner account"}
-          </button>
-        ))}
-      </div>
+      {!isAwaitingConfirmation ? (
+        <div className="mb-6 grid grid-cols-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-1">
+          {(["sign-in", "sign-up"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => {
+                setMode(value);
+                setError("");
+                setNotice("");
+              }}
+              className={`rounded-lg px-3 py-2 text-xs font-semibold transition ${
+                mode === value
+                  ? "bg-[color:var(--theme-surface-overlay)] text-[color:var(--theme-text-primary)] shadow-sm"
+                  : "text-[color:var(--theme-text-muted)] hover:text-[color:var(--theme-text-primary)]"
+              }`}
+            >
+              {value === "sign-in" ? "Sign in" : "Create owner account"}
+            </button>
+          ))}
+        </div>
+      ) : null}
 
       <div className="space-y-3">
         {error ? <AuthStatus tone="error">{error}</AuthStatus> : null}
         {notice ? <AuthStatus tone="success">{notice}</AuthStatus> : null}
       </div>
 
-      {isOpsSignIn && isSignIn ? (
+      {!isAwaitingConfirmation && isOpsSignIn && isSignIn ? (
         <button
           type="button"
           disabled={loading}
@@ -319,88 +501,139 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         </button>
       ) : null}
 
-      <form className="mt-5 space-y-4" onSubmit={handleSubmit}>
-        <div>
-          <label htmlFor="shop-identifier" className="mb-1.5 block text-xs font-semibold text-[color:var(--theme-text-secondary)]">
-            {isSignIn ? "Email or username" : "Owner email"}
-          </label>
-          <input
-            id="shop-identifier"
-            className={inputClass}
-            type={isSignIn ? "text" : "email"}
-            autoComplete={isSignIn ? "username" : "email"}
-            placeholder={isSignIn ? "name@shop.com or username" : "owner@shop.com"}
-            value={identifier}
-            onChange={(event) => setIdentifier(event.target.value)}
-            readOnly={isAcquisitionFlow && acquisitionContextStatus === "ready"}
-            aria-describedby={isAcquisitionFlow ? "acquisition-email-help" : undefined}
-            required
-          />
-          {isAcquisitionFlow ? (
-            <p id="acquisition-email-help" className="mt-1.5 text-xs text-[color:var(--theme-text-muted)]">
-              {acquisitionContextStatus === "loading"
-                ? "Verifying the email used for your trial checkout…"
-                : acquisitionContextStatus === "ready"
-                  ? "This email is locked to the completed trial checkout."
-                  : "The completed trial checkout must be verified before account setup."}
-            </p>
-          ) : null}
-        </div>
-
-        <div>
-          <div className="mb-1.5 flex items-center justify-between">
-            <label htmlFor="shop-password" className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
-              Password
+      {!isAwaitingConfirmation ? (
+        <form className="mt-5 space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label
+              htmlFor="shop-identifier"
+              className="mb-1.5 block text-xs font-semibold text-[color:var(--theme-text-secondary)]"
+            >
+              {isSignIn ? "Email or username" : "Owner email"}
             </label>
-            {isSignIn ? (
-              <Link href={forgotPasswordHref} className="text-xs font-semibold text-[var(--accent-copper)] hover:underline">
-                Forgot password?
-              </Link>
-            ) : null}
-          </div>
-          <div className="relative">
             <input
-              id="shop-password"
-              className={`${inputClass} pr-11`}
-              type={showPassword ? "text" : "password"}
-              autoComplete={isSignIn ? "current-password" : "new-password"}
-              placeholder={isSignIn ? "Enter your password" : "At least 12 characters"}
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              minLength={isSignIn ? 6 : 12}
+              id="shop-identifier"
+              className={inputClass}
+              type={isSignIn ? "text" : "email"}
+              autoComplete={isSignIn ? "username" : "email"}
+              placeholder={
+                isSignIn
+                  ? "name@business.com or username"
+                  : "owner@business.com"
+              }
+              value={identifier}
+              onChange={(event) => setIdentifier(event.target.value)}
+              readOnly={
+                isAcquisitionFlow && acquisitionContextStatus === "ready"
+              }
+              aria-describedby={
+                isAcquisitionFlow ? "acquisition-email-help" : undefined
+              }
               required
             />
-            <button
-              type="button"
-              onClick={() => setShowPassword((current) => !current)}
-              className="absolute inset-y-0 right-0 grid w-11 place-items-center text-[color:var(--theme-text-muted)] hover:text-[color:var(--theme-text-primary)]"
-              aria-label={showPassword ? "Hide password" : "Show password"}
-            >
-              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-            </button>
+            {isAcquisitionFlow ? (
+              <p
+                id="acquisition-email-help"
+                className="mt-1.5 text-xs text-[color:var(--theme-text-muted)]"
+              >
+                {acquisitionContextStatus === "loading"
+                  ? "Verifying the email used for your trial checkout…"
+                  : acquisitionContextStatus === "ready"
+                    ? "This email is locked to the completed trial checkout."
+                    : "The completed trial checkout must be verified before account setup."}
+              </p>
+            ) : null}
           </div>
-        </div>
 
-        <button
-          type="submit"
-          disabled={loading || (isAcquisitionFlow && acquisitionContextStatus !== "ready")}
-          className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--accent-copper)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-on-accent)] shadow-[0_14px_32px_color-mix(in_srgb,var(--accent-copper)_25%,transparent)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-          {loading ? "Please wait…" : isSignIn ? "Sign in to ProFixIQ Shop" : "Create owner account"}
-        </button>
-      </form>
+          <div>
+            <div className="mb-1.5 flex items-center justify-between">
+              <label
+                htmlFor="shop-password"
+                className="text-xs font-semibold text-[color:var(--theme-text-secondary)]"
+              >
+                Password
+              </label>
+              {isSignIn ? (
+                <Link
+                  href={forgotPasswordHref}
+                  className="text-xs font-semibold text-[var(--accent-copper)] hover:underline"
+                >
+                  Forgot password?
+                </Link>
+              ) : null}
+            </div>
+            <div className="relative">
+              <input
+                id="shop-password"
+                className={`${inputClass} pr-11`}
+                type={showPassword ? "text" : "password"}
+                autoComplete={isSignIn ? "current-password" : "new-password"}
+                placeholder={
+                  isSignIn ? "Enter your password" : "At least 12 characters"
+                }
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                minLength={isSignIn ? 6 : 12}
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((current) => !current)}
+                className="absolute inset-y-0 right-0 grid w-11 place-items-center text-[color:var(--theme-text-muted)] hover:text-[color:var(--theme-text-primary)]"
+                aria-label={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? (
+                  <EyeOff className="h-4 w-4" />
+                ) : (
+                  <Eye className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={
+              loading ||
+              (isAcquisitionFlow && acquisitionContextStatus !== "ready")
+            }
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--accent-copper)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-on-accent)] shadow-[0_14px_32px_color-mix(in_srgb,var(--accent-copper)_25%,transparent)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            {loading
+              ? "Please wait…"
+              : isSignIn
+                ? `Sign in to ${productCopy.label}`
+                : "Create owner account"}
+          </button>
+        </form>
+      ) : null}
 
       {!isSignIn && pendingConfirmationEmail ? (
-        <button
-          type="button"
-          disabled={resendLoading}
-          onClick={handleResendConfirmation}
-          className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper)] disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {resendLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-          {resendLoading ? "Resending…" : "Resend verification email"}
-        </button>
+        <div className="mt-5 space-y-3">
+          <button
+            type="button"
+            disabled={resendLoading}
+            onClick={handleResendConfirmation}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {resendLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : null}
+            {resendLoading ? "Resending…" : "Resend verification email"}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setPendingConfirmationEmail(null);
+              setMode("sign-in");
+              setNotice("");
+              setError("");
+            }}
+            className="w-full px-4 py-2 text-xs font-semibold text-[var(--accent-copper)] hover:underline"
+          >
+            Already verified? Sign in
+          </button>
+        </div>
       ) : null}
 
       <div className="mt-6 border-t border-[color:var(--theme-border-soft)] pt-5 text-center">

--- a/features/auth/lib/accessSurfaceRouting.test.ts
+++ b/features/auth/lib/accessSurfaceRouting.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   PRODUCT_SIGN_IN,
+  resolveAcquisitionSignupHref,
   resolveFieldPostSignInHref,
   resolveLegacySignInHref,
 } from "./accessSurfaceRouting";
@@ -22,9 +23,27 @@ describe("product access surface routing", () => {
     expect(acquisition).toBe(
       "/shop/sign-in?session_id=cs_test_123&flow=acquisition",
     );
-    expect(protectedRoute).toBe(
-      "/shop/sign-in?redirect=%2Fwork-orders%2Fwo-1",
-    );
+    expect(protectedRoute).toBe("/shop/sign-in?redirect=%2Fwork-orders%2Fwo-1");
+  });
+
+  it("keeps every self-serve product trial on the shared account setup route", () => {
+    for (const surface of ["shop", "field", "fleet"] as const) {
+      expect(
+        resolveAcquisitionSignupHref(
+          new URLSearchParams(
+            `flow=acquisition&session_id=cs_test_${surface}&surface=${surface}`,
+          ),
+        ),
+      ).toBe(
+        `/signup?session_id=cs_test_${surface}&flow=acquisition&surface=${surface}`,
+      );
+    }
+
+    expect(
+      resolveAcquisitionSignupHref(
+        new URLSearchParams("flow=acquisition&session_id=invalid"),
+      ),
+    ).toBeNull();
   });
 
   it("routes legacy continuations to Field, Fleet, and Customer Portal", () => {
@@ -38,17 +57,13 @@ describe("product access surface routing", () => {
       resolveLegacySignInHref(
         new URLSearchParams("redirect=%2Fportal%2Ffleet%2Fassets"),
       ),
-    ).toBe(
-      `${PRODUCT_SIGN_IN.fleet}?redirect=%2Fportal%2Ffleet%2Fassets`,
-    );
+    ).toBe(`${PRODUCT_SIGN_IN.fleet}?redirect=%2Fportal%2Ffleet%2Fassets`);
 
     expect(
       resolveLegacySignInHref(
         new URLSearchParams("surface=customer&redirect=%2Fportal%2Finvoices"),
       ),
-    ).toBe(
-      "/customer/sign-in?redirect=%2Fportal%2Finvoices&surface=customer",
-    );
+    ).toBe("/customer/sign-in?redirect=%2Fportal%2Finvoices&surface=customer");
   });
 
   it("does not classify an unsafe external redirect as another product", () => {
@@ -70,10 +85,7 @@ describe("product access surface routing", () => {
 
   it("applies Field continuations only to a normal Field home response", () => {
     expect(
-      resolveFieldPostSignInHref(
-        "/mobile/service",
-        "/mobile/service/today",
-      ),
+      resolveFieldPostSignInHref("/mobile/service", "/mobile/service/today"),
     ).toBe("/mobile/service/today");
     expect(
       resolveFieldPostSignInHref(

--- a/features/auth/lib/accessSurfaceRouting.ts
+++ b/features/auth/lib/accessSurfaceRouting.ts
@@ -56,7 +56,10 @@ function surfaceForLegacyContinuation(
   }
 
   const redirect = safeInternalRedirect(searchParams.get("redirect"), "");
-  if (redirect === "/mobile/service" || redirect.startsWith("/mobile/service/")) {
+  if (
+    redirect === "/mobile/service" ||
+    redirect.startsWith("/mobile/service/")
+  ) {
     return "field";
   }
   if (redirect === "/portal/fleet" || redirect.startsWith("/portal/fleet/")) {
@@ -85,6 +88,22 @@ export function resolveLegacySignInHref(
   return surface
     ? appendContinuation(PRODUCT_SIGN_IN[surface], searchParams)
     : null;
+}
+
+/**
+ * Completed self-serve checkout always continues through the shared owner
+ * account-setup form. Product-specific sign-in pages remain for existing
+ * accounts and invited users; they are not allowed to swallow a new trial.
+ */
+export function resolveAcquisitionSignupHref(
+  searchParams: URLSearchParams,
+): string | null {
+  const flow = searchParams.get("flow")?.trim();
+  const sessionId = searchParams.get("session_id")?.trim() ?? "";
+  if (flow !== "acquisition" || !/^cs_[A-Za-z0-9_]+$/.test(sessionId)) {
+    return null;
+  }
+  return appendContinuation("/signup", searchParams);
 }
 
 const FIELD_HOME = "/mobile/service";

--- a/features/auth/lib/acquisitionSurfaceRouting.test.ts
+++ b/features/auth/lib/acquisitionSurfaceRouting.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  acquisitionHomeHref,
+  acquisitionOnboardingHref,
+} from "./acquisitionSurfaceRouting";
+
+describe("acquisition product routing", () => {
+  it.each([
+    ["shop", "/dashboard", "/onboarding?surface=shop"],
+    ["field", "/mobile/service", "/onboarding?surface=field"],
+    ["fleet", "/dashboard/owner/fleet-access", "/onboarding?surface=fleet"],
+  ] as const)(
+    "keeps %s accounts on their verified product branch",
+    (surface, home, onboarding) => {
+      expect(acquisitionHomeHref(surface)).toBe(home);
+      expect(acquisitionOnboardingHref(surface)).toBe(onboarding);
+    },
+  );
+});

--- a/features/auth/lib/acquisitionSurfaceRouting.ts
+++ b/features/auth/lib/acquisitionSurfaceRouting.ts
@@ -1,0 +1,21 @@
+import type { ProductAcquisitionSurface } from "@/features/stripe/lib/stripe/product-packages";
+
+const ACQUISITION_HOME: Record<ProductAcquisitionSurface, string> = {
+  shop: "/dashboard",
+  field: "/mobile/service",
+  // A new Fleet trial owner must create the first fleet relationship before
+  // the explicit fleet-membership gate can release the Fleet portal.
+  fleet: "/dashboard/owner/fleet-access",
+};
+
+export function acquisitionHomeHref(
+  surface: ProductAcquisitionSurface,
+): string {
+  return ACQUISITION_HOME[surface];
+}
+
+export function acquisitionOnboardingHref(
+  surface: ProductAcquisitionSurface,
+): string {
+  return `/onboarding?surface=${encodeURIComponent(surface)}`;
+}

--- a/features/auth/lib/postAuthRouting.ts
+++ b/features/auth/lib/postAuthRouting.ts
@@ -15,20 +15,22 @@ export const PASSTHROUGH_KEYS = [
   "activationContext",
 ] as const;
 
-
 export async function resolvePostAuthDestination(args: {
   supabase: SupabaseClient<Database>;
   searchParams: URLSearchParams | ReadonlyURLSearchParams;
   isMobileMode?: boolean;
   defaultDashboardHref?: string;
+  unassignedAccountHref?: string;
 }): Promise<string> {
   const {
     supabase,
     searchParams,
     isMobileMode = false,
     defaultDashboardHref = "/dashboard",
+    unassignedAccountHref,
   } = args;
-  const activationContext = parseActivationContextFromSearchParams(searchParams);
+  const activationContext =
+    parseActivationContextFromSearchParams(searchParams);
 
   const {
     data: { user },
@@ -44,6 +46,10 @@ export async function resolvePostAuthDestination(args: {
 
   if (profile?.must_change_password) {
     return "/auth/set-password";
+  }
+
+  if (profile && !profile.shop_id && !profile.role && unassignedAccountHref) {
+    return unassignedAccountHref;
   }
 
   if (isMobileMode) return "/mobile";

--- a/features/shared/components/ProductMarketingPage.tsx
+++ b/features/shared/components/ProductMarketingPage.tsx
@@ -125,7 +125,7 @@ export default function ProductMarketingPage({
                   className="inline-flex items-center gap-2 rounded-xl px-5 py-3.5 text-sm font-bold text-[#07111f] shadow-[0_16px_40px_rgba(0,0,0,0.3)] transition hover:-translate-y-0.5"
                   style={{ backgroundColor: accent }}
                 >
-                  Start 14-day free trial <ArrowRight size={16} />
+                  Start 7-day free trial <ArrowRight size={16} />
                 </Link>
                 <Link
                   href={config.signInHref}

--- a/features/shared/components/ui/Footer.tsx
+++ b/features/shared/components/ui/Footer.tsx
@@ -39,7 +39,7 @@ export default function Footer({ className }: { className?: string }) {
             </Link>
             <h2 className="mt-8 text-3xl font-semibold leading-tight tracking-[-0.04em] sm:text-4xl">See how ProFixIQ fits your shop.</h2>
             <p className="mt-4 max-w-lg text-base leading-7 text-slate-400">Bring inspections, repair building, approvals, parts, workforce operations, invoicing, and portals into one connected system.</p>
-            <Link href="/compare-plans" className="mt-7 inline-flex items-center gap-2 rounded-xl bg-[color:var(--marketing-copper)] px-5 py-3 text-sm font-bold text-white transition hover:bg-[color:var(--marketing-copper-dark)]">Start 14-day free trial <ArrowRight size={15} /></Link>
+            <Link href="/compare-plans" className="mt-7 inline-flex items-center gap-2 rounded-xl bg-[color:var(--marketing-copper)] px-5 py-3 text-sm font-bold text-white transition hover:bg-[color:var(--marketing-copper-dark)]">Start 7-day free trial <ArrowRight size={15} /></Link>
           </div>
 
           {groups.map((group) => (

--- a/features/shared/components/ui/LandingHero.tsx
+++ b/features/shared/components/ui/LandingHero.tsx
@@ -60,7 +60,7 @@ export default function LandingHero() {
               href="/compare-plans"
               className="inline-flex items-center justify-center gap-2 rounded-xl bg-[color:var(--marketing-copper)] px-5 py-3.5 text-sm font-bold text-white shadow-[0_12px_30px_rgba(23,71,255,0.24)] transition hover:-translate-y-0.5 hover:bg-[color:var(--marketing-copper-dark)]"
             >
-              Start 14-day free trial
+              Start 7-day free trial
               <ArrowRight size={16} />
             </Link>
             <Link

--- a/features/shared/components/ui/PricingSection.tsx
+++ b/features/shared/components/ui/PricingSection.tsx
@@ -175,7 +175,7 @@ export default function PricingSection({
                   plan.featured ? styles.primaryButton : styles.secondaryButton
                 } mt-6 rounded-xl border px-4 py-3 text-sm font-bold transition`}
               >
-                {isBusy ? "Starting…" : "Start 14-day free trial"}
+                {isBusy ? "Starting…" : "Start 7-day free trial"}
               </button>
 
               <div className={`${styles.divider} my-6 h-px`} />

--- a/features/stripe/api/stripe/checkout/acquisition-context/route.ts
+++ b/features/stripe/api/stripe/checkout/acquisition-context/route.ts
@@ -80,7 +80,7 @@ export async function handleStripeAcquisitionContext(req: Request) {
       );
     }
 
-    return noStoreJson({ email: checkoutEmail });
+    return noStoreJson({ email: checkoutEmail, surface: metadata.surface });
   } catch (error) {
     console.error("stripe_acquisition_context_failed", {
       name: error instanceof Error ? error.name : "UnknownError",

--- a/features/stripe/api/stripe/checkout/link-user/route.ts
+++ b/features/stripe/api/stripe/checkout/link-user/route.ts
@@ -129,12 +129,25 @@ export async function handleStripeCheckoutLinkUser(req: Request) {
       );
     }
 
-    if (user.app_metadata?.profixiq_portal_only === true) {
+    const shouldUpgradePortalIdentity =
+      user.app_metadata?.profixiq_portal_only === true;
+    const shouldPersistAcquisitionSurface =
+      user.app_metadata?.profixiq_acquisition_surface !== metadata.surface ||
+      (metadata.packageKey &&
+        user.app_metadata?.profixiq_acquisition_package !==
+          metadata.packageKey);
+    if (shouldUpgradePortalIdentity || shouldPersistAcquisitionSurface) {
       const { error: identityUpgradeError } =
         await admin.auth.admin.updateUserById(user.id, {
           app_metadata: {
             ...user.app_metadata,
-            profixiq_portal_only: false,
+            ...(shouldUpgradePortalIdentity
+              ? { profixiq_portal_only: false }
+              : {}),
+            profixiq_acquisition_surface: metadata.surface,
+            ...(metadata.packageKey
+              ? { profixiq_acquisition_package: metadata.packageKey }
+              : {}),
           },
         });
       if (identityUpgradeError) {
@@ -179,6 +192,7 @@ export async function handleStripeCheckoutLinkUser(req: Request) {
 
     return noStoreJson({
       success: true,
+      surface: metadata.surface,
       shopLinked: Boolean(claim.shopId),
       repeated: claim.repeated,
     });

--- a/features/stripe/lib/client/claim-acquisition.ts
+++ b/features/stripe/lib/client/claim-acquisition.ts
@@ -1,22 +1,31 @@
+import {
+  normalizeProductAcquisitionSurface,
+  type ProductAcquisitionSurface,
+} from "@/features/stripe/lib/stripe/product-packages";
+
 type SearchParamsReader = {
   get(name: string): string | null;
 };
 
 export type StripeAcquisitionClaimResult =
-  | { required: false; linked: true }
-  | { required: true; linked: true }
-  | { required: true; linked: false };
+  | { required: false; linked: true; surface: null }
+  | {
+      required: true;
+      linked: true;
+      surface: ProductAcquisitionSurface;
+    }
+  | { required: true; linked: false; surface: null };
 
 export async function claimStripeAcquisitionAfterAuth(
   searchParams: SearchParamsReader,
 ): Promise<StripeAcquisitionClaimResult> {
   if (searchParams.get("flow")?.trim() !== "acquisition") {
-    return { required: false, linked: true };
+    return { required: false, linked: true, surface: null };
   }
 
   const sessionId = searchParams.get("session_id")?.trim() ?? "";
   if (!/^cs_[A-Za-z0-9_]+$/.test(sessionId)) {
-    return { required: true, linked: false };
+    return { required: true, linked: false, surface: null };
   }
 
   try {
@@ -27,8 +36,14 @@ export async function claimStripeAcquisitionAfterAuth(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ sessionId }),
     });
-    return { required: true, linked: response.ok };
+    const body = (await response.json().catch(() => null)) as {
+      surface?: unknown;
+    } | null;
+    const surface = normalizeProductAcquisitionSurface(body?.surface);
+    return response.ok && surface
+      ? { required: true, linked: true, surface }
+      : { required: true, linked: false, surface: null };
   } catch {
-    return { required: true, linked: false };
+    return { required: true, linked: false, surface: null };
   }
 }

--- a/features/stripe/lib/server/stripe-acquisition-intent.ts
+++ b/features/stripe/lib/server/stripe-acquisition-intent.ts
@@ -4,6 +4,13 @@ import Stripe from "stripe";
 
 import type { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import type { PlanKey } from "@/features/stripe/lib/stripe/constants";
+import {
+  normalizeProductAcquisitionSurface,
+  normalizeProductPackageKey,
+  productAcquisitionSurface,
+  type ProductAcquisitionSurface,
+  type ProductPackageKey,
+} from "@/features/stripe/lib/stripe/product-packages";
 
 type AdminClient = ReturnType<typeof createAdminSupabase>;
 
@@ -13,7 +20,9 @@ export type StripeAcquisitionMetadata = {
   intentId: string;
   nonce: string;
   planKey: PlanKey;
+  packageKey: ProductPackageKey | null;
   priceId: string;
+  surface: ProductAcquisitionSurface;
 };
 
 type BeginIntentRow = {
@@ -66,7 +75,23 @@ export function readStripeAcquisitionMetadata(
   const intentId = String(metadata?.acquisition_intent_id ?? "").trim();
   const nonce = String(metadata?.acquisition_nonce ?? "").trim();
   const planKey = String(metadata?.plan_key ?? "").trim();
+  const packageKeyRaw = String(metadata?.package_key ?? "").trim();
   const priceId = String(metadata?.price_id ?? "").trim();
+  const surfaceRaw = String(metadata?.acquisition_surface ?? "").trim();
+  const packageKey = normalizeProductPackageKey(packageKeyRaw);
+  const explicitSurface = normalizeProductAcquisitionSurface(surfaceRaw);
+
+  if ((packageKeyRaw && !packageKey) || (surfaceRaw && !explicitSurface)) {
+    return null;
+  }
+
+  // Legacy plan-based sessions did not carry package identity and belong to
+  // Shop. Package sessions derive their surface from the server-owned package
+  // contract; an explicit Stripe value must agree with that derivation.
+  const derivedSurface = packageKey
+    ? productAcquisitionSurface(packageKey)
+    : "shop";
+  if (explicitSurface && explicitSurface !== derivedSurface) return null;
 
   if (
     purpose !== STRIPE_ACQUISITION_PURPOSE ||
@@ -78,7 +103,14 @@ export function readStripeAcquisitionMetadata(
     return null;
   }
 
-  return { intentId, nonce, planKey, priceId };
+  return {
+    intentId,
+    nonce,
+    planKey,
+    packageKey,
+    priceId,
+    surface: explicitSurface ?? derivedSurface,
+  };
 }
 
 export function isCompletedStripeAcquisitionSession(

--- a/features/stripe/lib/stripe/product-packages.ts
+++ b/features/stripe/lib/stripe/product-packages.ts
@@ -9,6 +9,19 @@ export const PRODUCT_PACKAGE_KEYS = [
 
 export type ProductPackageKey = (typeof PRODUCT_PACKAGE_KEYS)[number];
 export type ProductCapability = "shop" | "field_service" | "fleet_maintenance";
+export type ProductAcquisitionSurface = "shop" | "field" | "fleet";
+
+export const PRODUCT_PACKAGE_ACQUISITION_SURFACE: Record<
+  ProductPackageKey,
+  ProductAcquisitionSurface
+> = {
+  shop_operations: "shop",
+  field_service: "field",
+  fleet_maintenance: "fleet",
+  // Complete Operations starts with the Shop owner workspace, which owns the
+  // shared location and unlocks the Field and Fleet capabilities afterward.
+  complete_operations: "shop",
+};
 
 export const PRODUCT_PACKAGE_LOOKUP_KEYS: Record<ProductPackageKey, string> = {
   shop_operations: "profixiq_shop_operations_monthly_v1",
@@ -109,6 +122,25 @@ export function normalizeProductPackageKey(
     .trim()
     .toLowerCase();
   return isProductPackageKey(normalized) ? normalized : null;
+}
+
+export function normalizeProductAcquisitionSurface(
+  value: unknown,
+): ProductAcquisitionSurface | null {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return normalized === "shop" ||
+    normalized === "field" ||
+    normalized === "fleet"
+    ? normalized
+    : null;
+}
+
+export function productAcquisitionSurface(
+  packageKey: ProductPackageKey,
+): ProductAcquisitionSurface {
+  return PRODUCT_PACKAGE_ACQUISITION_SURFACE[packageKey];
 }
 
 export function productPackageAllows(

--- a/tests/acquisition-auth-handoff.test.ts
+++ b/tests/acquisition-auth-handoff.test.ts
@@ -55,6 +55,11 @@ describe("acquisition auth handoff", () => {
       expect(forgotPassword).toContain(`"${key}"`);
     }
 
+    expect(signIn).toContain(
+      'params.set("surface", acquisitionSurface ?? "shop")',
+    );
+    expect(forgotPassword).toContain('"surface"');
+
     expect(signIn).toContain("forgotPasswordHref");
     expect(signIn).toContain("href={forgotPasswordHref}");
     expect(forgotPassword).toContain('sp.get("email")');
@@ -74,10 +79,12 @@ describe("acquisition auth handoff", () => {
       "/api/stripe/checkout/acquisition-context?session_id=",
     );
     expect(signIn).toContain("setIdentifier(email)");
+    expect(signIn).toContain("setAcquisitionSurface(surface)");
     expect(signIn).toContain('acquisitionContextStatus === "ready"');
     expect(contextRoute).toContain("readStripeAcquisitionMetadata");
     expect(contextRoute).toContain("isCompletedStripeAcquisitionSession");
     expect(contextRoute).toContain("isStripeSubscriptionAccessBearing");
+    expect(contextRoute).toContain("surface: metadata.surface");
     expect(contextRoute).toContain('"Cache-Control": "no-store"');
   });
 
@@ -89,6 +96,40 @@ describe("acquisition auth handoff", () => {
     expect(signIn).toContain('type: "signup"');
     expect(signIn).toContain("options: { emailRedirectTo }");
     expect(signIn).toContain("Resend verification email");
+    expect(signIn).toContain("isAwaitingConfirmation");
+    expect(signIn).toContain("Verify your email");
+  });
+
+  it("routes a checkout and confirmed account using the verified product surface", () => {
+    const checkout = read("app/api/stripe/checkout/route.ts");
+    const callback = read("app/auth/callback/page.tsx");
+    const onboarding = read("app/onboarding/page.tsx");
+    const onboardingForm = read("app/onboarding/OwnerOnboardingForm.tsx");
+    const linkUser = read(
+      "features/stripe/api/stripe/checkout/link-user/route.ts",
+    );
+
+    expect(checkout).toContain(
+      "acquisition_surface: input.selection.acquisitionSurface",
+    );
+    expect(checkout).toContain("surface=${selection.acquisitionSurface}");
+    expect(callback).toContain("resolveAcquisitionSignupHref(passthrough)");
+    expect(callback).toContain("acquisitionHomeHref(claim.surface)");
+    expect(callback).toContain("acquisitionOnboardingHref(claim.surface)");
+    expect(linkUser).toContain("surface: metadata.surface");
+    expect(linkUser).toContain("profixiq_acquisition_surface");
+    expect(onboarding).toContain(
+      "user.app_metadata?.profixiq_acquisition_surface",
+    );
+    expect(onboarding).toContain(
+      "<OwnerOnboardingForm acquisitionSurface={acquisitionSurface} />",
+    );
+    expect(onboardingForm).toContain("field: {");
+    expect(onboardingForm).toContain("fleet: {");
+    expect(onboardingForm).toContain('destination: "/mobile/service/setup"');
+    expect(onboardingForm).toContain(
+      'destination: "/dashboard/owner/fleet-access"',
+    );
   });
 
   it("claims a completed acquisition before leaving password recovery", () => {
@@ -97,9 +138,8 @@ describe("acquisition auth handoff", () => {
     expect(setPassword).toContain("claimStripeAcquisitionAfterAuth");
     expect(setPassword).toContain("if (!claim.linked)");
     expect(setPassword).toContain("resolvePostAuthDestination");
-    expect(setPassword).toContain(
-      'defaultDashboardHref: claim.required ? "/onboarding" : getReturnPath(role)',
-    );
+    expect(setPassword).toContain("acquisitionHomeHref(claim.surface)");
+    expect(setPassword).toContain("acquisitionOnboardingHref(claim.surface)");
     expect(setPassword).toContain("window.location.replace(redirect)");
   });
 });

--- a/tests/owner-onboarding-bootstrap.test.ts
+++ b/tests/owner-onboarding-bootstrap.test.ts
@@ -165,7 +165,9 @@ describe("owner onboarding bootstrap", () => {
     const page = readFileSync("app/onboarding/page.tsx", "utf8");
     const form = readFileSync("app/onboarding/OwnerOnboardingForm.tsx", "utf8");
 
-    expect(page).toContain("<OwnerOnboardingForm />");
+    expect(page).toContain(
+      "<OwnerOnboardingForm acquisitionSurface={acquisitionSurface} />",
+    );
     expect(page).toContain("if (profile?.completed_onboarding)");
     expect(page).not.toContain(
       "profile?.shop_id || profile?.completed_onboarding",

--- a/tests/p0-006-stripe-identity.test.ts
+++ b/tests/p0-006-stripe-identity.test.ts
@@ -91,6 +91,10 @@ describe("P0-006 Stripe identity boundary", () => {
     );
     expect(checkout).not.toContain("STRIPE_PRICE_BASE_MONTHLY");
     expect(checkout).toContain("configuredTrialDays()");
+    expect(checkout).toContain(
+      'process.env.STRIPE_TRIAL_DAYS ?? "7"',
+    );
+    expect(checkout).toMatch(/\? parsed : 7;/);
     expect(checkout).toContain("allow_promotion_codes: true");
     expect(checkout).not.toContain("STRIPE_FOUNDING_COUPON_ID");
     expect(discountMigration).toContain(

--- a/tests/p0-006-stripe-identity.test.ts
+++ b/tests/p0-006-stripe-identity.test.ts
@@ -17,16 +17,23 @@ describe("P0-006 Stripe identity boundary", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      claimStripeAcquisitionAfterAuth(new URLSearchParams("flow=owner&session_id=cs_valid")),
-    ).resolves.toEqual({ required: false, linked: true });
+      claimStripeAcquisitionAfterAuth(
+        new URLSearchParams("flow=owner&session_id=cs_valid"),
+      ),
+    ).resolves.toEqual({ required: false, linked: true, surface: null });
     await expect(
-      claimStripeAcquisitionAfterAuth(new URLSearchParams("flow=acquisition&session_id=invalid")),
-    ).resolves.toEqual({ required: true, linked: false });
+      claimStripeAcquisitionAfterAuth(
+        new URLSearchParams("flow=acquisition&session_id=invalid"),
+      ),
+    ).resolves.toEqual({ required: true, linked: false, surface: null });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("submits only the server-verifiable Checkout Session identifier", async () => {
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ success: true })));
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ success: true, surface: "field" })),
+    );
     vi.stubGlobal("fetch", fetchMock);
     const sessionId = "cs_test_identity_006";
 
@@ -34,7 +41,7 @@ describe("P0-006 Stripe identity boundary", () => {
       claimStripeAcquisitionAfterAuth(
         new URLSearchParams(`flow=acquisition&session_id=${sessionId}`),
       ),
-    ).resolves.toEqual({ required: true, linked: true });
+    ).resolves.toEqual({ required: true, linked: true, surface: "field" });
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/stripe/checkout/link-user",
@@ -47,9 +54,29 @@ describe("P0-006 Stripe identity boundary", () => {
     );
   });
 
+  it("requires the linking route to return a verified product surface", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ success: true }), { status: 200 }),
+      ),
+    );
+
+    await expect(
+      claimStripeAcquisitionAfterAuth(
+        new URLSearchParams(
+          "flow=acquisition&session_id=cs_test_missing_surface",
+        ),
+      ),
+    ).resolves.toEqual({ required: true, linked: false, surface: null });
+  });
+
   it("keeps price, trial, governed discounts, redirects, and Stripe retries server-owned", async () => {
     const checkout = await source("app/api/stripe/checkout/route.ts");
-    const landing = await source("features/shared/components/ProFixIQLanding.tsx");
+    const landing = await source(
+      "features/shared/components/ProFixIQLanding.tsx",
+    );
     const comparison = await source("app/compare-plans/page.tsx");
     const discountMigration = await source(
       "supabase/migrations/20260802170000_stripe_billing_model_connect_correction.sql",
@@ -70,7 +97,9 @@ describe("P0-006 Stripe identity boundary", () => {
       "create table if not exists public.billing_discount_grants",
     );
     expect(checkout).toContain("profixiq:acquisition:${intent.id}");
-    expect(checkout).toContain("profixiq:shop-checkout:${shop.id}:${attemptId}");
+    expect(checkout).toContain(
+      "profixiq:shop-checkout:${shop.id}:${attemptId}",
+    );
     expect(landing).not.toContain("enableTrial:");
     expect(landing).not.toContain("applyFoundingDiscount:");
     expect(comparison).not.toContain("cancelPath:");
@@ -78,14 +107,20 @@ describe("P0-006 Stripe identity boundary", () => {
   });
 
   it("requires verified acquisition artifacts before the atomic claim", async () => {
-    const linking = await source("features/stripe/api/stripe/checkout/link-user/route.ts");
+    const linking = await source(
+      "features/stripe/api/stripe/checkout/link-user/route.ts",
+    );
 
     expect(linking).toContain("isCompletedStripeAcquisitionSession(session)");
     expect(linking).toContain("getStripeCheckoutPriceId(stripe, session.id)");
     expect(linking).toContain("getStripeCheckoutEmail(stripe, session)");
     expect(linking).toContain("claimStripeAcquisitionIntent({");
-    expect(linking).toContain("idempotencyKey: `profixiq:acquisition-customer-link:");
-    expect(linking).toContain("idempotencyKey: `profixiq:acquisition-subscription-link:");
+    expect(linking).toContain(
+      "idempotencyKey: `profixiq:acquisition-customer-link:",
+    );
+    expect(linking).toContain(
+      "idempotencyKey: `profixiq:acquisition-subscription-link:",
+    );
   });
 
   it("reconciles canonical payment amounts before the application contract", async () => {
@@ -96,7 +131,9 @@ describe("P0-006 Stripe identity boundary", () => {
     const correction = await source(correctionPath);
 
     expect(correctionPath.localeCompare(applicationPath)).toBeLessThan(0);
-    expect(correction).toContain("ADD COLUMN IF NOT EXISTS amount numeric(14,2)");
+    expect(correction).toContain(
+      "ADD COLUMN IF NOT EXISTS amount numeric(14,2)",
+    );
     expect(correction).toContain("amount_cents::numeric / 100");
     expect(correction).toContain("ALTER COLUMN amount SET NOT NULL");
     expect(correction).toContain("cannot infer payments.amount");
@@ -105,9 +142,13 @@ describe("P0-006 Stripe identity boundary", () => {
   it("does not expose acquisition email by bearer Checkout Session ID", async () => {
     const sessionRoute = await source("app/api/stripe/session/route.ts");
     const accessIndex = sessionRoute.indexOf("requireShopScopedApiAccess({");
-    const retrieveIndex = sessionRoute.indexOf("checkout.sessions.retrieve(sessionId)");
+    const retrieveIndex = sessionRoute.indexOf(
+      "checkout.sessions.retrieve(sessionId)",
+    );
 
-    expect(sessionRoute).not.toContain('metadataPurpose === "profixiq_acquisition"');
+    expect(sessionRoute).not.toContain(
+      'metadataPurpose === "profixiq_acquisition"',
+    );
     expect(accessIndex).toBeGreaterThan(-1);
     expect(retrieveIndex).toBeGreaterThan(accessIndex);
     expect(sessionRoute).not.toContain("details: message");

--- a/tests/pricing-section-theme-contract.test.tsx
+++ b/tests/pricing-section-theme-contract.test.tsx
@@ -84,7 +84,7 @@ describe("PricingSection theme contract", () => {
       screen.getByRole("region", { name: "Pricing plans" }),
     ).toHaveAttribute("data-surface", "light");
     expect(
-      screen.getAllByRole("button", { name: "Start 14-day free trial" }),
+      screen.getAllByRole("button", { name: "Start 7-day free trial" }),
     ).toHaveLength(4);
   });
 

--- a/tests/product-package-billing-contract.test.ts
+++ b/tests/product-package-billing-contract.test.ts
@@ -9,6 +9,7 @@ import {
   PRODUCT_PACKAGE_KEYS,
   PRODUCT_PACKAGE_LOOKUP_KEYS,
   PRODUCT_PACKAGE_PRICING,
+  productAcquisitionSurface,
   productPackageAllows,
 } from "../features/stripe/lib/stripe/product-packages";
 import { resolveProductPackagePriceContract } from "../features/stripe/lib/server/product-package-price-contract";
@@ -101,6 +102,13 @@ describe("ProFixIQ product package billing contract", () => {
     ).toBe(true);
   });
 
+  it("maps every package to its canonical account acquisition surface", () => {
+    expect(productAcquisitionSurface("shop_operations")).toBe("shop");
+    expect(productAcquisitionSurface("field_service")).toBe("field");
+    expect(productAcquisitionSurface("fleet_maintenance")).toBe("fleet");
+    expect(productAcquisitionSurface("complete_operations")).toBe("shop");
+  });
+
   it("resolves every live package and capacity price by lookup key", async () => {
     const prices = [
       ...PRODUCT_PACKAGE_KEYS.map((packageKey) =>
@@ -160,14 +168,18 @@ describe("ProFixIQ product package billing contract", () => {
   it("binds Checkout and database gates to package identity", async () => {
     const [checkout, migration, scopeMigration, reconciler, worker] =
       await Promise.all([
-      readFile(CHECKOUT, "utf8"),
-      readFile(MIGRATION, "utf8"),
-      readFile(ENTITLEMENT_SCOPE_MIGRATION, "utf8"),
-      readFile(RECONCILER, "utf8"),
-      readFile(WORKER, "utf8"),
+        readFile(CHECKOUT, "utf8"),
+        readFile(MIGRATION, "utf8"),
+        readFile(ENTITLEMENT_SCOPE_MIGRATION, "utf8"),
+        readFile(RECONCILER, "utf8"),
+        readFile(WORKER, "utf8"),
       ]);
     expect(checkout).toContain("packageKey: z.enum(PRODUCT_PACKAGE_KEYS)");
     expect(checkout).toContain("package_key: selection.packageKey");
+    expect(checkout).toContain(
+      "acquisition_surface: input.selection.acquisitionSurface",
+    );
+    expect(checkout).toContain("surface=${selection.acquisitionSurface}");
     expect(checkout).not.toContain("payment_method_types");
     expect(checkout).toContain("payment_method_collection");
     expect(checkout).toContain('"if_required"');

--- a/tests/stripe-acquisition-surface.test.ts
+++ b/tests/stripe-acquisition-surface.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { readStripeAcquisitionMetadata } from "../features/stripe/lib/server/stripe-acquisition-intent";
+
+const BASE_METADATA = {
+  purpose: "profixiq_acquisition",
+  acquisition_intent_id: "11111111-1111-4111-8111-111111111111",
+  acquisition_nonce: "a".repeat(64),
+  plan_key: "starter",
+  price_id: "price_surface123",
+};
+
+describe("Stripe acquisition product surface", () => {
+  it.each([
+    ["shop_operations", "shop"],
+    ["field_service", "field"],
+    ["fleet_maintenance", "fleet"],
+    ["complete_operations", "shop"],
+  ] as const)(
+    "derives %s account setup from server-owned package metadata",
+    (packageKey, surface) => {
+      expect(
+        readStripeAcquisitionMetadata({
+          ...BASE_METADATA,
+          package_key: packageKey,
+        }),
+      ).toMatchObject({ packageKey, surface });
+    },
+  );
+
+  it("accepts an explicit surface only when it matches the package", () => {
+    expect(
+      readStripeAcquisitionMetadata({
+        ...BASE_METADATA,
+        package_key: "field_service",
+        acquisition_surface: "field",
+      }),
+    ).toMatchObject({ packageKey: "field_service", surface: "field" });
+
+    expect(
+      readStripeAcquisitionMetadata({
+        ...BASE_METADATA,
+        package_key: "field_service",
+        acquisition_surface: "shop",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps legacy plan-only trial sessions on the Shop path", () => {
+    expect(readStripeAcquisitionMetadata(BASE_METADATA)).toMatchObject({
+      packageKey: null,
+      surface: "shop",
+    });
+  });
+
+  it("fails closed on unknown package identity", () => {
+    expect(
+      readStripeAcquisitionMetadata({
+        ...BASE_METADATA,
+        package_key: "unknown_product",
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

- carry a server-owned Shop, Field, or Fleet acquisition surface from Stripe Checkout metadata through account setup
- keep completed self-serve trials on the shared owner signup path while preserving the verified product branch
- return the verified surface from acquisition context and claim endpoints, and persist it in Supabase app metadata
- replace the ambiguous post-signup form state with a dedicated **Verify your email** screen and resend/sign-in recovery actions
- continue confirmed users into product-specific onboarding: Shop setup, Field Service setup, or Fleet relationship setup
- preserve compatibility for existing package sessions and legacy plan-only Shop sessions
- shorten the server-owned free-trial default and invalid-configuration fallback from 14 days to 7 days
- update all acquisition, marketing, authentication, and deployment copy to the 7-day contract
- add focused routing, billing-contract, identity, acquisition metadata, onboarding, and trial-duration regressions

## Root cause

The signup component hardcoded `surface=shop` into confirmation and password-recovery URLs. Checkout metadata and success URLs also did not carry a canonical product surface. When the confirmation callback did not yet have a session, it routed the acquisition into product-specific sign-in pages; Field and Fleet sign-in are existing-account/invitation surfaces, not owner account creation. Finally, an unconfirmed signup stayed on the same form, which made successful account creation look like a redirect back to Create account.

The acquisition UI and server fallback also encoded a 14-day commercial contract in separate places. The coordinated update keeps Stripe Checkout, customer-facing copy, deployment documentation, and regression expectations aligned at 7 days.

## User impact

A 7-day trial remains attached to the package selected at checkout:

- Shop Operations → Shop
- Field Service → Field
- Fleet Maintenance → Fleet
- Complete Operations → Shop as the primary shared owner workspace

The product branch is derived from validated Stripe metadata rather than trusting a writable query string. Existing subscriptions keep their already-established Stripe trial end; the 7-day setting applies to newly created eligible Checkout subscriptions after deployment and environment coordination.

## Validation

GitHub Actions passed on `8f6fbc34`:

- Agent PR Checks: full-app inventory, TypeScript, changed-file ESLint, complete Vitest suite, and production Next.js build
- P0-006 Stripe Identity Validation
- Universal Scheduler Validation
- Mobile Dispatch Validation

Additional focused local validation passed:

- trial/Stripe/UI suite: 2 files, 12 tests
- API-route boundary audit
- regression inventory with 0 new errors

## Database and deployment

No migration and no production database write are included.

Deployment must coordinate the server-only production environment setting `STRIPE_TRIAL_DAYS=7`; otherwise an existing explicit environment override can continue to take precedence over the new code fallback.