### PR TITLE
Build Field dispatch and truck inventory activity

### DIFF
--- a/app/api/mobile/service/truck-inventory/_lib.ts
+++ b/app/api/mobile/service/truck-inventory/_lib.ts
@@ -63,7 +63,7 @@ export function fieldInventoryErrorResponse(
     publicMessagePatterns: [
       /^Authenticated actor mismatch\.?$/i,
       /^Field (?:Service|inventory) access is required\.?$/i,
-      /^Parts (?:receiving )?permission is required\.?$/i,
+      /^Parts (?:(?:receiving|management) )?permission is required\.?$/i,
       /^This (?:truck|service visit|service call).*$/i,
       /^The (?:service truck|assigned service truck).*$/i,
       /^A stable operation key is required\.?$/i,

--- a/app/api/mobile/service/truck-inventory/route.ts
+++ b/app/api/mobile/service/truck-inventory/route.ts
@@ -1,11 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
-import {
-  fieldInventoryErrorResponse,
-  fieldInventoryRpc,
-  isUuid,
-} from "./_lib";
+import { fieldInventoryErrorResponse, fieldInventoryRpc, isUuid } from "./_lib";
 
 export async function GET(request: NextRequest) {
   const access = await requireShopScopedApiAccess();
@@ -16,10 +12,16 @@ export async function GET(request: NextRequest) {
     request.nextUrl.searchParams.get("serviceVehicleId")?.trim() || null;
   const query = request.nextUrl.searchParams.get("query")?.trim() || null;
   if (visitId && !isUuid(visitId)) {
-    return NextResponse.json({ error: "Invalid service visit." }, { status: 400 });
+    return NextResponse.json(
+      { error: "Invalid service visit." },
+      { status: 400 },
+    );
   }
   if (serviceVehicleId && !isUuid(serviceVehicleId)) {
-    return NextResponse.json({ error: "Invalid service truck." }, { status: 400 });
+    return NextResponse.json(
+      { error: "Invalid service truck." },
+      { status: 400 },
+    );
   }
   if (query && query.length > 120) {
     return NextResponse.json({ error: "Search is too long." }, { status: 400 });
@@ -36,9 +38,43 @@ export async function GET(request: NextRequest) {
       p_query: query,
     },
   );
-  if (error) return fieldInventoryErrorResponse(error, "field-truck-inventory/snapshot");
+  if (error)
+    return fieldInventoryErrorResponse(error, "field-truck-inventory/snapshot");
 
-  return NextResponse.json(data, {
-    headers: { "Cache-Control": "private, no-store" },
-  });
+  const snapshot =
+    data && typeof data === "object" && !Array.isArray(data)
+      ? (data as Record<string, unknown>)
+      : {};
+  const truck =
+    snapshot.truck && typeof snapshot.truck === "object"
+      ? (snapshot.truck as Record<string, unknown>)
+      : null;
+  const resolvedTruckId = truck?.id;
+  let movements: unknown[] = [];
+  if (isUuid(resolvedTruckId)) {
+    const activity = await fieldInventoryRpc(
+      access.supabase,
+      "field_truck_inventory_activity",
+      {
+        p_shop_id: access.profile.shop_id,
+        p_actor_user_id: access.authUserId,
+        p_service_vehicle_id: resolvedTruckId,
+        p_limit: 50,
+      },
+    );
+    if (activity.error) {
+      return fieldInventoryErrorResponse(
+        activity.error,
+        "field-truck-inventory/activity",
+      );
+    }
+    movements = Array.isArray(activity.data) ? activity.data : [];
+  }
+
+  return NextResponse.json(
+    { ...snapshot, movements },
+    {
+      headers: { "Cache-Control": "private, no-store" },
+    },
+  );
 }

--- a/app/api/mobile/service/truck-inventory/route.ts
+++ b/app/api/mobile/service/truck-inventory/route.ts
@@ -29,13 +29,14 @@ export async function GET(request: NextRequest) {
 
   const { data, error } = await fieldInventoryRpc(
     access.supabase,
-    "field_truck_inventory_snapshot",
+    "field_truck_inventory_snapshot_with_activity",
     {
       p_shop_id: access.profile.shop_id,
       p_actor_user_id: access.authUserId,
       p_service_visit_id: visitId,
       p_service_vehicle_id: serviceVehicleId,
       p_query: query,
+      p_activity_limit: 50,
     },
   );
   if (error)
@@ -44,35 +45,10 @@ export async function GET(request: NextRequest) {
   const snapshot =
     data && typeof data === "object" && !Array.isArray(data)
       ? (data as Record<string, unknown>)
-      : {};
-  const truck =
-    snapshot.truck && typeof snapshot.truck === "object"
-      ? (snapshot.truck as Record<string, unknown>)
-      : null;
-  const resolvedTruckId = truck?.id;
-  let movements: unknown[] = [];
-  if (isUuid(resolvedTruckId)) {
-    const activity = await fieldInventoryRpc(
-      access.supabase,
-      "field_truck_inventory_activity",
-      {
-        p_shop_id: access.profile.shop_id,
-        p_actor_user_id: access.authUserId,
-        p_service_vehicle_id: resolvedTruckId,
-        p_limit: 50,
-      },
-    );
-    if (activity.error) {
-      return fieldInventoryErrorResponse(
-        activity.error,
-        "field-truck-inventory/activity",
-      );
-    }
-    movements = Array.isArray(activity.data) ? activity.data : [];
-  }
+      : { movements: [] };
 
   return NextResponse.json(
-    { ...snapshot, movements },
+    snapshot,
     {
       headers: { "Cache-Control": "private, no-store" },
     },

--- a/app/api/mobile/service/truck-inventory/transfer/route.ts
+++ b/app/api/mobile/service/truck-inventory/transfer/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: Request) {
 
   const { data, error } = await fieldInventoryRpc(
     access.supabase,
-    "field_transfer_stock_to_truck_atomic",
+    "field_transfer_stock_to_truck_authorized_atomic",
     {
       p_shop_id: access.profile.shop_id,
       p_service_vehicle_id: serviceVehicleId,

--- a/app/dashboard/dispatch/DispatchBoardClient.tsx
+++ b/app/dashboard/dispatch/DispatchBoardClient.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+} from "react";
 import {
   ArrowRight,
   CalendarClock,
@@ -18,6 +24,11 @@ import type {
   DispatchVisit,
 } from "@/features/dispatch/lib/contracts";
 import type { ServiceVisitStatus } from "@/features/scheduling/lib/service-visit-contract";
+
+const DISPATCH_THEME = {
+  "--theme-action-primary": "var(--brand-primary,#2563eb)",
+  "--theme-action-primary-text": "var(--theme-text-on-accent,#fff)",
+} as CSSProperties;
 
 const EMPTY_BOARD: DispatchBoardSnapshot = {
   generatedAt: new Date(0).toISOString(),
@@ -95,12 +106,20 @@ function visitMatchesLane(visit: DispatchVisit, lane: LaneKey): boolean {
   return ["arrived", "working", "paused"].includes(visit.status);
 }
 
-export default function DispatchBoardClient() {
+export default function DispatchBoardClient({
+  surface = "shop",
+}: {
+  surface?: "shop" | "field";
+}) {
   const [board, setBoard] = useState<DispatchBoardSnapshot>(EMPTY_BOARD);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [busyVisitId, setBusyVisitId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const fieldSurface = surface === "field";
+  const scheduleHref = fieldSurface
+    ? "/mobile/appointments"
+    : "/dashboard/appointments";
 
   const load = useCallback(async (quiet = false) => {
     if (quiet) setRefreshing(true);
@@ -241,7 +260,14 @@ export default function DispatchBoardClient() {
   );
 
   return (
-    <main className="min-h-screen bg-[color:var(--theme-page-bg)] px-4 py-5 text-[color:var(--theme-text-primary)] sm:px-6 lg:px-8">
+    <main
+      style={DISPATCH_THEME}
+      className={`${
+        fieldSurface
+          ? "w-full px-3 py-4 sm:px-4 lg:px-5"
+          : "min-h-screen px-4 py-5 sm:px-6 lg:px-8"
+      } bg-[color:var(--theme-page-bg)] text-[color:var(--theme-text-primary)]`}
+    >
       <div className="mx-auto max-w-[1800px] space-y-5">
         <header className="flex flex-col gap-4 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-5 shadow-[var(--theme-shadow-soft)] lg:flex-row lg:items-center lg:justify-between">
           <div>
@@ -254,8 +280,16 @@ export default function DispatchBoardClient() {
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
+            {fieldSurface ? (
+              <Link
+                href="/mobile/service/new"
+                className="inline-flex items-center gap-2 rounded-xl bg-[color:var(--theme-action-primary)] px-3 py-2 text-sm font-semibold text-[color:var(--theme-action-primary-text)] hover:opacity-90"
+              >
+                New service call
+              </Link>
+            ) : null}
             <Link
-              href="/dashboard/appointments"
+              href={scheduleHref}
               className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-sm font-medium hover:bg-[color:var(--theme-surface-subtle)]"
             >
               <CalendarClock className="h-4 w-4" /> Schedule

--- a/app/dashboard/dispatch/page.tsx
+++ b/app/dashboard/dispatch/page.tsx
@@ -1,17 +1,7 @@
-import type { CSSProperties } from "react";
 import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
 import DispatchBoardClient from "./DispatchBoardClient";
 
-const dispatchTheme = {
-  "--theme-action-primary": "var(--brand-primary,#2563eb)",
-  "--theme-action-primary-text": "var(--theme-text-on-accent,#fff)",
-} as CSSProperties;
-
 export default async function DispatchPage() {
   await requireShopPageAccess({ requiredCapability: "canManageScheduling" });
-  return (
-    <div style={dispatchTheme}>
-      <DispatchBoardClient />
-    </div>
-  );
+  return <DispatchBoardClient />;
 }

--- a/app/mobile/service/dispatch/page.tsx
+++ b/app/mobile/service/dispatch/page.tsx
@@ -1,0 +1,13 @@
+import DispatchBoardClient from "app/dashboard/dispatch/DispatchBoardClient";
+import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export const dynamic = "force-dynamic";
+
+export default async function FieldDispatchPage() {
+  await requireShopPageAccess({
+    requiredCapability: "canManageScheduling",
+    redirectTo: "/mobile/service",
+  });
+
+  return <DispatchBoardClient surface="field" />;
+}

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -98,6 +98,14 @@ const FIELD_PRIMARY_ACTIONS: FieldAction[] = [
 
 const FIELD_DASHBOARD_CARDS: FieldDashboardCard[] = [
   {
+    id: "dispatch_queue",
+    title: "Dispatch queue",
+    description: "Assign new service calls to an operator and truck.",
+    href: "/mobile/service/dispatch",
+    icon: RadioTower,
+    requiredCapability: "canManageScheduling",
+  },
+  {
     id: "jobs_in_progress",
     title: "Jobs in progress",
     description: "Return to active repairs and service calls.",
@@ -486,7 +494,10 @@ export default function FieldHub({
               All work <ArrowRight aria-hidden className="h-4 w-4" />
             </Link>
           </div>
-          <MobileServiceShell embedded />
+          <MobileServiceShell
+            embedded
+            canManageScheduling={capabilities.canManageScheduling}
+          />
         </section>
 
         <aside

--- a/features/mobile/service/FieldWorkspaceShell.tsx
+++ b/features/mobile/service/FieldWorkspaceShell.tsx
@@ -11,6 +11,7 @@ import {
   PackageOpen,
   PackagePlus,
   Plus,
+  RadioTower,
   Settings2,
   Wrench,
   X,
@@ -49,6 +50,12 @@ const WORK_NAV: FieldNavItem[] = [
     label: "Appointments",
     href: "/mobile/appointments",
     icon: CalendarDays,
+    requiredCapability: "canManageScheduling",
+  },
+  {
+    label: "Dispatch",
+    href: "/mobile/service/dispatch",
+    icon: RadioTower,
     requiredCapability: "canManageScheduling",
   },
   {
@@ -101,6 +108,7 @@ function pageTitle(pathname: string): string {
     return "Purchase orders";
   }
   if (pathname.startsWith("/mobile/service/new")) return "New service call";
+  if (pathname.startsWith("/mobile/service/dispatch")) return "Dispatch";
   if (pathname.startsWith("/mobile/service/truck-inventory")) {
     return "Truck inventory";
   }
@@ -273,13 +281,6 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
         </div>
 
         <div className="field-workspace-sidebar__footer">
-          <Link
-            href="/mobile/service/truck-inventory"
-            className="field-workspace-nav__link"
-          >
-            <PackageOpen aria-hidden className="h-[1.1rem] w-[1.1rem]" />
-            <span>Truck inventory</span>
-          </Link>
           {workspaceCapabilities.canConfigureFieldService ? (
             <Link
               href="/mobile/service/setup"
@@ -345,13 +346,13 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
         </Link>
         {workspaceCapabilities.canManageScheduling ? (
           <Link
-            href="/mobile/appointments"
+            href="/mobile/service/dispatch"
             data-active={
-              pathname.startsWith("/mobile/appointments") ? "true" : "false"
+              pathname.startsWith("/mobile/service/dispatch") ? "true" : "false"
             }
           >
-            <CalendarDays aria-hidden className="h-5 w-5" />
-            <span>Schedule</span>
+            <RadioTower aria-hidden className="h-5 w-5" />
+            <span>Dispatch</span>
           </Link>
         ) : (
           <Link
@@ -429,15 +430,6 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
           />
           <div className="field-workspace-nav__section">
             <div className="field-workspace-nav__label">Workspace</div>
-            <FieldNavLink
-              item={{
-                label: "Truck inventory",
-                href: "/mobile/service/truck-inventory",
-                icon: PackageOpen,
-              }}
-              pathname={pathname}
-              onNavigate={() => setMenuOpen(false)}
-            />
             {workspaceCapabilities.canConfigureFieldService ? (
               <FieldNavLink
                 item={{

--- a/features/mobile/service/MobileServiceShell.tsx
+++ b/features/mobile/service/MobileServiceShell.tsx
@@ -522,8 +522,10 @@ function VisitCard({
 
 export default function MobileServiceShell({
   embedded = false,
+  canManageScheduling = false,
 }: {
   embedded?: boolean;
+  canManageScheduling?: boolean;
 }) {
   const router = useRouter();
   const [snapshot, setSnapshot] = useState<MobileActiveJobContract | null>(null);
@@ -965,13 +967,25 @@ export default function MobileServiceShell({
           <p className="mx-auto mt-1 max-w-sm text-sm text-[color:var(--theme-text-secondary)]">
             Take the next call in seconds or keep working from the normal mobile work-order queue.
           </p>
-          <div className="mt-4 grid gap-2 sm:grid-cols-2">
+          <div
+            className={`mt-4 grid gap-2 ${
+              canManageScheduling ? "sm:grid-cols-3" : "sm:grid-cols-2"
+            }`}
+          >
             <Link
               href="/mobile/service/new"
               className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-sky-500 px-4 text-sm font-extrabold text-white"
             >
               <Plus className="h-4 w-4" /> New service call
             </Link>
+            {canManageScheduling ? (
+              <Link
+                href="/mobile/service/dispatch"
+                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl border border-sky-500/40 bg-sky-500/10 px-4 text-sm font-extrabold text-[color:var(--theme-text-primary)]"
+              >
+                <Route className="h-4 w-4" /> Open dispatch
+              </Link>
+            ) : null}
             <Link
               href="/mobile/work-orders/create"
               className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-4 text-sm font-bold"

--- a/features/mobile/service/MobileTruckInventoryScreen.tsx
+++ b/features/mobile/service/MobileTruckInventoryScreen.tsx
@@ -82,7 +82,7 @@ export default function MobileTruckInventoryScreen(props: Props) {
     { key: "stock", label: "Truck stock", icon: Boxes },
     { key: "load", label: "Transfer", icon: MoveRight },
     { key: "receive", label: "Receive", icon: PackageCheck },
-    { key: "history", label: "Used", icon: ClipboardList },
+    { key: "history", label: "Activity", icon: ClipboardList },
   ];
 
   return (

--- a/features/mobile/service/TruckHistoryPanel.tsx
+++ b/features/mobile/service/TruckHistoryPanel.tsx
@@ -4,6 +4,7 @@ import { RotateCcw } from "lucide-react";
 
 import type {
   FieldRecentPartUse,
+  FieldTruckInventoryMovement,
   FieldTruckInventorySnapshot,
 } from "./truckInventoryContracts";
 import { aggregateRecentPartUses, numeric } from "./truckInventoryContracts";
@@ -15,53 +16,161 @@ type Props = {
   handleReturn: (use: FieldRecentPartUse) => Promise<void>;
 };
 
-export default function TruckHistoryPanel({ snapshot, busy, handleReturn }: Props) {
-  const recentUses = aggregateRecentPartUses(snapshot.recentUses);
+const MOVEMENT_LABELS: Record<string, string> = {
+  receive: "Received to truck",
+  transfer_in: "Loaded onto truck",
+  consume: "Used on call",
+  return: "Returned to truck",
+  adjust: "Inventory adjusted",
+  wo_allocate: "Reserved for work",
+  wo_release: "Reservation released",
+  seed: "Opening inventory",
+};
+
+function movementLabel(movement: FieldTruckInventoryMovement): string {
   return (
-    <section className="space-y-3">
-      {recentUses.map((use) => {
-        const returnable = Math.max(
-          0,
-          numeric(use.quantity) - numeric(use.returnedQuantity),
-        );
-        return (
-          <article
-            key={use.stockMoveId}
-            className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <h3 className="font-bold">{use.name}</h3>
-                <p className="text-xs text-[color:var(--theme-text-secondary)]">
-                  {use.partNumber || use.partId}
-                </p>
-              </div>
-              <div className="text-right text-sm">
-                <strong>{quantityLabel(use.quantity)} used</strong>
-                <div className="text-xs text-[color:var(--theme-text-muted)]">
-                  {new Date(use.createdAt).toLocaleString()}
+    MOVEMENT_LABELS[movement.reason] ??
+    (movement.direction === "in" ? "Added to truck" : "Removed from truck")
+  );
+}
+
+function movementContext(movement: FieldTruckInventoryMovement): string[] {
+  const context: string[] = [];
+  if (movement.sourceLocationName && movement.destinationLocationName) {
+    context.push(
+      `${movement.sourceLocationName} → ${movement.destinationLocationName}`,
+    );
+  } else if (movement.destinationLocationName) {
+    context.push(movement.destinationLocationName);
+  }
+  if (movement.purchaseOrderNumber) {
+    context.push(`PO ${movement.purchaseOrderNumber}`);
+  }
+  if (movement.workOrderNumber) {
+    context.push(`WO ${movement.workOrderNumber}`);
+  }
+  if (movement.actorName) context.push(movement.actorName);
+  return context;
+}
+
+export default function TruckHistoryPanel({
+  snapshot,
+  busy,
+  handleReturn,
+}: Props) {
+  const recentUses = aggregateRecentPartUses(snapshot.recentUses);
+  const movements = snapshot.movements ?? [];
+  return (
+    <div className="space-y-5">
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-lg font-bold">Return parts from this call</h2>
+          <p className="text-sm text-[color:var(--theme-text-secondary)]">
+            Returns restore the same truck location and work-order part ledger.
+          </p>
+        </div>
+        {recentUses.map((use) => {
+          const returnable = Math.max(
+            0,
+            numeric(use.quantity) - numeric(use.returnedQuantity),
+          );
+          return (
+            <article
+              key={use.stockMoveId}
+              className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="font-bold">{use.name}</h3>
+                  <p className="text-xs text-[color:var(--theme-text-secondary)]">
+                    {use.partNumber || use.partId}
+                  </p>
+                </div>
+                <div className="text-right text-sm">
+                  <strong>{quantityLabel(use.quantity)} used</strong>
+                  <div className="text-xs text-[color:var(--theme-text-muted)]">
+                    {new Date(use.createdAt).toLocaleString()}
+                  </div>
                 </div>
               </div>
-            </div>
-            <button
-              type="button"
-              className={`${actionClass} mt-3 w-full`}
-              disabled={busy || returnable <= 0}
-              onClick={() => void handleReturn(use)}
-            >
-              <RotateCcw className="h-4 w-4" />
-              {returnable > 0
-                ? `Return ${quantityLabel(returnable)} to truck`
-                : "Fully returned"}
-            </button>
-          </article>
-        );
-      })}
-      {recentUses.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-[color:var(--theme-border-soft)] p-8 text-center text-sm text-[color:var(--theme-text-muted)]">
-          No truck parts have been used on this call yet.
+              <button
+                type="button"
+                className={`${actionClass} mt-3 w-full`}
+                disabled={busy || returnable <= 0}
+                onClick={() => void handleReturn(use)}
+              >
+                <RotateCcw className="h-4 w-4" />
+                {returnable > 0
+                  ? `Return ${quantityLabel(returnable)} to truck`
+                  : "Fully returned"}
+              </button>
+            </article>
+          );
+        })}
+        {recentUses.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-[color:var(--theme-border-soft)] p-6 text-center text-sm text-[color:var(--theme-text-muted)]">
+            No truck parts have been used on this call yet.
+          </div>
+        ) : null}
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-lg font-bold">Truck movement history</h2>
+          <p className="text-sm text-[color:var(--theme-text-secondary)]">
+            Receive, transfer, use, return, and reservation entries from the
+            canonical stock ledger.
+          </p>
         </div>
-      ) : null}
-    </section>
+        {movements.map((movement) => {
+          const context = movementContext(movement);
+          return (
+            <article
+              key={movement.id}
+              className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-xs font-bold uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">
+                    {movementLabel(movement)}
+                  </p>
+                  <h3 className="mt-1 truncate font-bold">
+                    {movement.partName}
+                  </h3>
+                  <p className="text-xs text-[color:var(--theme-text-secondary)]">
+                    {movement.partNumber || movement.partId}
+                  </p>
+                  {context.length > 0 ? (
+                    <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
+                      {context.join(" · ")}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="shrink-0 text-right">
+                  <strong
+                    className={
+                      movement.direction === "in"
+                        ? "text-emerald-500"
+                        : "text-amber-500"
+                    }
+                  >
+                    {movement.direction === "in" ? "+" : "−"}
+                    {quantityLabel(movement.quantity)}
+                  </strong>
+                  <div className="text-xs text-[color:var(--theme-text-muted)]">
+                    {new Date(movement.createdAt).toLocaleString()}
+                  </div>
+                </div>
+              </div>
+            </article>
+          );
+        })}
+        {movements.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-[color:var(--theme-border-soft)] p-6 text-center text-sm text-[color:var(--theme-text-muted)]">
+            No inventory movement has been recorded for this truck yet.
+          </div>
+        ) : null}
+      </section>
+    </div>
   );
 }

--- a/features/mobile/service/fieldDashboardLayout.ts
+++ b/features/mobile/service/fieldDashboardLayout.ts
@@ -5,6 +5,7 @@ export const FIELD_DASHBOARD_LEGACY_LAYOUT_CACHE_KEY =
   "profixiq:field-dashboard:layout:v1";
 
 export const FIELD_DASHBOARD_CARD_IDS = [
+  "dispatch_queue",
   "jobs_in_progress",
   "awaiting_approval",
   "parts_required",

--- a/features/mobile/service/truckInventoryContracts.ts
+++ b/features/mobile/service/truckInventoryContracts.ts
@@ -131,6 +131,22 @@ export type FieldRecentPartUse = {
   returnedQuantity: number;
 };
 
+export type FieldTruckInventoryMovement = {
+  id: string;
+  partId: string;
+  partName: string;
+  partNumber: string | null;
+  quantity: number;
+  direction: "in" | "out";
+  reason: string;
+  createdAt: string;
+  actorName: string | null;
+  sourceLocationName: string | null;
+  destinationLocationName: string | null;
+  purchaseOrderNumber: string | null;
+  workOrderNumber: string | null;
+};
+
 export function aggregateRecentPartUses(
   uses: FieldRecentPartUse[],
 ): FieldRecentPartUse[] {
@@ -171,6 +187,7 @@ export type FieldTruckInventorySnapshot = {
   openReceipts: FieldOpenReceipt[];
   locations: FieldStockLocation[];
   recentUses: FieldRecentPartUse[];
+  movements: FieldTruckInventoryMovement[];
 };
 
 export type FieldPartIdentityResult =

--- a/features/mobile/service/truckInventoryOffline.ts
+++ b/features/mobile/service/truckInventoryOffline.ts
@@ -132,7 +132,10 @@ export async function loadCachedFieldTruckInventorySnapshot(args: {
         };
       }
       return snapshot;
-    }, stored.data);
+    }, {
+      ...stored.data,
+      movements: stored.data.movements ?? [],
+    });
 }
 
 export async function consumeFieldTruckPart(args: {

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -28164,6 +28164,18 @@ export type Database = {
         }
         Returns: Json
       }
+      field_transfer_stock_to_truck_authorized_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_operation_key: string
+          p_part_id: string
+          p_quantity: number
+          p_service_vehicle_id: string
+          p_shop_id: string
+          p_source_location_id: string
+        }
+        Returns: Json
+      }
       field_truck_inventory_activity: {
         Args: {
           p_actor_user_id: string
@@ -30822,3 +30834,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -28164,6 +28164,15 @@ export type Database = {
         }
         Returns: Json
       }
+      field_truck_inventory_activity: {
+        Args: {
+          p_actor_user_id: string
+          p_limit?: number
+          p_service_vehicle_id: string
+          p_shop_id: string
+        }
+        Returns: Json
+      }
       field_truck_inventory_snapshot: {
         Args: {
           p_actor_user_id: string
@@ -30813,4 +30822,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -28195,6 +28195,17 @@ export type Database = {
         }
         Returns: Json
       }
+      field_truck_inventory_snapshot_with_activity: {
+        Args: {
+          p_activity_limit?: number
+          p_actor_user_id: string
+          p_query?: string
+          p_service_vehicle_id?: string
+          p_service_visit_id?: string
+          p_shop_id: string
+        }
+        Returns: Json
+      }
       field_use_truck_part_atomic: {
         Args: {
           p_actor_user_id: string

--- a/supabase/migrations/20260818093000_field_truck_inventory_activity.sql
+++ b/supabase/migrations/20260818093000_field_truck_inventory_activity.sql
@@ -1,0 +1,208 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+set local check_function_bodies = false;
+
+-- Stock loading is a Parts-management command. Keep the existing paired,
+-- idempotent ledger implementation private and put the capability check at the
+-- database boundary so direct Data API RPC calls cannot bypass the route guard.
+alter function public.field_transfer_stock_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) rename to field_transfer_stock_to_truck_atomic_impl;
+
+alter function public.field_transfer_stock_to_truck_atomic_impl(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) set schema private;
+
+revoke all on function private.field_transfer_stock_to_truck_atomic_impl(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) from public, anon, authenticated, service_role;
+
+create function public.field_transfer_stock_to_truck_atomic(
+  p_shop_id uuid,
+  p_service_vehicle_id uuid,
+  p_source_location_id uuid,
+  p_part_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.can_manage_parts then
+    raise exception using errcode = '42501', message = 'Parts management permission is required.';
+  end if;
+
+  return private.field_transfer_stock_to_truck_atomic_impl(
+    p_shop_id,
+    p_service_vehicle_id,
+    p_source_location_id,
+    p_part_id,
+    p_quantity,
+    p_actor_user_id,
+    p_operation_key
+  );
+end;
+$$;
+
+revoke all on function public.field_transfer_stock_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) from public, anon;
+grant execute on function public.field_transfer_stock_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) to authenticated, service_role;
+
+comment on function public.field_transfer_stock_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) is
+  'Parts-authorized Field command that delegates to the canonical paired truck-transfer ledger implementation.';
+
+create index if not exists stock_moves_shop_location_created_idx
+  on public.stock_moves (shop_id, location_id, created_at desc);
+
+create or replace function public.field_truck_inventory_activity(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_service_vehicle_id uuid,
+  p_limit integer default 50
+) returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_truck public.service_vehicles%rowtype;
+  v_limit integer := least(greatest(coalesce(p_limit, 50), 1), 100);
+  v_activity jsonb := '[]'::jsonb;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.can_view_field then
+    raise exception using errcode = '42501', message = 'Field inventory access is required.';
+  end if;
+  if not private.profixiq_field_inventory_actor_can_use_truck(
+    p_shop_id,
+    p_actor_user_id,
+    p_service_vehicle_id
+  ) then
+    raise exception using errcode = '42501', message = 'This truck is not available to the authenticated actor.';
+  end if;
+
+  select * into v_truck
+  from public.service_vehicles vehicle
+  where vehicle.id = p_service_vehicle_id
+    and vehicle.shop_id = p_shop_id
+    and vehicle.active;
+  if not found or v_truck.stock_location_id is null then
+    raise exception using errcode = 'P0002', message = 'The service truck has no inventory location.';
+  end if;
+
+  select coalesce(jsonb_agg(activity.payload order by activity.created_at desc), '[]'::jsonb)
+  into v_activity
+  from (
+    select
+      move.created_at,
+      jsonb_build_object(
+        'id', move.id,
+        'partId', move.part_id,
+        'partName', coalesce(nullif(trim(part.name), ''), 'Part'),
+        'partNumber', coalesce(part.part_number, part.sku),
+        'quantity', abs(move.qty_change),
+        'direction', case when move.qty_change >= 0 then 'in' else 'out' end,
+        'reason', move.reason::text,
+        'createdAt', move.created_at,
+        'actorName', creator.actor_name,
+        'sourceLocationName', source_location.name,
+        'destinationLocationName', destination_location.name,
+        'purchaseOrderNumber', purchase_order.po_number,
+        'workOrderNumber', work_order.custom_id
+      ) as payload
+    from public.stock_moves move
+    join public.parts part
+      on part.id = move.part_id
+     and part.shop_id = move.shop_id
+    left join public.purchase_order_lines purchase_line
+      on purchase_line.id = move.purchase_order_line_id
+    left join public.purchase_orders purchase_order
+      on purchase_order.shop_id = move.shop_id
+     and (
+       purchase_order.id = purchase_line.po_id
+       or (
+         move.reference_kind = 'purchase_order'
+         and purchase_order.id = move.reference_id
+       )
+     )
+    left join public.work_order_parts work_part
+      on work_part.id = move.work_order_part_id
+     and work_part.shop_id = move.shop_id
+    left join public.work_orders work_order
+      on work_order.id = work_part.work_order_id
+     and work_order.shop_id = move.shop_id
+    left join public.stock_locations source_location
+      on source_location.shop_id = move.shop_id
+     and source_location.id::text = move.metadata ->> 'source_location_id'
+    left join public.stock_locations destination_location
+      on destination_location.shop_id = move.shop_id
+     and destination_location.id::text = coalesce(
+       move.metadata ->> 'destination_location_id',
+       move.location_id::text
+     )
+    left join lateral (
+      select coalesce(
+        nullif(trim(profile.full_name), ''),
+        nullif(trim(profile.email), '')
+      ) as actor_name
+      from public.profiles profile
+      where profile.shop_id = p_shop_id
+        and (
+          profile.id = move.created_by
+          or profile.user_id = move.created_by
+        )
+      order by (profile.id = move.created_by) desc, profile.id
+      limit 1
+    ) creator on true
+    where move.shop_id = p_shop_id
+      and move.location_id = v_truck.stock_location_id
+    order by move.created_at desc, move.id desc
+    limit v_limit
+  ) activity;
+
+  return v_activity;
+end;
+$$;
+
+revoke all on function public.field_truck_inventory_activity(uuid,uuid,uuid,integer)
+  from public, anon;
+grant execute on function public.field_truck_inventory_activity(uuid,uuid,uuid,integer)
+  to authenticated, service_role;
+
+comment on function public.field_truck_inventory_activity(uuid,uuid,uuid,integer) is
+  'Tenant- and truck-scoped Field inventory activity projection over the canonical stock_moves ledger.';
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260818153429_field_truck_inventory_activity.sql
+++ b/supabase/migrations/20260818153429_field_truck_inventory_activity.sql
@@ -4,22 +4,17 @@ set local lock_timeout = '5s';
 set local statement_timeout = '10min';
 set local check_function_bodies = false;
 
--- Stock loading is a Parts-management command. Keep the existing paired,
--- idempotent ledger implementation private and put the capability check at the
--- database boundary so direct Data API RPC calls cannot bypass the route guard.
-alter function public.field_transfer_stock_to_truck_atomic(
+-- Preserve the canonical paired/idempotent transfer function and its schema
+-- identity. Authenticated callers use the additive Parts-authorized endpoint;
+-- the original implementation remains available only to service-role jobs.
+revoke all on function public.field_transfer_stock_to_truck_atomic(
   uuid,uuid,uuid,uuid,numeric,uuid,text
-) rename to field_transfer_stock_to_truck_atomic_impl;
-
-alter function public.field_transfer_stock_to_truck_atomic_impl(
+) from public, anon, authenticated;
+grant execute on function public.field_transfer_stock_to_truck_atomic(
   uuid,uuid,uuid,uuid,numeric,uuid,text
-) set schema private;
+) to service_role;
 
-revoke all on function private.field_transfer_stock_to_truck_atomic_impl(
-  uuid,uuid,uuid,uuid,numeric,uuid,text
-) from public, anon, authenticated, service_role;
-
-create function public.field_transfer_stock_to_truck_atomic(
+create or replace function public.field_transfer_stock_to_truck_authorized_atomic(
   p_shop_id uuid,
   p_service_vehicle_id uuid,
   p_source_location_id uuid,
@@ -48,7 +43,7 @@ begin
     raise exception using errcode = '42501', message = 'Parts management permission is required.';
   end if;
 
-  return private.field_transfer_stock_to_truck_atomic_impl(
+  return public.field_transfer_stock_to_truck_atomic(
     p_shop_id,
     p_service_vehicle_id,
     p_source_location_id,
@@ -60,17 +55,17 @@ begin
 end;
 $$;
 
-revoke all on function public.field_transfer_stock_to_truck_atomic(
+revoke all on function public.field_transfer_stock_to_truck_authorized_atomic(
   uuid,uuid,uuid,uuid,numeric,uuid,text
 ) from public, anon;
-grant execute on function public.field_transfer_stock_to_truck_atomic(
+grant execute on function public.field_transfer_stock_to_truck_authorized_atomic(
   uuid,uuid,uuid,uuid,numeric,uuid,text
 ) to authenticated, service_role;
 
-comment on function public.field_transfer_stock_to_truck_atomic(
+comment on function public.field_transfer_stock_to_truck_authorized_atomic(
   uuid,uuid,uuid,uuid,numeric,uuid,text
 ) is
-  'Parts-authorized Field command that delegates to the canonical paired truck-transfer ledger implementation.';
+  'Additive Parts-authorized Field command that delegates to the preserved canonical paired truck-transfer ledger implementation.';
 
 create index if not exists stock_moves_shop_location_created_idx
   on public.stock_moves (shop_id, location_id, created_at desc);

--- a/supabase/migrations/20260818161654_field_truck_transfer_additive_authorization.sql
+++ b/supabase/migrations/20260818161654_field_truck_transfer_additive_authorization.sql
@@ -1,0 +1,74 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+set local check_function_bodies = false;
+
+-- Forward-only production reconciliation for the already-applied Phase 3
+-- migration. Preserve every existing function and schema object. The original
+-- paired/idempotent transfer command becomes service-role-only, while the
+-- additive endpoint performs actor and Parts-capability authorization before
+-- delegating to it.
+revoke all on function public.field_transfer_stock_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) from public, anon, authenticated;
+grant execute on function public.field_transfer_stock_to_truck_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) to service_role;
+
+create or replace function public.field_transfer_stock_to_truck_authorized_atomic(
+  p_shop_id uuid,
+  p_service_vehicle_id uuid,
+  p_source_location_id uuid,
+  p_part_id uuid,
+  p_quantity numeric,
+  p_actor_user_id uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.can_manage_parts then
+    raise exception using errcode = '42501', message = 'Parts management permission is required.';
+  end if;
+
+  return public.field_transfer_stock_to_truck_atomic(
+    p_shop_id,
+    p_service_vehicle_id,
+    p_source_location_id,
+    p_part_id,
+    p_quantity,
+    p_actor_user_id,
+    p_operation_key
+  );
+end;
+$$;
+
+revoke all on function public.field_transfer_stock_to_truck_authorized_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) from public, anon;
+grant execute on function public.field_transfer_stock_to_truck_authorized_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) to authenticated, service_role;
+
+comment on function public.field_transfer_stock_to_truck_authorized_atomic(
+  uuid,uuid,uuid,uuid,numeric,uuid,text
+) is
+  'Additive Parts-authorized Field command that delegates to the preserved canonical paired truck-transfer ledger implementation.';
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260818184534_field_truck_inventory_consistent_activity.sql
+++ b/supabase/migrations/20260818184534_field_truck_inventory_consistent_activity.sql
@@ -1,0 +1,225 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+set local check_function_bodies = false;
+
+-- The snapshot is read-only. Marking it STABLE makes every query executed by
+-- the snapshot use the calling statement's MVCC snapshot. The additive
+-- wrapper below can therefore return quantities and activity that describe
+-- the same database state without changing the existing snapshot contract.
+alter function public.field_truck_inventory_snapshot(uuid,uuid,uuid,uuid,text)
+  stable;
+
+create or replace function public.field_truck_inventory_activity(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_service_vehicle_id uuid,
+  p_limit integer default 50
+) returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor record;
+  v_truck public.service_vehicles%rowtype;
+  v_limit integer := least(greatest(coalesce(p_limit, 50), 1), 100);
+  v_activity jsonb := '[]'::jsonb;
+begin
+  if not public.scheduler_actor_matches(p_actor_user_id) then
+    raise exception using errcode = '42501', message = 'Authenticated actor mismatch.';
+  end if;
+
+  select * into v_actor
+  from private.profixiq_field_inventory_actor_context(
+    p_shop_id,
+    p_actor_user_id
+  );
+  if not found or not v_actor.can_view_field then
+    raise exception using errcode = '42501', message = 'Field inventory access is required.';
+  end if;
+  if not private.profixiq_field_inventory_actor_can_use_truck(
+    p_shop_id,
+    p_actor_user_id,
+    p_service_vehicle_id
+  ) then
+    raise exception using errcode = '42501', message = 'This truck is not available to the authenticated actor.';
+  end if;
+
+  select * into v_truck
+  from public.service_vehicles vehicle
+  where vehicle.id = p_service_vehicle_id
+    and vehicle.shop_id = p_shop_id
+    and vehicle.active;
+  if not found or v_truck.stock_location_id is null then
+    raise exception using errcode = 'P0002', message = 'The service truck has no inventory location.';
+  end if;
+
+  select coalesce(jsonb_agg(activity.payload order by activity.created_at desc), '[]'::jsonb)
+  into v_activity
+  from (
+    select
+      move.created_at,
+      jsonb_build_object(
+        'id', move.id,
+        'partId', move.part_id,
+        'partName', coalesce(nullif(trim(part.name), ''), 'Part'),
+        'partNumber', coalesce(part.part_number, part.sku),
+        'quantity', case
+          when move.reason in ('wo_allocate', 'wo_release')
+            then abs(coalesce(move.lifecycle_quantity, 0))
+          else abs(move.qty_change)
+        end,
+        'direction', case
+          when move.reason = 'wo_allocate' then 'out'
+          when move.reason = 'wo_release' then 'in'
+          when move.qty_change >= 0 then 'in'
+          else 'out'
+        end,
+        'reason', move.reason::text,
+        'createdAt', move.created_at,
+        'actorName', creator.actor_name,
+        'sourceLocationName', source_location.name,
+        'destinationLocationName', destination_location.name,
+        'purchaseOrderNumber', purchase_order.po_number,
+        'workOrderNumber', work_order.custom_id
+      ) as payload
+    from public.stock_moves move
+    join public.parts part
+      on part.id = move.part_id
+     and part.shop_id = move.shop_id
+    left join public.purchase_order_lines purchase_line
+      on purchase_line.id = move.purchase_order_line_id
+    left join public.purchase_orders purchase_order
+      on purchase_order.shop_id = move.shop_id
+     and (
+       purchase_order.id = purchase_line.po_id
+       or (
+         move.reference_kind = 'purchase_order'
+         and purchase_order.id = move.reference_id
+       )
+     )
+    left join public.work_order_parts work_part
+      on work_part.id = move.work_order_part_id
+     and work_part.shop_id = move.shop_id
+    left join public.work_orders work_order
+      on work_order.id = work_part.work_order_id
+     and work_order.shop_id = move.shop_id
+    left join public.stock_locations source_location
+      on source_location.shop_id = move.shop_id
+     and source_location.id::text = move.metadata ->> 'source_location_id'
+    left join public.stock_locations destination_location
+      on destination_location.shop_id = move.shop_id
+     and destination_location.id::text = coalesce(
+       move.metadata ->> 'destination_location_id',
+       move.location_id::text
+     )
+    left join lateral (
+      select coalesce(
+        nullif(trim(profile.full_name), ''),
+        nullif(trim(profile.email), '')
+      ) as actor_name
+      from public.profiles profile
+      where profile.shop_id = p_shop_id
+        and (
+          profile.id = move.created_by
+          or profile.user_id = move.created_by
+        )
+      order by (profile.id = move.created_by) desc, profile.id
+      limit 1
+    ) creator on true
+    where move.shop_id = p_shop_id
+      and move.location_id = v_truck.stock_location_id
+    order by move.created_at desc, move.id desc
+    limit v_limit
+  ) activity;
+
+  return v_activity;
+end;
+$$;
+
+create or replace function public.field_truck_inventory_snapshot_with_activity(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_service_visit_id uuid default null,
+  p_service_vehicle_id uuid default null,
+  p_query text default null,
+  p_activity_limit integer default 50
+) returns jsonb
+language plpgsql
+stable
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_snapshot jsonb;
+  v_service_vehicle_id uuid;
+  v_activity jsonb := '[]'::jsonb;
+begin
+  v_snapshot := public.field_truck_inventory_snapshot(
+    p_shop_id,
+    p_actor_user_id,
+    p_service_visit_id,
+    p_service_vehicle_id,
+    p_query
+  );
+
+  v_service_vehicle_id := nullif(v_snapshot -> 'truck' ->> 'id', '')::uuid;
+  if v_service_vehicle_id is not null then
+    v_activity := public.field_truck_inventory_activity(
+      p_shop_id,
+      p_actor_user_id,
+      v_service_vehicle_id,
+      p_activity_limit
+    );
+  end if;
+
+  return v_snapshot || jsonb_build_object('movements', v_activity);
+end;
+$$;
+
+revoke all on function public.field_truck_inventory_snapshot_with_activity(
+  uuid,uuid,uuid,uuid,text,integer
+) from public, anon;
+grant execute on function public.field_truck_inventory_snapshot_with_activity(
+  uuid,uuid,uuid,uuid,text,integer
+) to authenticated, service_role;
+
+comment on function public.field_truck_inventory_snapshot_with_activity(
+  uuid,uuid,uuid,uuid,text,integer
+) is
+  'Returns the authorized Field truck snapshot and movement ledger from one stable MVCC snapshot.';
+
+do $postcheck$
+begin
+  if not exists (
+    select 1
+    from pg_proc proc
+    join pg_namespace namespace on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'public'
+      and proc.proname = 'field_truck_inventory_snapshot'
+      and pg_get_function_identity_arguments(proc.oid) = 'p_shop_id uuid, p_actor_user_id uuid, p_service_visit_id uuid, p_service_vehicle_id uuid, p_query text'
+      and proc.provolatile = 's'
+  ) then
+    raise exception 'field_truck_inventory_snapshot must be STABLE';
+  end if;
+
+  if not has_function_privilege(
+    'authenticated',
+    'public.field_truck_inventory_snapshot_with_activity(uuid,uuid,uuid,uuid,text,integer)',
+    'EXECUTE'
+  ) or has_function_privilege(
+    'anon',
+    'public.field_truck_inventory_snapshot_with_activity(uuid,uuid,uuid,uuid,text,integer)',
+    'EXECUTE'
+  ) then
+    raise exception 'field_truck_inventory_snapshot_with_activity ACL mismatch';
+  end if;
+end;
+$postcheck$;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/field-dashboard-layout.test.ts
+++ b/tests/field-dashboard-layout.test.ts
@@ -25,6 +25,7 @@ describe("Field dashboard layout", () => {
 
     expect(layout.map((item) => item.id)).toEqual([
       "followups_due",
+      "dispatch_queue",
       "jobs_in_progress",
       "awaiting_approval",
       "parts_required",

--- a/tests/field-hub-shell.test.ts
+++ b/tests/field-hub-shell.test.ts
@@ -31,6 +31,7 @@ describe("Field Hub workspace", () => {
   it("links the Hub to canonical mobile operations instead of duplicating their data flows", () => {
     for (const href of [
       "/mobile/appointments",
+      "/mobile/service/dispatch",
       "/mobile/work-orders",
       "/mobile/inspections",
       "/mobile/parts",
@@ -40,7 +41,7 @@ describe("Field Hub workspace", () => {
       expect(`${fieldShell}\n${fieldHub}`).toContain(href);
     }
 
-    expect(fieldHub).toContain("<MobileServiceShell embedded />");
+    expect(fieldHub).toContain("<MobileServiceShell");
     expect(fieldHub).not.toContain('.from("');
   });
 
@@ -95,7 +96,14 @@ describe("Field Hub workspace", () => {
     expect(fieldHub).toContain("createFieldDashboardLayoutSaveQueue");
     expect(fieldHub).toContain("!saveQueue.hasWork()");
     expect(fieldHub).toContain('title: "Scan or create part"');
+    expect(fieldHub).toMatch(
+      /id: "dispatch_queue"[\s\S]*?requiredCapability: "canManageScheduling"/,
+    );
+    expect(fieldHub).toContain(
+      "canManageScheduling={capabilities.canManageScheduling}",
+    );
     expect(fieldShell).toContain('label: "Truck inventory"');
+    expect(fieldShell.match(/label: "Truck inventory"/g)).toHaveLength(1);
   });
 
   it("does not leak Fleet navigation and hides workspace switching unless another product is verified", () => {

--- a/tests/field-service-call-dispatch.test.ts
+++ b/tests/field-service-call-dispatch.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const fieldShell = read("features/mobile/service/FieldWorkspaceShell.tsx");
+const fieldHub = read("features/mobile/service/FieldHub.tsx");
+const fieldDispatchPage = read("app/mobile/service/dispatch/page.tsx");
+const dispatchBoard = read("app/dashboard/dispatch/DispatchBoardClient.tsx");
+const boardApi = read("app/api/dispatch/board/route.ts");
+const visitApi = read("app/api/dispatch/visits/[id]/route.ts");
+const intakeApi = read("app/api/mobile/service/intake/route.ts");
+
+describe("Field service-call dispatch", () => {
+  it("gives scheduling-capable Field operators a native Dispatch destination", () => {
+    expect(fieldShell).toMatch(
+      /label: "Dispatch"[\s\S]*?href: "\/mobile\/service\/dispatch"[\s\S]*?requiredCapability: "canManageScheduling"/,
+    );
+    expect(fieldHub).toMatch(
+      /id: "dispatch_queue"[\s\S]*?href: "\/mobile\/service\/dispatch"[\s\S]*?requiredCapability: "canManageScheduling"/,
+    );
+    expect(fieldShell).toContain("<span>Dispatch</span>");
+  });
+
+  it("server-guards the Field dispatch page and reuses the canonical board", () => {
+    expect(fieldDispatchPage).toContain("requireShopPageAccess");
+    expect(fieldDispatchPage).toContain(
+      'requiredCapability: "canManageScheduling"',
+    );
+    expect(fieldDispatchPage).toContain(
+      '<DispatchBoardClient surface="field" />',
+    );
+    expect(dispatchBoard).toContain('fetch("/api/dispatch/board"');
+    expect(dispatchBoard).toContain("/api/dispatch/visits/${visit.id}");
+    expect(dispatchBoard).toContain('href="/mobile/service/new"');
+    expect(dispatchBoard).toContain('"/mobile/appointments"');
+    expect(dispatchBoard).toContain("style={DISPATCH_THEME}");
+    expect(dispatchBoard).toContain(
+      '"--theme-action-primary": "var(--brand-primary,#2563eb)"',
+    );
+    expect(dispatchBoard).toContain(
+      '"--theme-action-primary-text": "var(--theme-text-on-accent,#fff)"',
+    );
+  });
+
+  it("keeps intake, assignment, and transitions on tenant-scoped commands", () => {
+    expect(intakeApi).toContain("requireMobileServiceOperatorApiAccess");
+    expect(intakeApi).toContain('"mobile_create_service_call_atomic"');
+    expect(boardApi).toContain('requiredCapability: "canManageScheduling"');
+    expect(boardApi).toContain("getDispatchBoard");
+    expect(visitApi).toContain("assignServiceVisit");
+    expect(visitApi).toContain("transitionServiceVisit");
+    expect(visitApi).toContain("access.profile.shop_id");
+  });
+
+  it("does not repeat Truck inventory in the Field navigation", () => {
+    expect(fieldShell.match(/label: "Truck inventory"/g)).toHaveLength(1);
+  });
+});

--- a/tests/field-truck-inventory-activity-ui.test.tsx
+++ b/tests/field-truck-inventory-activity-ui.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import TruckHistoryPanel from "@/features/mobile/service/TruckHistoryPanel";
+import type { FieldTruckInventorySnapshot } from "@/features/mobile/service/truckInventoryContracts";
+
+afterEach(cleanup);
+
+function snapshot(): FieldTruckInventorySnapshot {
+  return {
+    generatedAt: "2026-08-18T15:00:00.000Z",
+    actorProfileId: "manager",
+    canManageParts: true,
+    hasFieldAccess: true,
+    visit: null,
+    trucks: [],
+    truck: null,
+    workOrderLines: [],
+    items: [],
+    catalog: [],
+    openReceipts: [],
+    locations: [],
+    recentUses: [],
+    movements: [
+      {
+        id: "move-1",
+        partId: "part-1",
+        partName: "Wheel seal",
+        partNumber: "WS-100",
+        quantity: 2,
+        direction: "in",
+        reason: "transfer_in",
+        createdAt: "2026-08-18T14:45:00.000Z",
+        actorName: "Field Manager",
+        sourceLocationName: "MAIN",
+        destinationLocationName: "QA-01 Inventory",
+        purchaseOrderNumber: null,
+        workOrderNumber: null,
+      },
+    ],
+  };
+}
+
+describe("Field truck inventory activity", () => {
+  it("renders canonical movement context for the selected truck", () => {
+    render(
+      <TruckHistoryPanel
+        snapshot={snapshot()}
+        busy={false}
+        handleReturn={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Truck movement history")).toBeInTheDocument();
+    expect(screen.getByText("Loaded onto truck")).toBeInTheDocument();
+    expect(screen.getByText("Wheel seal")).toBeInTheDocument();
+    expect(screen.getByText(/MAIN → QA-01 Inventory/)).toBeInTheDocument();
+    expect(screen.getByText(/Field Manager/)).toBeInTheDocument();
+  });
+});

--- a/tests/field-truck-inventory-contract.test.ts
+++ b/tests/field-truck-inventory-contract.test.ts
@@ -13,6 +13,7 @@ const migration = [
   "supabase/migrations/20260815050000_field_part_identity_review_hardening.sql",
   "supabase/migrations/20260815050100_field_truck_line_review_hardening.sql",
   "supabase/migrations/20260815050200_field_truck_receipt_review_hardening.sql",
+  "supabase/migrations/20260818093000_field_truck_inventory_activity.sql",
 ]
   .map(read)
   .join("\n");
@@ -98,6 +99,21 @@ describe("Field Service truck inventory", () => {
     expect(snapshotApi).toContain("p_service_vehicle_id");
     expect(contracts).toContain("trucks: FieldTruck[]");
     expect(inventoryUi).toContain("Select service truck");
+    expect(migration).toContain(
+      "private.field_transfer_stock_to_truck_atomic_impl",
+    );
+    expect(migration).toContain("not v_actor.can_manage_parts");
+    expect(migration).toContain("Parts management permission is required.");
+  });
+
+  it("exposes a tenant-scoped truck ledger activity projection", () => {
+    expect(migration).toContain("field_truck_inventory_activity");
+    expect(migration).toContain("stock_moves_shop_location_created_idx");
+    expect(migration).toContain("move.shop_id = p_shop_id");
+    expect(migration).toContain("move.location_id = v_truck.stock_location_id");
+    expect(snapshotApi).toContain("field_truck_inventory_activity");
+    expect(contracts).toContain("movements: FieldTruckInventoryMovement[]");
+    expect(inventoryUi).toContain("Truck movement history");
   });
 
   it("receives canonical or free-text PO lines directly to the truck without a setup detour", () => {
@@ -157,6 +173,7 @@ describe("Field Service truck inventory", () => {
     expect(offline).toContain('const SNAPSHOT_KIND = "field-truck-inventory"');
     expect(offline).toContain('actionType: "field-inventory:use-part"');
     expect(offline).toContain('actionType: "field-inventory:return-part"');
+    expect(offline).toContain("movements: stored.data.movements ?? []");
     expect(offline).toContain('orderKey: `service-visit:${args.payload.visitId}`');
     expect(offline).toContain("lastVisitMutationDependency");
     expect(offline.match(/bestEffortOnlineHistory: true/g)).toHaveLength(2);
@@ -228,11 +245,13 @@ describe("Field Service truck inventory", () => {
     expect(runtime).toContain("field_receive_po_part_to_truck_atomic");
     expect(runtime).toContain("free-text PO line becomes a canonical part");
     expect(runtime).toContain("field_transfer_stock_to_truck_atomic");
+    expect(runtime).toContain("technician bypassed Parts permission");
     expect(runtime).toContain("field_use_truck_part_atomic");
     expect(runtime).toContain("repeated use decremented inventory twice");
     expect(runtime).toContain("field_return_truck_part_atomic");
     expect(runtime).toContain("return replay changed inventory twice");
     expect(runtime).toContain("field_truck_inventory_snapshot");
+    expect(runtime).toContain("field_truck_inventory_activity");
     expect(workflow).toContain("tests/field-truck-inventory-contract.test.ts");
     expect(workflow).toContain("tests/mobile/field-truck-inventory.runtime.sql");
     expect(workflow).toContain("Field truck inventory runtime");

--- a/tests/field-truck-inventory-contract.test.ts
+++ b/tests/field-truck-inventory-contract.test.ts
@@ -15,6 +15,7 @@ const migration = [
   "supabase/migrations/20260815050200_field_truck_receipt_review_hardening.sql",
   "supabase/migrations/20260818153429_field_truck_inventory_activity.sql",
   "supabase/migrations/20260818161654_field_truck_transfer_additive_authorization.sql",
+  "supabase/migrations/20260818184534_field_truck_inventory_consistent_activity.sql",
 ]
   .map(read)
   .join("\n");
@@ -24,6 +25,9 @@ const additiveHardening = [
 ]
   .map(read)
   .join("\n");
+const consistentActivity = read(
+  "supabase/migrations/20260818184534_field_truck_inventory_consistent_activity.sql",
+);
 const inventoryUi = [
   "features/mobile/service/MobileTruckInventory.tsx",
   "features/mobile/service/MobileTruckInventoryScreen.tsx",
@@ -128,7 +132,29 @@ describe("Field Service truck inventory", () => {
     expect(migration).toContain("stock_moves_shop_location_created_idx");
     expect(migration).toContain("move.shop_id = p_shop_id");
     expect(migration).toContain("move.location_id = v_truck.stock_location_id");
-    expect(snapshotApi).toContain("field_truck_inventory_activity");
+    expect(snapshotApi).toContain(
+      "field_truck_inventory_snapshot_with_activity",
+    );
+    expect(snapshotApi).not.toContain('"field_truck_inventory_activity"');
+    expect(snapshotApi.match(/fieldInventoryRpc\(/g)).toHaveLength(1);
+    expect(consistentActivity).toContain(
+      "alter function public.field_truck_inventory_snapshot(uuid,uuid,uuid,uuid,text)",
+    );
+    expect(consistentActivity).toContain(
+      "field_truck_inventory_snapshot_with_activity",
+    );
+    expect(consistentActivity).toContain(
+      "when move.reason in ('wo_allocate', 'wo_release')",
+    );
+    expect(consistentActivity).toContain(
+      "then abs(coalesce(move.lifecycle_quantity, 0))",
+    );
+    expect(consistentActivity).toContain(
+      "when move.reason = 'wo_allocate' then 'out'",
+    );
+    expect(consistentActivity).toContain(
+      "when move.reason = 'wo_release' then 'in'",
+    );
     expect(contracts).toContain("movements: FieldTruckInventoryMovement[]");
     expect(inventoryUi).toContain("Truck movement history");
   });
@@ -261,14 +287,14 @@ describe("Field Service truck inventory", () => {
   it("proves canonicalization, paired transfer, use, return, and exact replay on a clean database", () => {
     expect(runtime).toContain("field_receive_po_part_to_truck_atomic");
     expect(runtime).toContain("free-text PO line becomes a canonical part");
-    expect(runtime).toContain("field_transfer_stock_to_truck_atomic");
+    expect(runtime).toContain("field_transfer_stock_to_truck_authorized_atomic");
     expect(runtime).toContain("technician bypassed Parts permission");
     expect(runtime).toContain("field_use_truck_part_atomic");
     expect(runtime).toContain("repeated use decremented inventory twice");
     expect(runtime).toContain("field_return_truck_part_atomic");
     expect(runtime).toContain("return replay changed inventory twice");
-    expect(runtime).toContain("field_truck_inventory_snapshot");
-    expect(runtime).toContain("field_truck_inventory_activity");
+    expect(runtime).toContain("field_truck_inventory_snapshot_with_activity");
+    expect(runtime).toContain("reservation movement quantity or direction is wrong");
     expect(workflow).toContain("tests/field-truck-inventory-contract.test.ts");
     expect(workflow).toContain("tests/mobile/field-truck-inventory.runtime.sql");
     expect(workflow).toContain("Field truck inventory runtime");

--- a/tests/field-truck-inventory-contract.test.ts
+++ b/tests/field-truck-inventory-contract.test.ts
@@ -13,7 +13,14 @@ const migration = [
   "supabase/migrations/20260815050000_field_part_identity_review_hardening.sql",
   "supabase/migrations/20260815050100_field_truck_line_review_hardening.sql",
   "supabase/migrations/20260815050200_field_truck_receipt_review_hardening.sql",
-  "supabase/migrations/20260818093000_field_truck_inventory_activity.sql",
+  "supabase/migrations/20260818153429_field_truck_inventory_activity.sql",
+  "supabase/migrations/20260818161654_field_truck_transfer_additive_authorization.sql",
+]
+  .map(read)
+  .join("\n");
+const additiveHardening = [
+  "supabase/migrations/20260818153429_field_truck_inventory_activity.sql",
+  "supabase/migrations/20260818161654_field_truck_transfer_additive_authorization.sql",
 ]
   .map(read)
   .join("\n");
@@ -95,12 +102,22 @@ describe("Field Service truck inventory", () => {
     expect(migration).toContain("FIELD_TRUCK_TRANSFER_KEY_CONFLICT");
     expect(migration).toContain("public.parts_available(");
     expect(transferApi).toContain('requiredCapability: "canManageParts"');
-    expect(transferApi).toContain("field_transfer_stock_to_truck_atomic");
+    expect(transferApi).toContain(
+      "field_transfer_stock_to_truck_authorized_atomic",
+    );
     expect(snapshotApi).toContain("p_service_vehicle_id");
     expect(contracts).toContain("trucks: FieldTruck[]");
     expect(inventoryUi).toContain("Select service truck");
     expect(migration).toContain(
-      "private.field_transfer_stock_to_truck_atomic_impl",
+      "field_transfer_stock_to_truck_authorized_atomic",
+    );
+    expect(migration).toContain(
+      "return public.field_transfer_stock_to_truck_atomic(",
+    );
+    expect(migration).not.toContain("rename to field_transfer_stock_to_truck");
+    expect(migration).not.toContain("set schema private");
+    expect(additiveHardening).not.toMatch(
+      /drop\s+(?:function|table|column|type)/i,
     );
     expect(migration).toContain("not v_actor.can_manage_parts");
     expect(migration).toContain("Parts management permission is required.");

--- a/tests/mobile-service-shell.test.ts
+++ b/tests/mobile-service-shell.test.ts
@@ -18,7 +18,7 @@ describe("Mobile Service shell", () => {
   it("uses the merged Dispatch contracts instead of duplicating service-visit state", () => {
     expect(page).toContain("MobileServiceScopeGate");
     expect(scopeGate).toContain("FieldHub");
-    expect(fieldHub).toContain("MobileServiceShell embedded");
+    expect(fieldHub).toContain("<MobileServiceShell");
     expect(shell).toContain("/api/mobile/service-visits/active");
     expect(shell).toContain("/api/dispatch/visits/${visit.id}");
     expect(shell).not.toContain('.from("service_visits")');
@@ -43,6 +43,8 @@ describe("Mobile Service shell", () => {
     expect(shell).toContain('toStatus: "completed"');
     expect(shell).toContain('runTransition(visit, "paused")');
     expect(shell).toContain('transitionVisit(current, "dispatched")');
+    expect(shell).toContain('href="/mobile/service/dispatch"');
+    expect(shell).toContain("canManageScheduling ?");
   });
 
   it("keeps dispatch mutations online-only but preserves an authenticated actor-scoped snapshot", () => {

--- a/tests/mobile/field-truck-inventory.runtime.sql
+++ b/tests/mobile/field-truck-inventory.runtime.sql
@@ -352,7 +352,7 @@ begin
     'field_runtime_seed',
     v_po_line_id
   );
-  v_transfer := public.field_transfer_stock_to_truck_atomic(
+  v_transfer := public.field_transfer_stock_to_truck_authorized_atomic(
     v_shop_id,
     v_truck_id,
     v_source_location_id,
@@ -366,7 +366,7 @@ begin
        <> v_truck_before_transfer + 1 then
     raise exception 'Field truck runtime failed: paired transfer quantities are wrong';
   end if;
-  v_transfer_replay := public.field_transfer_stock_to_truck_atomic(
+  v_transfer_replay := public.field_transfer_stock_to_truck_authorized_atomic(
     v_shop_id,
     v_truck_id,
     v_source_location_id,
@@ -553,12 +553,13 @@ begin
     raise exception 'Field truck runtime failed: return replay changed inventory twice';
   end if;
 
-  v_snapshot := public.field_truck_inventory_snapshot(
+  v_snapshot := public.field_truck_inventory_snapshot_with_activity(
     v_shop_id,
     v_actor_id,
     v_visit_id,
     v_truck_id,
-    'FT-SEAL-100'
+    'FT-SEAL-100',
+    50
   );
   if v_snapshot -> 'truck' ->> 'id' is distinct from v_truck_id::text
      or jsonb_array_length(coalesce(v_snapshot -> 'items', '[]'::jsonb)) < 1
@@ -566,12 +567,7 @@ begin
     raise exception 'Field truck runtime failed: assigned truck snapshot is incomplete';
   end if;
 
-  v_activity := public.field_truck_inventory_activity(
-    v_shop_id,
-    v_actor_id,
-    v_truck_id,
-    50
-  );
+  v_activity := coalesce(v_snapshot -> 'movements', '[]'::jsonb);
   if jsonb_array_length(v_activity) < 4
      or not exists (
        select 1
@@ -584,6 +580,97 @@ begin
        where movement ->> 'reason' = 'consume'
      ) then
     raise exception 'Field truck runtime failed: canonical truck activity is incomplete';
+  end if;
+end;
+$$;
+
+reset role;
+
+-- Reservation ledger entries have zero physical quantity change. Seed both
+-- directions as the database owner, then verify the authenticated Field RPC
+-- projects lifecycle_quantity without exposing a separate read window.
+insert into public.stock_moves (
+  shop_id,
+  part_id,
+  location_id,
+  qty_change,
+  reason,
+  reference_kind,
+  reference_id,
+  created_by,
+  idempotency_key,
+  lifecycle_quantity,
+  metadata
+)
+select
+  '9f200000-0000-4000-8000-000000000001'::uuid,
+  line.part_id,
+  vehicle.stock_location_id,
+  0,
+  movement.reason::public.stock_move_reason,
+  'field_runtime_reservation',
+  line.part_id,
+  '9f100000-0000-4000-8000-000000000001'::uuid,
+  'field-runtime:reservation:' || movement.reason,
+  movement.quantity,
+  jsonb_build_object('operation', 'field_runtime_reservation')
+from public.purchase_order_lines line
+cross join lateral (
+  select truck.stock_location_id
+  from public.service_vehicles truck
+  where truck.shop_id = '9f200000-0000-4000-8000-000000000001'::uuid
+    and truck.active
+  order by truck.created_at desc, truck.id
+  limit 1
+) vehicle
+cross join (
+  values
+    ('wo_allocate'::text, 3::numeric),
+    ('wo_release'::text, 2::numeric)
+) movement(reason, quantity)
+where line.id = '9f500000-0000-4000-8000-000000000001'::uuid;
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', '9f100000-0000-4000-8000-000000000001', true);
+set local role authenticated;
+
+do $$
+declare
+  v_snapshot jsonb;
+  v_truck_id uuid;
+  v_activity jsonb;
+begin
+  select vehicle.id into v_truck_id
+  from public.service_vehicles vehicle
+  where vehicle.shop_id = '9f200000-0000-4000-8000-000000000001'::uuid
+    and vehicle.active
+  order by vehicle.created_at desc, vehicle.id
+  limit 1;
+
+  v_snapshot := public.field_truck_inventory_snapshot_with_activity(
+    '9f200000-0000-4000-8000-000000000001'::uuid,
+    '9f100000-0000-4000-8000-000000000001'::uuid,
+    null,
+    v_truck_id,
+    null,
+    50
+  );
+  v_activity := coalesce(v_snapshot -> 'movements', '[]'::jsonb);
+
+  if not exists (
+    select 1
+    from jsonb_array_elements(v_activity) movement
+    where movement ->> 'reason' = 'wo_allocate'
+      and (movement ->> 'quantity')::numeric = 3
+      and movement ->> 'direction' = 'out'
+  ) or not exists (
+    select 1
+    from jsonb_array_elements(v_activity) movement
+    where movement ->> 'reason' = 'wo_release'
+      and (movement ->> 'quantity')::numeric = 2
+      and movement ->> 'direction' = 'in'
+  ) then
+    raise exception 'Field truck runtime failed: reservation movement quantity or direction is wrong';
   end if;
 end;
 $$;

--- a/tests/mobile/field-truck-inventory.runtime.sql
+++ b/tests/mobile/field-truck-inventory.runtime.sql
@@ -62,6 +62,30 @@ update public.profiles
 set shop_id = '9f200000-0000-4000-8000-000000000001'
 where id = '9f100000-0000-4000-8000-000000000001';
 
+insert into auth.users (id, email, raw_user_meta_data)
+values (
+  '9f100000-0000-4000-8000-000000000002',
+  'field-truck-runtime-tech@example.com',
+  '{"full_name":"Field Truck Runtime Technician"}'::jsonb
+)
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name, email, shop_id)
+values (
+  '9f100000-0000-4000-8000-000000000002',
+  '9f100000-0000-4000-8000-000000000002',
+  'mechanic',
+  'Field Truck Runtime Technician',
+  'field-truck-runtime-tech@example.com',
+  '9f200000-0000-4000-8000-000000000001'
+)
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name,
+    email = excluded.email,
+    shop_id = excluded.shop_id;
+
 insert into public.suppliers (id, shop_id, name, is_active)
 values (
   '9f300000-0000-4000-8000-000000000001',
@@ -122,6 +146,7 @@ do $$
 declare
   v_shop_id constant uuid := '9f200000-0000-4000-8000-000000000001';
   v_actor_id constant uuid := '9f100000-0000-4000-8000-000000000001';
+  v_technician_id constant uuid := '9f100000-0000-4000-8000-000000000002';
   v_source_location_id constant uuid := '9f600000-0000-4000-8000-000000000001';
   v_po_id constant uuid := '9f400000-0000-4000-8000-000000000001';
   v_po_line_id constant uuid := '9f500000-0000-4000-8000-000000000001';
@@ -150,6 +175,7 @@ declare
   v_transfer jsonb;
   v_transfer_replay jsonb;
   v_snapshot jsonb;
+  v_activity jsonb;
   v_count integer;
   v_before numeric;
   v_after numeric;
@@ -182,6 +208,30 @@ begin
   if v_truck_id is null or v_truck_location_id is null then
     raise exception 'Field truck runtime failed: setup did not create truck inventory';
   end if;
+
+  -- Route guards are not the authority: a technician cannot call the public
+  -- transfer RPC directly even when the truck is assigned to them.
+  update public.service_vehicles
+  set primary_user_id = v_technician_id
+  where id = v_truck_id;
+  perform set_config('request.jwt.claim.sub', v_technician_id::text, true);
+  begin
+    perform public.field_transfer_stock_to_truck_atomic(
+      v_shop_id,
+      v_truck_id,
+      v_source_location_id,
+      '9f700000-0000-4000-8000-000000000001'::uuid,
+      1,
+      v_technician_id,
+      'field-runtime:technician-transfer-denied'
+    );
+    raise exception 'Field truck runtime failed: technician bypassed Parts permission';
+  exception when others then
+    if sqlstate <> '42501' or sqlerrm not like '%Parts management permission is required%' then
+      raise;
+    end if;
+  end;
+  perform set_config('request.jwt.claim.sub', v_actor_id::text, true);
 
   -- A free-text PO line becomes a canonical part inside the receipt command.
   v_receipt := public.field_receive_po_part_to_truck_atomic(
@@ -514,6 +564,26 @@ begin
      or jsonb_array_length(coalesce(v_snapshot -> 'items', '[]'::jsonb)) < 1
      or jsonb_array_length(coalesce(v_snapshot -> 'catalog', '[]'::jsonb)) < 1 then
     raise exception 'Field truck runtime failed: assigned truck snapshot is incomplete';
+  end if;
+
+  v_activity := public.field_truck_inventory_activity(
+    v_shop_id,
+    v_actor_id,
+    v_truck_id,
+    50
+  );
+  if jsonb_array_length(v_activity) < 4
+     or not exists (
+       select 1
+       from jsonb_array_elements(v_activity) movement
+       where movement ->> 'reason' = 'transfer_in'
+     )
+     or not exists (
+       select 1
+       from jsonb_array_elements(v_activity) movement
+       where movement ->> 'reason' = 'consume'
+     ) then
+    raise exception 'Field truck runtime failed: canonical truck activity is incomplete';
   end if;
 end;
 $$;

--- a/tests/mobile/field-truck-inventory.runtime.sql
+++ b/tests/mobile/field-truck-inventory.runtime.sql
@@ -216,7 +216,7 @@ begin
   where id = v_truck_id;
   perform set_config('request.jwt.claim.sub', v_technician_id::text, true);
   begin
-    perform public.field_transfer_stock_to_truck_atomic(
+    perform public.field_transfer_stock_to_truck_authorized_atomic(
       v_shop_id,
       v_truck_id,
       v_source_location_id,


### PR DESCRIPTION
## Outcome

Completes the Field dispatch and truck-inventory Activity phase, then addresses both Codex review findings without changing either migration already recorded in production.

## What changed

- adds the Field dispatch route and manager/dispatcher handoff into the canonical Dispatch board
- preserves Field theme inheritance across the shared dispatch shell
- projects the selected truck's tenant-scoped canonical `stock_moves` history
- preserves the canonical transfer function and adds the Parts-authorized wrapper
- corrects reservation Activity rows to use `lifecycle_quantity`
- reports `wo_allocate` as outbound and `wo_release` as inbound
- returns the inventory snapshot and Activity ledger through one stable RPC/MVCC snapshot, removing the route's two-query race
- updates the generated Supabase contract and runtime coverage

## Database safety

The production-recorded files remain byte-for-byte unchanged:

- `20260818153429_field_truck_inventory_activity.sql` — SHA-256 `b612997be382096c03a418a00e5b750073ee226aeaf83e81962a8503591f1ae4`
- `20260818161654_field_truck_transfer_additive_authorization.sql` — SHA-256 `a3cc5f117aa1a0786fdfb523fcfae90cee6a39ff84c720ee85bebbb8660326c7`

The review repair is a new forward-only migration:

- `20260818184534_field_truck_inventory_consistent_activity.sql`

It alters function volatility, replaces only the Activity projection, and adds a combined read RPC. It does not drop or rename tables, columns, types, functions, or data. The new migration has not been applied to production.

## Validation

- `pnpm check`: 442 test files and 2,544 tests passed; 1 file / 2 database integration tests skipped
- focused Field suite: 6 files / 37 tests passed
- typecheck and changed-file ESLint
- `pnpm regression:inventory:check`: 0 new errors
- `pnpm audit:api-routes`: 461 routes analyzed
- GitHub Agent PR Checks, Mobile V1, P0-006, and Supabase Clean Replay all passed
- clean replay passed fresh application, generated-type comparison, second reset/replay, all runtime integrations, and baseline-path verification
- the Supabase preview was recreated to remove the obsolete `20260818093000` ledger entry; Database, Services, APIs, Configurations, Migrations, and Seeding are green
- preview migration history now ends `153429 → 160000 → 161654 → 184534`
- live preview inspection confirms reservation activity uses `lifecycle_quantity` with correct directions and the combined RPC reads snapshot plus activity under one stable statement snapshot
- the final GitHub tree matches the fully validated local tree exactly

## Delivery state

Automated validation and the configured preview are green. The PR remains draft for device acceptance. The new forward migration remains unapplied to production and should be applied only after this PR is merged.