### PR TITLE
Fix shop assistant assignment and parts lookups

### DIFF
--- a/features/shop-assistant/server/orchestrator/formatToolOutput.ts
+++ b/features/shop-assistant/server/orchestrator/formatToolOutput.ts
@@ -93,6 +93,26 @@ export function formatShopAssistantToolOutput(
         ? `${name}: ${active} active job(s), ${utilization}% utilization.`
         : null;
     });
+  } else if (toolName === "list_technician_assignments") {
+    bullets = formatListRows(record.workOrders, (item) => {
+      const customId = stringValue(item.customId);
+      const status = stringValue(item.status);
+      const vehicle = stringValue(item.vehicle);
+      const lineLabels = Array.isArray(item.lines)
+        ? item.lines
+            .map((line) => stringValue(asRecord(line).label))
+            .filter((label): label is string => Boolean(label))
+            .slice(0, 3)
+        : [];
+      return [
+        customId ? `WO #${customId}` : "Assigned work order",
+        status,
+        vehicle,
+        lineLabels.length ? lineLabels.join("; ") : null,
+      ]
+        .filter(Boolean)
+        .join(" - ");
+    });
   } else if (toolName === "list_my_assigned_work") {
     bullets = formatListRows(record.workOrders, (item) => {
       const customId = stringValue(item.customId);

--- a/features/shop-assistant/server/orchestrator/planner.ts
+++ b/features/shop-assistant/server/orchestrator/planner.ts
@@ -115,6 +115,26 @@ function customerSearchQuery(question: string): string | null {
   return trailing?.replace(/[?.!]+$/, "").trim() || null;
 }
 
+function technicianAssignmentQuery(question: string): string | null {
+  const patterns = [
+    /\bwhat(?:['’]s|\s+is)\s+(.{2,120}?)\s+(?:assigned\s+to|working\s+on)\b/i,
+    /\b(?:show|list)\s+(?:the\s+)?assignments?\s+(?:for|of)\s+(.{2,120})[?.!]*$/i,
+    /\b(?:show|list)\s+(.{2,120}?)['’]s\s+assignments?\b/i,
+  ];
+  for (const pattern of patterns) {
+    const match = question.match(pattern)?.[1]
+      ?.replace(/[?.!]+$/, "")
+      .trim();
+    if (
+      match &&
+      !/^(?:he|she|they|them|that|the technician|the tech)$/i.test(match)
+    ) {
+      return match;
+    }
+  }
+  return null;
+}
+
 function callsPlan(
   calls: Array<{ name: string; input?: Record<string, unknown> }>,
   rationale: string,
@@ -207,6 +227,24 @@ export function selectDeterministicShopAssistantPlan(params: {
     return callsPlan(
       [{ name: "list_my_assigned_work", input: { limit: 20 } }],
       "Read only the signed-in mechanic's assigned active work.",
+    );
+  }
+
+  const namedTechnician = technicianAssignmentQuery(question);
+  if (namedTechnician) {
+    return (
+      permitted(
+        [
+          {
+            name: "list_technician_assignments",
+            input: { query: namedTechnician, limit: 20 },
+          },
+        ],
+        "Resolve the named same-shop technician and read assigned active work regardless of shift state.",
+      ) ?? {
+        kind: "clarification",
+        message: "Your role cannot view shop-wide technician assignments.",
+      }
     );
   }
 

--- a/features/shop-assistant/server/tools/domains/inventory.ts
+++ b/features/shop-assistant/server/tools/domains/inventory.ts
@@ -62,7 +62,11 @@ type PartRequestItemRow = {
   qty_approved: number | null;
   qty_received: number | null;
   work_order_id: string | null;
-  work_orders: { custom_id: string | null; shop_id: string | null } | null;
+};
+
+type PartBlockerWorkOrderRow = {
+  id: string;
+  custom_id: string | null;
 };
 
 const PartRequestCreateResultSchema = z.object({
@@ -346,9 +350,7 @@ export const listPartsBlockersTool = defineShopAssistantTool({
     for (let from = 0; blockers.length < input.limit; from += pageSize) {
       let query = context.actor.supabase
         .from("part_request_items")
-        .select(
-          "id, description, qty_approved, qty_received, work_order_id, work_orders(custom_id, shop_id)",
-        )
+        .select("id, description, qty_approved, qty_received, work_order_id")
         .eq("shop_id", context.actor.shopId)
         .order("updated_at", { ascending: false })
         .order("id", { ascending: true })
@@ -373,7 +375,6 @@ export const listPartsBlockersTool = defineShopAssistantTool({
         );
         if (remainingQuantity <= 0) continue;
 
-        const customId = row.work_orders?.custom_id?.trim() || null;
         const workOrderId = row.work_order_id?.trim() || null;
         blockers.push({
           requestItemId,
@@ -382,8 +383,8 @@ export const listPartsBlockersTool = defineShopAssistantTool({
           receivedQuantity,
           remainingQuantity,
           workOrderId,
-          workOrderLabel: customId ? `WO #${customId}` : null,
-          href: workOrderId ? `/work-orders/${workOrderId}` : "/parts/requests",
+          workOrderLabel: null,
+          href: "/parts/requests",
         });
 
         if (blockers.length >= input.limit) break;
@@ -392,10 +393,50 @@ export const listPartsBlockersTool = defineShopAssistantTool({
       if (rows.length < pageSize) break;
     }
 
+    // part_request_items.work_order_id is intentionally not backed by a
+    // database foreign key in the current schema, so PostgREST cannot resolve
+    // a nested work_orders relationship. Resolve display labels explicitly and
+    // keep the lookup same-shop scoped.
+    const workOrdersById = new Map<string, PartBlockerWorkOrderRow>();
+    const workOrderIds = [
+      ...new Set(
+        blockers
+          .map((blocker) => blocker.workOrderId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ];
+    for (let from = 0; from < workOrderIds.length; from += 100) {
+      const ids = workOrderIds.slice(from, from + 100);
+      const { data, error } = await context.actor.supabase
+        .from("work_orders")
+        .select("id, custom_id")
+        .eq("shop_id", context.actor.shopId)
+        .in("id", ids)
+        .range(0, ids.length - 1);
+      if (error) throw new Error(error.message);
+      for (const row of (data ?? []) as PartBlockerWorkOrderRow[]) {
+        workOrdersById.set(row.id, row);
+      }
+    }
+
+    const resolvedBlockers = blockers.map((blocker) => {
+      const workOrder = blocker.workOrderId
+        ? workOrdersById.get(blocker.workOrderId)
+        : undefined;
+      const workOrderId = workOrder?.id ?? null;
+      const customId = workOrder?.custom_id?.trim() || null;
+      return {
+        ...blocker,
+        workOrderId,
+        workOrderLabel: customId ? `WO #${customId}` : null,
+        href: workOrderId ? `/work-orders/${workOrderId}` : "/parts/requests",
+      };
+    });
+
     return {
       ok: true as const,
-      blockers,
-      summary: `${blockers.length} part request item(s) still have unreceived quantity.`,
+      blockers: resolvedBlockers,
+      summary: `${resolvedBlockers.length} part request item(s) still have unreceived quantity.`,
       href: "/parts/requests",
     };
   },

--- a/features/shop-assistant/server/tools/domains/workforce.ts
+++ b/features/shop-assistant/server/tools/domains/workforce.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { z } from "zod";
 
+import { listTechnicianWorkCandidates } from "@/features/copilot/technician/server/assignedWork";
 import { canonicalizeRole } from "@/features/shared/lib/rbac";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { getTechnicianLoadMetricsWithClient } from "@/features/shared/lib/stats/getTechnicianLoadMetricsCore";
@@ -17,6 +18,21 @@ const TechnicianLoadSchema = z.object({
   completedJobsToday: z.number().int().nonnegative(),
   utilizationPct: z.number(),
   shiftSecondsToday: z.number().nonnegative(),
+});
+
+const TechnicianAssignmentLineSchema = z.object({
+  lineId: z.string().uuid(),
+  label: z.string(),
+  status: z.string(),
+});
+
+const TechnicianAssignmentWorkOrderSchema = z.object({
+  workOrderId: z.string().uuid(),
+  customId: z.string().nullable(),
+  status: z.string().nullable(),
+  vehicle: z.string().nullable(),
+  lines: z.array(TechnicianAssignmentLineSchema),
+  href: z.string(),
 });
 
 const AssignmentResultSchema = z.object({
@@ -66,6 +82,13 @@ type AssignmentLineRow = {
   job_priority: string | null;
 };
 
+type TechnicianProfileRow = {
+  id: string;
+  user_id: string | null;
+  full_name: string | null;
+  role: string | null;
+};
+
 function isAssignableTechnicianRole(role: string | null | undefined): boolean {
   const canonical = canonicalizeRole(role);
   return (
@@ -93,6 +116,32 @@ function normalizedStatus(value: unknown): string {
     .trim()
     .toLowerCase()
     .replaceAll(" ", "_");
+}
+
+function normalizedTechnicianName(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLocaleLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+function technicianVehicleLabel(candidate: {
+  vehicleYear: number | null;
+  vehicleMake: string | null;
+  vehicleModel: string | null;
+  vehicleUnitNumber: string | null;
+}): string | null {
+  const description = [
+    candidate.vehicleYear,
+    candidate.vehicleMake,
+    candidate.vehicleModel,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    [candidate.vehicleUnitNumber, description].filter(Boolean).join(" • ") ||
+    null
+  );
 }
 
 export const listTechnicianLoadTool = defineShopAssistantTool({
@@ -136,6 +185,114 @@ export const listTechnicianLoadTool = defineShopAssistantTool({
       shopUtilizationPct: load.summary.shopUtilizationPct,
       summary: `${technicians.length} technician(s) are included in the current load view.`,
       href: "/dashboard",
+    };
+  },
+});
+
+export const listTechnicianAssignmentsTool = defineShopAssistantTool({
+  name: "list_technician_assignments",
+  domain: "workforce",
+  description:
+    "Resolve a same-shop technician by name and list their canonically assigned active job lines, including off-shift technicians.",
+  mode: "read",
+  risk: "low",
+  requiredAnyCapabilities: ["canAssignWork", "canManageWorkforce"],
+  confirmation: "never",
+  inputSchema: z.object({
+    query: z.string().trim().min(1).max(120),
+    limit: z.number().int().min(1).max(30).default(20),
+  }),
+  outputSchema: z.object({
+    ok: z.literal(true),
+    technician: z.object({
+      technicianId: z.string().uuid(),
+      name: z.string(),
+      role: z.string().nullable(),
+    }),
+    workOrders: z.array(TechnicianAssignmentWorkOrderSchema),
+    summary: z.string(),
+    href: z.string(),
+  }),
+  async execute(input, context) {
+    const profiles: TechnicianProfileRow[] = [];
+    const pageSize = 500;
+    for (let from = 0; ; from += pageSize) {
+      const { data, error } = await context.actor.supabase
+        .from("profiles")
+        .select("id, user_id, full_name, role")
+        .eq("shop_id", context.actor.shopId)
+        .order("full_name", { ascending: true, nullsFirst: false })
+        .order("id", { ascending: true })
+        .range(from, from + pageSize - 1);
+      if (error) throw new Error(error.message);
+      const page = (data ?? []) as TechnicianProfileRow[];
+      profiles.push(...page);
+      if (page.length < pageSize) break;
+    }
+
+    const query = normalizedTechnicianName(input.query);
+    const eligible = profiles.filter(
+      (profile) =>
+        isAssignableTechnicianRole(profile.role) &&
+        Boolean(profile.full_name?.trim()),
+    );
+    const exactMatches = eligible.filter(
+      (profile) => normalizedTechnicianName(profile.full_name) === query,
+    );
+    const matches =
+      exactMatches.length > 0
+        ? exactMatches
+        : eligible.filter((profile) =>
+            normalizedTechnicianName(profile.full_name).includes(query),
+          );
+
+    if (matches.length === 0) {
+      throw new ShopAssistantHttpError(
+        404,
+        `No technician named "${input.query}" was found in this shop.`,
+      );
+    }
+    if (matches.length > 1) {
+      throw new ShopAssistantHttpError(
+        409,
+        `More than one technician matched "${input.query}". Use the technician's full name.`,
+      );
+    }
+
+    const technician = matches[0];
+    const assignments = await listTechnicianWorkCandidates({
+      supabase: context.actor.supabase,
+      shopId: context.actor.shopId,
+      technicianIds: [technician.id, technician.user_id ?? ""],
+    });
+    const workOrders = assignments.slice(0, input.limit).map((candidate) => ({
+      workOrderId: candidate.id,
+      customId: candidate.customId,
+      status: candidate.status,
+      vehicle: technicianVehicleLabel(candidate),
+      lines: candidate.lines.map((line) => ({
+        lineId: line.id,
+        label: line.description ?? line.complaint ?? "Job line",
+        status: line.status,
+      })),
+      href: `/work-orders/${candidate.id}`,
+    }));
+    const lineCount = workOrders.reduce(
+      (total, workOrder) => total + workOrder.lines.length,
+      0,
+    );
+    const technicianName = technician.full_name?.trim() || input.query;
+
+    return {
+      ok: true as const,
+      technician: {
+        technicianId: technician.id,
+        name: technicianName,
+        role: technician.role,
+      },
+      workOrders,
+      summary: `${technicianName} has ${lineCount} active job line(s) across ${workOrders.length} assigned work order(s).`,
+      href: "/work-orders",
     };
   },
 });

--- a/features/shop-assistant/server/tools/registry.ts
+++ b/features/shop-assistant/server/tools/registry.ts
@@ -82,6 +82,7 @@ import {
 } from "./domains/workOrders";
 import {
   assignWorkOrderTool,
+  listTechnicianAssignmentsTool,
   listTechnicianLoadTool,
   recommendWorkAssignmentsTool,
 } from "./domains/workforce";
@@ -144,6 +145,7 @@ const TOOL_DEFINITIONS = [
   searchInvoicesTool,
   listMyAssignedWorkTool,
   requestTechnicianCopilotTool,
+  listTechnicianAssignmentsTool,
   listTechnicianLoadTool,
   recommendWorkAssignmentsTool,
   assignWorkOrderTool,

--- a/tests/shop-assistant-prefilled-prompts.test.ts
+++ b/tests/shop-assistant-prefilled-prompts.test.ts
@@ -14,6 +14,7 @@ const availableToolNames = new Set([
   "list_parts_blockers",
   "read_daily_activity",
   "recommend_work_assignments",
+  "list_technician_assignments",
   "list_technician_load",
   "find_customers",
 ]);
@@ -62,6 +63,19 @@ describe("shop assistant prefilled prompts", () => {
       startsAt: clock.todayStart,
       endsAt: clock.todayEnd,
     });
+  });
+
+  it("routes named technician assignment questions independently of shift load", () => {
+    const result = plan("What is Test Mechanic assigned to?");
+    expect(result.kind).toBe("tools");
+    if (result.kind !== "tools") return;
+    expect(result.calls).toEqual([
+      {
+        name: "list_technician_assignments",
+        input: { query: "Test Mechanic", limit: 20 },
+        mode: "read",
+      },
+    ]);
   });
 
   it("keeps customer lookup deterministic when the model is unavailable", () => {

--- a/tests/shop-assistant-review-hardening.test.ts
+++ b/tests/shop-assistant-review-hardening.test.ts
@@ -2,9 +2,14 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 
 const technicianLoadMock = vi.hoisted(() => vi.fn());
+const technicianAssignmentsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/features/shared/lib/stats/getTechnicianLoadMetricsCore", () => ({
   getTechnicianLoadMetricsWithClient: technicianLoadMock,
+}));
+
+vi.mock("@/features/copilot/technician/server/assignedWork", () => ({
+  listTechnicianWorkCandidates: technicianAssignmentsMock,
 }));
 
 import {
@@ -16,7 +21,10 @@ import {
   listPartsBlockersTool,
 } from "@/features/shop-assistant/server/tools/domains/inventory";
 import { listBookingsTool } from "@/features/shop-assistant/server/tools/domains/scheduling";
-import { recommendWorkAssignmentsTool } from "@/features/shop-assistant/server/tools/domains/workforce";
+import {
+  listTechnicianAssignmentsTool,
+  recommendWorkAssignmentsTool,
+} from "@/features/shop-assistant/server/tools/domains/workforce";
 import { listStalledWorkOrdersTool } from "@/features/shop-assistant/server/tools/domains/workOrders";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
 
@@ -128,11 +136,13 @@ describe("shop assistant review hardening", () => {
       qty_approved: index === 500 ? 3 : 1,
       qty_received: index === 500 ? 1 : 1,
       work_order_id: uuid(70_000),
-      work_orders: { custom_id: "WO-70000", shop_id: uuid(90_000) },
     }));
     const ranges: number[] = [];
     const supabase = queryClient(
-      { part_request_items: requestItems },
+      {
+        part_request_items: requestItems,
+        work_orders: [{ id: uuid(70_000), custom_id: "WO-70000" }],
+      },
       (table, from) => {
         if (table === "part_request_items") ranges.push(from);
       },
@@ -150,6 +160,74 @@ describe("shop assistant review hardening", () => {
       requestItemId: uuid(501),
       remainingQuantity: 2,
       workOrderId: uuid(70_000),
+      workOrderLabel: "WO #WO-70000",
+    });
+  });
+
+  it("lists a named technician's canonical assignments without requiring an active shift", async () => {
+    technicianLoadMock.mockClear();
+    technicianAssignmentsMock.mockResolvedValueOnce([
+      {
+        id: uuid(80_000),
+        customId: "EL000004",
+        status: "active",
+        concern: null,
+        description: null,
+        vehicleYear: 2021,
+        vehicleMake: "Ford",
+        vehicleModel: "F-150",
+        vehicleVin: null,
+        vehicleUnitNumber: null,
+        lineIds: [uuid(80_001)],
+        lines: [
+          {
+            id: uuid(80_001),
+            complaint: null,
+            description: "Replace front brake pads",
+            status: "in_progress",
+            cause: null,
+            correction: null,
+            holdReason: null,
+            priority: null,
+            createdAt: null,
+            updatedAt: null,
+          },
+        ],
+        lineComplaints: [],
+      },
+    ]);
+    const supabase = queryClient({
+      profiles: [
+        {
+          id: uuid(79_000),
+          user_id: uuid(79_001),
+          shop_id: uuid(90_000),
+          full_name: "Test Mechanic",
+          role: "mechanic",
+        },
+      ],
+    });
+
+    const result = await listTechnicianAssignmentsTool.execute(
+      { query: "test mechanic", limit: 20 },
+      {
+        actor: { shopId: uuid(90_000), supabase },
+        threadId: uuid(90_001),
+        idempotencyKey: "named-technician-assignments-test",
+      } as never,
+    );
+
+    expect(technicianLoadMock).not.toHaveBeenCalled();
+    expect(technicianAssignmentsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shopId: uuid(90_000),
+        technicianIds: [uuid(79_000), uuid(79_001)],
+      }),
+    );
+    expect(result.technician.name).toBe("Test Mechanic");
+    expect(result.workOrders[0]).toMatchObject({
+      customId: "EL000004",
+      lines: [{ label: "Replace front brake pads" }],
     });
   });
 


### PR DESCRIPTION
## What changed

- add a `list_technician_assignments` Shop Assistant tool that resolves a same-shop technician by name and reads canonical active assignments regardless of shift state
- route named questions such as “What is Test Mechanic assigned to?” deterministically to the new tool
- format the new assignment results with work order, status, vehicle, and job-line details
- replace the parts-blocker nested relationship query with an explicit same-shop work-order lookup
- add focused regressions for parts blockers, named technician assignments, and planner routing

## Root cause

The existing technician-load tool filtered out off-shift technicians, so it could report zero technicians instead of answering a named assignment question.

The parts-blocker query asked PostgREST to embed `work_orders` from `part_request_items`, but the current schema has no foreign key relationship for that join. Supabase therefore rejected the request while resolving its schema cache.

## Impact

Managers can now ask what a named technician is assigned to even when that technician is off shift. Parts-delay summaries no longer depend on a nonexistent database relationship, and all work-order label resolution remains explicitly shop scoped.

## Validation

- focused Vitest regressions: 9 passed
- TypeScript `tsc --noEmit`: passed
- ESLint on changed TypeScript files: passed
- inventory regression check: zero new errors
- Next.js production compilation: passed; page-data collection then stopped because the fresh local checkout has no Supabase URL configured

## Notes

No database migration or production data change is required. One broader pre-existing SQL assertion remains Windows-line-ending sensitive and was not changed by this PR.