### PR TITLE
Fix mobile CoPilot overlay and voice recovery

### DIFF
--- a/docs/architecture/technician-copilot-v2-persistent-shell.md
+++ b/docs/architecture/technician-copilot-v2-persistent-shell.md
@@ -15,8 +15,10 @@ technician moves through:
 - the Field Service mobile surface when the same technician has access.
 
 The desktop shell presents the collaborator as a right-side panel. Shop Mobile
-uses a full-height overlay above the mobile navigation. Closing either surface
-keeps the Repair Session client mounted but stops active microphone capture.
+opens as a compact, opaque voice dock that occupies only its own bounds, leaves
+the current workflow visible and interactive, and can be explicitly expanded
+to the full conversation. Closing either surface keeps the Repair Session
+client mounted but stops active microphone capture.
 
 ## Canonical runtime
 
@@ -45,6 +47,11 @@ second page-owned voice or conversation client.
 - Closing the panel stops Realtime capture and speech output.
 - Route changes do not unmount the collaborator, so text, voice state, and the
   hydrated Repair Session remain available throughout the technician workflow.
+- The mobile home action opens the shell in place instead of navigating away
+  from the technician's current screen.
+- A persisted reply is visible in the compact dock even when device speech
+  output is unavailable or stalls. Speech output has a bounded watchdog and
+  returns to listening instead of remaining indefinitely in a replying state.
 - Server-side authorization, tenant scope, assignment checks, action replay,
   and mutation rules are unchanged.
 
@@ -57,14 +64,16 @@ dedicated route URLs remain valid compatibility entry points.
 
 ## Acceptance path
 
-1. Open CoPilot from the desktop or Shop Mobile launcher.
+1. Open CoPilot from the desktop or Shop Mobile launcher and confirm the mobile
+   workflow remains visible, scrollable, and interactive outside the dock.
 2. Start or resume an assigned repair and exchange at least one turn.
 3. Navigate to the technician queue, focused job, work order, inspection, and
    another shop route.
 4. Reopen the panel and confirm the same Repair Session context is present.
 5. Start voice, close the panel, and confirm microphone/speech output stops.
 6. Reopen the panel and explicitly restart voice.
-7. Disable technician CoPilot access and confirm the launcher disappears.
+7. Expand and collapse the mobile conversation without remounting the runtime.
+8. Disable technician CoPilot access and confirm the launcher disappears.
 
 ## Next slice
 

--- a/features/copilot/technician/components/TechnicianCopilotShell.tsx
+++ b/features/copilot/technician/components/TechnicianCopilotShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Bot, X } from "lucide-react";
+import { Bot, Maximize2, Minimize2, X } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
@@ -10,6 +10,11 @@ import { TechnicianTextCopilot } from "./TechnicianTextCopilot";
 
 export const OPEN_TECHNICIAN_COPILOT_EVENT =
   "profixiq:technician-copilot-open";
+
+export function openTechnicianCopilot(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(OPEN_TECHNICIAN_COPILOT_EVENT));
+}
 
 function isCopilotRoute(pathname: string): boolean {
   return (
@@ -29,24 +34,34 @@ export function TechnicianCopilotShell({
   const router = useRouter();
   const availability = useTechnicianCopilotAvailabilityState(shouldCheck);
   const [open, setOpen] = useState(() => isCopilotRoute(pathname));
+  const [expanded, setExpanded] = useState(false);
+
+  const openCompact = useCallback(() => {
+    setExpanded(false);
+    setOpen(true);
+  }, []);
 
   const close = useCallback(() => {
     setOpen(false);
+    setExpanded(false);
     if (isCopilotRoute(pathname)) {
       router.replace(surface === "mobile" ? "/mobile/tech/queue" : "/tech/queue");
     }
   }, [pathname, router, surface]);
 
   useEffect(() => {
-    if (isCopilotRoute(pathname)) setOpen(true);
+    if (isCopilotRoute(pathname)) {
+      setOpen(true);
+      setExpanded(false);
+    }
   }, [pathname]);
 
   useEffect(() => {
-    const handleOpen = () => setOpen(true);
+    const handleOpen = () => openCompact();
     window.addEventListener(OPEN_TECHNICIAN_COPILOT_EVENT, handleOpen);
     return () =>
       window.removeEventListener(OPEN_TECHNICIAN_COPILOT_EVENT, handleOpen);
-  }, []);
+  }, [openCompact]);
 
   useEffect(() => {
     if (!open) return;
@@ -62,7 +77,7 @@ export function TechnicianCopilotShell({
   const launcher = (
     <button
       type="button"
-      onClick={() => setOpen(true)}
+      onClick={openCompact}
       aria-label="Open Technician CoPilot"
       aria-expanded={open}
       tabIndex={open ? -1 : 0}
@@ -89,35 +104,75 @@ export function TechnicianCopilotShell({
       <>
         {launcher}
         <section
-          role="dialog"
-          aria-modal="true"
+          role={expanded ? "dialog" : "region"}
+          aria-modal={expanded ? "true" : undefined}
           aria-label="Technician CoPilot"
           aria-hidden={!open}
           className={cn(
-            "fixed inset-0 z-50 flex h-[100dvh] w-full flex-col overflow-hidden overscroll-contain bg-background transition-opacity duration-200",
+            "fixed z-40 flex min-h-0 flex-col overflow-hidden border text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-strong)] transition-[opacity,transform,border-radius] duration-200",
+            expanded
+              ? "inset-0 h-[100dvh] w-full rounded-none"
+              : "inset-x-3 bottom-[calc(1rem+env(safe-area-inset-bottom))] max-h-[min(21rem,calc(100dvh-7rem))] rounded-2xl",
             open
               ? "visible pointer-events-auto opacity-100"
-              : "invisible pointer-events-none opacity-0",
+              : "invisible pointer-events-none translate-y-3 opacity-0",
           )}
+          style={{
+            borderColor: "var(--theme-border-strong)",
+            background: expanded
+              ? "var(--theme-surface-page)"
+              : "var(--theme-surface-panel-strong)",
+          }}
         >
-          <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">
+          <div
+            className="flex shrink-0 items-center justify-between gap-3 border-b px-4 py-3"
+            style={{ borderColor: "var(--theme-border-soft)" }}
+          >
             <div>
               <div className="text-sm font-semibold">Technician CoPilot</div>
-              <div className="text-xs text-muted-foreground">
-                Stays with you as you move through the app
+              <div className="text-xs text-[color:var(--theme-text-secondary)]">
+                {expanded
+                  ? "Conversation and repair memory"
+                  : "Voice stays active while you keep working"}
               </div>
             </div>
-            <button
-              type="button"
-              onClick={close}
-              aria-label="Close Technician CoPilot"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-full border bg-background"
-            >
-              <X className="h-5 w-5" aria-hidden />
-            </button>
+            <div className="flex shrink-0 gap-2">
+              <button
+                type="button"
+                onClick={() => setExpanded((current) => !current)}
+                aria-label={
+                  expanded
+                    ? "Return to compact voice controls"
+                    : "Show full CoPilot conversation"
+                }
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border"
+                style={{
+                  borderColor: "var(--theme-border-soft)",
+                  background: "var(--theme-surface-panel)",
+                }}
+              >
+                {expanded ? (
+                  <Minimize2 className="h-5 w-5" aria-hidden />
+                ) : (
+                  <Maximize2 className="h-5 w-5" aria-hidden />
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={close}
+                aria-label="Close Technician CoPilot"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border"
+                style={{
+                  borderColor: "var(--theme-border-soft)",
+                  background: "var(--theme-surface-panel)",
+                }}
+              >
+                <X className="h-5 w-5" aria-hidden />
+              </button>
+            </div>
           </div>
           <div className="min-h-0 flex-1">
-            <TechnicianTextCopilot embedded active={open} />
+            <TechnicianTextCopilot embedded active={open} compact={!expanded} />
           </div>
         </section>
       </>
@@ -132,16 +187,23 @@ export function TechnicianCopilotShell({
         aria-label="Technician CoPilot"
         aria-hidden={!open}
         className={cn(
-          "fixed bottom-4 right-4 top-16 z-30 flex w-[min(32rem,calc(100vw-2rem))] min-h-0 flex-col overflow-hidden rounded-2xl border bg-background shadow-2xl transition duration-200",
+          "fixed bottom-4 right-4 top-16 z-30 flex w-[min(32rem,calc(100vw-2rem))] min-h-0 flex-col overflow-hidden rounded-2xl border text-[color:var(--theme-text-primary)] shadow-2xl transition duration-200",
           open
             ? "translate-x-0 opacity-100"
             : "invisible pointer-events-none translate-x-[calc(100%+2rem)] opacity-0",
         )}
+        style={{
+          borderColor: "var(--theme-border-strong)",
+          background: "var(--theme-surface-panel-strong)",
+        }}
       >
-        <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">
+        <div
+          className="flex shrink-0 items-center justify-between border-b px-4 py-3"
+          style={{ borderColor: "var(--theme-border-soft)" }}
+        >
           <div>
             <div className="text-sm font-semibold">Technician CoPilot</div>
-            <div className="text-xs text-muted-foreground">
+            <div className="text-xs text-[color:var(--theme-text-secondary)]">
               Stays with you as you move through the app
             </div>
           </div>
@@ -149,7 +211,11 @@ export function TechnicianCopilotShell({
             type="button"
             onClick={close}
             aria-label="Close Technician CoPilot"
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border bg-background"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border"
+            style={{
+              borderColor: "var(--theme-border-soft)",
+              background: "var(--theme-surface-panel)",
+            }}
           >
             <X className="h-5 w-5" aria-hidden />
           </button>

--- a/features/copilot/technician/components/TechnicianTextCopilot.tsx
+++ b/features/copilot/technician/components/TechnicianTextCopilot.tsx
@@ -74,6 +74,8 @@ type Snapshot = {
 
 type InputMode = "ui" | "voice";
 
+const COPILOT_TURN_TIMEOUT_MS = 45_000;
+
 function timeLabel(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "";
@@ -92,9 +94,11 @@ function voiceStatus(phase: ReturnType<typeof useTechnicianInteractionGateway>["
 export function TechnicianTextCopilot({
   embedded = false,
   active = true,
+  compact = false,
 }: {
   embedded?: boolean;
   active?: boolean;
+  compact?: boolean;
 }) {
   const [snapshot, setSnapshot] = useState<Snapshot>({
     context: null,
@@ -147,10 +151,16 @@ export function TechnicianTextCopilot({
 
       setBusy(true);
       setError(null);
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(
+        () => controller.abort(),
+        COPILOT_TURN_TIMEOUT_MS,
+      );
       try {
         const response = await fetch("/api/copilot/technician/chat", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
+          signal: controller.signal,
           body: JSON.stringify({
             message: normalized,
             sessionId,
@@ -174,13 +184,15 @@ export function TechnicianTextCopilot({
         }));
         return body;
       } catch (reason) {
-        const message =
-          reason instanceof Error
-            ? reason.message
-            : "CoPilot could not process that turn.";
-        setError(message);
-        throw reason instanceof Error ? reason : new Error(message);
+        const failure = controller.signal.aborted
+          ? new Error("CoPilot took too long to respond. Please try again.")
+          : reason instanceof Error
+            ? reason
+            : new Error("CoPilot could not process that turn.");
+        setError(failure.message);
+        throw failure;
       } finally {
+        window.clearTimeout(timeoutId);
         setBusy(false);
       }
     },
@@ -237,16 +249,124 @@ export function TechnicianTextCopilot({
     return (
       <main
         className={cn(
-          "mx-auto max-w-4xl p-4 text-sm text-muted-foreground",
+          "mx-auto max-w-4xl p-4 text-sm text-[color:var(--theme-text-secondary)]",
           embedded && "flex h-full items-center justify-center",
+          compact && "min-h-20",
         )}
       >
-        Loading Technician CoPilot…
+        Connecting Technician CoPilot…
       </main>
     );
   }
 
   const recentTimeline = snapshot.context?.documentation.timeline.slice(-8) ?? [];
+  const latestAssistantReply =
+    snapshot.reply?.trim() ||
+    [...(snapshot.context?.conversation ?? [])]
+      .reverse()
+      .find((turn) => turn.role === "assistant")
+      ?.text.trim() ||
+    null;
+  const visibleVoiceError = voice.error ?? error;
+
+  if (compact) {
+    return (
+      <main className="h-full min-h-0 overflow-y-auto p-3 text-[color:var(--theme-text-primary)]">
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <span
+              className={cn(
+                "h-2.5 w-2.5 shrink-0 rounded-full",
+                voice.phase === "listening"
+                  ? "animate-pulse bg-emerald-400"
+                  : voice.phase === "thinking" || voice.phase === "speaking"
+                    ? "animate-pulse bg-sky-400"
+                    : voice.phase === "error"
+                      ? "bg-rose-400"
+                      : "bg-[color:var(--theme-text-muted)]",
+              )}
+              aria-hidden
+            />
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-semibold" aria-live="polite">
+                {voiceEnabled
+                  ? voiceStatus(voice.phase)
+                  : "Voice is not enabled for this technician"}
+              </div>
+              {vehicleLabel ? (
+                <div className="truncate text-xs text-[color:var(--theme-text-secondary)]">
+                  {vehicleLabel}
+                </div>
+              ) : null}
+            </div>
+            {voiceEnabled ? (
+              <button
+                type="button"
+                disabled={busy && !voice.active}
+                onClick={() =>
+                  voice.active ? voice.stop() : void voice.start()
+                }
+                className="inline-flex min-h-11 shrink-0 items-center gap-2 rounded-xl border px-3 py-2 text-sm font-semibold disabled:opacity-50"
+                style={{
+                  borderColor: "var(--theme-border-soft)",
+                  background: "var(--theme-surface-panel)",
+                }}
+              >
+                {voice.active ? (
+                  <Square className="h-4 w-4" aria-hidden />
+                ) : (
+                  <Mic className="h-4 w-4" aria-hidden />
+                )}
+                {voice.active ? "Stop" : "Start"}
+              </button>
+            ) : null}
+          </div>
+
+          {voice.heardTranscript ? (
+            <div
+              className="rounded-xl px-3 py-2 text-sm"
+              style={{ background: "var(--theme-surface-subtle)" }}
+            >
+              <span className="font-semibold">You:</span>{" "}
+              {voice.heardTranscript}
+            </div>
+          ) : null}
+
+          {latestAssistantReply ? (
+            <div
+              className="max-h-24 overflow-y-auto rounded-xl px-3 py-2 text-sm"
+              style={{ background: "var(--theme-surface-panel)" }}
+              aria-live="polite"
+            >
+              <span className="font-semibold">CoPilot:</span>{" "}
+              {latestAssistantReply}
+            </div>
+          ) : null}
+
+          {visibleVoiceError ? (
+            <div className="text-sm text-rose-400" role="alert">
+              {visibleVoiceError}
+            </div>
+          ) : null}
+
+          {voice.phase === "speaking" ? (
+            <button
+              type="button"
+              onClick={voice.interrupt}
+              className="inline-flex min-h-11 items-center gap-2 rounded-xl border px-3 py-2 text-sm font-semibold"
+              style={{
+                borderColor: "var(--theme-border-soft)",
+                background: "var(--theme-surface-panel)",
+              }}
+            >
+              <VolumeX className="h-4 w-4" aria-hidden />
+              Interrupt reply
+            </button>
+          ) : null}
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main

--- a/features/copilot/technician/components/TechnicianTextCopilot.tsx
+++ b/features/copilot/technician/components/TechnicianTextCopilot.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { Mic, Square, VolumeX } from "lucide-react";
@@ -74,7 +75,33 @@ type Snapshot = {
 
 type InputMode = "ui" | "voice";
 
+type TurnRequest = {
+  message: string;
+  sessionId: string | null;
+  turnId: string;
+  inputMode: InputMode;
+};
+
 const COPILOT_TURN_TIMEOUT_MS = 45_000;
+const RECOVERABLE_TURN_STATUSES = new Set([408, 425, 429, 502, 503, 504]);
+
+class TechnicianCopilotTurnRequestError extends Error {
+  readonly recoverable: boolean;
+
+  constructor(message: string, recoverable: boolean) {
+    super(message);
+    this.name = "TechnicianCopilotTurnRequestError";
+    this.recoverable = recoverable;
+  }
+}
+
+function sameTurnInput(
+  request: TurnRequest,
+  message: string,
+  inputMode: InputMode,
+) {
+  return request.message === message && request.inputMode === inputMode;
+}
 
 function timeLabel(value: string) {
   const date = new Date(value);
@@ -108,6 +135,7 @@ export function TechnicianTextCopilot({
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const pendingTurnRef = useRef<TurnRequest | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -139,6 +167,73 @@ export function TechnicianTextCopilot({
     snapshot.capabilities?.documentation !== false;
   const voiceEnabled = snapshot.capabilities?.voice === true;
 
+  const applyTurnSnapshot = useCallback((body: Snapshot) => {
+    setSnapshot((current) => ({
+      ...current,
+      ...body,
+      session:
+        Object.prototype.hasOwnProperty.call(body, "session")
+          ? body.session
+          : body.sessionId
+            ? { id: body.sessionId }
+            : current.session,
+    }));
+  }, []);
+
+  const requestTurn = useCallback(async (request: TurnRequest) => {
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(
+      () => controller.abort(),
+      COPILOT_TURN_TIMEOUT_MS,
+    );
+
+    try {
+      const response = await fetch("/api/copilot/technician/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: controller.signal,
+        body: JSON.stringify(request),
+      });
+      const body = (await response.json()) as Snapshot;
+      if (!response.ok) {
+        const recoverable = RECOVERABLE_TURN_STATUSES.has(response.status);
+        if (recoverable) {
+          pendingTurnRef.current = request;
+        } else if (pendingTurnRef.current?.turnId === request.turnId) {
+          pendingTurnRef.current = null;
+        }
+        throw new TechnicianCopilotTurnRequestError(
+          body.error || "CoPilot could not process that turn.",
+          recoverable,
+        );
+      }
+
+      if (pendingTurnRef.current?.turnId === request.turnId) {
+        pendingTurnRef.current = null;
+      }
+      return body;
+    } catch (reason) {
+      if (reason instanceof TechnicianCopilotTurnRequestError) throw reason;
+
+      // Aborting the browser request does not cancel the server operation. Keep
+      // the exact turn key so the next attempt reconciles the persisted result
+      // instead of issuing a second mutation under a fresh idempotency key.
+      pendingTurnRef.current = request;
+      if (controller.signal.aborted) {
+        throw new TechnicianCopilotTurnRequestError(
+          "CoPilot took too long to respond. Please try again; the same turn will resume safely.",
+          true,
+        );
+      }
+      throw new TechnicianCopilotTurnRequestError(
+        "The CoPilot connection was interrupted. Please try again; the same turn will resume safely.",
+        true,
+      );
+    } finally {
+      window.clearTimeout(timeoutId);
+    }
+  }, []);
+
   const sendTurn = useCallback(
     async (text: string, inputMode: InputMode): Promise<Snapshot> => {
       const normalized = text.trim();
@@ -151,52 +246,39 @@ export function TechnicianTextCopilot({
 
       setBusy(true);
       setError(null);
-      const controller = new AbortController();
-      const timeoutId = window.setTimeout(
-        () => controller.abort(),
-        COPILOT_TURN_TIMEOUT_MS,
-      );
       try {
-        const response = await fetch("/api/copilot/technician/chat", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          signal: controller.signal,
-          body: JSON.stringify({
-            message: normalized,
-            sessionId,
-            turnId: crypto.randomUUID(),
-            inputMode,
-          }),
-        });
-        const body = (await response.json()) as Snapshot;
-        if (!response.ok) {
-          throw new Error(body.error || "CoPilot could not process that turn.");
+        let activeSessionId = sessionId;
+        const pending = pendingTurnRef.current;
+        if (pending) {
+          const reconciled = await requestTurn(pending);
+          applyTurnSnapshot(reconciled);
+          activeSessionId =
+            reconciled.session?.id ?? reconciled.sessionId ?? activeSessionId;
+          if (sameTurnInput(pending, normalized, inputMode)) {
+            return reconciled;
+          }
         }
-        setSnapshot((current) => ({
-          ...current,
-          ...body,
-          session:
-            Object.prototype.hasOwnProperty.call(body, "session")
-              ? body.session
-              : body.sessionId
-                ? { id: body.sessionId }
-                : current.session,
-        }));
+
+        const body = await requestTurn({
+          message: normalized,
+          sessionId: activeSessionId,
+          turnId: crypto.randomUUID(),
+          inputMode,
+        });
+        applyTurnSnapshot(body);
         return body;
       } catch (reason) {
-        const failure = controller.signal.aborted
-          ? new Error("CoPilot took too long to respond. Please try again.")
-          : reason instanceof Error
+        const failure =
+          reason instanceof Error
             ? reason
             : new Error("CoPilot could not process that turn.");
         setError(failure.message);
         throw failure;
       } finally {
-        window.clearTimeout(timeoutId);
         setBusy(false);
       }
     },
-    [busy, sessionId],
+    [applyTurnSnapshot, busy, requestTurn, sessionId],
   );
 
   const handleVoiceUtterance = useCallback(

--- a/features/copilot/technician/voice/useTechnicianInteractionGateway.ts
+++ b/features/copilot/technician/voice/useTechnicianInteractionGateway.ts
@@ -36,6 +36,11 @@ function normalizedTranscript(text: string): string | null {
   return value || null;
 }
 
+function speechWatchdogDelay(text: string): number {
+  const wordCount = Math.max(1, text.trim().split(/\s+/).length);
+  return Math.min(90_000, Math.max(10_000, wordCount * 750 + 6_000));
+}
+
 export function useTechnicianInteractionGateway({
   enabled,
   autoStart = false,
@@ -57,6 +62,8 @@ export function useTechnicianInteractionGateway({
   const startListeningRef = useRef<() => Promise<void>>(async () => undefined);
   const speakReplyRef = useRef<(text: string) => void>(() => undefined);
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+  const speechWatchdogRef = useRef<number | null>(null);
+  const speechStartWatchdogRef = useRef<number | null>(null);
 
   const setVoicePhase = useCallback((next: TechnicianVoicePhase) => {
     phaseRef.current = next;
@@ -67,10 +74,22 @@ export function useTechnicianInteractionGateway({
     onUtteranceRef.current = onUtterance;
   }, [onUtterance]);
 
+  const clearSpeechWatchdog = useCallback(() => {
+    if (speechWatchdogRef.current !== null) {
+      window.clearTimeout(speechWatchdogRef.current);
+      speechWatchdogRef.current = null;
+    }
+    if (speechStartWatchdogRef.current !== null) {
+      window.clearTimeout(speechStartWatchdogRef.current);
+      speechStartWatchdogRef.current = null;
+    }
+  }, []);
+
   const invalidateGeneration = useCallback(() => {
     generationRef.current += 1;
     inFlightRef.current = false;
-  }, []);
+    clearSpeechWatchdog();
+  }, [clearSpeechWatchdog]);
 
   const handleTransportState = useCallback(
     (state: TechnicianRealtimeVoiceState) => {
@@ -152,19 +171,12 @@ export function useTechnicianInteractionGateway({
           ) {
             return;
           }
-          try {
-            realtimeRef.current?.stop();
-          } catch {}
-          transportStartedRef.current = false;
-          invalidateGeneration();
-          activeRef.current = false;
-          setModeActive(false);
-          setVoicePhase("error");
           setError(
             caught instanceof Error
               ? caught.message
               : "Technician CoPilot could not process that voice turn.",
           );
+          await startListeningRef.current();
         } finally {
           if (generationRef.current === generation) {
             inFlightRef.current = false;
@@ -172,7 +184,7 @@ export function useTechnicianInteractionGateway({
         }
       })();
     },
-    [invalidateGeneration, setVoicePhase],
+    [setVoicePhase],
   );
 
   const realtime = useTechnicianRealtimeVoice(
@@ -244,7 +256,7 @@ export function useTechnicianInteractionGateway({
         return;
       }
 
-      window.speechSynthesis.cancel();
+      const speechSynthesis = window.speechSynthesis;
       const utterance = new SpeechSynthesisUtterance(text);
       utterance.lang = "en-US";
       utterance.rate = 1;
@@ -259,6 +271,7 @@ export function useTechnicianInteractionGateway({
         ) {
           return;
         }
+        clearSpeechWatchdog();
         utteranceRef.current = null;
         void startListeningRef.current();
       };
@@ -274,18 +287,67 @@ export function useTechnicianInteractionGateway({
         setError("Spoken reply could not play. Continuing in listening mode.");
         resume();
       };
-      window.speechSynthesis.speak(utterance);
+
+      clearSpeechWatchdog();
+      speechWatchdogRef.current = window.setTimeout(() => {
+        if (
+          utteranceRef.current !== utterance ||
+          !activeRef.current ||
+          generationRef.current !== generation
+        ) {
+          return;
+        }
+        utteranceRef.current = null;
+        speechWatchdogRef.current = null;
+        try {
+          speechSynthesis.cancel();
+        } catch {}
+        setError(
+          "The spoken reply stalled. The reply is shown here and voice is listening again.",
+        );
+        void startListeningRef.current();
+      }, speechWatchdogDelay(text));
+
+      try {
+        // WebKit can leave speech synthesis paused after route changes or an
+        // interrupted utterance. Resume it and avoid cancel-then-speak, which
+        // can silently strand a new utterance on iOS Safari.
+        speechSynthesis.resume();
+        speechSynthesis.speak(utterance);
+        speechStartWatchdogRef.current = window.setTimeout(() => {
+          speechStartWatchdogRef.current = null;
+          if (
+            utteranceRef.current !== utterance ||
+            !activeRef.current ||
+            generationRef.current !== generation ||
+            speechSynthesis.speaking ||
+            speechSynthesis.pending
+          ) {
+            return;
+          }
+          utteranceRef.current = null;
+          clearSpeechWatchdog();
+          setError(
+            "Spoken reply could not start. The reply is shown here and voice is listening again.",
+          );
+          void startListeningRef.current();
+        }, 1_500);
+      } catch {
+        clearSpeechWatchdog();
+        utteranceRef.current = null;
+        setError(
+          "Spoken reply could not start. The reply is shown here and voice is listening again.",
+        );
+        void startListeningRef.current();
+      }
     },
-    [setVoicePhase],
+    [clearSpeechWatchdog, setVoicePhase],
   );
   speakReplyRef.current = speakReply;
 
   const start = useCallback(async () => {
     if (!enabled || activeRef.current) return;
     invalidateGeneration();
-    if (typeof window !== "undefined") {
-      window.speechSynthesis?.cancel();
-    }
     utteranceRef.current = null;
     activeRef.current = true;
     setModeActive(true);
@@ -311,9 +373,10 @@ export function useTechnicianInteractionGateway({
     if (typeof window !== "undefined") {
       window.speechSynthesis?.cancel();
     }
+    clearSpeechWatchdog();
     utteranceRef.current = null;
     setVoicePhase("idle");
-  }, [invalidateGeneration, setVoicePhase]);
+  }, [clearSpeechWatchdog, invalidateGeneration, setVoicePhase]);
 
   const interrupt = useCallback(() => {
     if (!activeRef.current || phaseRef.current !== "speaking") return;
@@ -322,10 +385,11 @@ export function useTechnicianInteractionGateway({
     if (typeof window !== "undefined") {
       window.speechSynthesis?.cancel();
     }
+    clearSpeechWatchdog();
     if (currentUtterance && activeRef.current) {
       void startListeningRef.current();
     }
-  }, []);
+  }, [clearSpeechWatchdog]);
 
   useEffect(() => {
     if (!enabled && activeRef.current) {

--- a/features/copilot/technician/voice/useTechnicianInteractionGateway.ts
+++ b/features/copilot/technician/voice/useTechnicianInteractionGateway.ts
@@ -38,7 +38,35 @@ function normalizedTranscript(text: string): string | null {
 
 function speechWatchdogDelay(text: string): number {
   const wordCount = Math.max(1, text.trim().split(/\s+/).length);
-  return Math.min(90_000, Math.max(10_000, wordCount * 750 + 6_000));
+  // A validated reply may contain 2,000 characters. Slow mobile voices can
+  // legitimately need several minutes for that much text, so the completion
+  // watchdog scales with both words and characters instead of truncating at a
+  // fixed 90-second ceiling.
+  return Math.max(
+    10_000,
+    wordCount * 750 + 6_000,
+    text.trim().length * 150 + 6_000,
+  );
+}
+
+function isRecoverableTurnFailure(caught: unknown): boolean {
+  if (caught && typeof caught === "object" && "recoverable" in caught) {
+    const marker = (caught as { recoverable?: unknown }).recoverable;
+    if (typeof marker === "boolean") return marker;
+  }
+  if (
+    typeof DOMException !== "undefined" &&
+    caught instanceof DOMException &&
+    caught.name === "AbortError"
+  ) {
+    return true;
+  }
+  if (caught instanceof TypeError) return true;
+
+  const message = caught instanceof Error ? caught.message : "";
+  return /took too long|network|connection was interrupted|temporar|try again/i.test(
+    message,
+  );
 }
 
 export function useTechnicianInteractionGateway({
@@ -171,12 +199,26 @@ export function useTechnicianInteractionGateway({
           ) {
             return;
           }
-          setError(
+          const failureMessage =
             caught instanceof Error
               ? caught.message
-              : "Technician CoPilot could not process that voice turn.",
-          );
-          await startListeningRef.current();
+              : "Technician CoPilot could not process that voice turn.";
+          setError(failureMessage);
+          if (isRecoverableTurnFailure(caught)) {
+            await startListeningRef.current();
+          } else {
+            // Authorization, stale-session, capability, and configuration
+            // failures require user action. Stop the microphone instead of
+            // resubmitting every subsequent transcript into a terminal state.
+            invalidateGeneration();
+            activeRef.current = false;
+            setModeActive(false);
+            transportStartedRef.current = false;
+            try {
+              realtimeRef.current?.stop();
+            } catch {}
+            setVoicePhase("error");
+          }
         } finally {
           if (generationRef.current === generation) {
             inFlightRef.current = false;
@@ -184,7 +226,7 @@ export function useTechnicianInteractionGateway({
         }
       })();
     },
-    [setVoicePhase],
+    [invalidateGeneration, setVoicePhase],
   );
 
   const realtime = useTechnicianRealtimeVoice(

--- a/features/mobile/dashboard/MobileTechHome.tsx
+++ b/features/mobile/dashboard/MobileTechHome.tsx
@@ -19,6 +19,7 @@ import type { MobileRole } from "@/features/mobile/config/mobile-tiles";
 import { fetchMobileShiftState } from "@/features/mobile/shifts/client";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { useTechnicianCopilotAvailability } from "@/features/copilot/technician/client/useTechnicianCopilotAvailability";
+import { openTechnicianCopilot } from "@/features/copilot/technician/components/TechnicianCopilotShell";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -492,7 +493,7 @@ export function MobileTechHome({
           />
           {technicianCopilotAvailable ? (
             <ActionTile
-              href="/mobile/copilot/technician"
+              onClick={openTechnicianCopilot}
               title="Technician CoPilot"
               detail="Voice repair collaborator"
               icon={Mic2}
@@ -723,22 +724,19 @@ function CurrentJobCard({
   );
 }
 
-function ActionTile({
-  href,
-  title,
-  detail,
-  icon: Icon,
-}: {
-  href: string;
+type ActionTileProps = {
   title: string;
   detail: string;
   icon: typeof BriefcaseBusiness;
-}) {
-  return (
-    <Link
-      href={href}
-      className="mobile-tech-subpanel min-w-0 border p-3.5 active:scale-[0.992]"
-    >
+} & (
+  | { href: string; onClick?: never }
+  | { href?: never; onClick: () => void }
+);
+
+function ActionTile(props: ActionTileProps) {
+  const { title, detail, icon: Icon } = props;
+  const content = (
+    <>
       <span className="inline-grid h-10 w-10 place-items-center rounded-xl bg-[color:var(--theme-surface-subtle)] text-[color:var(--accent-copper)]">
         <Icon aria-hidden className="h-5 w-5" />
       </span>
@@ -748,6 +746,23 @@ function ActionTile({
       <span className="mt-1 block text-[0.7rem] leading-4 text-[color:var(--theme-text-secondary)]">
         {detail}
       </span>
+    </>
+  );
+
+  const className =
+    "mobile-tech-subpanel min-w-0 border p-3.5 text-left active:scale-[0.992]";
+
+  if (!props.href) {
+    return (
+      <button type="button" onClick={props.onClick} className={className}>
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <Link href={props.href} className={className}>
+      {content}
     </Link>
   );
 }

--- a/tests/mobile-technician-first-ux.test.ts
+++ b/tests/mobile-technician-first-ux.test.ts
@@ -77,6 +77,8 @@ describe("technician-first mobile UX", () => {
     expect(techHome).toContain("Open current job");
     expect(techHome).toContain("Hours &amp; efficiency");
     expect(techHome).toContain("<details");
+    expect(techHome).toContain("onClick={openTechnicianCopilot}");
+    expect(techHome).not.toContain('href="/mobile/copilot/technician"');
     expect(techHome).not.toContain("Bench-side view");
   });
 

--- a/tests/technician-copilot-compact-dock.test.tsx
+++ b/tests/technician-copilot-compact-dock.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const voice = vi.hoisted(() => ({
+  phase: "speaking" as const,
+  active: true,
+  heardTranscript: "What's my next job?",
+  error: null as string | null,
+  start: vi.fn(async () => undefined),
+  stop: vi.fn(),
+  interrupt: vi.fn(),
+}));
+
+vi.mock(
+  "@/features/copilot/technician/voice/useTechnicianInteractionGateway",
+  () => ({
+    useTechnicianInteractionGateway: () => voice,
+  }),
+);
+
+import { TechnicianTextCopilot } from "@/features/copilot/technician/components/TechnicianTextCopilot";
+
+describe("compact Technician CoPilot dock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          session: { id: "session-1" },
+          capabilities: { documentation: true, voice: true },
+          reply: "Your next assigned job is EL000008, the Ford.",
+          workOrder: {
+            customId: "EL000008",
+            vehicleYear: 2018,
+            vehicleMake: "Ford",
+            vehicleModel: "F-550",
+            vehicleUnitNumber: "41",
+          },
+          context: {
+            currentTask: null,
+            complaint: null,
+            conversation: [],
+            observations: [],
+            findings: [],
+            measurements: [],
+            dtcs: [],
+            documentation: {
+              capturedEventCount: 0,
+              lastCapturedAt: null,
+              repairNoteDraft: "",
+              timeline: [],
+            },
+          },
+        }),
+      })),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows both the heard request and persisted reply without the full page", async () => {
+    render(<TechnicianTextCopilot embedded active compact />);
+
+    expect(
+      await screen.findByText("Your next assigned job is EL000008, the Ford."),
+    ).toBeVisible();
+    expect(screen.getByText("What's my next job?")).toBeVisible();
+    expect(screen.getByText("CoPilot is replying…")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Interrupt reply" }),
+    ).toBeVisible();
+    expect(
+      screen.queryByText("Persistent repair collaborator"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/tests/technician-copilot-persistent-shell.test.tsx
+++ b/tests/technician-copilot-persistent-shell.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { readFileSync } from "node:fs";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const replace = vi.fn();
@@ -29,13 +29,26 @@ vi.mock(
 vi.mock(
   "@/features/copilot/technician/components/TechnicianTextCopilot",
   () => ({
-    TechnicianTextCopilot: ({ active }: { active?: boolean }) => (
-      <div data-testid="copilot-runtime" data-active={String(active)} />
+    TechnicianTextCopilot: ({
+      active,
+      compact,
+    }: {
+      active?: boolean;
+      compact?: boolean;
+    }) => (
+      <div
+        data-testid="copilot-runtime"
+        data-active={String(active)}
+        data-compact={String(compact)}
+      />
     ),
   }),
 );
 
-import { TechnicianCopilotShell } from "@/features/copilot/technician/components/TechnicianCopilotShell";
+import {
+  openTechnicianCopilot,
+  TechnicianCopilotShell,
+} from "@/features/copilot/technician/components/TechnicianCopilotShell";
 import { TechnicianCopilotCompatibilityRoute } from "@/features/copilot/technician/components/TechnicianCopilotCompatibilityRoute";
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
@@ -80,7 +93,7 @@ describe("persistent Technician CoPilot shell", () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
-  it("keeps the mobile collaborator mounted without retaining modal locks", () => {
+  it("keeps a compact mobile voice dock mounted without blocking the page", () => {
     pathname = "/mobile/tech/queue";
     render(<TechnicianCopilotShell shouldCheck surface="mobile" />);
 
@@ -91,26 +104,47 @@ describe("persistent Technician CoPilot shell", () => {
       screen.getByRole("button", { name: "Open Technician CoPilot" }),
     );
 
-    const dialog = screen.getByRole("dialog", { name: "Technician CoPilot" });
-    expect(dialog).toHaveAttribute("aria-hidden", "false");
-    expect(dialog).toHaveClass(
+    const dock = screen.getByRole("region", { name: "Technician CoPilot" });
+    expect(dock).toHaveAttribute("aria-hidden", "false");
+    expect(dock).not.toHaveAttribute("aria-modal");
+    expect(dock).toHaveClass(
       "visible",
       "pointer-events-auto",
       "opacity-100",
+      "inset-x-3",
     );
+    expect(dock).not.toHaveClass("inset-0");
     expect(screen.getByTestId("copilot-runtime")).toBe(runtime);
     expect(runtime).toHaveAttribute("data-active", "true");
+    expect(runtime).toHaveAttribute("data-compact", "true");
+    expect(document.body.style.pointerEvents).not.toBe("none");
+    expect(document.body).not.toHaveAttribute("data-scroll-locked");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show full CoPilot conversation" }),
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Technician CoPilot" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveClass("inset-0");
+    expect(screen.getByTestId("copilot-runtime")).toBe(runtime);
+    expect(runtime).toHaveAttribute("data-compact", "false");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Return to compact voice controls" }),
+    );
+    expect(
+      screen.getByRole("region", { name: "Technician CoPilot" }),
+    ).toBeVisible();
+    expect(screen.getByTestId("copilot-runtime")).toBe(runtime);
+    expect(runtime).toHaveAttribute("data-compact", "true");
 
     fireEvent.click(
       screen.getByRole("button", { name: "Close Technician CoPilot" }),
     );
 
-    expect(dialog).toHaveAttribute("aria-hidden", "true");
-    expect(dialog).toHaveClass(
-      "invisible",
-      "pointer-events-none",
-      "opacity-0",
-    );
+    expect(dock).toHaveAttribute("aria-hidden", "true");
+    expect(dock).toHaveClass("invisible", "pointer-events-none", "opacity-0");
     expect(screen.getByTestId("copilot-runtime")).toBe(runtime);
     expect(runtime).toHaveAttribute("data-active", "false");
     expect(document.body.style.pointerEvents).not.toBe("none");
@@ -124,12 +158,28 @@ describe("persistent Technician CoPilot shell", () => {
     expect(runtime).toHaveAttribute("data-active", "true");
   });
 
+  it("opens the compact dock in place through the shared mobile action", () => {
+    pathname = "/mobile";
+    render(<TechnicianCopilotShell shouldCheck surface="mobile" />);
+
+    act(() => openTechnicianCopilot());
+
+    expect(
+      screen.getByRole("region", { name: "Technician CoPilot" }),
+    ).toBeVisible();
+    expect(screen.getByTestId("copilot-runtime")).toHaveAttribute(
+      "data-compact",
+      "true",
+    );
+    expect(replace).not.toHaveBeenCalled();
+  });
+
   it("opens from the legacy mobile destination and returns to the job queue on close", () => {
     pathname = "/mobile/copilot/technician";
     render(<TechnicianCopilotShell shouldCheck surface="mobile" />);
 
     expect(
-      screen.getByRole("dialog", { name: "Technician CoPilot" }),
+      screen.getByRole("region", { name: "Technician CoPilot" }),
     ).toBeVisible();
     const closeButtons = screen.getAllByRole("button", {
       name: "Close Technician CoPilot",

--- a/tests/technician-copilot-turn-timeout.test.tsx
+++ b/tests/technician-copilot-turn-timeout.test.tsx
@@ -1,0 +1,146 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const voice = vi.hoisted(() => ({
+  phase: "idle" as const,
+  active: false,
+  heardTranscript: "",
+  error: null,
+  start: vi.fn(async () => undefined),
+  stop: vi.fn(),
+  interrupt: vi.fn(),
+}));
+
+vi.mock(
+  "@/features/copilot/technician/voice/useTechnicianInteractionGateway",
+  () => ({
+    useTechnicianInteractionGateway: () => voice,
+  }),
+);
+
+import { TechnicianTextCopilot } from "@/features/copilot/technician/components/TechnicianTextCopilot";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+function contextWithReply(turnId: string) {
+  return {
+    currentTask: null,
+    complaint: null,
+    conversation: [
+      {
+        eventId: "event-user",
+        role: "user",
+        text: "Complete this job.",
+        turnId,
+      },
+      {
+        eventId: "event-assistant",
+        role: "assistant",
+        text: "The original turn completed safely.",
+        turnId,
+      },
+    ],
+    observations: [],
+    findings: [],
+    measurements: [],
+    dtcs: [],
+    documentation: {
+      capturedEventCount: 0,
+      lastCapturedAt: null,
+      repairNoteDraft: "",
+      timeline: [],
+    },
+  };
+}
+
+describe("Technician CoPilot turn timeout recovery", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("reuses the timed-out turn id when the technician retries", async () => {
+    const chatBodies: Array<{
+      message: string;
+      sessionId: string | null;
+      turnId: string;
+      inputMode: string;
+    }> = [];
+    const fetchMock = vi.fn(
+      (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        const url = String(input);
+        if (url.endsWith("/api/copilot/technician/session")) {
+          return Promise.resolve(
+            jsonResponse({
+              session: { id: "session-1" },
+              capabilities: { documentation: true, voice: false },
+              context: null,
+              workOrder: null,
+            }),
+          );
+        }
+
+        const body = JSON.parse(String(init?.body)) as (typeof chatBodies)[number];
+        chatBodies.push(body);
+        if (chatBodies.length === 1) {
+          return new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("Aborted", "AbortError")),
+              { once: true },
+            );
+          });
+        }
+
+        return Promise.resolve(
+          jsonResponse({
+            session: { id: "session-1" },
+            capabilities: { documentation: true, voice: false },
+            context: contextWithReply(body.turnId),
+            workOrder: null,
+            reply: "The original turn completed safely.",
+            turnId: body.turnId,
+            replayed: true,
+          }),
+        );
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TechnicianTextCopilot embedded active />);
+    const input = await screen.findByPlaceholderText("Talk to your CoPilot…");
+
+    vi.useFakeTimers();
+    fireEvent.change(input, { target: { value: "Complete this job." } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_001);
+    });
+
+    expect(
+      screen.getByText(/same turn will resume safely/i),
+    ).toBeInTheDocument();
+    expect(chatBodies).toHaveLength(1);
+
+    vi.useRealTimers();
+    fireEvent.change(input, { target: { value: "Complete this job." } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(
+      await screen.findByText("The original turn completed safely."),
+    ).toBeVisible();
+    expect(chatBodies).toHaveLength(2);
+    expect(chatBodies[1]).toMatchObject({
+      message: chatBodies[0]?.message,
+      sessionId: chatBodies[0]?.sessionId,
+      turnId: chatBodies[0]?.turnId,
+      inputMode: chatBodies[0]?.inputMode,
+    });
+  });
+});

--- a/tests/technician-copilot-voice-gateway.test.tsx
+++ b/tests/technician-copilot-voice-gateway.test.tsx
@@ -199,6 +199,37 @@ describe("Technician CoPilot voice interaction gateway", () => {
     expect(realtime.stop).not.toHaveBeenCalled();
   });
 
+  it("stops voice after a terminal CoPilot turn failure", async () => {
+    const terminalFailure = Object.assign(
+      new Error(
+        "The active CoPilot repair context changed. Reload before continuing.",
+      ),
+      { recoverable: false },
+    );
+    const onUtterance = vi.fn(async () => {
+      throw terminalFailure;
+    });
+    const { result } = renderHook(() =>
+      useTechnicianInteractionGateway({ enabled: true, onUtterance }),
+    );
+
+    await act(async () => {
+      await result.current.start();
+    });
+    act(() => {
+      realtime.onFinal?.("Complete this job.");
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe("error");
+      expect(result.current.active).toBe(false);
+    });
+    expect(result.current.error).toContain("Reload before continuing");
+    expect(result.current.heardTranscript).toBe("Complete this job.");
+    expect(realtime.stop).toHaveBeenCalledTimes(1);
+    expect(realtime.resume).not.toHaveBeenCalled();
+  });
+
   it("recovers when iOS speech synthesis never emits a completion event", async () => {
     vi.useFakeTimers();
     try {
@@ -230,6 +261,43 @@ describe("Technician CoPilot voice interaction gateway", () => {
       expect(result.current.phase).toBe("listening");
       expect(result.current.error).toContain("spoken reply stalled");
       expect(result.current.active).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not truncate a maximum-length valid reply at 90 seconds", async () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() =>
+        useTechnicianInteractionGateway({
+          enabled: true,
+          onUtterance: vi.fn(async () => ({ reply: "x".repeat(2_000) })),
+        }),
+      );
+
+      await act(async () => {
+        await result.current.start();
+      });
+      await act(async () => {
+        realtime.onFinal?.("Read the full answer.");
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.phase).toBe("speaking");
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(90_001);
+      });
+
+      expect(speech.cancel).not.toHaveBeenCalled();
+      expect(result.current.phase).toBe("speaking");
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(216_000);
+      });
+      expect(speech.cancel).toHaveBeenCalledTimes(1);
+      expect(result.current.phase).toBe("listening");
     } finally {
       vi.useRealTimers();
     }

--- a/tests/technician-copilot-voice-gateway.test.tsx
+++ b/tests/technician-copilot-voice-gateway.test.tsx
@@ -48,7 +48,10 @@ class FakeSpeechSynthesisUtterance {
 
 const speech = {
   cancel: vi.fn(),
+  resume: vi.fn(),
   speak: vi.fn((_utterance: SpeechSynthesisUtterance) => undefined),
+  speaking: true,
+  pending: false,
 };
 
 function deferred<T>() {
@@ -65,6 +68,8 @@ describe("Technician CoPilot voice interaction gateway", () => {
     realtime.connected = false;
     realtime.onFinal = null;
     realtime.onStateChange = null;
+    speech.speaking = true;
+    speech.pending = false;
     realtime.start.mockImplementation(async () => {
       realtime.connected = true;
       realtime.onStateChange?.("listening");
@@ -146,6 +151,7 @@ describe("Technician CoPilot voice interaction gateway", () => {
     });
     expect(realtime.pause).toHaveBeenCalledTimes(1);
     expect(realtime.stop).not.toHaveBeenCalled();
+    expect(speech.resume).toHaveBeenCalledTimes(1);
     expect(speech.speak).toHaveBeenCalledTimes(1);
 
     act(() => {
@@ -167,6 +173,100 @@ describe("Technician CoPilot voice interaction gateway", () => {
       expect(realtime.start).toHaveBeenCalledTimes(1);
       expect(result.current.phase).toBe("listening");
     });
+  });
+
+  it("returns to listening when a persisted CoPilot turn fails", async () => {
+    const onUtterance = vi.fn(async () => {
+      throw new Error("CoPilot took too long to respond. Please try again.");
+    });
+    const { result } = renderHook(() =>
+      useTechnicianInteractionGateway({ enabled: true, onUtterance }),
+    );
+
+    await act(async () => {
+      await result.current.start();
+    });
+    act(() => {
+      realtime.onFinal?.("What is my next job?");
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe("listening");
+      expect(result.current.error).toContain("took too long");
+    });
+    expect(result.current.active).toBe(true);
+    expect(realtime.resume).toHaveBeenCalledTimes(1);
+    expect(realtime.stop).not.toHaveBeenCalled();
+  });
+
+  it("recovers when iOS speech synthesis never emits a completion event", async () => {
+    vi.useFakeTimers();
+    try {
+      const onUtterance = vi.fn(async () => ({
+        reply: "Your next assigned job is the Ford.",
+      }));
+      const { result } = renderHook(() =>
+        useTechnicianInteractionGateway({ enabled: true, onUtterance }),
+      );
+
+      await act(async () => {
+        await result.current.start();
+      });
+      await act(async () => {
+        realtime.onFinal?.("What is my next job?");
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.phase).toBe("speaking");
+      expect(speech.speak).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(90_001);
+      });
+
+      expect(speech.cancel).toHaveBeenCalledTimes(1);
+      expect(realtime.resume).toHaveBeenCalledTimes(1);
+      expect(result.current.phase).toBe("listening");
+      expect(result.current.error).toContain("spoken reply stalled");
+      expect(result.current.active).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns to listening quickly when device speech never starts", async () => {
+    vi.useFakeTimers();
+    try {
+      speech.speaking = false;
+      speech.pending = false;
+      const { result } = renderHook(() =>
+        useTechnicianInteractionGateway({
+          enabled: true,
+          onUtterance: vi.fn(async () => ({ reply: "The reply is ready." })),
+        }),
+      );
+
+      await act(async () => {
+        await result.current.start();
+      });
+      await act(async () => {
+        realtime.onFinal?.("Can you hear me?");
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current.phase).toBe("speaking");
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_501);
+      });
+
+      expect(result.current.phase).toBe("listening");
+      expect(result.current.error).toContain("could not start");
+      expect(result.current.active).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("lets the technician interrupt a spoken reply and resume the same Realtime session", async () => {


### PR DESCRIPTION
## What changed

- Replace the transparent full-screen mobile CoPilot layer with a compact, opaque voice dock that leaves the current screen usable.
- Let technicians expand the full conversation without remounting or losing the active voice runtime.
- Open CoPilot in place from the mobile dashboard instead of navigating away from the technician's current context.
- Keep the heard transcript, persisted text reply, phase, vehicle context, and errors visible in the compact dock.
- Add explicit opaque theme surfaces for both mobile and desktop CoPilot shells.
- Add a 45-second chat request timeout with an actionable error and listening recovery.
- Make iOS/WebKit speech playback more resilient by avoiding cancel-before-speak, resuming synthesis first, and adding start/completion watchdogs.
- Resume listening after turn or device-speech failures while preserving the persisted reply on screen.

## Root cause

The mobile shell used a full-viewport fixed layer with an undefined semantic Tailwind background class, so the entire CoPilot page rendered transparently over the technician dashboard. The screenshots' stuck **“CoPilot is replying…”** state meant the reply had already persisted, but Safari speech synthesis could stall indefinitely because each reply cancelled immediately before speaking and no playback watchdog could recover it.

## User impact

- CoPilot no longer obscures or blocks the mobile workflow.
- The current screen remains visible and interactive while voice mode is active.
- A reply remains readable even when iOS cannot speak it.
- Stalled requests or speech return to listening automatically with a visible explanation.

## Validation

- Focused tests: 4 files, 29 tests passed.
- Full Vitest suite: 427 files passed, 1 skipped; 2,448 tests passed, 2 skipped.
- TypeScript: `tsc --noEmit` passed.
- Production Next.js build passed with CI placeholder environment values.
- Changed-file ESLint: 0 errors; 6 pre-existing unused-disable warnings in `MobileTechHome.tsx`.
- Regression inventory: 0 new errors. Reported warnings are existing unrelated dynamic-RPC inventory items in files outside this change.
- `git diff --check` passed.

## Database

No migration, schema, production-data, or environment changes.

## Remaining live verification

Validate the deployed preview on iPhone/iPad Safari: open the dock, continue using the underlying dashboard, hear or read a reply, interrupt playback, expand/collapse, and confirm listening resumes after a simulated speech failure.