### PR TITLE
Build Field service-call dispatch flow

### DIFF
--- a/app/dashboard/dispatch/DispatchBoardClient.tsx
+++ b/app/dashboard/dispatch/DispatchBoardClient.tsx
@@ -95,12 +95,20 @@ function visitMatchesLane(visit: DispatchVisit, lane: LaneKey): boolean {
   return ["arrived", "working", "paused"].includes(visit.status);
 }
 
-export default function DispatchBoardClient() {
+export default function DispatchBoardClient({
+  surface = "shop",
+}: {
+  surface?: "shop" | "field";
+}) {
   const [board, setBoard] = useState<DispatchBoardSnapshot>(EMPTY_BOARD);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [busyVisitId, setBusyVisitId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const fieldSurface = surface === "field";
+  const scheduleHref = fieldSurface
+    ? "/mobile/appointments"
+    : "/dashboard/appointments";
 
   const load = useCallback(async (quiet = false) => {
     if (quiet) setRefreshing(true);
@@ -241,7 +249,13 @@ export default function DispatchBoardClient() {
   );
 
   return (
-    <main className="min-h-screen bg-[color:var(--theme-page-bg)] px-4 py-5 text-[color:var(--theme-text-primary)] sm:px-6 lg:px-8">
+    <main
+      className={`${
+        fieldSurface
+          ? "w-full px-3 py-4 sm:px-4 lg:px-5"
+          : "min-h-screen px-4 py-5 sm:px-6 lg:px-8"
+      } bg-[color:var(--theme-page-bg)] text-[color:var(--theme-text-primary)]`}
+    >
       <div className="mx-auto max-w-[1800px] space-y-5">
         <header className="flex flex-col gap-4 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-5 shadow-[var(--theme-shadow-soft)] lg:flex-row lg:items-center lg:justify-between">
           <div>
@@ -254,8 +268,16 @@ export default function DispatchBoardClient() {
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
+            {fieldSurface ? (
+              <Link
+                href="/mobile/service/new"
+                className="inline-flex items-center gap-2 rounded-xl bg-[color:var(--theme-action-primary)] px-3 py-2 text-sm font-semibold text-[color:var(--theme-action-primary-text)] hover:opacity-90"
+              >
+                New service call
+              </Link>
+            ) : null}
             <Link
-              href="/dashboard/appointments"
+              href={scheduleHref}
               className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-sm font-medium hover:bg-[color:var(--theme-surface-subtle)]"
             >
               <CalendarClock className="h-4 w-4" /> Schedule

--- a/app/dashboard/dispatch/DispatchBoardClient.tsx
+++ b/app/dashboard/dispatch/DispatchBoardClient.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+} from "react";
 import {
   ArrowRight,
   CalendarClock,
@@ -18,6 +24,11 @@ import type {
   DispatchVisit,
 } from "@/features/dispatch/lib/contracts";
 import type { ServiceVisitStatus } from "@/features/scheduling/lib/service-visit-contract";
+
+const DISPATCH_THEME = {
+  "--theme-action-primary": "var(--brand-primary,#2563eb)",
+  "--theme-action-primary-text": "var(--theme-text-on-accent,#fff)",
+} as CSSProperties;
 
 const EMPTY_BOARD: DispatchBoardSnapshot = {
   generatedAt: new Date(0).toISOString(),
@@ -250,6 +261,7 @@ export default function DispatchBoardClient({
 
   return (
     <main
+      style={DISPATCH_THEME}
       className={`${
         fieldSurface
           ? "w-full px-3 py-4 sm:px-4 lg:px-5"

--- a/app/dashboard/dispatch/page.tsx
+++ b/app/dashboard/dispatch/page.tsx
@@ -1,17 +1,7 @@
-import type { CSSProperties } from "react";
 import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
 import DispatchBoardClient from "./DispatchBoardClient";
 
-const dispatchTheme = {
-  "--theme-action-primary": "var(--brand-primary,#2563eb)",
-  "--theme-action-primary-text": "var(--theme-text-on-accent,#fff)",
-} as CSSProperties;
-
 export default async function DispatchPage() {
   await requireShopPageAccess({ requiredCapability: "canManageScheduling" });
-  return (
-    <div style={dispatchTheme}>
-      <DispatchBoardClient />
-    </div>
-  );
+  return <DispatchBoardClient />;
 }

--- a/app/mobile/service/dispatch/page.tsx
+++ b/app/mobile/service/dispatch/page.tsx
@@ -1,0 +1,13 @@
+import DispatchBoardClient from "app/dashboard/dispatch/DispatchBoardClient";
+import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export const dynamic = "force-dynamic";
+
+export default async function FieldDispatchPage() {
+  await requireShopPageAccess({
+    requiredCapability: "canManageScheduling",
+    redirectTo: "/mobile/service",
+  });
+
+  return <DispatchBoardClient surface="field" />;
+}

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -98,6 +98,14 @@ const FIELD_PRIMARY_ACTIONS: FieldAction[] = [
 
 const FIELD_DASHBOARD_CARDS: FieldDashboardCard[] = [
   {
+    id: "dispatch_queue",
+    title: "Dispatch queue",
+    description: "Assign new service calls to an operator and truck.",
+    href: "/mobile/service/dispatch",
+    icon: RadioTower,
+    requiredCapability: "canManageScheduling",
+  },
+  {
     id: "jobs_in_progress",
     title: "Jobs in progress",
     description: "Return to active repairs and service calls.",
@@ -483,7 +491,10 @@ export default function FieldHub({
               All work <ArrowRight aria-hidden className="h-4 w-4" />
             </Link>
           </div>
-          <MobileServiceShell embedded />
+          <MobileServiceShell
+            embedded
+            canManageScheduling={capabilities.canManageScheduling}
+          />
         </section>
 
         <aside

--- a/features/mobile/service/FieldWorkspaceShell.tsx
+++ b/features/mobile/service/FieldWorkspaceShell.tsx
@@ -11,6 +11,7 @@ import {
   PackageOpen,
   PackagePlus,
   Plus,
+  RadioTower,
   Settings2,
   Wrench,
   X,
@@ -49,6 +50,12 @@ const WORK_NAV: FieldNavItem[] = [
     label: "Appointments",
     href: "/mobile/appointments",
     icon: CalendarDays,
+    requiredCapability: "canManageScheduling",
+  },
+  {
+    label: "Dispatch",
+    href: "/mobile/service/dispatch",
+    icon: RadioTower,
     requiredCapability: "canManageScheduling",
   },
   {
@@ -101,6 +108,7 @@ function pageTitle(pathname: string): string {
     return "Purchase orders";
   }
   if (pathname.startsWith("/mobile/service/new")) return "New service call";
+  if (pathname.startsWith("/mobile/service/dispatch")) return "Dispatch";
   if (pathname.startsWith("/mobile/service/truck-inventory")) {
     return "Truck inventory";
   }
@@ -273,13 +281,6 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
         </div>
 
         <div className="field-workspace-sidebar__footer">
-          <Link
-            href="/mobile/service/truck-inventory"
-            className="field-workspace-nav__link"
-          >
-            <PackageOpen aria-hidden className="h-[1.1rem] w-[1.1rem]" />
-            <span>Truck inventory</span>
-          </Link>
           {workspaceCapabilities.canConfigureFieldService ? (
             <Link
               href="/mobile/service/setup"
@@ -345,13 +346,13 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
         </Link>
         {workspaceCapabilities.canManageScheduling ? (
           <Link
-            href="/mobile/appointments"
+            href="/mobile/service/dispatch"
             data-active={
-              pathname.startsWith("/mobile/appointments") ? "true" : "false"
+              pathname.startsWith("/mobile/service/dispatch") ? "true" : "false"
             }
           >
-            <CalendarDays aria-hidden className="h-5 w-5" />
-            <span>Schedule</span>
+            <RadioTower aria-hidden className="h-5 w-5" />
+            <span>Dispatch</span>
           </Link>
         ) : (
           <Link
@@ -429,15 +430,6 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
           />
           <div className="field-workspace-nav__section">
             <div className="field-workspace-nav__label">Workspace</div>
-            <FieldNavLink
-              item={{
-                label: "Truck inventory",
-                href: "/mobile/service/truck-inventory",
-                icon: PackageOpen,
-              }}
-              pathname={pathname}
-              onNavigate={() => setMenuOpen(false)}
-            />
             {workspaceCapabilities.canConfigureFieldService ? (
               <FieldNavLink
                 item={{

--- a/features/mobile/service/MobileServiceShell.tsx
+++ b/features/mobile/service/MobileServiceShell.tsx
@@ -522,8 +522,10 @@ function VisitCard({
 
 export default function MobileServiceShell({
   embedded = false,
+  canManageScheduling = false,
 }: {
   embedded?: boolean;
+  canManageScheduling?: boolean;
 }) {
   const router = useRouter();
   const [snapshot, setSnapshot] = useState<MobileActiveJobContract | null>(null);
@@ -965,13 +967,25 @@ export default function MobileServiceShell({
           <p className="mx-auto mt-1 max-w-sm text-sm text-[color:var(--theme-text-secondary)]">
             Take the next call in seconds or keep working from the normal mobile work-order queue.
           </p>
-          <div className="mt-4 grid gap-2 sm:grid-cols-2">
+          <div
+            className={`mt-4 grid gap-2 ${
+              canManageScheduling ? "sm:grid-cols-3" : "sm:grid-cols-2"
+            }`}
+          >
             <Link
               href="/mobile/service/new"
               className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-sky-500 px-4 text-sm font-extrabold text-white"
             >
               <Plus className="h-4 w-4" /> New service call
             </Link>
+            {canManageScheduling ? (
+              <Link
+                href="/mobile/service/dispatch"
+                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl border border-sky-500/40 bg-sky-500/10 px-4 text-sm font-extrabold text-[color:var(--theme-text-primary)]"
+              >
+                <Route className="h-4 w-4" /> Open dispatch
+              </Link>
+            ) : null}
             <Link
               href="/mobile/work-orders/create"
               className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-4 text-sm font-bold"

--- a/features/mobile/service/fieldDashboardLayout.ts
+++ b/features/mobile/service/fieldDashboardLayout.ts
@@ -5,6 +5,7 @@ export const FIELD_DASHBOARD_LEGACY_LAYOUT_CACHE_KEY =
   "profixiq:field-dashboard:layout:v1";
 
 export const FIELD_DASHBOARD_CARD_IDS = [
+  "dispatch_queue",
   "jobs_in_progress",
   "awaiting_approval",
   "parts_required",

--- a/tests/field-dashboard-layout.test.ts
+++ b/tests/field-dashboard-layout.test.ts
@@ -22,6 +22,7 @@ describe("Field dashboard layout", () => {
 
     expect(layout.map((item) => item.id)).toEqual([
       "followups_due",
+      "dispatch_queue",
       "jobs_in_progress",
       "awaiting_approval",
       "parts_required",

--- a/tests/field-hub-shell.test.ts
+++ b/tests/field-hub-shell.test.ts
@@ -31,6 +31,7 @@ describe("Field Hub workspace", () => {
   it("links the Hub to canonical mobile operations instead of duplicating their data flows", () => {
     for (const href of [
       "/mobile/appointments",
+      "/mobile/service/dispatch",
       "/mobile/work-orders",
       "/mobile/inspections",
       "/mobile/parts",
@@ -40,7 +41,7 @@ describe("Field Hub workspace", () => {
       expect(`${fieldShell}\n${fieldHub}`).toContain(href);
     }
 
-    expect(fieldHub).toContain("<MobileServiceShell embedded />");
+    expect(fieldHub).toContain("<MobileServiceShell");
     expect(fieldHub).not.toContain('.from("');
   });
 
@@ -94,7 +95,14 @@ describe("Field Hub workspace", () => {
     expect(fieldHub).toContain("getFieldDashboardLayoutCacheKey");
     expect(fieldHub).toContain("createFieldDashboardLayoutSaveQueue");
     expect(fieldHub).toContain('title: "Scan or create part"');
+    expect(fieldHub).toMatch(
+      /id: "dispatch_queue"[\s\S]*?requiredCapability: "canManageScheduling"/,
+    );
+    expect(fieldHub).toContain(
+      "canManageScheduling={capabilities.canManageScheduling}",
+    );
     expect(fieldShell).toContain('label: "Truck inventory"');
+    expect(fieldShell.match(/label: "Truck inventory"/g)).toHaveLength(1);
   });
 
   it("does not leak Fleet navigation and hides workspace switching unless another product is verified", () => {

--- a/tests/field-service-call-dispatch.test.ts
+++ b/tests/field-service-call-dispatch.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const fieldShell = read("features/mobile/service/FieldWorkspaceShell.tsx");
+const fieldHub = read("features/mobile/service/FieldHub.tsx");
+const fieldDispatchPage = read("app/mobile/service/dispatch/page.tsx");
+const dispatchBoard = read("app/dashboard/dispatch/DispatchBoardClient.tsx");
+const boardApi = read("app/api/dispatch/board/route.ts");
+const visitApi = read("app/api/dispatch/visits/[id]/route.ts");
+const intakeApi = read("app/api/mobile/service/intake/route.ts");
+
+describe("Field service-call dispatch", () => {
+  it("gives scheduling-capable Field operators a native Dispatch destination", () => {
+    expect(fieldShell).toMatch(
+      /label: "Dispatch"[\s\S]*?href: "\/mobile\/service\/dispatch"[\s\S]*?requiredCapability: "canManageScheduling"/,
+    );
+    expect(fieldHub).toMatch(
+      /id: "dispatch_queue"[\s\S]*?href: "\/mobile\/service\/dispatch"[\s\S]*?requiredCapability: "canManageScheduling"/,
+    );
+    expect(fieldShell).toContain("<span>Dispatch</span>");
+  });
+
+  it("server-guards the Field dispatch page and reuses the canonical board", () => {
+    expect(fieldDispatchPage).toContain("requireShopPageAccess");
+    expect(fieldDispatchPage).toContain(
+      'requiredCapability: "canManageScheduling"',
+    );
+    expect(fieldDispatchPage).toContain(
+      '<DispatchBoardClient surface="field" />',
+    );
+    expect(dispatchBoard).toContain('fetch("/api/dispatch/board"');
+    expect(dispatchBoard).toContain("/api/dispatch/visits/${visit.id}");
+    expect(dispatchBoard).toContain('href="/mobile/service/new"');
+    expect(dispatchBoard).toContain('"/mobile/appointments"');
+  });
+
+  it("keeps intake, assignment, and transitions on tenant-scoped commands", () => {
+    expect(intakeApi).toContain("requireMobileServiceOperatorApiAccess");
+    expect(intakeApi).toContain('"mobile_create_service_call_atomic"');
+    expect(boardApi).toContain('requiredCapability: "canManageScheduling"');
+    expect(boardApi).toContain("getDispatchBoard");
+    expect(visitApi).toContain("assignServiceVisit");
+    expect(visitApi).toContain("transitionServiceVisit");
+    expect(visitApi).toContain("access.profile.shop_id");
+  });
+
+  it("does not repeat Truck inventory in the Field navigation", () => {
+    expect(fieldShell.match(/label: "Truck inventory"/g)).toHaveLength(1);
+  });
+});

--- a/tests/field-service-call-dispatch.test.ts
+++ b/tests/field-service-call-dispatch.test.ts
@@ -33,6 +33,13 @@ describe("Field service-call dispatch", () => {
     expect(dispatchBoard).toContain("/api/dispatch/visits/${visit.id}");
     expect(dispatchBoard).toContain('href="/mobile/service/new"');
     expect(dispatchBoard).toContain('"/mobile/appointments"');
+    expect(dispatchBoard).toContain("style={DISPATCH_THEME}");
+    expect(dispatchBoard).toContain(
+      '"--theme-action-primary": "var(--brand-primary,#2563eb)"',
+    );
+    expect(dispatchBoard).toContain(
+      '"--theme-action-primary-text": "var(--theme-text-on-accent,#fff)"',
+    );
   });
 
   it("keeps intake, assignment, and transitions on tenant-scoped commands", () => {

--- a/tests/mobile-service-shell.test.ts
+++ b/tests/mobile-service-shell.test.ts
@@ -18,7 +18,7 @@ describe("Mobile Service shell", () => {
   it("uses the merged Dispatch contracts instead of duplicating service-visit state", () => {
     expect(page).toContain("MobileServiceScopeGate");
     expect(scopeGate).toContain("FieldHub");
-    expect(fieldHub).toContain("MobileServiceShell embedded");
+    expect(fieldHub).toContain("<MobileServiceShell");
     expect(shell).toContain("/api/mobile/service-visits/active");
     expect(shell).toContain("/api/dispatch/visits/${visit.id}");
     expect(shell).not.toContain('.from("service_visits")');
@@ -43,6 +43,8 @@ describe("Mobile Service shell", () => {
     expect(shell).toContain('toStatus: "completed"');
     expect(shell).toContain('runTransition(visit, "paused")');
     expect(shell).toContain('transitionVisit(current, "dispatched")');
+    expect(shell).toContain('href="/mobile/service/dispatch"');
+    expect(shell).toContain("canManageScheduling ?");
   });
 
   it("keeps dispatch mutations online-only but preserves an authenticated actor-scoped snapshot", () => {


### PR DESCRIPTION
## Summary
- adds a Field-native Dispatch surface for scheduling-capable operators
- wires the dashboard card, sidebar, mobile bottom tab, and empty state to the canonical dispatch board
- lets managers create a service call, assign an operator and truck, and release it without leaving the Field shell
- removes duplicate Truck inventory navigation entries

## Architecture
Reuses `/api/dispatch/board`, `/api/dispatch/visits/[id]`, and the existing atomic dispatch RPCs. This adds no schema migration or parallel state machine.

## Codex review follow-up
- the shared dispatch board now owns its required action-theme variables, so both Shop and Field controls remain legible
- the desktop-only theme wrapper was removed to prevent future surfaces from omitting the variables

## Validation
- focused Vitest after Codex follow-up: 29 passed
- full `pnpm check`: 2,538 passed, 2 skipped
- TypeScript passed
- changed-file ESLint passed
- regression inventory: 0 new errors; 17/19 critical flows
- API route audit passed
- live QA dispatch snapshot: manager and QA-01 truck assignable and tenant-scoped
- production compilation succeeded; local page-data collection is blocked only by the workspace's absent Supabase URL
- `git diff --check` passed

## Stack
This draft targets #1466's branch and should be retargeted to `main` after #1466 merges.