### PR TITLE
Use shared modal shell for customer creation

### DIFF
--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -24,6 +24,7 @@ import {
 import { ImportedHistoryRecordCard } from "@/features/work-orders/components/ImportedHistoryRecordCard";
 import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
+import ModalShell from "@/features/shared/components/ModalShell";
 
 type DB = Database;
 
@@ -1911,33 +1912,17 @@ export default function CustomerProfilePage(): JSX.Element {
           </div>
         </div>
 
-        <Modal
+        <ModalShell
           title="Create customer"
-          open={createCustomerOpen}
+          isOpen={createCustomerOpen}
           onClose={() => {
             if (creatingCustomer) return;
             setCreateCustomerOpen(false);
           }}
-          footer={
-            <>
-              <button
-                type="button"
-                onClick={() => setCreateCustomerOpen(false)}
-                disabled={creatingCustomer}
-                className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-inset)] disabled:opacity-60"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => void createCustomer(false)}
-                disabled={creatingCustomer}
-                className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-on-accent)] shadow-[0_0_22px_rgba(212,118,49,0.75)] hover:brightness-110 disabled:opacity-60"
-              >
-                {creatingCustomer ? "Creating…" : "Create customer"}
-              </button>
-            </>
-          }
+          onSubmit={() => createCustomer(false)}
+          submitText={creatingCustomer ? "Creating…" : "Create customer"}
+          size="lg"
+          busy={creatingCustomer}
         >
           <div className="space-y-4">
             <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
@@ -2160,7 +2145,7 @@ export default function CustomerProfilePage(): JSX.Element {
               />
             </label>
           </div>
-        </Modal>
+        </ModalShell>
       </div>
     );
   }

--- a/features/shared/components/ModalShell.tsx
+++ b/features/shared/components/ModalShell.tsx
@@ -16,6 +16,7 @@ type ModalShellProps = {
   size?: "sm" | "md" | "lg" | "xl";
   hideFooter?: boolean;
   bodyScrollable?: boolean;
+  busy?: boolean;
 };
 
 const widthMap: Record<NonNullable<ModalShellProps["size"]>, string> = {
@@ -36,13 +37,17 @@ export default function ModalShell({
   size = "md",
   hideFooter = false,
   bodyScrollable = true,
+  busy = false,
 }: ModalShellProps) {
   const width = widthMap[size];
+  const handleClose = () => {
+    if (!busy) onClose();
+  };
 
   return (
     <Dialog
       open={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
       className="fixed inset-0 z-[500] flex items-center justify-center px-3 py-6 sm:px-4"
     >
       <div
@@ -51,7 +56,10 @@ export default function ModalShell({
       />
 
       <div className={`relative z-[510] w-full ${width}`}>
-        <Dialog.Panel className="relative w-full overflow-hidden rounded-[26px] border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)]">
+        <Dialog.Panel
+          aria-busy={busy}
+          className="relative w-full overflow-hidden rounded-[26px] border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)]"
+        >
           <div className="absolute inset-x-0 top-0 z-20 h-[3px] bg-[linear-gradient(90deg,transparent,var(--brand-primary),var(--brand-accent),transparent)]" />
           <div className="pointer-events-none absolute inset-x-10 top-0 z-10 h-24 bg-[radial-gradient(circle_at_top,color-mix(in_srgb,var(--brand-primary)_18%,transparent),transparent_72%)]" />
 
@@ -73,8 +81,9 @@ export default function ModalShell({
 
             <button
               type="button"
-              onClick={onClose}
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[0.78rem] text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper-soft)] hover:bg-[color:var(--theme-surface-subtle)] hover:text-[color:var(--theme-text-primary)] active:scale-95"
+              onClick={handleClose}
+              disabled={busy}
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[0.78rem] text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper-soft)] hover:bg-[color:var(--theme-surface-subtle)] hover:text-[color:var(--theme-text-primary)] active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
               aria-label="Close"
               title="Close"
             >
@@ -101,7 +110,8 @@ export default function ModalShell({
                   type="button"
                   variant="ghost"
                   size="sm"
-                  onClick={onClose}
+                  onClick={handleClose}
+                  disabled={busy}
                 >
                   Cancel
                 </Button>
@@ -112,6 +122,7 @@ export default function ModalShell({
                     variant="copper"
                     size="sm"
                     onClick={() => void onSubmit()}
+                    disabled={busy}
                   >
                     {submitText}
                   </Button>

--- a/tests/customer-create-modal-shell.test.ts
+++ b/tests/customer-create-modal-shell.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const customerPage = readFileSync(
+  "features/customers/app/customers/[id]/page.tsx",
+  "utf8",
+);
+const modalShell = readFileSync(
+  "features/shared/components/ModalShell.tsx",
+  "utf8",
+);
+
+describe("customer creation modal shell", () => {
+  it("uses the canonical shared shell for customer creation", () => {
+    expect(customerPage).toContain(
+      'import ModalShell from "@/features/shared/components/ModalShell"',
+    );
+    expect(customerPage).toMatch(
+      /<ModalShell\s+title="Create customer"\s+isOpen={createCustomerOpen}/,
+    );
+    expect(customerPage).toContain(
+      'submitText={creatingCustomer ? "Creating…" : "Create customer"}',
+    );
+    expect(customerPage).toContain("busy={creatingCustomer}");
+    expect(customerPage).not.toMatch(
+      /<Modal\s+title="Create customer"\s+open={createCustomerOpen}/,
+    );
+  });
+
+  it("prevents dismissal and duplicate submission while the shell is busy", () => {
+    expect(modalShell).toContain("if (!busy) onClose()");
+    expect(modalShell).toContain("aria-busy={busy}");
+    expect(modalShell).toContain("disabled={busy}");
+  });
+});


### PR DESCRIPTION
## What changed

- replace the customer directory's page-local create modal framing with the canonical shared `ModalShell`
- preserve the existing create form, duplicate-customer review, and navigation behavior
- add a reusable busy state that prevents close, cancel, or duplicate submit actions while a modal request is running
- add focused regression coverage for the shared-shell contract

## Root cause

The customer directory rendered the create flow inside a one-off page-local `Modal`, so its header, backdrop, scrolling, and footer diverged from the canonical modal experience used elsewhere in ProFixIQ.

## User impact

Customer creation now has the same modal framing and interaction behavior as other core workflows. An in-progress create request cannot be dismissed or submitted again accidentally.

## Validation

- focused Vitest regressions: 2 files, 7 tests passed
- TypeScript typecheck passed
- ESLint passed for all changed TypeScript files
- `git diff --check` passed

## Database and deployment

No migration or environment change.