### PR TITLE
Fix work-order overlays and operational timeline

### DIFF
--- a/app/api/parts/picker/route.ts
+++ b/app/api/parts/picker/route.ts
@@ -3,6 +3,18 @@ import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
+const MENU_EDITOR_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "service",
+  "parts",
+  "mechanic",
+  "lead_hand",
+  "foreman",
+] as const;
+
 function cleanSearch(value: string | null): string {
   return (value ?? "")
     .replace(/[,%_().]/g, " ")
@@ -12,12 +24,15 @@ function cleanSearch(value: string | null): string {
 }
 
 export async function GET(request: Request) {
-  const access = await requireShopScopedApiAccess({
-    requiredCapability: "canManageParts",
-  });
+  const url = new URL(request.url);
+  const pickerContext = url.searchParams.get("context");
+  const access = await requireShopScopedApiAccess(
+    pickerContext === "menu-editor"
+      ? { allowRoles: MENU_EDITOR_ROLES }
+      : { requiredCapability: "canManageParts" },
+  );
   if (!access.ok) return access.response;
 
-  const url = new URL(request.url);
   const search = cleanSearch(url.searchParams.get("q"));
   const admin = createAdminSupabase();
 

--- a/app/api/parts/picker/route.ts
+++ b/app/api/parts/picker/route.ts
@@ -2,27 +2,6 @@ import { NextResponse } from "next/server";
 
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
-import type { Database } from "@shared/types/types/supabase";
-
-type DB = Database;
-type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
-type WorkOrderLineTechnician =
-  DB["public"]["Tables"]["work_order_line_technicians"]["Row"];
-
-const ALLOWED_ROLES = [
-  "owner",
-  "admin",
-  "manager",
-  "advisor",
-  "service",
-  "parts",
-  "mechanic",
-  "lead_hand",
-  "foreman",
-] as const;
-
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function cleanSearch(value: string | null): string {
   return (value ?? "")
@@ -32,66 +11,15 @@ function cleanSearch(value: string | null): string {
     .slice(0, 80);
 }
 
-async function mechanicCanUseLine(input: {
-  admin: ReturnType<typeof createAdminSupabase>;
-  lineId: string | null;
-  shopId: string;
-  technicianId: string;
-}): Promise<boolean> {
-  if (!input.lineId || !UUID_PATTERN.test(input.lineId)) return false;
-
-  const { data: line, error } = await input.admin
-    .from("work_order_lines")
-    .select("id,assigned_tech_id,assigned_to")
-    .eq("id", input.lineId)
-    .eq("shop_id", input.shopId)
-    .maybeSingle<
-      Pick<WorkOrderLine, "id" | "assigned_tech_id" | "assigned_to">
-    >();
-
-  if (error || !line) return false;
-  if (
-    line.assigned_tech_id === input.technicianId ||
-    line.assigned_to === input.technicianId
-  ) {
-    return true;
-  }
-
-  const { data: sharedAssignment, error: sharedError } = await input.admin
-    .from("work_order_line_technicians")
-    .select("id")
-    .eq("work_order_line_id", line.id)
-    .eq("technician_id", input.technicianId)
-    .maybeSingle<Pick<WorkOrderLineTechnician, "id">>();
-
-  return !sharedError && Boolean(sharedAssignment);
-}
-
 export async function GET(request: Request) {
   const access = await requireShopScopedApiAccess({
-    allowRoles: ALLOWED_ROLES,
+    requiredCapability: "canManageParts",
   });
   if (!access.ok) return access.response;
 
   const url = new URL(request.url);
-  const lineId = url.searchParams.get("workOrderLineId")?.trim() || null;
   const search = cleanSearch(url.searchParams.get("q"));
   const admin = createAdminSupabase();
-
-  if (
-    access.canonicalRole === "mechanic" &&
-    !(await mechanicCanUseLine({
-      admin,
-      lineId,
-      shopId: access.profile.shop_id,
-      technicianId: access.profile.id,
-    }))
-  ) {
-    return NextResponse.json(
-      { error: "This inventory picker is limited to your assigned jobs." },
-      { status: 403 },
-    );
-  }
 
   let partsQuery = admin
     .from("parts")

--- a/app/menu/item/[id]/page.tsx
+++ b/app/menu/item/[id]/page.tsx
@@ -761,6 +761,7 @@ export default function MenuItemDetailPage() {
       {pickerOpenForRow !== null && (
         <PartPicker
           open={true}
+          accessContext="menu-editor"
           onClose={() => setPickerOpenForRow(null)}
           onPick={(sel) => {
             const idx = pickerOpenForRow;

--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -1006,6 +1006,7 @@ export default function MenuItemsPage() {
       {pickerOpenForRow !== null ? (
         <PartPicker
           open
+          accessContext="menu-editor"
           onClose={() => setPickerOpenForRow(null)}
           onPick={(selection) => handlePickPart(pickerOpenForRow)(selection)}
         />

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -766,7 +766,6 @@ export default function WorkOrderIdClient(): JSX.Element {
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "Failed to load work order.";
         setViewError(msg);
-        // eslint-disable-next-line no-console
         console.error("[WO id page] load error:", e);
       } finally {
         setLoading(false);
@@ -1188,6 +1187,7 @@ export default function WorkOrderIdClient(): JSX.Element {
   const canAssign = currentActor.canAssignWork;
   const canApprove = currentActor.canAuthorizeQuotes;
   const canRequestParts = currentActor.canManageWorkOrders;
+  const canUseInventoryPicker = currentActor.canManageParts;
 
   const canDeleteLine = currentUserRole ? LINE_DELETE_ROLES.has(currentUserRole) : false;
 
@@ -2201,7 +2201,11 @@ export default function WorkOrderIdClient(): JSX.Element {
                             ? () => void openInspectionForLine(ln)
                             : undefined
                         }
-                        onAddPart={() => setPartsLineId(ln.id)}
+                        onAddPart={
+                          canUseInventoryPicker
+                            ? () => setPartsLineId(ln.id)
+                            : undefined
+                        }
                         onRequestParts={
                           hasRequestableParts
                             ? () => void requestAllPartsForLine(ln.id, linePartRequests)

--- a/features/operations/components/OperationalObservabilityWorkspace.tsx
+++ b/features/operations/components/OperationalObservabilityWorkspace.tsx
@@ -17,6 +17,10 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  formatOperationalEventType,
+  getOperationalEventPresentation,
+} from "@/features/operations/lib/eventPresentation";
 
 type PipelineStatus =
   | "healthy"
@@ -54,6 +58,7 @@ type EventItem = {
   severity: "info" | "warning" | "critical";
   domain: Domain;
   href: string | null;
+  metadata: unknown;
 };
 
 type FailureItem = {
@@ -183,19 +188,6 @@ function relativeTime(value: string | null): string {
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h ago`;
   return `${Math.floor(hours / 24)}d ago`;
-}
-
-function eventLabel(value: string): string {
-  return value
-    .split(".")
-    .map((part) => part.replaceAll("_", " "))
-    .join(" · ")
-    .replace(/\b\w/g, (letter) => letter.toUpperCase());
-}
-
-function entityLabel(event: EventItem): string {
-  const id = event.entity_id?.slice(0, 8);
-  return id ? `${event.entity_type.replaceAll("_", " ")} ${id}` : event.entity_type;
 }
 
 function severityClass(severity: EventItem["severity"]): string {
@@ -501,44 +493,46 @@ export default function OperationalObservabilityWorkspace({
 
             <div className="divide-y divide-[color:var(--theme-border-soft)] overflow-hidden rounded-xl border border-[color:var(--theme-border-soft)]">
               {filteredEvents.length ? (
-                filteredEvents.map((event) => (
-                  <div
-                    key={event.id}
-                    className="grid gap-2 bg-[color:var(--theme-surface-subtle)] p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
-                  >
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <span
-                          className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${severityClass(event.severity)}`}
-                        >
-                          {event.severity}
-                        </span>
-                        <span className="text-xs font-medium text-[color:var(--theme-text-muted)]">
-                          {DOMAIN_LABELS[event.domain]}
-                        </span>
-                        <span className="text-xs text-[color:var(--theme-text-muted)]">
-                          {relativeTime(event.occurred_at)}
-                        </span>
+                filteredEvents.map((event) => {
+                  const presentation = getOperationalEventPresentation(event);
+                  return (
+                    <div
+                      key={event.id}
+                      className="grid gap-2 bg-[color:var(--theme-surface-subtle)] p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span
+                            className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${severityClass(event.severity)}`}
+                          >
+                            {event.severity}
+                          </span>
+                          <span className="text-xs font-medium text-[color:var(--theme-text-muted)]">
+                            {DOMAIN_LABELS[event.domain]}
+                          </span>
+                          <span className="text-xs text-[color:var(--theme-text-muted)]">
+                            {relativeTime(event.occurred_at)}
+                          </span>
+                        </div>
+                        <h3 className="mt-1 truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                          {presentation.title}
+                        </h3>
+                        <p className="mt-0.5 truncate text-xs text-[color:var(--theme-text-secondary)]">
+                          {presentation.detail}
+                          {event.source ? ` · ${event.source.replace("database_trigger:", "")}` : ""}
+                        </p>
                       </div>
-                      <h3 className="mt-1 truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                        {eventLabel(event.event_type)}
-                      </h3>
-                      <p className="mt-0.5 truncate text-xs text-[color:var(--theme-text-secondary)]">
-                        {entityLabel(event)}
-                        {event.actor_role ? ` · ${event.actor_role.replaceAll("_", " ")}` : ""}
-                        {event.source ? ` · ${event.source.replace("database_trigger:", "")}` : ""}
-                      </p>
+                      {event.href ? (
+                        <Link
+                          href={event.href}
+                          className="inline-flex min-h-9 items-center justify-center gap-1 rounded-lg border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-inset)]"
+                        >
+                          Open record <ArrowUpRight className="h-3.5 w-3.5" />
+                        </Link>
+                      ) : null}
                     </div>
-                    {event.href ? (
-                      <Link
-                        href={event.href}
-                        className="inline-flex min-h-9 items-center justify-center gap-1 rounded-lg border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-inset)]"
-                      >
-                        Open record <ArrowUpRight className="h-3.5 w-3.5" />
-                      </Link>
-                    ) : null}
-                  </div>
-                ))
+                  );
+                })
               ) : (
                 <div className="p-8 text-center text-sm text-[color:var(--theme-text-secondary)]">
                   No operational events match the current filters.
@@ -628,7 +622,11 @@ export default function OperationalObservabilityWorkspace({
           <Panel
             eyebrow="Event mix"
             title="Most active event types"
-            description="The highest-volume transitions in the loaded seven-day window."
+            description={
+              timelineFiltered
+                ? "The highest-volume transitions in this filtered timeline."
+                : "The highest-volume transitions in the loaded seven-day window."
+            }
           >
             <div className="space-y-2">
               {data.operational.eventTypes.slice(0, 10).map((item) => (
@@ -637,7 +635,7 @@ export default function OperationalObservabilityWorkspace({
                   className="flex items-center gap-3 rounded-lg border border-[color:var(--theme-border-soft)] px-3 py-2"
                 >
                   <span className="min-w-0 flex-1 truncate text-xs font-medium text-[color:var(--theme-text-secondary)]">
-                    {eventLabel(item.eventType)}
+                    {formatOperationalEventType(item.eventType)}
                   </span>
                   <strong className="text-sm text-[color:var(--theme-text-primary)]">
                     {item.count}

--- a/features/operations/components/WorkOrderOperationalTimelineDock.tsx
+++ b/features/operations/components/WorkOrderOperationalTimelineDock.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import { Activity, ArrowUpRight, ChevronDown, RefreshCw, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { getOperationalEventPresentation } from "@/features/operations/lib/eventPresentation";
 import { canonicalizeRole } from "@/features/shared/lib/rbac";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
@@ -19,6 +20,7 @@ type EventItem = {
   actor_role: string | null;
   severity: "info" | "warning" | "critical";
   href: string | null;
+  metadata: unknown;
 };
 
 type TimelinePayload = {
@@ -41,14 +43,6 @@ function relativeTime(value: string): string {
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h ago`;
   return `${Math.floor(hours / 24)}d ago`;
-}
-
-function eventLabel(value: string): string {
-  return value
-    .split(".")
-    .map((part) => part.replaceAll("_", " "))
-    .join(" · ")
-    .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
 function severityDot(value: EventItem["severity"]): string {
@@ -152,6 +146,11 @@ export default function WorkOrderOperationalTimelineDock() {
     return () => window.clearInterval(interval);
   }, [eligible, load, open, workOrderId]);
 
+  const handleToggle = () => {
+    if (!open) void load();
+    setOpen((value) => !value);
+  };
+
   if (!eligible || !workOrderId) return null;
 
   return (
@@ -197,41 +196,44 @@ export default function WorkOrderOperationalTimelineDock() {
               </div>
             ) : events.length ? (
               <div className="space-y-2">
-                {events.slice(0, 10).map((event) => (
-                  <div
-                    key={event.id}
-                    className="flex gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3"
-                  >
-                    <span className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${severityDot(event.severity)}`} />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                        <p className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                          {eventLabel(event.event_type)}
+                {events.slice(0, 10).map((event) => {
+                  const presentation = getOperationalEventPresentation(event);
+                  return (
+                    <div
+                      key={event.id}
+                      className="flex gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3"
+                    >
+                      <span className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${severityDot(event.severity)}`} />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                          <p className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                            {presentation.title}
+                          </p>
+                          <span className="text-[11px] text-[color:var(--theme-text-muted)]">
+                            {relativeTime(event.occurred_at)}
+                          </span>
+                        </div>
+                        <p className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">
+                          {presentation.detail}
                         </p>
-                        <span className="text-[11px] text-[color:var(--theme-text-muted)]">
-                          {relativeTime(event.occurred_at)}
-                        </span>
                       </div>
-                      <p className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">
-                        {event.entity_type.replaceAll("_", " ")}
-                        {event.actor_role ? ` · ${event.actor_role.replaceAll("_", " ")}` : ""}
-                      </p>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             ) : loading ? (
               <div className="h-24 animate-pulse rounded-xl bg-[color:var(--theme-surface-inset)]" />
             ) : (
               <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-6 text-center text-sm text-[color:var(--theme-text-secondary)]">
-                No canonical operational events have been recorded for this work order yet.
+                No operational activity has been recorded for this work order yet.
               </div>
             )}
           </div>
 
           <footer className="flex items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] px-4 py-3">
             <span className="text-xs text-[color:var(--theme-text-muted)]">
-              {events.length} recent event{events.length === 1 ? "" : "s"}
+              {events.length} event{events.length === 1 ? "" : "s"}
+              {events[0]?.occurred_at ? ` · Latest ${relativeTime(events[0].occurred_at)}` : ""}
             </span>
             <Link
               href={`/dashboard/operations/observability?correlationId=${encodeURIComponent(workOrderId)}`}
@@ -245,7 +247,7 @@ export default function WorkOrderOperationalTimelineDock() {
 
       <button
         type="button"
-        onClick={() => setOpen((value) => !value)}
+        onClick={handleToggle}
         className="inline-flex min-h-11 items-center gap-2 rounded-full border border-blue-400/35 bg-blue-950 px-4 text-sm font-semibold text-white shadow-xl transition hover:bg-blue-900"
       >
         <Activity className="h-4 w-4" /> Timeline

--- a/features/operations/lib/eventPresentation.test.ts
+++ b/features/operations/lib/eventPresentation.test.ts
@@ -43,4 +43,23 @@ describe("operational event presentation", () => {
       detail: "Requested",
     });
   });
+
+  it("shows the changed stage for stage-transition events", () => {
+    expect(
+      getOperationalEventPresentation({
+        event_type: "quote_line.stage.ready_to_send",
+        entity_type: "work_order_quote_line",
+        actor_role: "advisor",
+        metadata: {
+          old_status: "draft",
+          new_status: "draft",
+          old_stage: "pricing",
+          new_stage: "ready_to_send",
+        },
+      }),
+    ).toEqual({
+      title: "Quote Line · Stage · Ready To Send",
+      detail: "Pricing → Ready To Send · by Advisor",
+    });
+  });
 });

--- a/features/operations/lib/eventPresentation.test.ts
+++ b/features/operations/lib/eventPresentation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { getOperationalEventPresentation } from "./eventPresentation";
+
+describe("operational event presentation", () => {
+  it("explains work-order status transitions in operator language", () => {
+    expect(
+      getOperationalEventPresentation({
+        event_type: "work_order.status.awaiting_approval",
+        entity_type: "work_order",
+        actor_role: "owner",
+        metadata: {
+          old_status: "in_progress",
+          new_status: "awaiting_approval",
+        },
+      }),
+    ).toEqual({
+      title: "Work order status changed",
+      detail: "In Progress → Awaiting Approval · by Owner",
+    });
+  });
+
+  it("turns job and parts events into useful summaries", () => {
+    expect(
+      getOperationalEventPresentation({
+        event_type: "work_order_line.created",
+        entity_type: "work_order_line",
+        actor_role: "parts",
+        metadata: { new_status: "awaiting_approval" },
+      }),
+    ).toEqual({
+      title: "Job added",
+      detail: "Awaiting Approval · by Parts",
+    });
+
+    expect(
+      getOperationalEventPresentation({
+        event_type: "parts.request.created",
+        entity_type: "part_request",
+        metadata: { new_status: "requested" },
+      }),
+    ).toEqual({
+      title: "Parts request created",
+      detail: "Requested",
+    });
+  });
+});

--- a/features/operations/lib/eventPresentation.ts
+++ b/features/operations/lib/eventPresentation.ts
@@ -1,0 +1,73 @@
+export type OperationalEventPresentationInput = {
+  event_type: string;
+  entity_type: string;
+  actor_role?: string | null;
+  metadata?: unknown;
+};
+
+function metadataRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function metadataText(metadata: Record<string, unknown>, key: string): string | null {
+  const value = metadata[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function formatOperationalToken(value: string): string {
+  return value
+    .replaceAll("_", " ")
+    .replaceAll("-", " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export function formatOperationalEventType(value: string): string {
+  return value
+    .split(".")
+    .map(formatOperationalToken)
+    .join(" · ");
+}
+
+function eventTitle(eventType: string): string {
+  if (eventType.startsWith("work_order.status.")) return "Work order status changed";
+  if (eventType === "work_order_line.created") return "Job added";
+  if (eventType.startsWith("work_order_line.status.")) return "Job status changed";
+  if (eventType === "work_order_line.assignment.changed") return "Primary technician updated";
+  if (eventType === "work_order_line.documentation.changed") return "Job details updated";
+  if (eventType === "parts.request.created") return "Parts request created";
+  if (eventType === "parts.request_item.created") return "Part request item added";
+  if (eventType.startsWith("parts.request_item.status.")) return "Part request item updated";
+  if (eventType === "parts.work_order_part.created") return "Part added to work order";
+  if (eventType.startsWith("parts.work_order_part.status.")) return "Work-order part updated";
+  if (eventType === "messaging.conversation.created") return "Conversation started";
+  if (eventType === "messaging.message.created") return "Message added";
+  return formatOperationalEventType(eventType);
+}
+
+export function getOperationalEventPresentation(
+  event: OperationalEventPresentationInput,
+): { title: string; detail: string } {
+  const metadata = metadataRecord(event.metadata);
+  const oldStatus = metadataText(metadata, "old_status") ?? metadataText(metadata, "old_stage");
+  const newStatus = metadataText(metadata, "new_status") ?? metadataText(metadata, "new_stage");
+  const details: string[] = [];
+
+  if (oldStatus && newStatus && oldStatus !== newStatus) {
+    details.push(`${formatOperationalToken(oldStatus)} → ${formatOperationalToken(newStatus)}`);
+  } else if (newStatus) {
+    details.push(formatOperationalToken(newStatus));
+  } else if (event.event_type === "work_order_line.assignment.changed") {
+    details.push("Assignment changed");
+  } else {
+    details.push(formatOperationalToken(event.entity_type));
+  }
+
+  if (event.actor_role) details.push(`by ${formatOperationalToken(event.actor_role)}`);
+
+  return {
+    title: eventTitle(event.event_type),
+    detail: details.join(" · "),
+  };
+}

--- a/features/operations/lib/eventPresentation.ts
+++ b/features/operations/lib/eventPresentation.ts
@@ -50,8 +50,13 @@ export function getOperationalEventPresentation(
   event: OperationalEventPresentationInput,
 ): { title: string; detail: string } {
   const metadata = metadataRecord(event.metadata);
-  const oldStatus = metadataText(metadata, "old_status") ?? metadataText(metadata, "old_stage");
-  const newStatus = metadataText(metadata, "new_status") ?? metadataText(metadata, "new_stage");
+  const isStageTransition = event.event_type.includes(".stage.");
+  const oldStatus = isStageTransition
+    ? metadataText(metadata, "old_stage")
+    : metadataText(metadata, "old_status") ?? metadataText(metadata, "old_stage");
+  const newStatus = isStageTransition
+    ? metadataText(metadata, "new_stage")
+    : metadataText(metadata, "new_status") ?? metadataText(metadata, "new_stage");
   const details: string[] = [];
 
   if (oldStatus && newStatus && oldStatus !== newStatus) {

--- a/features/operations/server/getOperationalObservability.test.ts
+++ b/features/operations/server/getOperationalObservability.test.ts
@@ -3,6 +3,7 @@ import {
   deriveOperationalPipelineStatus,
   getOperationalDomain,
   getOperationalEntityHref,
+  hasOperationalEventFilter,
 } from "./getOperationalObservability";
 
 const NOW = new Date("2026-08-02T15:00:00.000Z");
@@ -60,5 +61,15 @@ describe("operational observability helpers", () => {
         metadata: {},
       }),
     ).toBe("/work-orders/11111111-1111-4111-8111-111111111111");
+  });
+
+  it("keeps filtered timelines historical while the shop dashboard stays recent", () => {
+    expect(hasOperationalEventFilter({ correlationId: null, entityId: null, entityType: null })).toBe(false);
+    expect(
+      hasOperationalEventFilter({
+        correlationId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).toBe(true);
+    expect(hasOperationalEventFilter({ entityType: "work_order" })).toBe(true);
   });
 });

--- a/features/operations/server/getOperationalObservability.ts
+++ b/features/operations/server/getOperationalObservability.ts
@@ -107,6 +107,12 @@ export type GetOperationalObservabilityInput = {
   correlationId?: string | null;
 };
 
+export function hasOperationalEventFilter(
+  input: Pick<GetOperationalObservabilityInput, "entityType" | "entityId" | "correlationId">,
+): boolean {
+  return Boolean(input.entityType || input.entityId || input.correlationId);
+}
+
 function relationMissing(error: unknown): boolean {
   const candidate = error as { code?: string; message?: string } | null;
   const code = String(candidate?.code ?? "");
@@ -220,9 +226,12 @@ export async function getOperationalObservability(
       "id, shop_id, event_type, occurred_at, actor_user_id, actor_role, entity_type, entity_id, parent_entity_type, parent_entity_id, correlation_id, source, severity, metadata",
     )
     .eq("shop_id", input.shopId)
-    .gte("occurred_at", since7d)
     .order("occurred_at", { ascending: false })
     .limit(eventLimit);
+
+  if (!hasOperationalEventFilter(input)) {
+    eventsQuery = eventsQuery.gte("occurred_at", since7d);
+  }
 
   if (input.entityType) eventsQuery = eventsQuery.eq("entity_type", input.entityType);
   if (input.entityId) eventsQuery = eventsQuery.eq("entity_id", input.entityId);

--- a/features/parts/components/PartPicker.tsx
+++ b/features/parts/components/PartPicker.tsx
@@ -19,6 +19,7 @@ import {
   type AiPartSuggestion,
 } from "@/features/parts/hooks/useAiPartSuggestions";
 import { toPartDisplaySummary } from "@/features/parts/lib/part-display";
+import ModalShell from "@/features/shared/components/ModalShell";
 
 type DB = Database;
 type UUID = string;
@@ -428,29 +429,30 @@ export function PartPicker({
       aria-busy={submitting}
       className="metal-card rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--theme-surface-overlay)] p-4 shadow-[var(--theme-shadow-medium)] backdrop-blur-xl md:p-6"
     >
-      {/* Header */}
-      <div className="mb-4 flex items-center justify-between gap-4">
-        <div>
-          <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">
-            Select a part
+      {variant === "inline" ? (
+        <div className="mb-4 flex items-center justify-between gap-4">
+          <div>
+            <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">
+              Select a part
+            </div>
+            <h3
+              className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]"
+              style={{ fontFamily: "var(--font-blackops), system-ui" }}
+            >
+              Part Picker
+            </h3>
           </div>
-          <h3
-            className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]"
-            style={{ fontFamily: "var(--font-blackops), system-ui" }}
-          >
-            Part Picker
-          </h3>
-        </div>
 
-        <button
-          onClick={close}
-          disabled={submitting}
-          className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-4 py-2 text-sm text-[color:var(--theme-text-primary)] hover:border-orange-500 hover:bg-[color:var(--theme-surface-panel)]"
-          type="button"
-        >
-          Close
-        </button>
-      </div>
+          <button
+            onClick={close}
+            disabled={submitting}
+            className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-4 py-2 text-sm text-[color:var(--theme-text-primary)] hover:border-orange-500 hover:bg-[color:var(--theme-surface-panel)]"
+            type="button"
+          >
+            Close
+          </button>
+        </div>
+      ) : null}
 
       {/* AI Suggestions */}
       <div className="mb-4 rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--theme-surface-overlay)] shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
@@ -780,26 +782,16 @@ export function PartPicker({
   if (variant === "inline") return panel;
 
   return (
-    <div
-      className="fixed inset-0 z-[500] flex items-center justify-center"
-      onClick={(e) => {
-        e.stopPropagation();
-      }}
+    <ModalShell
+      isOpen={open}
+      onClose={close}
+      title="Part Picker"
+      size="lg"
+      hideFooter
+      busy={submitting}
     >
-      <div
-        className="fixed inset-0 bg-[color:var(--theme-surface-overlay)] backdrop-blur-sm"
-        aria-hidden="true"
-        onClick={() => {
-          if (!submittingRef.current) close();
-        }}
-      />
-      <div
-        className="relative z-[510] w-full max-w-4xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {panel}
-      </div>
-    </div>
+      {panel}
+    </ModalShell>
   );
 }
 

--- a/features/parts/components/PartPicker.tsx
+++ b/features/parts/components/PartPicker.tsx
@@ -60,6 +60,7 @@ export type PickedPart = {
 type Props = {
   open: boolean;
   channel?: string;
+  accessContext?: "inventory" | "menu-editor";
   initialSearch?: string;
   initialQty?: number;
   workOrderId?: string;
@@ -118,6 +119,7 @@ function actionErrorMessage(error: unknown): string {
 export function PartPicker({
   open,
   channel = "partpicker",
+  accessContext = "inventory",
   initialSearch = "",
   initialQty = 1,
   workOrderId,
@@ -217,6 +219,9 @@ export function PartPicker({
         const params = new URLSearchParams();
         const term = search.trim();
         if (term) params.set("q", term);
+        if (accessContext === "menu-editor") {
+          params.set("context", accessContext);
+        }
         if (workOrderLineId) {
           params.set("workOrderLineId", workOrderLineId);
         }
@@ -267,7 +272,7 @@ export function PartPicker({
     return () => {
       cancelled = true;
     };
-  }, [open, search, workOrderLineId]);
+  }, [accessContext, open, search, workOrderLineId]);
 
   useEffect(() => {
     if (!open) return;

--- a/features/parts/components/PartsDrawer.tsx
+++ b/features/parts/components/PartsDrawer.tsx
@@ -1,7 +1,5 @@
 // features/work-orders/components/workorders/PartsDrawer.tsx (FULL FILE REPLACEMENT)
-// Drawer modal with tabs: Use from Inventory vs Request to Purchase
-// IMPORTANT: PartPicker must be rendered inline (no fixed inset/backdrop) to avoid nested modals.
-// This file assumes PartPicker supports `variant="inline"`.
+// Shared modal with tabs: Use from Inventory vs Request to Purchase.
 
 "use client";
 
@@ -10,6 +8,7 @@ import PartPicker, {
   type PickedPart,
 } from "@/features/parts/components/PartPicker";
 import PartsRequestModal from "@/features/work-orders/components/workorders/PartsRequestModal";
+import ModalShell from "@/features/shared/components/ModalShell";
 import { toast } from "sonner";
 import { consumePart } from "@/features/work-orders/lib/parts/consumePart";
 
@@ -110,55 +109,26 @@ export default function PartsDrawer({
       : "rounded-full border border-transparent px-4 py-2 text-sm text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]";
 
   return (
-    <div className="fixed inset-0 z-[510]" onClick={(e) => e.stopPropagation()}>
-      {/* Backdrop */}
-      <div
-        className="absolute inset-0 bg-[color:var(--theme-surface-overlay)] backdrop-blur-sm"
-        onClick={() => {
-          if (!usePartPending) emitClose();
-        }}
-        aria-hidden="true"
-      />
-
-      {/* Panel */}
-      <div
-        className="absolute inset-x-0 bottom-0 z-[520] w-full overflow-hidden rounded-t-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--theme-surface-overlay)] text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)] backdrop-blur-xl md:inset-auto md:top-1/2 md:left-1/2 md:h-[85vh] md:w-[960px] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* subtle radial like menu page */}
+    <ModalShell
+      isOpen={open}
+      onClose={emitClose}
+      title="Parts Drawer"
+      size="xl"
+      hideFooter
+      bodyScrollable={false}
+      busy={usePartPending}
+    >
+      <div className="flex max-h-[calc(100vh-9rem)] min-h-0 flex-col">
         <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 -z-10 bg-[var(--theme-gradient-panel)]"
-        />
-
-        {/* Header */}
-        <div className="metal-card flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] bg-gradient-to-r from-[color:var(--theme-surface-page)] via-[color:var(--theme-surface-panel)] to-[color:var(--theme-surface-page)] px-4 py-3 md:px-5">
-          <div>
-            <div className="text-[11px] uppercase tracking-[0.22em] text-[color:var(--theme-text-secondary)]">
-              Parts
-            </div>
-            <div
-              className="text-lg font-semibold text-[color:var(--theme-text-primary)]"
-              style={{ fontFamily: "var(--font-blackops), system-ui" }}
-            >
-              Parts Drawer
-            </div>
-          </div>
-
-          <button
-            onClick={emitClose}
-            disabled={usePartPending}
-            className="rounded-full border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--theme-surface-overlay)] px-4 py-2 text-sm text-[color:var(--theme-text-primary)] hover:border-[color:var(--accent-copper,#f97316)]/70 hover:bg-[color:var(--theme-surface-overlay)]"
-          >
-            Close
-          </button>
-        </div>
-
-        {/* Tabs */}
-        <div className="flex flex-wrap items-center gap-2 border-b border-[color:var(--theme-border-soft)] px-4 py-3 md:px-5">
+          role="tablist"
+          aria-label="Parts workflow"
+          className="flex flex-wrap items-center gap-2 border-b border-[color:var(--theme-border-soft)] pb-3"
+        >
           <button
             className={tabBtn(tab === "use")}
             disabled={usePartPending}
+            role="tab"
+            aria-selected={tab === "use"}
             onClick={() => {
               if (!usePartPending) setTab("use");
             }}
@@ -169,6 +139,8 @@ export default function PartsDrawer({
           <button
             className={tabBtn(tab === "request")}
             disabled={usePartPending}
+            role="tab"
+            aria-selected={tab === "request"}
             onClick={() => {
               if (!usePartPending) setTab("request");
             }}
@@ -176,16 +148,11 @@ export default function PartsDrawer({
           >
             Request to Purchase
           </button>
-
-          <div className="ml-auto hidden rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[11px] text-[color:var(--theme-text-secondary)] md:block">
-            Copper / glass theme
-          </div>
         </div>
 
-        {/* Body */}
-        <div className="h-[70vh] overflow-auto p-4 md:h-[calc(85vh-120px)] md:p-5">
+        <div className="min-h-0 flex-1 overflow-auto pt-4">
           {tab === "use" ? (
-            <div className="metal-card rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--theme-surface-overlay)] p-3 shadow-[var(--theme-shadow-medium)] backdrop-blur-xl md:p-4">
+            <div role="tabpanel">
               <PartPicker
                 open={true}
                 variant="inline"
@@ -202,7 +169,7 @@ export default function PartsDrawer({
               />
             </div>
           ) : (
-            <div className="metal-card rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--theme-surface-overlay)] p-3 shadow-[var(--theme-shadow-medium)] backdrop-blur-xl md:p-4">
+            <div role="tabpanel">
               <PartsRequestModal
                 isOpen={true}
                 workOrderId={workOrderId}
@@ -214,6 +181,6 @@ export default function PartsDrawer({
           )}
         </div>
       </div>
-    </div>
+    </ModalShell>
   );
 }

--- a/features/shared/components/pwa/PwaRuntime.tsx
+++ b/features/shared/components/pwa/PwaRuntime.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
+import { createPortal } from "react-dom";
 
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
@@ -56,6 +57,25 @@ export default function PwaRuntime() {
   const updateReloading = useRef(false);
   const pending = summary.queued + summary.syncing + summary.failed;
   const mobileSurface = pathname.startsWith("/mobile");
+  const workOrderSurface = pathname.startsWith("/work-orders/");
+  const [runtimeStatusTarget, setRuntimeStatusTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!workOrderSurface) {
+      setRuntimeStatusTarget(null);
+      return;
+    }
+
+    const resolveTarget = () => {
+      const nextTarget = document.getElementById("work-order-runtime-status");
+      setRuntimeStatusTarget((current) => (current === nextTarget ? current : nextTarget));
+    };
+
+    resolveTarget();
+    const observer = new MutationObserver(resolveTarget);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [workOrderSurface]);
 
   const publishInstallAvailability = useCallback(
     (detail: InstallAvailability) => {
@@ -292,6 +312,67 @@ export default function PwaRuntime() {
   const showRuntimeStatus =
     !online || pending > 0 || Boolean(updateReady) || Boolean(syncBlocked);
 
+  const runtimeStatusControl = showRuntimeStatus && !mobileSurface ? (
+    <div
+      className={
+        runtimeStatusTarget
+          ? "flex w-full flex-wrap items-center gap-2 rounded-xl border border-slate-700 bg-slate-950/95 px-3 py-2 text-xs font-semibold text-slate-100 shadow-lg"
+          : "fixed z-[100] flex max-w-[calc(100vw-2rem)] flex-wrap items-center justify-end gap-2 rounded-2xl border border-slate-700 bg-slate-950/95 px-3 py-2 text-xs font-semibold text-slate-100 shadow-xl backdrop-blur sm:flex-nowrap sm:rounded-full"
+      }
+      style={
+        runtimeStatusTarget
+          ? undefined
+          : {
+              bottom: `calc(1rem + env(safe-area-inset-bottom, 0px) + ${viewportInsets.bottom}px)`,
+              right: `calc(1rem + env(safe-area-inset-right, 0px) + ${viewportInsets.right}px)`,
+            }
+      }
+    >
+      {runtimeStatusTarget ? (
+        <span className="w-full text-[10px] uppercase tracking-[0.16em] text-slate-400">
+          App status
+        </span>
+      ) : null}
+      <span
+        className={`h-2 w-2 rounded-full ${
+          online ? "bg-emerald-400" : "bg-amber-400"
+        }`}
+      />
+      <span>
+        {syncBlocked
+          ? "Sync needs attention"
+          : online
+            ? pending
+              ? `Syncing ${pending}`
+              : "Online"
+            : `Offline · ${pending} pending`}
+      </span>
+      {pending > 0 || !online || syncBlocked ? (
+        <button
+          type="button"
+          onClick={() => window.location.assign("/offline/sync")}
+          className="rounded-full border border-slate-600 px-3 py-1"
+        >
+          Details
+        </button>
+      ) : null}
+      {updateReady ? (
+        <button
+          type="button"
+          onClick={activateUpdate}
+          disabled={activatingUpdate || pending > 0}
+          className="rounded-full bg-sky-400 px-3 py-1 text-slate-950"
+        >
+          {activatingUpdate
+            ? "Updating…"
+            : pending > 0
+              ? "Sync first"
+              : "Update"}
+        </button>
+      ) : null}
+    </div>
+  ) : null;
+
   if (
     isStandalonePublicRoute(pathname) ||
     ((!showRuntimeStatus || mobileSurface) && !showIosInstructions)
@@ -301,53 +382,11 @@ export default function PwaRuntime() {
 
   return (
     <>
-      {showRuntimeStatus && !mobileSurface ? (
-        <div
-          className="fixed z-[100] flex max-w-[calc(100vw-2rem)] flex-wrap items-center justify-end gap-2 rounded-2xl border border-slate-700 bg-slate-950/95 px-3 py-2 text-xs font-semibold text-slate-100 shadow-xl backdrop-blur sm:flex-nowrap sm:rounded-full"
-          style={{
-            bottom: `calc(1rem + env(safe-area-inset-bottom, 0px) + ${viewportInsets.bottom}px)`,
-            right: `calc(1rem + env(safe-area-inset-right, 0px) + ${viewportInsets.right}px)`,
-          }}
-        >
-          <span
-            className={`h-2 w-2 rounded-full ${
-              online ? "bg-emerald-400" : "bg-amber-400"
-            }`}
-          />
-          <span>
-            {syncBlocked
-              ? "Sync needs attention"
-              : online
-                ? pending
-                  ? `Syncing ${pending}`
-                  : "Online"
-                : `Offline · ${pending} pending`}
-          </span>
-          {(pending > 0 || !online || syncBlocked) && (
-            <button
-              type="button"
-              onClick={() => window.location.assign("/offline/sync")}
-              className="rounded-full border border-slate-600 px-3 py-1"
-            >
-              Details
-            </button>
-          )}
-          {updateReady && (
-            <button
-              type="button"
-              onClick={activateUpdate}
-              disabled={activatingUpdate || pending > 0}
-              className="rounded-full bg-sky-400 px-3 py-1 text-slate-950"
-            >
-              {activatingUpdate
-                ? "Updating…"
-                : pending > 0
-                  ? "Sync first"
-                  : "Update"}
-            </button>
-          )}
-        </div>
-      ) : null}
+      {runtimeStatusControl && runtimeStatusTarget
+        ? createPortal(runtimeStatusControl, runtimeStatusTarget)
+        : workOrderSurface
+          ? null
+          : runtimeStatusControl}
 
       {showIosInstructions && (
         <div className="fixed inset-0 z-[110] grid place-items-center bg-slate-950/80 p-4 backdrop-blur-sm">

--- a/features/shared/components/pwa/PwaRuntime.tsx
+++ b/features/shared/components/pwa/PwaRuntime.tsx
@@ -384,9 +384,7 @@ export default function PwaRuntime() {
     <>
       {runtimeStatusControl && runtimeStatusTarget
         ? createPortal(runtimeStatusControl, runtimeStatusTarget)
-        : workOrderSurface
-          ? null
-          : runtimeStatusControl}
+        : runtimeStatusControl}
 
       {showIosInstructions && (
         <div className="fixed inset-0 z-[110] grid place-items-center bg-slate-950/80 p-4 backdrop-blur-sm">

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -1775,6 +1775,10 @@ export default function FocusedJobModal(props: {
                 <div className="flex justify-between gap-3"><dt className="text-[color:var(--theme-text-secondary)]">Finish</dt><dd className="text-right text-[color:var(--theme-text-primary)]">{createdFinish}</dd></div>
               </dl>
             </section>
+            <div
+              id="work-order-runtime-status"
+              className="border-t border-[color:var(--theme-border-soft)] pt-4 empty:hidden"
+            />
           </div>
         ) : null}
       </aside>

--- a/tests/parts-async-handoff.test.tsx
+++ b/tests/parts-async-handoff.test.tsx
@@ -189,7 +189,7 @@ describe("PartsDrawer async use-part handoff", () => {
     mocks.consumePart.mockReturnValue(consumption.promise);
     const closeListener = listenFor("test:parts-drawer-close");
 
-    const { container } = render(
+    render(
       <PartsDrawer
         closeEventName="test:parts-drawer-close"
         open
@@ -219,7 +219,7 @@ describe("PartsDrawer async use-part handoff", () => {
     fireEvent.click(headerClose);
     fireEvent.click(pickerClose);
 
-    const backdrop = container.querySelector<HTMLDivElement>(
+    const backdrop = document.querySelector<HTMLDivElement>(
       'div.fixed.inset-0 > div[aria-hidden="true"]',
     );
     expect(backdrop).not.toBeNull();

--- a/tests/technician-part-picker-access.test.ts
+++ b/tests/technician-part-picker-access.test.ts
@@ -11,6 +11,8 @@ const usePartButton = readFileSync(
 );
 const pickerRoute = readFileSync("app/api/parts/picker/route.ts", "utf8");
 const workOrderDetail = readFileSync("app/work-orders/[id]/Client.tsx", "utf8");
+const menuBuilder = readFileSync("app/menu/page.tsx", "utf8");
+const menuItemEditor = readFileSync("app/menu/item/[id]/page.tsx", "utf8");
 
 describe("parts-role part picker access", () => {
   it("loads inventory through a server-scoped route", () => {
@@ -22,7 +24,7 @@ describe("parts-role part picker access", () => {
     );
   });
 
-  it("requires the canonical parts capability in both UI and API", () => {
+  it("requires the canonical parts capability for inventory actions", () => {
     expect(pickerRoute).toContain('requiredCapability: "canManageParts"');
     expect(pickerRoute).not.toContain('access.canonicalRole === "mechanic"');
     expect(workOrderDetail).toContain(
@@ -30,6 +32,15 @@ describe("parts-role part picker access", () => {
     );
     expect(workOrderDetail).toContain("canUseInventoryPicker");
     expect(workOrderDetail).toContain("? () => setPartsLineId(ln.id)");
+  });
+
+  it("preserves read-only catalog lookup for authorized menu editors", () => {
+    expect(picker).toContain('accessContext?: "inventory" | "menu-editor"');
+    expect(picker).toContain('params.set("context", accessContext)');
+    expect(pickerRoute).toContain('pickerContext === "menu-editor"');
+    expect(pickerRoute).toContain("{ allowRoles: MENU_EDITOR_ROLES }");
+    expect(menuBuilder).toContain('accessContext="menu-editor"');
+    expect(menuItemEditor).toContain('accessContext="menu-editor"');
   });
 
   it("keeps every inventory query scoped to the authenticated shop", () => {

--- a/tests/technician-part-picker-access.test.ts
+++ b/tests/technician-part-picker-access.test.ts
@@ -10,8 +10,9 @@ const usePartButton = readFileSync(
   "utf8",
 );
 const pickerRoute = readFileSync("app/api/parts/picker/route.ts", "utf8");
+const workOrderDetail = readFileSync("app/work-orders/[id]/Client.tsx", "utf8");
 
-describe("technician part picker access", () => {
+describe("parts-role part picker access", () => {
   it("loads inventory through a server-scoped route", () => {
     expect(picker).toContain("fetch(`/api/parts/picker?");
     expect(picker).toContain('params.set("workOrderLineId", workOrderLineId)');
@@ -21,22 +22,14 @@ describe("technician part picker access", () => {
     );
   });
 
-  it("limits mechanic inventory to an assigned work-order line", () => {
-    expect(pickerRoute).toContain('"mechanic"');
-    expect(pickerRoute).toContain(
-      'access.canonicalRole === "mechanic"',
+  it("requires the canonical parts capability in both UI and API", () => {
+    expect(pickerRoute).toContain('requiredCapability: "canManageParts"');
+    expect(pickerRoute).not.toContain('access.canonicalRole === "mechanic"');
+    expect(workOrderDetail).toContain(
+      "const canUseInventoryPicker = currentActor.canManageParts",
     );
-    expect(pickerRoute).toContain("line.assigned_tech_id");
-    expect(pickerRoute).toContain("line.assigned_to");
-    expect(pickerRoute).toContain(
-      '.from("work_order_line_technicians")',
-    );
-    expect(pickerRoute).toContain(
-      '.eq("technician_id", input.technicianId)',
-    );
-    expect(pickerRoute).toContain(
-      "This inventory picker is limited to your assigned jobs.",
-    );
+    expect(workOrderDetail).toContain("canUseInventoryPicker");
+    expect(workOrderDetail).toContain("? () => setPartsLineId(ln.id)");
   });
 
   it("keeps every inventory query scoped to the authenticated shop", () => {

--- a/tests/work-order-cockpit-layout.test.ts
+++ b/tests/work-order-cockpit-layout.test.ts
@@ -10,6 +10,18 @@ const jobCard = readFileSync(
   "features/work-orders/components/JobCard.tsx",
   "utf8",
 );
+const partsDrawer = readFileSync(
+  "features/parts/components/PartsDrawer.tsx",
+  "utf8",
+);
+const partPicker = readFileSync(
+  "features/parts/components/PartPicker.tsx",
+  "utf8",
+);
+const pwaRuntime = readFileSync(
+  "features/shared/components/pwa/PwaRuntime.tsx",
+  "utf8",
+);
 
 describe("desktop work-order cockpit", () => {
   it("uses stable navigator, workspace, command-center, and activity surfaces", () => {
@@ -31,6 +43,8 @@ describe("desktop work-order cockpit", () => {
     expect(focusedJob).toContain('"Add hold"');
     expect(focusedJob).not.toContain('"Add blocker"');
     expect(jobCard).toContain('display === "navigator"');
+    expect(focusedJob).toContain('id="work-order-runtime-status"');
+    expect(pwaRuntime).toContain("createPortal(runtimeStatusControl, runtimeStatusTarget)");
   });
 
   it("keeps canonical work-order actions behind their existing handlers", () => {
@@ -49,5 +63,14 @@ describe("desktop work-order cockpit", () => {
     expect(focusedJob).toContain("<NewChatModal");
     expect(focusedJob).toContain("<AIAssistantModal");
     expect(focusedJob).toContain("<VehicleHistoryModal");
+  });
+
+  it("keeps parts workflows in the shared top-level modal layer", () => {
+    expect(partsDrawer).toContain("<ModalShell");
+    expect(partsDrawer).toContain('title="Parts Drawer"');
+    expect(partsDrawer).toContain('variant="inline"');
+    expect(partPicker).toContain("<ModalShell");
+    expect(partPicker).toContain('title="Part Picker"');
+    expect(partsDrawer).not.toContain('className="fixed inset-0 z-[510]"');
   });
 });

--- a/tests/work-order-cockpit-layout.test.ts
+++ b/tests/work-order-cockpit-layout.test.ts
@@ -47,6 +47,11 @@ describe("desktop work-order cockpit", () => {
     expect(pwaRuntime).toContain("createPortal(runtimeStatusControl, runtimeStatusTarget)");
   });
 
+  it("keeps the fixed runtime status visible until its dock target mounts", () => {
+    expect(pwaRuntime).toContain(": runtimeStatusControl}");
+    expect(pwaRuntime).not.toContain("workOrderSurface\n          ? null");
+  });
+
   it("keeps canonical work-order actions behind their existing handlers", () => {
     expect(detail).toContain("assignWorkOrderLineTechnician");
     expect(detail).toContain("requestAllPartsForLine");

--- a/tests/work-order-operational-timeline-dock.test.ts
+++ b/tests/work-order-operational-timeline-dock.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const dock = readFileSync(
+  "features/operations/components/WorkOrderOperationalTimelineDock.tsx",
+  "utf8",
+);
+const server = readFileSync(
+  "features/operations/server/getOperationalObservability.ts",
+  "utf8",
+);
+
+describe("work-order operational timeline", () => {
+  it("refreshes when opened and explains canonical event metadata", () => {
+    expect(dock).toContain("if (!open) void load()");
+    expect(dock).toContain("getOperationalEventPresentation(event)");
+    expect(dock).toContain("Latest ${relativeTime(events[0].occurred_at)}");
+  });
+
+  it("does not discard older events from an explicitly filtered timeline", () => {
+    expect(server).toContain("if (!hasOperationalEventFilter(input))");
+    expect(server).toContain('eventsQuery = eventsQuery.gte("occurred_at", since7d)');
+  });
+});


### PR DESCRIPTION
## What changed

- dock the PWA online/update status inside the work-order command center so it no longer covers the operational timeline
- load the full filtered work-order event history, refresh it when the dock opens, and present event metadata as operator-readable activity
- render parts workflows through the shared top-level modal shell so the picker cannot be trapped behind work-order stacking contexts
- gate the job-card inventory picker and its server endpoint with the canonical `canManageParts` capability

## Root cause

The work-order timeline reused the seven-day dashboard cutoff even when a specific correlation ID was requested, cached its initial result, and displayed only technical event identifiers. The online/update control was globally fixed at the same bottom-right position as the timeline. The parts flow used a locally nested fixed layer, while the picker API still allowed broad shop roles plus an assigned-mechanic exception.

## Impact

Parts-management roles retain the fast job-card inventory workflow. Mechanics, advisors, and service roles no longer see or access the inventory picker. Work-order operators can see historical, plain-language operational activity without overlay collisions.

## Validation

- focused Vitest regressions: 6 files / 18 tests passed
- `pnpm typecheck`: passed
- changed-file ESLint: passed with zero warnings
- `pnpm regression:inventory:check`: passed with 0 new errors
- optimized Next.js compilation: passed; local page-data collection then stopped because this checkout has no Supabase URL
- repository-wide `pnpm check`: reached pre-existing lint errors in untouched files
- repository-wide tests on Windows hit existing LF-sensitive source-contract fixtures after CRLF checkout conversion

No database migration or production data change is included.