### PR TITLE
chore: force Vercel preview builds during hardening

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,7 @@
       "schedule": "*/5 * * * *"
     }
   ],
+  "ignoreCommand": "exit 1",
   "git": {
     "deploymentEnabled": {
       "main": true,


### PR DESCRIPTION
Production-hardening release-control fix.

Vercel is still canceling PR deployments before a build starts. The canceled deployments report the Ignored Build Step path and contain no build-log events. Vercel documents that `ignoreCommand` in `vercel.json` overrides the dashboard Ignored Build Step, and exit code `1` means continue the build.

This sets `ignoreCommand` to `exit 1` so Git deployments are never skipped by the Ignored Build Step. Existing branch allowlisting remains unchanged (`main`, `agent/*`, `codex/*`).

No application code, cron schedule, database state, production deployment, or customer-facing behavior is changed by this PR. Its own Vercel result is the diagnostic: if it builds, the skipped-build setting was the remaining preview blocker; if it is still canceled, project-level commit-verification is the next boundary to address.