### PR TITLE
Fix Field dashboard Codex review findings

### DIFF
--- a/app/api/mobile/field-service/access/route.ts
+++ b/app/api/mobile/field-service/access/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
 
-import {
-  getMobileFieldServiceWorkspaceAccess,
-} from "@/features/mobile/service/server/access";
+import { getMobileFieldServiceWorkspaceAccess } from "@/features/mobile/service/server/access";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 export async function GET() {
@@ -14,6 +12,8 @@ export async function GET() {
     return NextResponse.json(
       {
         ...fieldAccess,
+        userId: access.authUserId,
+        shopId: access.profile.shop_id,
         mustChangePassword: access.profile.must_change_password === true,
       },
       { headers: { "Cache-Control": "private, no-store" } },

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -388,7 +388,10 @@ export default function FieldHub({
   useEffect(() => {
     if (!preferencesLoaded || !cacheKey || !pendingSyncRef.current) return;
     const serialized = serializeLayout(layout);
-    if (serialized === lastRemoteLayoutRef.current) {
+    if (
+      serialized === lastRemoteLayoutRef.current &&
+      !saveQueue.hasWork()
+    ) {
       pendingSyncRef.current = false;
       writeCachedLayout(cacheKey, cacheScope, layout, false);
       return;

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -27,15 +27,21 @@ import {
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
 import MobileServiceShell from "./MobileServiceShell";
 import {
+  buildFieldDashboardLayoutCache,
   buildDefaultFieldDashboardLayout,
-  FIELD_DASHBOARD_LAYOUT_CACHE_KEY,
+  createFieldDashboardLayoutSaveQueue,
+  FIELD_DASHBOARD_LEGACY_LAYOUT_CACHE_KEY,
   FIELD_DASHBOARD_LAYOUT_SCOPE,
+  getFieldDashboardLayoutCacheKey,
   moveFieldDashboardCard,
   normalizeFieldDashboardLayout,
+  parseFieldDashboardLayoutCache,
   setFieldDashboardCardVisibility,
   type FieldDashboardCardId,
+  type FieldDashboardLayoutCacheRecord,
   type FieldDashboardLayoutItem,
 } from "./fieldDashboardLayout";
 import {
@@ -71,6 +77,7 @@ const FIELD_PRIMARY_ACTIONS: FieldAction[] = [
     title: "New work order",
     href: "/mobile/work-orders/create",
     icon: FilePlus2,
+    requiredCapability: "canManageOperations",
   },
   {
     title: "Scan or create part",
@@ -150,15 +157,33 @@ function serializeLayout(layout: FieldDashboardLayoutItem[]): string {
   return JSON.stringify(layout);
 }
 
-function readCachedLayout(): FieldDashboardLayoutItem[] {
+function readCachedLayout(
+  cacheKey: string,
+  scope: OfflineMutationScope,
+): FieldDashboardLayoutCacheRecord | null {
   try {
-    return normalizeFieldDashboardLayout(
-      JSON.parse(
-        window.localStorage.getItem(FIELD_DASHBOARD_LAYOUT_CACHE_KEY) ?? "null",
-      ),
+    return parseFieldDashboardLayoutCache(
+      JSON.parse(window.localStorage.getItem(cacheKey) ?? "null"),
+      scope,
     );
   } catch {
-    return buildDefaultFieldDashboardLayout();
+    return null;
+  }
+}
+
+function writeCachedLayout(
+  cacheKey: string,
+  scope: OfflineMutationScope,
+  layout: FieldDashboardLayoutItem[],
+  pendingSync: boolean,
+): void {
+  const record = buildFieldDashboardLayoutCache(scope, layout, pendingSync);
+  if (!record) return;
+
+  try {
+    window.localStorage.setItem(cacheKey, JSON.stringify(record));
+  } catch {
+    // Remote preferences remain authoritative when device storage is unavailable.
   }
 }
 
@@ -186,8 +211,10 @@ function FieldDashboardCardLink({ card }: { card: FieldDashboardCard }) {
 
 export default function FieldHub({
   capabilities,
+  scope,
 }: {
   capabilities: FieldWorkspaceCapabilities;
+  scope: OfflineMutationScope;
 }) {
   const [online, setOnline] = useState(true);
   const [dateLabel, setDateLabel] = useState("Today");
@@ -197,6 +224,44 @@ export default function FieldHub({
   );
   const [preferencesLoaded, setPreferencesLoaded] = useState(false);
   const lastRemoteLayoutRef = useRef<string | null>(null);
+  const latestLayoutRef = useRef(serializeLayout(layout));
+  const pendingSyncRef = useRef(false);
+  const cacheScope = useMemo(
+    () => ({ userId: scope.userId, shopId: scope.shopId }),
+    [scope.shopId, scope.userId],
+  );
+  const cacheKey = useMemo(
+    () => getFieldDashboardLayoutCacheKey(cacheScope),
+    [cacheScope],
+  );
+  const saveQueue = useMemo(
+    () =>
+      createFieldDashboardLayoutSaveQueue(async (request) => {
+        if (!navigator.onLine) return false;
+
+        const response = await fetch("/api/dashboard/layout", {
+          method: "PUT",
+          credentials: "include",
+          keepalive: true,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            scope: FIELD_DASHBOARD_LAYOUT_SCOPE,
+            layout: request.layout,
+          }),
+        }).catch(() => null);
+        if (!response?.ok) return false;
+
+        lastRemoteLayoutRef.current = request.serialized;
+        if (cacheKey && latestLayoutRef.current === request.serialized) {
+          pendingSyncRef.current = false;
+          writeCachedLayout(cacheKey, cacheScope, request.layout, false);
+        }
+        return true;
+      }),
+    [cacheKey, cacheScope],
+  );
+
+  latestLayoutRef.current = serializeLayout(layout);
 
   const eligibleCards = useMemo(
     () =>
@@ -263,8 +328,29 @@ export default function FieldHub({
 
   useEffect(() => {
     let active = true;
-    const cached = readCachedLayout();
-    setLayout(cached);
+    setPreferencesLoaded(false);
+    lastRemoteLayoutRef.current = null;
+
+    if (!cacheKey) {
+      setLayout(buildDefaultFieldDashboardLayout());
+      pendingSyncRef.current = false;
+      setPreferencesLoaded(true);
+      return () => {
+        active = false;
+      };
+    }
+
+    try {
+      window.localStorage.removeItem(FIELD_DASHBOARD_LEGACY_LAYOUT_CACHE_KEY);
+    } catch {
+      // The legacy unscoped cache is never read, even if cleanup is unavailable.
+    }
+
+    const cached = readCachedLayout(cacheKey, cacheScope);
+    const cachedLayout = cached?.layout ?? buildDefaultFieldDashboardLayout();
+    pendingSyncRef.current = cached?.pendingSync === true;
+    setLayout(cachedLayout);
+    latestLayoutRef.current = serializeLayout(cachedLayout);
 
     void fetch(
       `/api/dashboard/layout?scope=${encodeURIComponent(FIELD_DASHBOARD_LAYOUT_SCOPE)}`,
@@ -279,12 +365,13 @@ export default function FieldHub({
         } | null;
         if (!active || !response.ok) return;
         const remote = normalizeFieldDashboardLayout(body?.layout);
-        setLayout(remote);
-        window.localStorage.setItem(
-          FIELD_DASHBOARD_LAYOUT_CACHE_KEY,
-          serializeLayout(remote),
-        );
-        lastRemoteLayoutRef.current = serializeLayout(remote);
+        const serializedRemote = serializeLayout(remote);
+        lastRemoteLayoutRef.current = serializedRemote;
+        if (!pendingSyncRef.current) {
+          setLayout(remote);
+          latestLayoutRef.current = serializedRemote;
+          writeCachedLayout(cacheKey, cacheScope, remote, false);
+        }
       })
       .catch(() => {
         // Device preferences remain usable while the operator is offline.
@@ -296,37 +383,39 @@ export default function FieldHub({
     return () => {
       active = false;
     };
-  }, []);
+  }, [cacheKey, cacheScope]);
 
   useEffect(() => {
-    if (!preferencesLoaded) return;
+    if (!preferencesLoaded || !cacheKey || !pendingSyncRef.current) return;
     const serialized = serializeLayout(layout);
-    window.localStorage.setItem(FIELD_DASHBOARD_LAYOUT_CACHE_KEY, serialized);
-    if (!online || serialized === lastRemoteLayoutRef.current) return;
+    if (serialized === lastRemoteLayoutRef.current) {
+      pendingSyncRef.current = false;
+      writeCachedLayout(cacheKey, cacheScope, layout, false);
+      return;
+    }
+
+    writeCachedLayout(cacheKey, cacheScope, layout, true);
+    saveQueue.enqueue(layout);
+    if (!online) return;
 
     const timeout = window.setTimeout(() => {
-      void fetch("/api/dashboard/layout", {
-        method: "PUT",
-        credentials: "include",
-        keepalive: true,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          scope: FIELD_DASHBOARD_LAYOUT_SCOPE,
-          layout,
-        }),
-      })
-        .then((response) => {
-          if (response.ok) lastRemoteLayoutRef.current = serialized;
-        })
-        .catch(() => {
-          // The device cache is the offline fallback; sync retries after a change.
-        });
+      void saveQueue.flush();
     }, 350);
 
     return () => window.clearTimeout(timeout);
-  }, [layout, online, preferencesLoaded]);
+  }, [cacheKey, cacheScope, layout, online, preferencesLoaded, saveQueue]);
 
-  const resetLayout = () => setLayout(buildDefaultFieldDashboardLayout());
+  const updateLayout = (
+    updater: (
+      current: FieldDashboardLayoutItem[],
+    ) => FieldDashboardLayoutItem[],
+  ) => {
+    pendingSyncRef.current = true;
+    setLayout(updater);
+  };
+
+  const resetLayout = () =>
+    updateLayout(() => buildDefaultFieldDashboardLayout());
 
   return (
     <main className="field-hub">
@@ -482,7 +571,7 @@ export default function FieldHub({
                       <button
                         type="button"
                         onClick={() =>
-                          setLayout((current) =>
+                          updateLayout((current) =>
                             moveFieldDashboardCard(
                               current,
                               item.id,
@@ -499,7 +588,7 @@ export default function FieldHub({
                       <button
                         type="button"
                         onClick={() =>
-                          setLayout((current) =>
+                          updateLayout((current) =>
                             moveFieldDashboardCard(
                               current,
                               item.id,
@@ -519,7 +608,7 @@ export default function FieldHub({
                         data-visible={visible ? "true" : "false"}
                         aria-pressed={visible}
                         onClick={() =>
-                          setLayout((current) =>
+                          updateLayout((current) =>
                             setFieldDashboardCardVisibility(
                               current,
                               item.id,

--- a/features/mobile/service/MobileFieldServiceRouteGate.tsx
+++ b/features/mobile/service/MobileFieldServiceRouteGate.tsx
@@ -6,6 +6,18 @@ import {
   resolveFieldExistingSessionHref,
   type FieldExistingSessionAccess,
 } from "@/features/auth/lib/accessSurfaceRouting";
+import {
+  getOfflineMutationScope,
+  setOfflineMutationScope,
+} from "@/features/shared/lib/offline/mutations";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import {
+  clearFieldServiceOfflineAccess,
+  readFieldServiceOfflineAccess,
+  resolveFieldServiceAccessScope,
+  writeFieldServiceOfflineAccess,
+  type FieldServiceAccessPayload,
+} from "./fieldOfflineAccess";
 
 export default function MobileFieldServiceRouteGate({
   children,
@@ -20,19 +32,52 @@ export default function MobileFieldServiceRouteGate({
     let active = true;
 
     void (async () => {
-      const response = await fetch("/api/mobile/field-service/access", {
-        credentials: "include",
-        cache: "no-store",
-      }).catch(() => null);
-      const access = (await response?.json().catch(() => null)) as
-        | FieldExistingSessionAccess
-        | null;
+      const supabase = createBrowserSupabase();
+      const [sessionResult, response] = await Promise.all([
+        supabase.auth.getSession(),
+        fetch("/api/mobile/field-service/access", {
+          credentials: "include",
+          cache: "no-store",
+        }).catch(() => null),
+      ]);
+      const authUserId = sessionResult.data.session?.user.id?.trim() ?? "";
+      const cachedScope = getOfflineMutationScope();
+      const operatorScope =
+        cachedScope?.userId === authUserId ? cachedScope : null;
+      const cachedAccess = operatorScope
+        ? readFieldServiceOfflineAccess(operatorScope)
+        : null;
+      const responseAccess = (await response
+        ?.json()
+        .catch(() => null)) as FieldServiceAccessPayload | null;
       if (!active) return;
 
-      const destination =
-        response?.ok && access
-          ? resolveFieldExistingSessionHref(access, pathname)
-          : null;
+      let access: FieldExistingSessionAccess | null = null;
+      if (response?.ok && responseAccess) {
+        const verifiedScope = resolveFieldServiceAccessScope(
+          responseAccess,
+          authUserId,
+        );
+        if (verifiedScope) {
+          access = responseAccess;
+        }
+        if (verifiedScope && responseAccess.canAccessFieldService === true) {
+          setOfflineMutationScope(verifiedScope);
+          writeFieldServiceOfflineAccess(verifiedScope, responseAccess);
+        } else if (verifiedScope) {
+          clearFieldServiceOfflineAccess(verifiedScope);
+        } else if (operatorScope) {
+          clearFieldServiceOfflineAccess(operatorScope);
+        }
+      } else if ((!response || response.status >= 500) && cachedAccess) {
+        access = cachedAccess;
+      } else if (operatorScope) {
+        clearFieldServiceOfflineAccess(operatorScope);
+      }
+
+      const destination = access
+        ? resolveFieldExistingSessionHref(access, pathname)
+        : null;
 
       if (destination === pathname) {
         setAllowed(true);
@@ -40,7 +85,9 @@ export default function MobileFieldServiceRouteGate({
       }
 
       router.replace(destination ?? "/mobile");
-    })();
+    })().catch(() => {
+      if (active) router.replace("/mobile");
+    });
 
     return () => {
       active = false;

--- a/features/mobile/service/MobileFieldServiceRouteGate.tsx
+++ b/features/mobile/service/MobileFieldServiceRouteGate.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/features/auth/lib/accessSurfaceRouting";
 import {
   getOfflineMutationScope,
+  isRetryableOfflineStatus,
   setOfflineMutationScope,
 } from "@/features/shared/lib/offline/mutations";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
@@ -69,7 +70,12 @@ export default function MobileFieldServiceRouteGate({
         } else if (operatorScope) {
           clearFieldServiceOfflineAccess(operatorScope);
         }
-      } else if ((!response || response.status >= 500) && cachedAccess) {
+      } else if (
+        (!response ||
+          response.status >= 500 ||
+          isRetryableOfflineStatus(response.status)) &&
+        cachedAccess
+      ) {
         access = cachedAccess;
       } else if (operatorScope) {
         clearFieldServiceOfflineAccess(operatorScope);

--- a/features/mobile/service/MobileServiceScopeGate.tsx
+++ b/features/mobile/service/MobileServiceScopeGate.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
-import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
 import {
   getOfflineMutationScope,
   setOfflineMutationScope,
@@ -16,18 +15,28 @@ import {
   normalizeFieldWorkspaceCapabilities,
   type FieldWorkspaceCapabilities,
 } from "./fieldWorkspaceCapabilities";
+import {
+  clearFieldServiceOfflineAccess,
+  readFieldServiceOfflineAccess,
+  resolveFieldServiceAccessScope,
+  writeFieldServiceOfflineAccess,
+  type FieldServiceAccessPayload,
+} from "./fieldOfflineAccess";
 
 const SNAPSHOT_CACHE_KEY = "profixiq:mobile-service:active:v1";
 const SNAPSHOT_SCOPE_KEY = "profixiq:mobile-service:active-scope:v1";
 
 type StoredScope = Pick<OfflineMutationScope, "userId" | "shopId">;
 
-function sameScope(left: StoredScope | null, right: StoredScope | null): boolean {
+function sameScope(
+  left: StoredScope | null,
+  right: StoredScope | null,
+): boolean {
   return Boolean(
     left &&
-      right &&
-      left.userId === right.userId &&
-      left.shopId === right.shopId,
+    right &&
+    left.userId === right.userId &&
+    left.shopId === right.shopId,
   );
 }
 
@@ -62,6 +71,7 @@ function protectSnapshot(scope: OfflineMutationScope | null): void {
 
 export default function MobileServiceScopeGate() {
   const [ready, setReady] = useState(false);
+  const [scope, setScope] = useState<OfflineMutationScope | null>(null);
   const [workspaceCapabilities, setWorkspaceCapabilities] =
     useState<FieldWorkspaceCapabilities>(EMPTY_FIELD_WORKSPACE_CAPABILITIES);
   const router = useRouter();
@@ -71,58 +81,82 @@ export default function MobileServiceScopeGate() {
 
     void (async () => {
       const supabase = createBrowserSupabase();
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
+      const [sessionResult, fieldAccessResponse] = await Promise.all([
+        supabase.auth.getSession(),
+        fetch("/api/mobile/field-service/access", {
+          credentials: "include",
+          cache: "no-store",
+        }).catch(() => null),
+      ]);
+      const session = sessionResult.data.session;
       const authUserId = session?.user?.id?.trim() ?? "";
 
       if (!authUserId) {
         if (!active) return;
         protectSnapshot(null);
+        router.replace("/mobile");
+        return;
+      }
+
+      const fieldAccess = (await fieldAccessResponse
+        ?.json()
+        .catch(() => null)) as FieldServiceAccessPayload | null;
+      if (!active) return;
+
+      const cached = getOfflineMutationScope();
+      const cachedScope = cached?.userId === authUserId ? cached : null;
+
+      if (fieldAccessResponse?.ok && fieldAccess?.canAccessFieldService) {
+        const verifiedScope = resolveFieldServiceAccessScope(
+          fieldAccess,
+          authUserId,
+        );
+        if (!verifiedScope) {
+          if (cachedScope) clearFieldServiceOfflineAccess(cachedScope);
+          protectSnapshot(null);
+          router.replace("/mobile");
+          return;
+        }
+
+        setOfflineMutationScope(verifiedScope);
+        writeFieldServiceOfflineAccess(verifiedScope, fieldAccess);
+        setWorkspaceCapabilities(
+          normalizeFieldWorkspaceCapabilities(
+            fieldAccess.workspaceCapabilities,
+          ),
+        );
+        setScope(verifiedScope);
+        protectSnapshot(verifiedScope);
         setReady(true);
         return;
       }
 
-      const fieldAccessResponse = await fetch("/api/mobile/field-service/access", {
-        credentials: "include",
-        cache: "no-store",
-      });
-      const fieldAccess = (await fieldAccessResponse.json().catch(() => null)) as
-        | {
-            canAccessFieldService?: boolean;
-            canConfigure?: boolean;
-            workspaceCapabilities?: unknown;
-          }
-        | null;
-      if (!active) return;
-      if (!fieldAccessResponse.ok || !fieldAccess?.canAccessFieldService) {
-        protectSnapshot(null);
-        router.replace(fieldAccess?.canConfigure ? "/mobile/service/setup" : "/mobile");
+      const verificationUnavailable =
+        !fieldAccessResponse || fieldAccessResponse.status >= 500;
+      const offlineAccess =
+        verificationUnavailable && cachedScope
+          ? readFieldServiceOfflineAccess(cachedScope)
+          : null;
+      if (offlineAccess) {
+        setWorkspaceCapabilities(offlineAccess.workspaceCapabilities);
+        setScope(cachedScope);
+        protectSnapshot(cachedScope);
+        setReady(true);
         return;
       }
-      setWorkspaceCapabilities(
-        normalizeFieldWorkspaceCapabilities(fieldAccess.workspaceCapabilities),
-      );
 
-      const cached = getOfflineMutationScope();
-      let scope: OfflineMutationScope | null =
-        cached?.userId === authUserId ? cached : null;
-
-      if (!scope && typeof navigator !== "undefined" && navigator.onLine) {
-        const actor = await resolveCurrentActor(supabase);
-        if (actor.user?.id === authUserId && actor.shopId) {
-          scope = { userId: authUserId, shopId: actor.shopId };
-          setOfflineMutationScope(scope);
-        }
+      if (cachedScope && !verificationUnavailable) {
+        clearFieldServiceOfflineAccess(cachedScope);
       }
-
-      if (!active) return;
-      protectSnapshot(scope);
-      setReady(true);
+      if (!fieldAccessResponse?.ok || !fieldAccess?.canAccessFieldService) {
+        protectSnapshot(null);
+        router.replace(
+          fieldAccess?.canConfigure ? "/mobile/service/setup" : "/mobile",
+        );
+        return;
+      }
     })().catch(() => {
       if (!active) return;
-      window.localStorage.removeItem(SNAPSHOT_CACHE_KEY);
-      window.localStorage.removeItem(SNAPSHOT_SCOPE_KEY);
       router.replace("/mobile");
     });
 
@@ -139,5 +173,13 @@ export default function MobileServiceScopeGate() {
     );
   }
 
-  return <FieldHub capabilities={workspaceCapabilities} />;
+  if (!scope) return null;
+
+  return (
+    <FieldHub
+      key={`${scope.shopId}:${scope.userId}`}
+      capabilities={workspaceCapabilities}
+      scope={scope}
+    />
+  );
 }

--- a/features/mobile/service/MobileServiceScopeGate.tsx
+++ b/features/mobile/service/MobileServiceScopeGate.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 
 import {
   getOfflineMutationScope,
+  isRetryableOfflineStatus,
   setOfflineMutationScope,
   type OfflineMutationScope,
 } from "@/features/shared/lib/offline/mutations";
@@ -54,18 +55,22 @@ function readStoredScope(): StoredScope | null {
 }
 
 function protectSnapshot(scope: OfflineMutationScope | null): void {
-  const storedScope = readStoredScope();
-  if (!scope || !sameScope(storedScope, scope)) {
-    window.localStorage.removeItem(SNAPSHOT_CACHE_KEY);
-  }
+  try {
+    const storedScope = readStoredScope();
+    if (!scope || !sameScope(storedScope, scope)) {
+      window.localStorage.removeItem(SNAPSHOT_CACHE_KEY);
+    }
 
-  if (scope) {
-    window.localStorage.setItem(
-      SNAPSHOT_SCOPE_KEY,
-      JSON.stringify({ userId: scope.userId, shopId: scope.shopId }),
-    );
-  } else {
-    window.localStorage.removeItem(SNAPSHOT_SCOPE_KEY);
+    if (scope) {
+      window.localStorage.setItem(
+        SNAPSHOT_SCOPE_KEY,
+        JSON.stringify({ userId: scope.userId, shopId: scope.shopId }),
+      );
+    } else {
+      window.localStorage.removeItem(SNAPSHOT_SCOPE_KEY);
+    }
+  } catch {
+    // Snapshot persistence is best-effort; verified online access remains usable.
   }
 }
 
@@ -132,7 +137,9 @@ export default function MobileServiceScopeGate() {
       }
 
       const verificationUnavailable =
-        !fieldAccessResponse || fieldAccessResponse.status >= 500;
+        !fieldAccessResponse ||
+        fieldAccessResponse.status >= 500 ||
+        isRetryableOfflineStatus(fieldAccessResponse.status);
       const offlineAccess =
         verificationUnavailable && cachedScope
           ? readFieldServiceOfflineAccess(cachedScope)

--- a/features/mobile/service/fieldDashboardLayout.ts
+++ b/features/mobile/service/fieldDashboardLayout.ts
@@ -1,5 +1,7 @@
 export const FIELD_DASHBOARD_LAYOUT_SCOPE = "field";
-export const FIELD_DASHBOARD_LAYOUT_CACHE_KEY =
+export const FIELD_DASHBOARD_LAYOUT_CACHE_PREFIX =
+  "profixiq:field-dashboard:layout:v2";
+export const FIELD_DASHBOARD_LEGACY_LAYOUT_CACHE_KEY =
   "profixiq:field-dashboard:layout:v1";
 
 export const FIELD_DASHBOARD_CARD_IDS = [
@@ -23,7 +25,45 @@ export type FieldDashboardLayoutItem = {
   hidden?: boolean;
 };
 
+export type FieldDashboardLayoutCacheScope = {
+  userId: string;
+  shopId: string;
+};
+
+export type FieldDashboardLayoutCacheRecord = {
+  version: 2;
+  userId: string;
+  shopId: string;
+  layout: FieldDashboardLayoutItem[];
+  pendingSync: boolean;
+};
+
+export type FieldDashboardLayoutSaveRequest = {
+  layout: FieldDashboardLayoutItem[];
+  serialized: string;
+};
+
+export type FieldDashboardLayoutSaveQueue = {
+  enqueue: (layout: FieldDashboardLayoutItem[]) => void;
+  flush: () => Promise<void>;
+  hasPending: () => boolean;
+};
+
 const CARD_ID_SET = new Set<string>(FIELD_DASHBOARD_CARD_IDS);
+
+function cleanScopePart(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function getFieldDashboardLayoutCacheKey(
+  scope: FieldDashboardLayoutCacheScope,
+): string | null {
+  const userId = cleanScopePart(scope.userId);
+  const shopId = cleanScopePart(scope.shopId);
+  if (!userId || !shopId) return null;
+
+  return `${FIELD_DASHBOARD_LAYOUT_CACHE_PREFIX}:${encodeURIComponent(shopId)}:${encodeURIComponent(userId)}`;
+}
 
 function isFieldDashboardCardId(value: unknown): value is FieldDashboardCardId {
   return typeof value === "string" && CARD_ID_SET.has(value);
@@ -86,6 +126,92 @@ export function normalizeFieldDashboardLayout(
   );
 
   return orderLayout([...parsed, ...missing]);
+}
+
+export function parseFieldDashboardLayoutCache(
+  value: unknown,
+  scope: FieldDashboardLayoutCacheScope,
+): FieldDashboardLayoutCacheRecord | null {
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as Record<string, unknown>;
+  const userId = cleanScopePart(scope.userId);
+  const shopId = cleanScopePart(scope.shopId);
+  if (
+    record.version !== 2 ||
+    cleanScopePart(record.userId) !== userId ||
+    cleanScopePart(record.shopId) !== shopId ||
+    !userId ||
+    !shopId
+  ) {
+    return null;
+  }
+
+  return {
+    version: 2,
+    userId,
+    shopId,
+    layout: normalizeFieldDashboardLayout(record.layout),
+    pendingSync: record.pendingSync === true,
+  };
+}
+
+export function buildFieldDashboardLayoutCache(
+  scope: FieldDashboardLayoutCacheScope,
+  layout: FieldDashboardLayoutItem[],
+  pendingSync: boolean,
+): FieldDashboardLayoutCacheRecord | null {
+  const userId = cleanScopePart(scope.userId);
+  const shopId = cleanScopePart(scope.shopId);
+  if (!userId || !shopId) return null;
+
+  return {
+    version: 2,
+    userId,
+    shopId,
+    layout: normalizeFieldDashboardLayout(layout),
+    pendingSync,
+  };
+}
+
+export function createFieldDashboardLayoutSaveQueue(
+  persist: (request: FieldDashboardLayoutSaveRequest) => Promise<boolean>,
+): FieldDashboardLayoutSaveQueue {
+  let pending: FieldDashboardLayoutSaveRequest | null = null;
+  let inFlight: Promise<void> | null = null;
+
+  const flush = (): Promise<void> => {
+    if (inFlight) return inFlight;
+
+    inFlight = (async () => {
+      while (pending) {
+        const request = pending;
+        pending = null;
+        const saved = await persist(request).catch(() => false);
+        if (!saved) {
+          // Preserve the newest edit if another one arrived during the failed save.
+          if (!pending) pending = request;
+          break;
+        }
+      }
+    })().finally(() => {
+      inFlight = null;
+    });
+
+    return inFlight;
+  };
+
+  return {
+    enqueue(layout) {
+      const normalized = normalizeFieldDashboardLayout(layout);
+      pending = {
+        layout: normalized,
+        serialized: JSON.stringify(normalized),
+      };
+    },
+    flush,
+    hasPending: () => pending !== null,
+  };
 }
 
 export function setFieldDashboardCardVisibility(

--- a/features/mobile/service/fieldDashboardLayout.ts
+++ b/features/mobile/service/fieldDashboardLayout.ts
@@ -47,6 +47,16 @@ export type FieldDashboardLayoutSaveQueue = {
   enqueue: (layout: FieldDashboardLayoutItem[]) => void;
   flush: () => Promise<void>;
   hasPending: () => boolean;
+  hasWork: () => boolean;
+};
+
+type FieldDashboardLayoutSaveQueueOptions = {
+  retryDelayMs?: number;
+  maxAutomaticRetries?: number;
+};
+
+type PendingFieldDashboardLayoutSave = FieldDashboardLayoutSaveRequest & {
+  failedAttempts: number;
 };
 
 const CARD_ID_SET = new Set<string>(FIELD_DASHBOARD_CARD_IDS);
@@ -176,12 +186,38 @@ export function buildFieldDashboardLayoutCache(
 
 export function createFieldDashboardLayoutSaveQueue(
   persist: (request: FieldDashboardLayoutSaveRequest) => Promise<boolean>,
+  options: FieldDashboardLayoutSaveQueueOptions = {},
 ): FieldDashboardLayoutSaveQueue {
-  let pending: FieldDashboardLayoutSaveRequest | null = null;
+  const retryDelayMs = Math.max(0, options.retryDelayMs ?? 1_000);
+  const maxAutomaticRetries = Math.max(
+    0,
+    options.maxAutomaticRetries ?? 2,
+  );
+  let pending: PendingFieldDashboardLayoutSave | null = null;
   let inFlight: Promise<void> | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const flush = (): Promise<void> => {
+  const scheduleRetry = () => {
+    if (
+      !pending ||
+      pending.failedAttempts > maxAutomaticRetries ||
+      retryTimer
+    ) {
+      return;
+    }
+
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      void flush();
+    }, retryDelayMs);
+  };
+
+  function flush(): Promise<void> {
     if (inFlight) return inFlight;
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
 
     inFlight = (async () => {
       while (pending) {
@@ -190,16 +226,22 @@ export function createFieldDashboardLayoutSaveQueue(
         const saved = await persist(request).catch(() => false);
         if (!saved) {
           // Preserve the newest edit if another one arrived during the failed save.
-          if (!pending) pending = request;
+          if (!pending) {
+            pending = {
+              ...request,
+              failedAttempts: request.failedAttempts + 1,
+            };
+          }
           break;
         }
       }
     })().finally(() => {
       inFlight = null;
+      scheduleRetry();
     });
 
     return inFlight;
-  };
+  }
 
   return {
     enqueue(layout) {
@@ -207,10 +249,12 @@ export function createFieldDashboardLayoutSaveQueue(
       pending = {
         layout: normalized,
         serialized: JSON.stringify(normalized),
+        failedAttempts: 0,
       };
     },
     flush,
     hasPending: () => pending !== null,
+    hasWork: () => pending !== null || inFlight !== null,
   };
 }
 

--- a/features/mobile/service/fieldOfflineAccess.ts
+++ b/features/mobile/service/fieldOfflineAccess.ts
@@ -1,0 +1,162 @@
+"use client";
+
+import type { FieldExistingSessionAccess } from "@/features/auth/lib/accessSurfaceRouting";
+import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
+import {
+  normalizeFieldWorkspaceCapabilities,
+  type FieldWorkspaceCapabilities,
+} from "./fieldWorkspaceCapabilities";
+
+export const FIELD_SERVICE_OFFLINE_ACCESS_CACHE_PREFIX =
+  "profixiq:field-service:access:v1";
+
+type StorageReader = Pick<Storage, "getItem">;
+type StorageWriter = Pick<Storage, "setItem" | "removeItem">;
+
+export type FieldServiceAccessPayload = FieldExistingSessionAccess & {
+  userId?: string;
+  shopId?: string;
+  workspaceCapabilities?: unknown;
+};
+
+export type FieldServiceOfflineAccessSnapshot = {
+  version: 1;
+  userId: string;
+  shopId: string;
+  canAccessFieldService: true;
+  canConfigure: boolean;
+  mustChangePassword: false;
+  workspaceCapabilities: FieldWorkspaceCapabilities;
+  validatedAt: string;
+};
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function browserStorage(): Storage | null {
+  return typeof window !== "undefined" ? window.localStorage : null;
+}
+
+export function getFieldServiceOfflineAccessCacheKey(
+  scope: OfflineMutationScope,
+): string | null {
+  const userId = clean(scope.userId);
+  const shopId = clean(scope.shopId);
+  if (!userId || !shopId) return null;
+
+  return `${FIELD_SERVICE_OFFLINE_ACCESS_CACHE_PREFIX}:${encodeURIComponent(shopId)}:${encodeURIComponent(userId)}`;
+}
+
+export function resolveFieldServiceAccessScope(
+  access: FieldServiceAccessPayload | null,
+  authUserId: string,
+): OfflineMutationScope | null {
+  const userId = clean(access?.userId);
+  const shopId = clean(access?.shopId);
+  const expectedUserId = clean(authUserId);
+  if (!userId || !shopId || !expectedUserId || userId !== expectedUserId) {
+    return null;
+  }
+
+  return { userId, shopId };
+}
+
+export function readFieldServiceOfflineAccess(
+  scope: OfflineMutationScope,
+  storage: StorageReader | null = browserStorage(),
+): FieldServiceOfflineAccessSnapshot | null {
+  const key = getFieldServiceOfflineAccessCacheKey(scope);
+  if (!key || !storage) return null;
+
+  try {
+    const parsed = JSON.parse(storage.getItem(key) ?? "null") as Record<
+      string,
+      unknown
+    > | null;
+    if (
+      !parsed ||
+      parsed.version !== 1 ||
+      clean(parsed.userId) !== clean(scope.userId) ||
+      clean(parsed.shopId) !== clean(scope.shopId) ||
+      parsed.canAccessFieldService !== true ||
+      parsed.mustChangePassword !== false ||
+      !Number.isFinite(Date.parse(clean(parsed.validatedAt)))
+    ) {
+      return null;
+    }
+
+    return {
+      version: 1,
+      userId: clean(parsed.userId),
+      shopId: clean(parsed.shopId),
+      canAccessFieldService: true,
+      canConfigure: parsed.canConfigure === true,
+      mustChangePassword: false,
+      workspaceCapabilities: normalizeFieldWorkspaceCapabilities(
+        parsed.workspaceCapabilities,
+      ),
+      validatedAt: clean(parsed.validatedAt),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeFieldServiceOfflineAccess(
+  scope: OfflineMutationScope,
+  access: FieldServiceAccessPayload,
+  storage: StorageWriter | null = browserStorage(),
+): FieldServiceOfflineAccessSnapshot | null {
+  const key = getFieldServiceOfflineAccessCacheKey(scope);
+  if (!key || !storage) return null;
+
+  const verifiedScope = resolveFieldServiceAccessScope(access, scope.userId);
+
+  if (
+    verifiedScope?.shopId !== scope.shopId.trim() ||
+    access.canAccessFieldService !== true ||
+    access.mustChangePassword === true
+  ) {
+    try {
+      storage.removeItem(key);
+    } catch {
+      // Storage can be unavailable in private browsing or under quota pressure.
+    }
+    return null;
+  }
+
+  const snapshot: FieldServiceOfflineAccessSnapshot = {
+    version: 1,
+    userId: scope.userId.trim(),
+    shopId: scope.shopId.trim(),
+    canAccessFieldService: true,
+    canConfigure: access.canConfigure === true,
+    mustChangePassword: false,
+    workspaceCapabilities: normalizeFieldWorkspaceCapabilities(
+      access.workspaceCapabilities,
+    ),
+    validatedAt: new Date().toISOString(),
+  };
+
+  try {
+    storage.setItem(key, JSON.stringify(snapshot));
+    return snapshot;
+  } catch {
+    return null;
+  }
+}
+
+export function clearFieldServiceOfflineAccess(
+  scope: OfflineMutationScope,
+  storage: StorageWriter | null = browserStorage(),
+): void {
+  const key = getFieldServiceOfflineAccessCacheKey(scope);
+  if (!key || !storage) return;
+
+  try {
+    storage.removeItem(key);
+  } catch {
+    // An explicit server denial remains authoritative even if cache cleanup fails.
+  }
+}

--- a/features/mobile/service/fieldOfflineAccess.ts
+++ b/features/mobile/service/fieldOfflineAccess.ts
@@ -9,6 +9,7 @@ import {
 
 export const FIELD_SERVICE_OFFLINE_ACCESS_CACHE_PREFIX =
   "profixiq:field-service:access:v1";
+export const FIELD_SERVICE_OFFLINE_ACCESS_MAX_AGE_MS = 12 * 60 * 60 * 1000;
 
 type StorageReader = Pick<Storage, "getItem">;
 type StorageWriter = Pick<Storage, "setItem" | "removeItem">;
@@ -35,7 +36,13 @@ function clean(value: unknown): string {
 }
 
 function browserStorage(): Storage | null {
-  return typeof window !== "undefined" ? window.localStorage : null;
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
 }
 
 export function getFieldServiceOfflineAccessCacheKey(
@@ -65,6 +72,7 @@ export function resolveFieldServiceAccessScope(
 export function readFieldServiceOfflineAccess(
   scope: OfflineMutationScope,
   storage: StorageReader | null = browserStorage(),
+  nowMs: number = Date.now(),
 ): FieldServiceOfflineAccessSnapshot | null {
   const key = getFieldServiceOfflineAccessCacheKey(scope);
   if (!key || !storage) return null;
@@ -74,6 +82,9 @@ export function readFieldServiceOfflineAccess(
       string,
       unknown
     > | null;
+    const validatedAt = clean(parsed?.validatedAt);
+    const validatedAtMs = Date.parse(validatedAt);
+    const snapshotAgeMs = nowMs - validatedAtMs;
     if (
       !parsed ||
       parsed.version !== 1 ||
@@ -81,7 +92,10 @@ export function readFieldServiceOfflineAccess(
       clean(parsed.shopId) !== clean(scope.shopId) ||
       parsed.canAccessFieldService !== true ||
       parsed.mustChangePassword !== false ||
-      !Number.isFinite(Date.parse(clean(parsed.validatedAt)))
+      !Number.isFinite(validatedAtMs) ||
+      !Number.isFinite(snapshotAgeMs) ||
+      snapshotAgeMs < 0 ||
+      snapshotAgeMs > FIELD_SERVICE_OFFLINE_ACCESS_MAX_AGE_MS
     ) {
       return null;
     }
@@ -96,7 +110,7 @@ export function readFieldServiceOfflineAccess(
       workspaceCapabilities: normalizeFieldWorkspaceCapabilities(
         parsed.workspaceCapabilities,
       ),
-      validatedAt: clean(parsed.validatedAt),
+      validatedAt,
     };
   } catch {
     return null;

--- a/features/shared/lib/offline/mutations.ts
+++ b/features/shared/lib/offline/mutations.ts
@@ -85,7 +85,11 @@ function clean(value: unknown): string {
 }
 
 function browserReady(): boolean {
-  return typeof window !== "undefined" && typeof localStorage !== "undefined";
+  try {
+    return typeof window !== "undefined" && typeof localStorage !== "undefined";
+  } catch {
+    return false;
+  }
 }
 
 function emitQueueUpdate(): void {
@@ -151,16 +155,21 @@ export function setOfflineMutationScope(
   scope: OfflineMutationScope | null,
 ): void {
   if (!browserReady()) return;
-  if (!scope?.userId.trim() || !scope.shopId.trim()) {
-    localStorage.removeItem(SCOPE_KEY);
-  } else {
-    localStorage.setItem(
-      SCOPE_KEY,
-      JSON.stringify({
-        userId: scope.userId.trim(),
-        shopId: scope.shopId.trim(),
-      }),
-    );
+  try {
+    if (!scope?.userId.trim() || !scope.shopId.trim()) {
+      localStorage.removeItem(SCOPE_KEY);
+    } else {
+      localStorage.setItem(
+        SCOPE_KEY,
+        JSON.stringify({
+          userId: scope.userId.trim(),
+          shopId: scope.shopId.trim(),
+        }),
+      );
+    }
+  } catch {
+    // Scope persistence is best-effort; verified online access remains usable.
+    return;
   }
   emitQueueUpdate();
 }
@@ -682,7 +691,7 @@ export function isRetryableOfflineError(error: unknown): boolean {
   const status = statusCode(error);
   if (status != null) {
     if (PERMANENT_STATUS_CODES.has(status)) return false;
-    if (RETRYABLE_STATUS_CODES.has(status)) return true;
+    if (isRetryableOfflineStatus(status)) return true;
   }
   const source = (error && typeof error === "object" ? error : {}) as ErrorLike;
   const code = clean(source.code).toUpperCase();
@@ -702,6 +711,11 @@ export function isRetryableOfflineError(error: unknown): boolean {
       message,
     )
   );
+}
+
+export function isRetryableOfflineStatus(status: unknown): boolean {
+  const parsed = typeof status === "number" ? status : Number(status);
+  return Number.isFinite(parsed) && RETRYABLE_STATUS_CODES.has(parsed);
 }
 
 export async function replayQueuedMutations(args: {

--- a/tests/field-dashboard-layout.test.ts
+++ b/tests/field-dashboard-layout.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildFieldDashboardLayoutCache,
+  createFieldDashboardLayoutSaveQueue,
   FIELD_DASHBOARD_CARD_IDS,
+  getFieldDashboardLayoutCacheKey,
   moveFieldDashboardCard,
   normalizeFieldDashboardLayout,
+  parseFieldDashboardLayoutCache,
   setFieldDashboardCardVisibility,
 } from "@/features/mobile/service/fieldDashboardLayout";
 
@@ -82,5 +86,67 @@ describe("Field dashboard layout", () => {
     expect(restored.map((item) => item.id)).toEqual(
       initial.map((item) => item.id),
     );
+  });
+
+  it("scopes cached layouts to one user and shop and preserves pending sync state", () => {
+    const firstScope = { userId: "user-a", shopId: "shop-a" };
+    const secondScope = { userId: "user-b", shopId: "shop-a" };
+    const layout = setFieldDashboardCardVisibility(
+      normalizeFieldDashboardLayout(null),
+      "followups_due",
+      false,
+    );
+    const cached = buildFieldDashboardLayoutCache(firstScope, layout, true);
+
+    expect(getFieldDashboardLayoutCacheKey(firstScope)).not.toBe(
+      getFieldDashboardLayoutCacheKey(secondScope),
+    );
+    expect(parseFieldDashboardLayoutCache(cached, secondScope)).toBeNull();
+    expect(
+      parseFieldDashboardLayoutCache(cached, firstScope)?.pendingSync,
+    ).toBe(true);
+    expect(
+      parseFieldDashboardLayoutCache(cached, firstScope)?.layout.find(
+        (item) => item.id === "followups_due",
+      )?.hidden,
+    ).toBe(true);
+  });
+
+  it("serializes saves and coalesces edits made while an older request is in flight", async () => {
+    let releaseFirstSave: (() => void) | undefined;
+    const firstSave = new Promise<void>((resolve) => {
+      releaseFirstSave = resolve;
+    });
+    const saved: string[] = [];
+    const queue = createFieldDashboardLayoutSaveQueue(async (request) => {
+      saved.push(request.serialized);
+      if (saved.length === 1) await firstSave;
+      return true;
+    });
+    const initial = normalizeFieldDashboardLayout(null);
+    const firstEdit = setFieldDashboardCardVisibility(
+      initial,
+      "followups_due",
+      false,
+    );
+    const latestEdit = setFieldDashboardCardVisibility(
+      firstEdit,
+      "purchase_orders",
+      false,
+    );
+
+    queue.enqueue(firstEdit);
+    const flushing = queue.flush();
+    await Promise.resolve();
+    queue.enqueue(latestEdit);
+    expect(queue.hasPending()).toBe(true);
+    releaseFirstSave?.();
+    await flushing;
+
+    expect(saved).toEqual([
+      JSON.stringify(firstEdit),
+      JSON.stringify(latestEdit),
+    ]);
+    expect(queue.hasPending()).toBe(false);
   });
 });

--- a/tests/field-dashboard-layout.test.ts
+++ b/tests/field-dashboard-layout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildFieldDashboardLayoutCache,
@@ -12,6 +12,9 @@ import {
 } from "@/features/mobile/service/fieldDashboardLayout";
 
 describe("Field dashboard layout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
   it("restores every known card while rejecting unknown and duplicate entries", () => {
     const layout = normalizeFieldDashboardLayout([
       { id: "followups_due", y: 0, hidden: true },
@@ -138,6 +141,7 @@ describe("Field dashboard layout", () => {
     queue.enqueue(firstEdit);
     const flushing = queue.flush();
     await Promise.resolve();
+    expect(queue.hasWork()).toBe(true);
     queue.enqueue(latestEdit);
     expect(queue.hasPending()).toBe(true);
     releaseFirstSave?.();
@@ -148,5 +152,32 @@ describe("Field dashboard layout", () => {
       JSON.stringify(latestEdit),
     ]);
     expect(queue.hasPending()).toBe(false);
+    expect(queue.hasWork()).toBe(false);
+  });
+
+  it("automatically retries the newest retained edit after a transient failure", async () => {
+    vi.useFakeTimers();
+    const saved: string[] = [];
+    const queue = createFieldDashboardLayoutSaveQueue(
+      async (request) => {
+        saved.push(request.serialized);
+        return saved.length > 1;
+      },
+      { retryDelayMs: 25, maxAutomaticRetries: 1 },
+    );
+    const layout = setFieldDashboardCardVisibility(
+      normalizeFieldDashboardLayout(null),
+      "followups_due",
+      false,
+    );
+
+    queue.enqueue(layout);
+    await queue.flush();
+    expect(queue.hasWork()).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(saved).toEqual([JSON.stringify(layout), JSON.stringify(layout)]);
+    expect(queue.hasWork()).toBe(false);
   });
 });

--- a/tests/field-hub-shell.test.ts
+++ b/tests/field-hub-shell.test.ts
@@ -21,7 +21,9 @@ describe("Field Hub workspace", () => {
   it("keeps the Field shell active while an operator moves through shared mobile workflows", () => {
     expect(mobileShell).toContain('pathname.startsWith("/mobile/service")');
     expect(mobileShell).toContain("FIELD_SURFACE_SESSION_KEY");
-    expect(mobileShell).toContain("<FieldWorkspaceShell>{children}</FieldWorkspaceShell>");
+    expect(mobileShell).toContain(
+      "<FieldWorkspaceShell>{children}</FieldWorkspaceShell>",
+    );
     expect(mobileShell).toContain('pathname === "/mobile"');
     expect(fieldShell).toContain("Switch workspace");
   });
@@ -61,7 +63,10 @@ describe("Field Hub workspace", () => {
       canUseFieldWorkspaceCapability(mechanicCapabilities, "canManageParts"),
     ).toBe(false);
     expect(
-      canUseFieldWorkspaceCapability(mechanicCapabilities, "canManageOperations"),
+      canUseFieldWorkspaceCapability(
+        mechanicCapabilities,
+        "canManageOperations",
+      ),
     ).toBe(false);
     expect(canUseFieldWorkspaceCapability(mechanicCapabilities)).toBe(true);
     expect(fieldShell).toContain("normalizeFieldWorkspaceCapabilities");
@@ -83,6 +88,11 @@ describe("Field Hub workspace", () => {
     expect(fieldHub).toContain("FIELD_DASHBOARD_LAYOUT_SCOPE");
     expect(fieldHub).toContain("moveFieldDashboardCard");
     expect(fieldHub).toContain("setFieldDashboardCardVisibility");
+    expect(fieldHub).toMatch(
+      /title: "New work order"[\s\S]*?requiredCapability: "canManageOperations"/,
+    );
+    expect(fieldHub).toContain("getFieldDashboardLayoutCacheKey");
+    expect(fieldHub).toContain("createFieldDashboardLayoutSaveQueue");
     expect(fieldHub).toContain('title: "Scan or create part"');
     expect(fieldShell).toContain('label: "Truck inventory"');
   });
@@ -90,9 +100,7 @@ describe("Field Hub workspace", () => {
   it("does not leak Fleet navigation and hides workspace switching unless another product is verified", () => {
     expect(fieldHub).not.toContain('href: "/mobile/fleet"');
     expect(fieldShell).not.toContain('href: "/mobile/fleet"');
-    expect(fieldShell).toContain(
-      "workspaceCapabilities.canSwitchWorkspace ?",
-    );
+    expect(fieldShell).toContain("workspaceCapabilities.canSwitchWorkspace ?");
     expect(fieldShell).toContain('href="/sign-in"');
     expect(fieldAccess).toContain(
       "fleetActor.capabilities.canAccessFleetIntake",
@@ -112,7 +120,9 @@ describe("Field Hub workspace", () => {
     expect(workOrderPage).toContain("SUPPORTED_STATUSES");
     expect(workOrderPage).toContain("SUPPORTED_STATUSES.has(requested)");
     expect(workOrderPage).toContain('key={`${status || "active"}');
-    expect(workOrderPage).toContain('requestedParams.mode === "field_closeout"');
+    expect(workOrderPage).toContain(
+      'requestedParams.mode === "field_closeout"',
+    );
   });
 
   it("routes only opted-in ready-to-invoice rows to canonical Field closeout", () => {
@@ -136,8 +146,8 @@ describe("Field Hub workspace", () => {
   it("signs out the Field session locally before returning to its dedicated sign-in", () => {
     expect(fieldShell).toContain('signOut({ scope: "local" })');
     expect(fieldShell).toContain('router.replace("/field/sign-in")');
-    expect(fieldShell.match(/onClick=\{\(\) => void signOut\(\)\}/g)).toHaveLength(
-      2,
-    );
+    expect(
+      fieldShell.match(/onClick=\{\(\) => void signOut\(\)\}/g),
+    ).toHaveLength(2);
   });
 });

--- a/tests/field-hub-shell.test.ts
+++ b/tests/field-hub-shell.test.ts
@@ -93,6 +93,7 @@ describe("Field Hub workspace", () => {
     );
     expect(fieldHub).toContain("getFieldDashboardLayoutCacheKey");
     expect(fieldHub).toContain("createFieldDashboardLayoutSaveQueue");
+    expect(fieldHub).toContain("!saveQueue.hasWork()");
     expect(fieldHub).toContain('title: "Scan or create part"');
     expect(fieldShell).toContain('label: "Truck inventory"');
   });

--- a/tests/field-offline-access.test.ts
+++ b/tests/field-offline-access.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  FIELD_SERVICE_OFFLINE_ACCESS_MAX_AGE_MS,
   getFieldServiceOfflineAccessCacheKey,
   readFieldServiceOfflineAccess,
   resolveFieldServiceAccessScope,
@@ -63,6 +64,33 @@ describe("Field offline access", () => {
     if (!firstKey || !secondKey) throw new Error("Expected scoped cache keys");
     storage.setItem(secondKey, storage.getItem(firstKey) ?? "");
     expect(readFieldServiceOfflineAccess(secondScope, storage)).toBeNull();
+  });
+
+  it("rejects an offline entitlement after one bounded field shift", () => {
+    const storage = createMemoryStorage();
+    const scope = { userId: "user-a", shopId: "shop-a" };
+    const snapshot = writeFieldServiceOfflineAccess(
+      scope,
+      grantedAccess,
+      storage,
+    );
+    if (!snapshot) throw new Error("Expected an offline access snapshot");
+    const validatedAtMs = Date.parse(snapshot.validatedAt);
+
+    expect(
+      readFieldServiceOfflineAccess(
+        scope,
+        storage,
+        validatedAtMs + FIELD_SERVICE_OFFLINE_ACCESS_MAX_AGE_MS,
+      ),
+    ).not.toBeNull();
+    expect(
+      readFieldServiceOfflineAccess(
+        scope,
+        storage,
+        validatedAtMs + FIELD_SERVICE_OFFLINE_ACCESS_MAX_AGE_MS + 1,
+      ),
+    ).toBeNull();
   });
 
   it("does not cache mismatched, denied, or password-blocked access", () => {

--- a/tests/field-offline-access.test.ts
+++ b/tests/field-offline-access.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getFieldServiceOfflineAccessCacheKey,
+  readFieldServiceOfflineAccess,
+  resolveFieldServiceAccessScope,
+  writeFieldServiceOfflineAccess,
+  type FieldServiceAccessPayload,
+} from "@/features/mobile/service/fieldOfflineAccess";
+
+function createMemoryStorage() {
+  const entries = new Map<string, string>();
+  return {
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => entries.set(key, value),
+    removeItem: (key: string) => entries.delete(key),
+  };
+}
+
+const grantedAccess: FieldServiceAccessPayload = {
+  userId: "user-a",
+  shopId: "shop-a",
+  canAccessFieldService: true,
+  canConfigure: false,
+  mustChangePassword: false,
+  workspaceCapabilities: {
+    canManageScheduling: false,
+    canManageParts: false,
+    canManageOperations: false,
+    canConfigureFieldService: false,
+    canSwitchWorkspace: false,
+  },
+};
+
+describe("Field offline access", () => {
+  it("accepts only API identity that matches the authenticated user", () => {
+    expect(resolveFieldServiceAccessScope(grantedAccess, "user-a")).toEqual({
+      userId: "user-a",
+      shopId: "shop-a",
+    });
+    expect(resolveFieldServiceAccessScope(grantedAccess, "user-b")).toBeNull();
+  });
+
+  it("stores and validates a user-and-shop-scoped entitlement snapshot", () => {
+    const storage = createMemoryStorage();
+    const firstScope = { userId: "user-a", shopId: "shop-a" };
+    const secondScope = { userId: "user-a", shopId: "shop-b" };
+
+    expect(
+      writeFieldServiceOfflineAccess(firstScope, grantedAccess, storage),
+    ).not.toBeNull();
+    expect(readFieldServiceOfflineAccess(firstScope, storage)).toMatchObject({
+      userId: "user-a",
+      shopId: "shop-a",
+      canAccessFieldService: true,
+    });
+    expect(getFieldServiceOfflineAccessCacheKey(firstScope)).not.toBe(
+      getFieldServiceOfflineAccessCacheKey(secondScope),
+    );
+
+    const firstKey = getFieldServiceOfflineAccessCacheKey(firstScope);
+    const secondKey = getFieldServiceOfflineAccessCacheKey(secondScope);
+    if (!firstKey || !secondKey) throw new Error("Expected scoped cache keys");
+    storage.setItem(secondKey, storage.getItem(firstKey) ?? "");
+    expect(readFieldServiceOfflineAccess(secondScope, storage)).toBeNull();
+  });
+
+  it("does not cache mismatched, denied, or password-blocked access", () => {
+    const storage = createMemoryStorage();
+    const scope = { userId: "user-a", shopId: "shop-a" };
+
+    expect(
+      writeFieldServiceOfflineAccess(
+        scope,
+        { ...grantedAccess, shopId: "shop-b" },
+        storage,
+      ),
+    ).toBeNull();
+    expect(
+      writeFieldServiceOfflineAccess(
+        scope,
+        { ...grantedAccess, canAccessFieldService: false },
+        storage,
+      ),
+    ).toBeNull();
+    expect(
+      writeFieldServiceOfflineAccess(
+        scope,
+        { ...grantedAccess, mustChangePassword: true },
+        storage,
+      ),
+    ).toBeNull();
+    expect(readFieldServiceOfflineAccess(scope, storage)).toBeNull();
+  });
+});

--- a/tests/mobile-service-shell.test.ts
+++ b/tests/mobile-service-shell.test.ts
@@ -5,7 +5,11 @@ const read = (path: string) => readFileSync(path, "utf8");
 const page = read("app/mobile/service/page.tsx");
 const shell = read("features/mobile/service/MobileServiceShell.tsx");
 const scopeGate = read("features/mobile/service/MobileServiceScopeGate.tsx");
+const routeGate = read(
+  "features/mobile/service/MobileFieldServiceRouteGate.tsx",
+);
 const fieldHub = read("features/mobile/service/FieldHub.tsx");
+const fieldAccessRoute = read("app/api/mobile/field-service/access/route.ts");
 const tiles = read("features/mobile/config/mobile-tiles.ts");
 const activeRoute = read("app/api/mobile/service-visits/active/route.ts");
 const dispatchRoute = read("app/api/dispatch/visits/[id]/route.ts");
@@ -49,17 +53,16 @@ describe("Mobile Service shell", () => {
     expect(shell).toContain("existing offline mobile workflow");
     expect(scopeGate).toContain("getOfflineMutationScope");
     expect(scopeGate).toContain("supabase.auth.getSession");
-    expect(scopeGate).toContain("resolveCurrentActor");
     expect(scopeGate).toContain("setOfflineMutationScope");
     expect(scopeGate).toContain("cached?.userId === authUserId");
     expect(scopeGate).toContain("SNAPSHOT_SCOPE_KEY");
-    expect(scopeGate).toContain("})().catch(() => {");
-    expect(scopeGate).toContain(
-      "window.localStorage.removeItem(SNAPSHOT_CACHE_KEY)",
-    );
-    expect(scopeGate).toContain(
-      "window.localStorage.removeItem(SNAPSHOT_SCOPE_KEY)",
-    );
+    expect(scopeGate).toContain("readFieldServiceOfflineAccess");
+    expect(scopeGate).toContain("verificationUnavailable");
+    expect(routeGate).toContain("readFieldServiceOfflineAccess");
+    expect(routeGate).toContain("response.status >= 500");
+    expect(fieldAccessRoute).toContain("userId: access.authUserId");
+    expect(fieldAccessRoute).toContain("shopId: access.profile.shop_id");
+    expect(scopeGate).not.toContain("resolveCurrentActor");
     expect(scopeGate).toContain('router.replace("/mobile")');
   });
 

--- a/tests/mobile-service-shell.test.ts
+++ b/tests/mobile-service-shell.test.ts
@@ -60,6 +60,11 @@ describe("Mobile Service shell", () => {
     expect(scopeGate).toContain("verificationUnavailable");
     expect(routeGate).toContain("readFieldServiceOfflineAccess");
     expect(routeGate).toContain("response.status >= 500");
+    expect(routeGate).toContain("isRetryableOfflineStatus(response.status)");
+    expect(scopeGate).toContain(
+      "isRetryableOfflineStatus(fieldAccessResponse.status)",
+    );
+    expect(scopeGate).toContain("Snapshot persistence is best-effort");
     expect(fieldAccessRoute).toContain("userId: access.authUserId");
     expect(fieldAccessRoute).toContain("shopId: access.profile.shop_id");
     expect(scopeGate).not.toContain("resolveCurrentActor");

--- a/tests/phase6-offline-mutations.test.ts
+++ b/tests/phase6-offline-mutations.test.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
-import { isRetryableOfflineError } from "@/features/shared/lib/offline/mutations";
+import {
+  isRetryableOfflineError,
+  isRetryableOfflineStatus,
+  setOfflineMutationScope,
+} from "@/features/shared/lib/offline/mutations";
 
 const source = readFileSync(
   "features/shared/lib/offline/mutations.ts",
@@ -46,6 +50,32 @@ describe("Phase 6 offline mutation reliability", () => {
     expect(isRetryableOfflineError(new TypeError("Failed to fetch"))).toBe(true);
     expect(isRetryableOfflineError({ status: 503, message: "Unavailable" })).toBe(true);
     expect(isRetryableOfflineError({ status: 429, message: "Retry later" })).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it("shares retryable response status policy with access verification", () => {
+    expect(isRetryableOfflineStatus(408)).toBe(true);
+    expect(isRetryableOfflineStatus(425)).toBe(true);
+    expect(isRetryableOfflineStatus(429)).toBe(true);
+    expect(isRetryableOfflineStatus(401)).toBe(false);
+    expect(isRetryableOfflineStatus(403)).toBe(false);
+  });
+
+  it("keeps local scope persistence best-effort when browser storage throws", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      removeItem: vi.fn(() => {
+        throw new DOMException("Blocked", "SecurityError");
+      }),
+      setItem: vi.fn(() => {
+        throw new DOMException("Blocked", "SecurityError");
+      }),
+    });
+
+    expect(() =>
+      setOfflineMutationScope({ userId: "user-a", shopId: "shop-a" }),
+    ).not.toThrow();
+    expect(() => setOfflineMutationScope(null)).not.toThrow();
     vi.unstubAllGlobals();
   });
 });


### PR DESCRIPTION
## Summary

Addresses the four unresolved Codex review findings from merged PR #1465:

- scope the Field dashboard offline layout cache to the authenticated user and shop
- hide the New work order action from mechanics who cannot access the guarded creation route
- serialize and coalesce dashboard layout saves so stale responses cannot overwrite newer edits
- allow safe Field Hub cold starts when the access endpoint is unavailable by using a previously validated, user-and-shop-scoped offline entitlement


## Follow-up Codex review fixes

- expire cached Field authorization after 12 hours so revoked access cannot be trusted indefinitely
- retry retained dashboard layout saves twice after transient failures
- keep revert edits queued while an earlier layout save is still in flight
- treat local storage as best-effort so verified online access remains available
- preserve valid cached access for retryable 408, 425, 429, and server failures while failing closed for authorization denials

## Root cause

PR #1465 was merged before its automated review completed. Its browser caches were globally keyed, dashboard preference writes could overlap, one action bypassed the UI capability gate, and the Field route gates required a live access response even when a validated offline session already existed.

## User impact

Field operators can cold-start the workspace during an outage, offline preferences remain isolated between operators and shops, mechanics no longer see an action they cannot use, and rapid dashboard edits persist in the correct order.

## Validation

- focused Vitest suite: 31 tests passed
- full Vitest suite: 2,538 tests passed, 2 skipped
- changed-file ESLint passed
- full ESLint passed with no errors (existing repository warnings remain)
- TypeScript typecheck passed
- regression inventory check passed with no new errors
- production build compiled, type-checked, and generated all 462 static pages; the local runner then hit an environment-only `.next/export` cleanup `ENOTEMPTY` error
- `git diff --check` passed

No database migration is included.