### PR TITLE
Field dashboard command center

### DIFF
--- a/app/mobile/appointments/page.tsx
+++ b/app/mobile/appointments/page.tsx
@@ -472,7 +472,10 @@ export default function MobileAppointmentsPage() {
         </section>
 
         {/* Create / edit form */}
-        <section className="space-y-2 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 shadow-card backdrop-blur-md">
+        <section
+          id="new-appointment"
+          className="scroll-mt-24 space-y-2 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 shadow-card backdrop-blur-md"
+        >
           {!online ? (
             <p className="text-xs text-[color:var(--theme-text-secondary)]">
               Appointment creation and changes require a connection. Saved

--- a/app/mobile/field-hub.css
+++ b/app/mobile/field-hub.css
@@ -344,6 +344,10 @@
   font-weight: 700;
 }
 
+.field-workspace-drawer__footer > :only-child {
+  grid-column: 1 / -1;
+}
+
 /* Field Hub dashboard */
 .field-hub {
   width: min(100%, 96rem);
@@ -395,94 +399,69 @@
   line-height: 1.45;
 }
 
-.field-hub-hero__actions {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.55rem;
-}
-
-.field-hub-primary-action,
-.field-hub-secondary-action {
+.field-hub-hero__status {
   display: inline-flex;
-  min-height: 3rem;
+  min-height: 2.6rem;
   align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  border-radius: 0.85rem;
-  padding: 0.65rem 0.9rem;
-  font-size: 0.8rem;
+  align-self: flex-start;
+  gap: 0.45rem;
+  border: 1px solid rgba(134, 213, 255, 0.24);
+  border-radius: 999px;
+  padding: 0.55rem 0.8rem;
+  background: rgba(41, 182, 246, 0.12);
+  color: #b7e7ff;
+  font-size: 0.72rem;
   font-weight: 800;
 }
 
-.field-hub-primary-action {
-  background: linear-gradient(135deg, #1747ff, #159ee7);
-  color: white;
-  box-shadow: 0 12px 28px rgba(23, 71, 255, 0.3);
+.field-hub-hero__status[data-online="false"] {
+  border-color: rgba(251, 191, 36, 0.3);
+  background: rgba(245, 158, 11, 0.13);
+  color: #fbd38d;
 }
 
-.field-hub-secondary-action {
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.075);
-  color: white;
-}
-
-.field-hub-signals {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.55rem;
+.field-hub-actions {
   margin-top: 0.7rem;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 1.35rem;
+  padding: 0.9rem;
+  background: color-mix(in srgb, var(--theme-surface-panel) 96%, transparent);
+  box-shadow: 0 16px 42px rgba(3, 13, 32, 0.08);
 }
 
-.field-hub-signal {
+.field-hub-actions__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.field-hub-action {
   display: flex;
   min-width: 0;
-  align-items: center;
-  gap: 0.7rem;
-  border: 1px solid var(--theme-border-soft);
+  min-height: 4.5rem;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--accent-copper) 25%, var(--theme-border-soft));
   border-radius: 1rem;
-  padding: 0.7rem 0.8rem;
-  background: var(--theme-surface-panel);
-  box-shadow: 0 10px 28px rgba(3, 13, 32, 0.07);
-}
-
-.field-hub-signal__icon {
-  display: grid;
-  width: 2.25rem;
-  height: 2.25rem;
-  flex: 0 0 auto;
-  place-items: center;
-  border-radius: 0.72rem;
-  background: rgba(41, 182, 246, 0.12);
-  color: #1585bd;
-}
-
-.field-hub-signal__icon[data-tone="green"] {
-  background: rgba(16, 185, 129, 0.12);
-  color: #0d956a;
-}
-
-.field-hub-signal__icon[data-tone="amber"] {
-  background: rgba(245, 158, 11, 0.13);
-  color: #b66b05;
-}
-
-.field-hub-signal strong,
-.field-hub-signal small {
-  display: block;
-}
-
-.field-hub-signal strong {
+  padding: 0.72rem;
+  background: color-mix(in srgb, var(--accent-copper) 7%, var(--theme-surface-page));
   color: var(--theme-text-primary);
-  font-size: 0.78rem;
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1.2;
+  transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
 }
 
-.field-hub-signal small {
-  overflow: hidden;
-  margin-top: 0.08rem;
-  color: var(--theme-text-secondary);
-  font-size: 0.66rem;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.field-hub-action svg {
+  color: var(--accent-copper);
+}
+
+.field-hub-action:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent-copper) 65%, var(--theme-border-soft));
+  box-shadow: 0 12px 26px rgba(3, 13, 32, 0.1);
 }
 
 .field-hub-grid {
@@ -536,6 +515,26 @@
   font-weight: 750;
 }
 
+.field-hub-customize {
+  display: inline-flex;
+  min-height: 2.65rem;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 999px;
+  padding: 0.45rem 0.7rem;
+  background: var(--theme-surface-page);
+  color: var(--theme-text-primary);
+  font-size: 0.66rem;
+  font-weight: 800;
+}
+
+.field-hub-customize:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
 .field-hub-module-grid {
   display: grid;
   grid-template-columns: 1fr;
@@ -559,11 +558,6 @@ a.field-hub-module:hover {
   transform: translateY(-1px);
   border-color: color-mix(in srgb, var(--accent-copper) 55%, var(--theme-border-soft));
   box-shadow: 0 12px 28px rgba(3, 13, 32, 0.09);
-}
-
-.field-hub-module[data-available="false"] {
-  border-style: dashed;
-  opacity: 0.74;
 }
 
 .field-hub-module__icon {
@@ -594,15 +588,210 @@ a.field-hub-module:hover {
   line-height: 1.35;
 }
 
-.field-hub-module__badge {
+.field-hub-empty-cards {
+  display: grid;
+  min-height: 12rem;
+  place-items: center;
+  align-content: center;
+  gap: 0.55rem;
+  border: 1px dashed var(--theme-border-soft);
+  border-radius: 1rem;
+  padding: 1.2rem;
+  color: var(--theme-text-secondary);
+  text-align: center;
+}
+
+.field-hub-empty-cards p {
+  font-size: 0.78rem;
+}
+
+.field-hub-empty-cards button {
+  min-height: 2.6rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--accent-copper) 12%, transparent);
-  padding: 0.12rem 0.38rem;
-  color: var(--accent-copper);
-  font-size: 0.55rem;
+  padding: 0.45rem 0.8rem;
+  background: var(--accent-copper);
+  color: var(--theme-text-on-accent);
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.field-hub-controls__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 75;
+  padding: 0.6rem;
+  background: rgba(1, 7, 19, 0.68);
+  backdrop-filter: blur(8px);
+}
+
+.field-hub-controls {
+  display: flex;
+  width: min(100%, 34rem);
+  height: 100%;
+  margin-left: auto;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 1.35rem;
+  background: var(--theme-surface-panel);
+  color: var(--theme-text-primary);
+  box-shadow: 0 28px 80px rgba(1, 7, 19, 0.36);
+}
+
+.field-hub-controls__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--theme-border-soft);
+  padding: calc(1rem + env(safe-area-inset-top, 0px)) 1rem 1rem;
+}
+
+.field-hub-controls__header h2 {
+  margin-top: 0.15rem;
+  font-size: 1.1rem;
   font-weight: 850;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  letter-spacing: -0.025em;
+}
+
+.field-hub-controls__header p {
+  margin-top: 0.25rem;
+  color: var(--theme-text-secondary);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.field-hub-controls__header > button {
+  display: grid;
+  width: 2.7rem;
+  height: 2.7rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 0.8rem;
+  background: var(--theme-surface-page);
+}
+
+.field-hub-controls__list {
+  display: grid;
+  min-height: 0;
+  flex: 1;
+  align-content: start;
+  gap: 0.55rem;
+  overflow-y: auto;
+  padding: 0.8rem;
+}
+
+.field-hub-control-row {
+  display: flex;
+  min-width: 0;
+  min-height: 4.35rem;
+  align-items: center;
+  gap: 0.65rem;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 1rem;
+  padding: 0.65rem;
+  background: var(--theme-surface-page);
+}
+
+.field-hub-control-row__icon {
+  display: grid;
+  width: 2.35rem;
+  height: 2.35rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--accent-copper) 12%, transparent);
+  color: var(--accent-copper);
+}
+
+.field-hub-control-row__label {
+  min-width: 0;
+  flex: 1;
+}
+
+.field-hub-control-row__label strong,
+.field-hub-control-row__label small {
+  display: block;
+}
+
+.field-hub-control-row__label strong {
+  overflow: hidden;
+  font-size: 0.75rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.field-hub-control-row__label small {
+  margin-top: 0.12rem;
+  color: var(--theme-text-secondary);
+  font-size: 0.62rem;
+}
+
+.field-hub-control-row__actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.field-hub-control-row__actions button {
+  display: grid;
+  min-width: 2.45rem;
+  height: 2.45rem;
+  place-items: center;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 0.7rem;
+  background: var(--theme-surface-inset);
+  color: var(--theme-text-primary);
+  font-size: 0.64rem;
+  font-weight: 850;
+}
+
+.field-hub-control-row__actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.36;
+}
+
+.field-hub-control-row__actions .field-hub-control-row__toggle {
+  width: auto;
+  min-width: 2.8rem;
+  padding-inline: 0.45rem;
+}
+
+.field-hub-control-row__toggle[data-visible="true"] {
+  border-color: color-mix(in srgb, var(--accent-copper) 62%, transparent);
+  background: color-mix(in srgb, var(--accent-copper) 15%, transparent);
+  color: var(--accent-copper);
+}
+
+.field-hub-controls__footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.65rem;
+  border-top: 1px solid var(--theme-border-soft);
+  padding: 0.8rem 0.8rem calc(0.8rem + env(safe-area-inset-bottom, 0px));
+}
+
+.field-hub-controls__footer button {
+  display: inline-flex;
+  min-height: 2.8rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 0.8rem;
+  padding: 0.55rem 0.8rem;
+  background: var(--theme-surface-page);
+  color: var(--theme-text-primary);
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.field-hub-controls__footer button:last-child {
+  border-color: var(--accent-copper);
+  background: var(--accent-copper);
+  color: var(--theme-text-on-accent);
 }
 
 @media (min-width: 36rem) {
@@ -614,13 +803,12 @@ a.field-hub-module:hover {
     padding: 1.5rem;
   }
 
-  .field-hub-hero__actions {
-    grid-template-columns: auto auto;
-    justify-content: start;
+  .field-hub-actions__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .field-hub-signals {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  .field-hub-action {
+    min-height: 5rem;
   }
 
   .field-hub-module-grid {
@@ -672,8 +860,12 @@ a.field-hub-module:hover {
     padding: 1.75rem 2rem;
   }
 
-  .field-hub-hero__actions {
-    flex: 0 0 auto;
+  .field-hub-hero__status {
+    align-self: center;
+  }
+
+  .field-hub-actions__grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
   }
 
   .field-hub-grid {

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -1,120 +1,185 @@
 "use client";
 
 import {
+  ArrowDown,
   ArrowRight,
+  ArrowUp,
   Boxes,
   BriefcaseBusiness,
   CalendarDays,
-  CheckCircle2,
   ClipboardCheck,
-  Clock3,
-  FileText,
+  CreditCard,
+  EyeOff,
+  FilePlus2,
   PackagePlus,
   Plus,
   RadioTower,
-  Truck,
-  UserRound,
+  ReceiptText,
+  RotateCcw,
+  Settings2,
+  SlidersHorizontal,
+  Wrench,
   Wifi,
   WifiOff,
+  X,
   type LucideIcon,
 } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import MobileServiceShell from "./MobileServiceShell";
+import {
+  buildDefaultFieldDashboardLayout,
+  FIELD_DASHBOARD_LAYOUT_CACHE_KEY,
+  FIELD_DASHBOARD_LAYOUT_SCOPE,
+  moveFieldDashboardCard,
+  normalizeFieldDashboardLayout,
+  setFieldDashboardCardVisibility,
+  type FieldDashboardCardId,
+  type FieldDashboardLayoutItem,
+} from "./fieldDashboardLayout";
 import {
   canUseFieldWorkspaceCapability,
   type FieldWorkspaceCapabilities,
 } from "./fieldWorkspaceCapabilities";
 
-type FieldModule = {
+type FieldAction = {
   title: string;
-  description: string;
   href: string;
   icon: LucideIcon;
   requiredCapability?: keyof FieldWorkspaceCapabilities;
 };
 
-const FIELD_MODULES: FieldModule[] = [
+type FieldDashboardCard = FieldAction & {
+  id: FieldDashboardCardId;
+  description: string;
+};
+
+const FIELD_PRIMARY_ACTIONS: FieldAction[] = [
   {
-    title: "Appointments",
-    description: "Accept, create and manage digital bookings.",
-    href: "/mobile/appointments",
+    title: "New appointment",
+    href: "/mobile/appointments#new-appointment",
     icon: CalendarDays,
     requiredCapability: "canManageScheduling",
   },
   {
-    title: "Work orders",
-    description: "Build the repair, labor and job record.",
-    href: "/mobile/work-orders",
-    icon: BriefcaseBusiness,
+    title: "New service call",
+    href: "/mobile/service/new",
+    icon: Plus,
   },
   {
-    title: "Inspections",
-    description: "Run forms, capture evidence and findings.",
+    title: "New work order",
+    href: "/mobile/work-orders/create",
+    icon: FilePlus2,
+  },
+  {
+    title: "Scan or create part",
+    href: "/mobile/service/truck-inventory",
+    icon: Boxes,
+  },
+  {
+    title: "Start inspection",
     href: "/mobile/inspections",
     icon: ClipboardCheck,
   },
   {
-    title: "Customer intake",
-    description: "Find or create the customer as you book the call.",
-    href: "/mobile/service/new",
-    icon: UserRound,
+    title: "Invoice or payment",
+    href: "/mobile/work-orders?status=ready_to_invoice&mode=field_closeout",
+    icon: CreditCard,
+  },
+];
+
+const FIELD_DASHBOARD_CARDS: FieldDashboardCard[] = [
+  {
+    id: "jobs_in_progress",
+    title: "Jobs in progress",
+    description: "Return to active repairs and service calls.",
+    href: "/mobile/work-orders?status=in_progress",
+    icon: Wrench,
   },
   {
-    title: "Parts & truck stock",
-    description: "Request, receive, allocate and consume parts.",
-    href: "/mobile/parts",
+    id: "awaiting_approval",
+    title: "Awaiting approval",
+    description: "Review work waiting on a customer decision.",
+    href: "/mobile/work-orders?status=awaiting_approval",
+    icon: ClipboardCheck,
+    requiredCapability: "canManageOperations",
+  },
+  {
+    id: "parts_required",
+    title: "Parts required",
+    description: "Open requests that need sourcing or review.",
+    href: "/mobile/parts?view=requests",
     icon: Boxes,
     requiredCapability: "canManageParts",
   },
   {
-    title: "Invoices & payment",
-    description: "Finish the invoice and collect in the field.",
+    id: "truck_inventory",
+    title: "Truck inventory",
+    description: "Scan, receive, transfer and consume truck stock.",
+    href: "/mobile/service/truck-inventory",
+    icon: RadioTower,
+  },
+  {
+    id: "unpaid_invoices",
+    title: "Ready for closeout",
+    description: "Invoice completed work and take payment in the field.",
     href: "/mobile/work-orders?status=ready_to_invoice&mode=field_closeout",
-    icon: FileText,
+    icon: ReceiptText,
+    requiredCapability: "canManageOperations",
   },
   {
-    title: "Fleet connections",
-    description: "Work with units, inspections and service requests.",
-    href: "/mobile/fleet",
-    icon: Truck,
-    requiredCapability: "canAccessFleet",
+    id: "followups_due",
+    title: "Follow-ups due",
+    description: "Turn deferred recommendations into future work.",
+    href: "/mobile/service/followups",
+    icon: BriefcaseBusiness,
+    requiredCapability: "canManageOperations",
   },
   {
+    id: "purchase_orders",
     title: "Purchase orders",
-    description: "Author supplier orders and receive parts into Field stock.",
+    description: "Order and receive parts into Field stock.",
     href: "/mobile/service/purchase-orders",
     icon: PackagePlus,
     requiredCapability: "canManageParts",
   },
 ];
 
-function FieldModuleCard({ module }: { module: FieldModule }) {
-  const Icon = module.icon;
-  const content = (
-    <>
+function serializeLayout(layout: FieldDashboardLayoutItem[]): string {
+  return JSON.stringify(layout);
+}
+
+function readCachedLayout(): FieldDashboardLayoutItem[] {
+  try {
+    return normalizeFieldDashboardLayout(
+      JSON.parse(
+        window.localStorage.getItem(FIELD_DASHBOARD_LAYOUT_CACHE_KEY) ?? "null",
+      ),
+    );
+  } catch {
+    return buildDefaultFieldDashboardLayout();
+  }
+}
+
+function FieldDashboardCardLink({ card }: { card: FieldDashboardCard }) {
+  const Icon = card.icon;
+
+  return (
+    <Link className="field-hub-module" href={card.href}>
       <span className="field-hub-module__icon">
         <Icon aria-hidden className="h-5 w-5" />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="flex items-center gap-2">
-          <span className="field-hub-module__title">{module.title}</span>
-        </span>
+        <span className="field-hub-module__title">{card.title}</span>
         <span className="field-hub-module__description">
-          {module.description}
+          {card.description}
         </span>
       </span>
       <ArrowRight
         aria-hidden
         className="h-4 w-4 shrink-0 text-[color:var(--accent-copper)]"
       />
-    </>
-  );
-
-  return (
-    <Link className="field-hub-module" href={module.href}>
-      {content}
     </Link>
   );
 }
@@ -126,6 +191,48 @@ export default function FieldHub({
 }) {
   const [online, setOnline] = useState(true);
   const [dateLabel, setDateLabel] = useState("Today");
+  const [controlsOpen, setControlsOpen] = useState(false);
+  const [layout, setLayout] = useState<FieldDashboardLayoutItem[]>(() =>
+    buildDefaultFieldDashboardLayout(),
+  );
+  const [preferencesLoaded, setPreferencesLoaded] = useState(false);
+  const lastRemoteLayoutRef = useRef<string | null>(null);
+
+  const eligibleCards = useMemo(
+    () =>
+      FIELD_DASHBOARD_CARDS.filter((card) =>
+        canUseFieldWorkspaceCapability(capabilities, card.requiredCapability),
+      ),
+    [capabilities],
+  );
+  const eligibleCardIds = useMemo(
+    () => eligibleCards.map((card) => card.id),
+    [eligibleCards],
+  );
+  const cardById = useMemo(
+    () => new Map(eligibleCards.map((card) => [card.id, card] as const)),
+    [eligibleCards],
+  );
+  const orderedEligibleCards = useMemo(
+    () =>
+      layout
+        .map((item) => ({ item, card: cardById.get(item.id) }))
+        .filter(
+          (
+            entry,
+          ): entry is {
+            item: FieldDashboardLayoutItem;
+            card: FieldDashboardCard;
+          } => Boolean(entry.card),
+        ),
+    [cardById, layout],
+  );
+  const visibleCards = orderedEligibleCards.filter(
+    ({ item }) => item.hidden !== true,
+  );
+  const primaryActions = FIELD_PRIMARY_ACTIONS.filter((action) =>
+    canUseFieldWorkspaceCapability(capabilities, action.requiredCapability),
+  );
 
   useEffect(() => {
     const update = () => setOnline(navigator.onLine);
@@ -145,6 +252,82 @@ export default function FieldHub({
     };
   }, []);
 
+  useEffect(() => {
+    if (!controlsOpen) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setControlsOpen(false);
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [controlsOpen]);
+
+  useEffect(() => {
+    let active = true;
+    const cached = readCachedLayout();
+    setLayout(cached);
+
+    void fetch(
+      `/api/dashboard/layout?scope=${encodeURIComponent(FIELD_DASHBOARD_LAYOUT_SCOPE)}`,
+      {
+        credentials: "include",
+        cache: "no-store",
+      },
+    )
+      .then(async (response) => {
+        const body = (await response.json().catch(() => null)) as {
+          layout?: unknown;
+        } | null;
+        if (!active || !response.ok) return;
+        const remote = normalizeFieldDashboardLayout(body?.layout);
+        setLayout(remote);
+        window.localStorage.setItem(
+          FIELD_DASHBOARD_LAYOUT_CACHE_KEY,
+          serializeLayout(remote),
+        );
+        lastRemoteLayoutRef.current = serializeLayout(remote);
+      })
+      .catch(() => {
+        // Device preferences remain usable while the operator is offline.
+      })
+      .finally(() => {
+        if (active) setPreferencesLoaded(true);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!preferencesLoaded) return;
+    const serialized = serializeLayout(layout);
+    window.localStorage.setItem(FIELD_DASHBOARD_LAYOUT_CACHE_KEY, serialized);
+    if (!online || serialized === lastRemoteLayoutRef.current) return;
+
+    const timeout = window.setTimeout(() => {
+      void fetch("/api/dashboard/layout", {
+        method: "PUT",
+        credentials: "include",
+        keepalive: true,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scope: FIELD_DASHBOARD_LAYOUT_SCOPE,
+          layout,
+        }),
+      })
+        .then((response) => {
+          if (response.ok) lastRemoteLayoutRef.current = serialized;
+        })
+        .catch(() => {
+          // The device cache is the offline fallback; sync retries after a change.
+        });
+    }, 350);
+
+    return () => window.clearTimeout(timeout);
+  }, [layout, online, preferencesLoaded]);
+
+  const resetLayout = () => setLayout(buildDefaultFieldDashboardLayout());
+
   return (
     <main className="field-hub">
       <section className="field-hub-hero">
@@ -157,90 +340,213 @@ export default function FieldHub({
             {dateLabel}. One workspace for the call, repair, customer and money.
           </p>
         </div>
-        <div className="field-hub-hero__actions">
-          <Link href="/mobile/service/new" className="field-hub-primary-action">
-            <Plus aria-hidden className="h-5 w-5" /> New service call
-          </Link>
-          {capabilities.canManageScheduling ? (
-            <Link
-              href="/mobile/appointments"
-              className="field-hub-secondary-action"
-            >
-              <CalendarDays aria-hidden className="h-4 w-4" /> Book appointment
-            </Link>
-          ) : null}
+        <div
+          className="field-hub-hero__status"
+          data-online={online ? "true" : "false"}
+        >
+          {online ? (
+            <Wifi aria-hidden className="h-4 w-4" />
+          ) : (
+            <WifiOff aria-hidden className="h-4 w-4" />
+          )}
+          <span>{online ? "Online" : "Working offline"}</span>
         </div>
       </section>
 
-      <section className="field-hub-signals" aria-label="Field workspace status">
-        <div className="field-hub-signal">
-          <span className="field-hub-signal__icon" data-tone="blue">
-            {online ? (
-              <Wifi aria-hidden className="h-4 w-4" />
-            ) : (
-              <WifiOff aria-hidden className="h-4 w-4" />
-            )}
-          </span>
-          <span>
-            <strong>{online ? "Online" : "Working offline"}</strong>
-            <small>
-              {online ? "Field data can refresh" : "Saved work remains available"}
-            </small>
-          </span>
+      <section
+        className="field-hub-actions"
+        aria-labelledby="field-actions-heading"
+      >
+        <div className="field-hub-section-heading">
+          <div>
+            <div className="field-hub-section-heading__eyebrow">Start here</div>
+            <h2 id="field-actions-heading">Primary actions</h2>
+          </div>
         </div>
-        <div className="field-hub-signal">
-          <span className="field-hub-signal__icon" data-tone="green">
-            <CheckCircle2 aria-hidden className="h-4 w-4" />
-          </span>
-          <span>
-            <strong>Full closeout</strong>
-            <small>Invoice, payment and receipt</small>
-          </span>
-        </div>
-        <div className="field-hub-signal">
-          <span className="field-hub-signal__icon" data-tone="amber">
-            <Clock3 aria-hidden className="h-4 w-4" />
-          </span>
-          <span>
-            <strong>All-day workspace</strong>
-            <small>Phone, tablet or laptop</small>
-          </span>
+        <div className="field-hub-actions__grid">
+          {primaryActions.map((action) => {
+            const Icon = action.icon;
+            return (
+              <Link
+                key={action.title}
+                href={action.href}
+                className="field-hub-action"
+              >
+                <Icon aria-hidden className="h-5 w-5" />
+                <span>{action.title}</span>
+              </Link>
+            );
+          })}
         </div>
       </section>
 
       <div className="field-hub-grid">
-        <section className="field-hub-today" aria-labelledby="field-today-heading">
+        <section
+          className="field-hub-today"
+          aria-labelledby="field-today-heading"
+        >
           <div className="field-hub-section-heading">
             <div>
               <div className="field-hub-section-heading__eyebrow">Today</div>
-              <h2 id="field-today-heading">Your field work</h2>
+              <h2 id="field-today-heading">Schedule and active work</h2>
             </div>
             <Link href="/mobile/work-orders" className="field-hub-text-link">
-              All work orders <ArrowRight aria-hidden className="h-4 w-4" />
+              All work <ArrowRight aria-hidden className="h-4 w-4" />
             </Link>
           </div>
           <MobileServiceShell embedded />
         </section>
 
-        <aside className="field-hub-operations" aria-labelledby="field-operations-heading">
+        <aside
+          className="field-hub-operations"
+          aria-labelledby="field-operations-heading"
+        >
           <div className="field-hub-section-heading">
             <div>
-              <div className="field-hub-section-heading__eyebrow">Operations</div>
-              <h2 id="field-operations-heading">Run the business</h2>
+              <div className="field-hub-section-heading__eyebrow">
+                Operations
+              </div>
+              <h2 id="field-operations-heading">Your command cards</h2>
             </div>
+            <button
+              type="button"
+              onClick={() => setControlsOpen(true)}
+              disabled={!preferencesLoaded}
+              className="field-hub-customize"
+            >
+              <SlidersHorizontal aria-hidden className="h-4 w-4" /> Customize
+            </button>
           </div>
-          <div className="field-hub-module-grid">
-            {FIELD_MODULES.filter((module) =>
-              canUseFieldWorkspaceCapability(
-                capabilities,
-                module.requiredCapability,
-              ),
-            ).map((module) => (
-              <FieldModuleCard key={module.title} module={module} />
-            ))}
-          </div>
+          {visibleCards.length > 0 ? (
+            <div className="field-hub-module-grid">
+              {visibleCards.map(({ card }) => (
+                <FieldDashboardCardLink key={card.id} card={card} />
+              ))}
+            </div>
+          ) : (
+            <div className="field-hub-empty-cards">
+              <EyeOff aria-hidden className="h-5 w-5" />
+              <p>Your optional cards are hidden.</p>
+              <button type="button" onClick={() => setControlsOpen(true)}>
+                Choose cards
+              </button>
+            </div>
+          )}
         </aside>
       </div>
+
+      {controlsOpen ? (
+        <div
+          className="field-hub-controls__backdrop"
+          onClick={() => setControlsOpen(false)}
+        >
+          <aside
+            className="field-hub-controls"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="field-controls-heading"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="field-hub-controls__header">
+              <div>
+                <div className="field-hub-section-heading__eyebrow">
+                  Dashboard
+                </div>
+                <h2 id="field-controls-heading">Arrange command cards</h2>
+                <p>Choose what appears and set the order for this workspace.</p>
+              </div>
+              <button
+                type="button"
+                autoFocus
+                onClick={() => setControlsOpen(false)}
+                aria-label="Close dashboard controls"
+              >
+                <X aria-hidden className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="field-hub-controls__list">
+              {orderedEligibleCards.map(({ item, card }, index) => {
+                const visible = item.hidden !== true;
+                const Icon = card.icon;
+                return (
+                  <div key={item.id} className="field-hub-control-row">
+                    <span className="field-hub-control-row__icon">
+                      <Icon aria-hidden className="h-4 w-4" />
+                    </span>
+                    <span className="field-hub-control-row__label">
+                      <strong>{card.title}</strong>
+                      <small>{visible ? "Shown" : "Hidden"}</small>
+                    </span>
+                    <span className="field-hub-control-row__actions">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setLayout((current) =>
+                            moveFieldDashboardCard(
+                              current,
+                              item.id,
+                              -1,
+                              eligibleCardIds,
+                            ),
+                          )
+                        }
+                        disabled={index === 0}
+                        aria-label={`Move ${card.title} up`}
+                      >
+                        <ArrowUp aria-hidden className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setLayout((current) =>
+                            moveFieldDashboardCard(
+                              current,
+                              item.id,
+                              1,
+                              eligibleCardIds,
+                            ),
+                          )
+                        }
+                        disabled={index === orderedEligibleCards.length - 1}
+                        aria-label={`Move ${card.title} down`}
+                      >
+                        <ArrowDown aria-hidden className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        className="field-hub-control-row__toggle"
+                        data-visible={visible ? "true" : "false"}
+                        aria-pressed={visible}
+                        onClick={() =>
+                          setLayout((current) =>
+                            setFieldDashboardCardVisibility(
+                              current,
+                              item.id,
+                              !visible,
+                            ),
+                          )
+                        }
+                      >
+                        {visible ? "On" : "Off"}
+                      </button>
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="field-hub-controls__footer">
+              <button type="button" onClick={resetLayout}>
+                <RotateCcw aria-hidden className="h-4 w-4" /> Reset cards
+              </button>
+              <button type="button" onClick={() => setControlsOpen(false)}>
+                <Settings2 aria-hidden className="h-4 w-4" /> Done
+              </button>
+            </div>
+          </aside>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/features/mobile/service/FieldWorkspaceShell.tsx
+++ b/features/mobile/service/FieldWorkspaceShell.tsx
@@ -12,7 +12,6 @@ import {
   PackagePlus,
   Plus,
   Settings2,
-  Truck,
   Wrench,
   X,
   type LucideIcon,
@@ -66,6 +65,11 @@ const WORK_NAV: FieldNavItem[] = [
 
 const OPERATIONS_NAV: FieldNavItem[] = [
   {
+    label: "Truck inventory",
+    href: "/mobile/service/truck-inventory",
+    icon: PackageOpen,
+  },
+  {
     label: "Parts",
     href: "/mobile/parts",
     icon: Boxes,
@@ -77,12 +81,6 @@ const OPERATIONS_NAV: FieldNavItem[] = [
     href: "/mobile/service/purchase-orders",
     icon: PackagePlus,
     requiredCapability: "canManageParts",
-  },
-  {
-    label: "Fleet",
-    href: "/mobile/fleet",
-    icon: Truck,
-    requiredCapability: "canAccessFleet",
   },
   {
     label: "Follow-ups",
@@ -291,9 +289,15 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
               <span>Field setup</span>
             </Link>
           ) : null}
-          <Link href="/mobile" onClick={exitField} className="field-workspace-exit">
-            Switch workspace
-          </Link>
+          {workspaceCapabilities.canSwitchWorkspace ? (
+            <Link
+              href="/sign-in"
+              onClick={exitField}
+              className="field-workspace-exit"
+            >
+              Switch workspace
+            </Link>
+          ) : null}
           <button
             type="button"
             onClick={() => void signOut()}
@@ -448,9 +452,11 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
           </div>
         </div>
         <div className="field-workspace-drawer__footer">
-          <Link href="/mobile" onClick={exitField}>
-            Switch workspace
-          </Link>
+          {workspaceCapabilities.canSwitchWorkspace ? (
+            <Link href="/sign-in" onClick={exitField}>
+              Switch workspace
+            </Link>
+          ) : null}
           <button type="button" onClick={() => void signOut()} disabled={signingOut}>
             <LogOut aria-hidden className="h-4 w-4" />
             {signingOut ? "Signing out…" : "Sign out"}

--- a/features/mobile/service/fieldDashboardLayout.ts
+++ b/features/mobile/service/fieldDashboardLayout.ts
@@ -1,0 +1,128 @@
+export const FIELD_DASHBOARD_LAYOUT_SCOPE = "field";
+export const FIELD_DASHBOARD_LAYOUT_CACHE_KEY =
+  "profixiq:field-dashboard:layout:v1";
+
+export const FIELD_DASHBOARD_CARD_IDS = [
+  "jobs_in_progress",
+  "awaiting_approval",
+  "parts_required",
+  "truck_inventory",
+  "unpaid_invoices",
+  "followups_due",
+  "purchase_orders",
+] as const;
+
+export type FieldDashboardCardId = (typeof FIELD_DASHBOARD_CARD_IDS)[number];
+
+export type FieldDashboardLayoutItem = {
+  id: FieldDashboardCardId;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  hidden?: boolean;
+};
+
+const CARD_ID_SET = new Set<string>(FIELD_DASHBOARD_CARD_IDS);
+
+function isFieldDashboardCardId(value: unknown): value is FieldDashboardCardId {
+  return typeof value === "string" && CARD_ID_SET.has(value);
+}
+
+function orderLayout(
+  layout: FieldDashboardLayoutItem[],
+): FieldDashboardLayoutItem[] {
+  return [...layout]
+    .sort((left, right) => left.y - right.y)
+    .map((item, index) => ({
+      id: item.id,
+      x: 0,
+      y: index,
+      w: 1,
+      h: 1,
+      ...(item.hidden === true ? { hidden: true } : {}),
+    }));
+}
+
+export function buildDefaultFieldDashboardLayout(): FieldDashboardLayoutItem[] {
+  return FIELD_DASHBOARD_CARD_IDS.map((id, index) => ({
+    id,
+    x: 0,
+    y: index,
+    w: 1,
+    h: 1,
+  }));
+}
+
+export function normalizeFieldDashboardLayout(
+  value: unknown,
+): FieldDashboardLayoutItem[] {
+  const seen = new Set<FieldDashboardCardId>();
+  const parsed: FieldDashboardLayoutItem[] = [];
+
+  if (Array.isArray(value)) {
+    for (const candidate of value) {
+      if (!candidate || typeof candidate !== "object") continue;
+      const record = candidate as Record<string, unknown>;
+      if (!isFieldDashboardCardId(record.id) || seen.has(record.id)) continue;
+
+      seen.add(record.id);
+      parsed.push({
+        id: record.id,
+        x: 0,
+        y:
+          typeof record.y === "number" && Number.isFinite(record.y)
+            ? record.y
+            : parsed.length,
+        w: 1,
+        h: 1,
+        ...(record.hidden === true ? { hidden: true } : {}),
+      });
+    }
+  }
+
+  const missing = buildDefaultFieldDashboardLayout().filter(
+    (item) => !seen.has(item.id),
+  );
+
+  return orderLayout([...parsed, ...missing]);
+}
+
+export function setFieldDashboardCardVisibility(
+  layout: FieldDashboardLayoutItem[],
+  cardId: FieldDashboardCardId,
+  visible: boolean,
+): FieldDashboardLayoutItem[] {
+  return orderLayout(
+    layout.map((item) => {
+      if (item.id !== cardId) return item;
+      const next = { ...item };
+      if (visible) delete next.hidden;
+      else next.hidden = true;
+      return next;
+    }),
+  );
+}
+
+export function moveFieldDashboardCard(
+  layout: FieldDashboardLayoutItem[],
+  cardId: FieldDashboardCardId,
+  direction: -1 | 1,
+  eligibleCardIds: readonly FieldDashboardCardId[] = FIELD_DASHBOARD_CARD_IDS,
+): FieldDashboardLayoutItem[] {
+  const ordered = orderLayout(layout);
+  const eligible = new Set(eligibleCardIds);
+  const eligibleItems = ordered.filter((item) => eligible.has(item.id));
+  const currentIndex = eligibleItems.findIndex((item) => item.id === cardId);
+  const target = eligibleItems[currentIndex + direction];
+  const current = eligibleItems[currentIndex];
+  if (!current || !target) return ordered;
+
+  return orderLayout(
+    ordered.map((item) => {
+      if (item.id === current.id) return { ...item, y: target.y };
+      if (item.id === target.id) return { ...item, y: current.y };
+      return item;
+    }),
+  );
+}

--- a/features/mobile/service/fieldWorkspaceCapabilities.ts
+++ b/features/mobile/service/fieldWorkspaceCapabilities.ts
@@ -1,15 +1,17 @@
 export type FieldWorkspaceCapabilities = {
   canManageScheduling: boolean;
   canManageParts: boolean;
-  canAccessFleet: boolean;
+  canManageOperations: boolean;
   canConfigureFieldService: boolean;
+  canSwitchWorkspace: boolean;
 };
 
 export const EMPTY_FIELD_WORKSPACE_CAPABILITIES: FieldWorkspaceCapabilities = {
   canManageScheduling: false,
   canManageParts: false,
-  canAccessFleet: false,
+  canManageOperations: false,
   canConfigureFieldService: false,
+  canSwitchWorkspace: false,
 };
 
 export function normalizeFieldWorkspaceCapabilities(
@@ -23,8 +25,9 @@ export function normalizeFieldWorkspaceCapabilities(
   return {
     canManageScheduling: capabilities?.canManageScheduling === true,
     canManageParts: capabilities?.canManageParts === true,
-    canAccessFleet: capabilities?.canAccessFleet === true,
+    canManageOperations: capabilities?.canManageOperations === true,
     canConfigureFieldService: capabilities?.canConfigureFieldService === true,
+    canSwitchWorkspace: capabilities?.canSwitchWorkspace === true,
   };
 }
 

--- a/features/mobile/service/server/access.test.ts
+++ b/features/mobile/service/server/access.test.ts
@@ -56,32 +56,34 @@ describe("resolveMobileFieldServiceAccess", () => {
 });
 
 describe("resolveFieldWorkspaceCapabilities", () => {
-  it("does not advertise scheduling, parts, or fleet tools to a mechanic", () => {
+  it("does not advertise management tools or a workspace switch to a Field-only mechanic", () => {
     expect(
       resolveFieldWorkspaceCapabilities({
         role: "mechanic",
-        canAccessFleet: false,
         canConfigureFieldService: false,
+        canSwitchWorkspace: false,
       }),
     ).toEqual({
       canManageScheduling: false,
       canManageParts: false,
-      canAccessFleet: false,
+      canManageOperations: false,
       canConfigureFieldService: false,
+      canSwitchWorkspace: false,
     });
   });
 
-  it("keeps fleet visibility tied to the canonical fleet scope", () => {
+  it("advertises workspace switching only after another product scope is verified", () => {
     expect(
       resolveFieldWorkspaceCapabilities({
         role: "manager",
-        canAccessFleet: false,
         canConfigureFieldService: false,
+        canSwitchWorkspace: true,
       }),
     ).toMatchObject({
       canManageScheduling: true,
       canManageParts: true,
-      canAccessFleet: false,
+      canManageOperations: true,
+      canSwitchWorkspace: true,
     });
   });
 });

--- a/features/mobile/service/server/access.ts
+++ b/features/mobile/service/server/access.ts
@@ -2,10 +2,7 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 
-import {
-  resolveFleetActorContext,
-  resolveFleetActorScope,
-} from "@/features/fleet/lib/resolveFleetActorContext";
+import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 import type { FieldWorkspaceCapabilities } from "@/features/mobile/service/fieldWorkspaceCapabilities";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
@@ -28,15 +25,16 @@ export type MobileFieldServiceWorkspaceAccess = MobileFieldServiceAccess & {
 
 export function resolveFieldWorkspaceCapabilities(input: {
   role: string | null | undefined;
-  canAccessFleet: boolean;
   canConfigureFieldService: boolean;
+  canSwitchWorkspace: boolean;
 }): FieldWorkspaceCapabilities {
   const actor = getActorCapabilities({ role: input.role });
   return {
     canManageScheduling: actor.canManageScheduling,
     canManageParts: actor.canManageParts,
-    canAccessFleet: input.canAccessFleet,
+    canManageOperations: actor.canManageWorkOrders,
     canConfigureFieldService: input.canConfigureFieldService,
+    canSwitchWorkspace: input.canSwitchWorkspace,
   };
 }
 
@@ -103,28 +101,37 @@ export async function getMobileFieldServiceWorkspaceAccess(
   access: ShopAccess,
 ): Promise<MobileFieldServiceWorkspaceAccess> {
   const fieldAccess = await getMobileFieldServiceAccess(access);
+  let canAccessShop = false;
   let canAccessFleet = false;
 
   if (fieldAccess.canAccessFieldService) {
-    try {
-      const fleetActor = await resolveFleetActorContext(access.supabase, {
-        userId: access.authUserId,
-      });
-      const fleetScope = resolveFleetActorScope(fleetActor, {
-        preferMembershipFleet: !fleetActor.isInternal,
-      });
-      canAccessFleet = fleetScope?.shopId === access.profile.shop_id;
-    } catch {
-      // Fleet navigation is optional; its own route remains authoritative.
-    }
+    const [shopEntitlement, fleetWorkspaceAccess] = await Promise.all([
+      access.supabase.rpc("profixiq_shop_has_product_access", {
+        p_capability: "shop",
+        p_shop_id: access.profile.shop_id,
+      }),
+      (async () => {
+        try {
+          const fleetActor = await resolveFleetActorContext(access.supabase, {
+            userId: access.authUserId,
+          });
+          return fleetActor.capabilities.canAccessFleetIntake;
+        } catch {
+          // Another workspace is optional; its own route remains authoritative.
+          return false;
+        }
+      })(),
+    ]);
+    canAccessShop = !shopEntitlement.error && shopEntitlement.data === true;
+    canAccessFleet = fleetWorkspaceAccess;
   }
 
   return {
     ...fieldAccess,
     workspaceCapabilities: resolveFieldWorkspaceCapabilities({
       role: access.profile.role,
-      canAccessFleet,
       canConfigureFieldService: fieldAccess.canConfigure,
+      canSwitchWorkspace: canAccessShop || canAccessFleet,
     }),
   };
 }

--- a/tests/field-dashboard-layout.test.ts
+++ b/tests/field-dashboard-layout.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FIELD_DASHBOARD_CARD_IDS,
+  moveFieldDashboardCard,
+  normalizeFieldDashboardLayout,
+  setFieldDashboardCardVisibility,
+} from "@/features/mobile/service/fieldDashboardLayout";
+
+describe("Field dashboard layout", () => {
+  it("restores every known card while rejecting unknown and duplicate entries", () => {
+    const layout = normalizeFieldDashboardLayout([
+      { id: "followups_due", y: 0, hidden: true },
+      { id: "jobs_in_progress", y: 1 },
+      { id: "followups_due", y: 2 },
+      { id: "shop_revenue", y: 3 },
+    ]);
+
+    expect(layout.map((item) => item.id)).toEqual([
+      "followups_due",
+      "jobs_in_progress",
+      "awaiting_approval",
+      "parts_required",
+      "truck_inventory",
+      "unpaid_invoices",
+      "purchase_orders",
+    ]);
+    expect(layout.find((item) => item.id === "followups_due")?.hidden).toBe(
+      true,
+    );
+    expect(new Set(layout.map((item) => item.id))).toEqual(
+      new Set(FIELD_DASHBOARD_CARD_IDS),
+    );
+  });
+
+  it("moves a card relative to the controls the operator can actually use", () => {
+    const layout = normalizeFieldDashboardLayout(null);
+    const eligible = [
+      "jobs_in_progress",
+      "awaiting_approval",
+      "unpaid_invoices",
+      "followups_due",
+    ] as const;
+
+    const moved = moveFieldDashboardCard(
+      layout,
+      "unpaid_invoices",
+      -1,
+      eligible,
+    );
+    const eligibleOrder = moved
+      .filter((item) => eligible.includes(item.id as (typeof eligible)[number]))
+      .map((item) => item.id);
+
+    expect(eligibleOrder).toEqual([
+      "jobs_in_progress",
+      "unpaid_invoices",
+      "awaiting_approval",
+      "followups_due",
+    ]);
+  });
+
+  it("hides and restores optional cards without changing their order", () => {
+    const initial = normalizeFieldDashboardLayout(null);
+    const hidden = setFieldDashboardCardVisibility(
+      initial,
+      "followups_due",
+      false,
+    );
+    const restored = setFieldDashboardCardVisibility(
+      hidden,
+      "followups_due",
+      true,
+    );
+
+    expect(hidden.find((item) => item.id === "followups_due")?.hidden).toBe(
+      true,
+    );
+    expect(
+      restored.find((item) => item.id === "followups_due")?.hidden,
+    ).toBeUndefined();
+    expect(restored.map((item) => item.id)).toEqual(
+      initial.map((item) => item.id),
+    );
+  });
+});

--- a/tests/field-hub-shell.test.ts
+++ b/tests/field-hub-shell.test.ts
@@ -11,6 +11,7 @@ const read = (path: string) => readFileSync(path, "utf8");
 const mobileShell = read("components/layout/MobileShell.tsx");
 const fieldShell = read("features/mobile/service/FieldWorkspaceShell.tsx");
 const fieldHub = read("features/mobile/service/FieldHub.tsx");
+const fieldAccess = read("features/mobile/service/server/access.ts");
 const workOrderPage = read("app/mobile/work-orders/page.tsx");
 const workOrderQueue = read(
   "features/mobile/work-orders/MobileWorkOrderQueue.tsx",
@@ -32,7 +33,6 @@ describe("Field Hub workspace", () => {
       "/mobile/inspections",
       "/mobile/parts",
       "/mobile/service/purchase-orders",
-      "/mobile/fleet",
       "/mobile/service/followups",
     ]) {
       expect(`${fieldShell}\n${fieldHub}`).toContain(href);
@@ -46,8 +46,9 @@ describe("Field Hub workspace", () => {
     const mechanicCapabilities = normalizeFieldWorkspaceCapabilities({
       canManageScheduling: false,
       canManageParts: false,
-      canAccessFleet: false,
+      canManageOperations: false,
       canConfigureFieldService: false,
+      canSwitchWorkspace: false,
     });
 
     expect(
@@ -60,11 +61,43 @@ describe("Field Hub workspace", () => {
       canUseFieldWorkspaceCapability(mechanicCapabilities, "canManageParts"),
     ).toBe(false);
     expect(
-      canUseFieldWorkspaceCapability(mechanicCapabilities, "canAccessFleet"),
+      canUseFieldWorkspaceCapability(mechanicCapabilities, "canManageOperations"),
     ).toBe(false);
     expect(canUseFieldWorkspaceCapability(mechanicCapabilities)).toBe(true);
     expect(fieldShell).toContain("normalizeFieldWorkspaceCapabilities");
     expect(fieldHub).toContain("canUseFieldWorkspaceCapability");
+  });
+
+  it("keeps permanent Field actions on canonical workflows", () => {
+    for (const href of [
+      "/mobile/appointments#new-appointment",
+      "/mobile/service/new",
+      "/mobile/work-orders/create",
+      "/mobile/service/truck-inventory",
+      "/mobile/inspections",
+      "/mobile/work-orders?status=ready_to_invoice&mode=field_closeout",
+    ]) {
+      expect(fieldHub).toContain(`href: "${href}"`);
+    }
+
+    expect(fieldHub).toContain("FIELD_DASHBOARD_LAYOUT_SCOPE");
+    expect(fieldHub).toContain("moveFieldDashboardCard");
+    expect(fieldHub).toContain("setFieldDashboardCardVisibility");
+    expect(fieldHub).toContain('title: "Scan or create part"');
+    expect(fieldShell).toContain('label: "Truck inventory"');
+  });
+
+  it("does not leak Fleet navigation and hides workspace switching unless another product is verified", () => {
+    expect(fieldHub).not.toContain('href: "/mobile/fleet"');
+    expect(fieldShell).not.toContain('href: "/mobile/fleet"');
+    expect(fieldShell).toContain(
+      "workspaceCapabilities.canSwitchWorkspace ?",
+    );
+    expect(fieldShell).toContain('href="/sign-in"');
+    expect(fieldAccess).toContain(
+      "fleetActor.capabilities.canAccessFleetIntake",
+    );
+    expect(fieldAccess).not.toContain("resolveFleetActorScope");
   });
 
   it("exposes the field-safe purchase-order surface only to parts-capable operators", () => {


### PR DESCRIPTION
## What

Refactors the existing ProFixIQ Field workspace into a role-aware command dashboard.

- adds six canonical Field quick actions with responsive command cards
- persists per-user Field card order and visibility through the existing dashboard layout API, with an offline cache
- exposes Truck Inventory to Field mechanics and keeps manager-only operational cards behind the existing work-order management capability
- removes Fleet from Field navigation and only offers workspace switching when canonical Shop or Fleet entitlement checks pass
- adds appointment deep-link targeting and focused layout/access coverage

## Why

Field operators need a fast, mobile-first launch point without turning the existing Field branch into a separate greenfield product. This keeps the current workspace, authorization model, and persistence infrastructure while making the dashboard task-oriented.

## Validation

- focused Field tests: 17 passed
- TypeScript: passed
- changed-file ESLint: 0 errors (4 pre-existing unused-disable warnings in the appointments page)
- production build: passed
- regression inventory: 0 new errors; 17/19 critical flows
- full repository suite still contains known baseline failures; an untouched main checkout reproduced 44 failing tests, while this branch reported 43

## Database

No migration files are added or changed. The authenticated Supabase migration history was compared with the checked-in history: all 332 versions match, through `20260817050600_restore_invoice_recompute_authenticated_grant`. No migration was pending, so no database mutation was performed.