### PR TITLE
chore: restore preview deploys for agent branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -32,6 +32,8 @@
   "git": {
     "deploymentEnabled": {
       "main": true,
+      "agent/*": true,
+      "codex/*": true,
       "*": false
     }
   }


### PR DESCRIPTION
Production-hardening infrastructure fix.

`vercel.json` currently has `git.deploymentEnabled` set to `main: true` and `*: false`, which is why every non-main PR preview is being canceled before build. This keeps the default-deny rule but explicitly enables preview deployments for `agent/*` and `codex/*` branches used by the assisted hardening workflow.

Vercel documents that overlapping `deploymentEnabled` patterns deploy when at least one matching rule is `true`, so `agent/*`/`codex/*` override the catch-all `*`: false without enabling arbitrary branches.

No production deployment, cron change, database change, or application code change is included.