### PR TITLE
fix: use supported completion token parameter

### DIFF
--- a/app/api/ai/summarize-tech-performance/route.ts
+++ b/app/api/ai/summarize-tech-performance/route.ts
@@ -112,7 +112,7 @@ export async function POST(req: Request) {
     const completion = await openai.chat.completions.create({
       model: getOpenAIModelForPurpose("fast"),
       ...openAITemperatureParam(getOpenAIModelForPurpose("fast"), 0.4),
-      max_tokens: 260,
+      max_completion_tokens: 260,
       messages: [
         {
           role: "system",


### PR DESCRIPTION
Production hardening fix for `/api/ai/summarize-tech-performance`.

Vercel runtime logs showed OpenAI returning HTTP 400 because `max_tokens` is unsupported by the configured GPT-5-family fast model and requires `max_completion_tokens` instead. This PR changes only that request parameter. Existing model-aware temperature gating remains unchanged.

Validation target:
- full Agent PR Checks (typecheck, changed-file lint, complete test suite, production build)
- preview deployment if Vercel preview builds are enabled

No production deploy or database changes are included.