### PR TITLE
security: enforce RLS on exposed public views

### DIFF
--- a/supabase/migrations/20260818160000_harden_security_definer_views.sql
+++ b/supabase/migrations/20260818160000_harden_security_definer_views.sql
@@ -47,3 +47,155 @@ grant select on table public.shop_reviews_public to anon, authenticated;
 -- projection behavior but remove every DML privilege and expose SELECT only.
 revoke all on table public.shop_public_profiles from public, anon, authenticated;
 grant select on table public.shop_public_profiles to anon, authenticated;
+
+-- Fail the migration during clean replay if a future baseline/default grant
+-- causes any of these boundaries to regress.
+do $$
+declare
+  v_relation text;
+  v_reloptions text[];
+begin
+  foreach v_relation in array array[
+    'ai_training_events_v',
+    'stock_balances',
+    'v_shift_rollups',
+    'v_vehicle_service_history',
+    'v_parts_reconciliation',
+    'v_global_saved_menu_items',
+    'v_video_performance_summary',
+    'v_top_content_types_by_shop'
+  ]
+  loop
+    select c.reloptions
+      into v_reloptions
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname = v_relation;
+
+    if not (
+      coalesce(v_reloptions, '{}'::text[])
+      @> array['security_invoker=true']
+    ) then
+      raise exception
+        'security hardening failed: public.% is not security-invoker',
+        v_relation;
+    end if;
+
+    if has_table_privilege('anon', 'public.' || v_relation, 'SELECT')
+       or has_table_privilege('anon', 'public.' || v_relation, 'INSERT')
+       or has_table_privilege('anon', 'public.' || v_relation, 'UPDATE')
+       or has_table_privilege('anon', 'public.' || v_relation, 'DELETE') then
+      raise exception
+        'security hardening failed: anon retains access to public.%',
+        v_relation;
+    end if;
+
+    if not has_table_privilege(
+      'authenticated',
+      'public.' || v_relation,
+      'SELECT'
+    )
+       or has_table_privilege(
+         'authenticated',
+         'public.' || v_relation,
+         'INSERT'
+       )
+       or has_table_privilege(
+         'authenticated',
+         'public.' || v_relation,
+         'UPDATE'
+       )
+       or has_table_privilege(
+         'authenticated',
+         'public.' || v_relation,
+         'DELETE'
+       ) then
+      raise exception
+        'security hardening failed: authenticated privilege contract changed for public.%',
+        v_relation;
+    end if;
+
+    if not has_table_privilege(
+      'service_role',
+      'public.' || v_relation,
+      'SELECT'
+    ) then
+      raise exception
+        'security hardening failed: service_role lost SELECT on public.%',
+        v_relation;
+    end if;
+  end loop;
+
+  select c.reloptions
+    into v_reloptions
+  from pg_catalog.pg_class c
+  join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+  where n.nspname = 'public'
+    and c.relname = 'shop_reviews_public';
+
+  if not (
+    coalesce(v_reloptions, '{}'::text[])
+    @> array['security_invoker=true']
+  ) then
+    raise exception
+      'security hardening failed: shop_reviews_public is not security-invoker';
+  end if;
+
+  if not has_table_privilege('anon', 'public.shop_reviews_public', 'SELECT')
+     or has_table_privilege('anon', 'public.shop_reviews_public', 'INSERT')
+     or has_table_privilege('anon', 'public.shop_reviews_public', 'UPDATE')
+     or has_table_privilege('anon', 'public.shop_reviews_public', 'DELETE')
+     or not has_table_privilege(
+       'authenticated',
+       'public.shop_reviews_public',
+       'SELECT'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_reviews_public',
+       'INSERT'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_reviews_public',
+       'UPDATE'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_reviews_public',
+       'DELETE'
+     ) then
+    raise exception
+      'security hardening failed: shop_reviews_public privilege contract changed';
+  end if;
+
+  if not has_table_privilege('anon', 'public.shop_public_profiles', 'SELECT')
+     or has_table_privilege('anon', 'public.shop_public_profiles', 'INSERT')
+     or has_table_privilege('anon', 'public.shop_public_profiles', 'UPDATE')
+     or has_table_privilege('anon', 'public.shop_public_profiles', 'DELETE')
+     or not has_table_privilege(
+       'authenticated',
+       'public.shop_public_profiles',
+       'SELECT'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_public_profiles',
+       'INSERT'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_public_profiles',
+       'UPDATE'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_public_profiles',
+       'DELETE'
+     ) then
+    raise exception
+      'security hardening failed: shop_public_profiles privilege contract changed';
+  end if;
+end
+$$;

--- a/supabase/migrations/20260818160000_harden_security_definer_views.sql
+++ b/supabase/migrations/20260818160000_harden_security_definer_views.sql
@@ -1,0 +1,49 @@
+-- Production hardening: remove unintended anonymous/cross-tenant access through
+-- public views that currently execute with the view owner's privileges.
+--
+-- Internal views become security-invoker so their base-table RLS policies are
+-- enforced for the calling user. Public-facing views retain only the minimum
+-- read grants required by their intended surface.
+
+alter view public.ai_training_events_v set (security_invoker = true);
+alter view public.stock_balances set (security_invoker = true);
+alter view public.v_shift_rollups set (security_invoker = true);
+alter view public.v_vehicle_service_history set (security_invoker = true);
+alter view public.v_parts_reconciliation set (security_invoker = true);
+alter view public.v_global_saved_menu_items set (security_invoker = true);
+alter view public.v_video_performance_summary set (security_invoker = true);
+alter view public.v_top_content_types_by_shop set (security_invoker = true);
+alter view public.shop_reviews_public set (security_invoker = true);
+
+-- Internal/authenticated views: never expose them to anon. Authenticated reads
+-- are permitted, but security_invoker ensures the underlying RLS policies
+-- determine which rows are visible.
+revoke all on table public.ai_training_events_v from public, anon, authenticated;
+revoke all on table public.stock_balances from public, anon, authenticated;
+revoke all on table public.v_shift_rollups from public, anon, authenticated;
+revoke all on table public.v_vehicle_service_history from public, anon, authenticated;
+revoke all on table public.v_parts_reconciliation from public, anon, authenticated;
+revoke all on table public.v_global_saved_menu_items from public, anon, authenticated;
+revoke all on table public.v_video_performance_summary from public, anon, authenticated;
+revoke all on table public.v_top_content_types_by_shop from public, anon, authenticated;
+
+grant select on table public.ai_training_events_v to authenticated;
+grant select on table public.stock_balances to authenticated;
+grant select on table public.v_shift_rollups to authenticated;
+grant select on table public.v_vehicle_service_history to authenticated;
+grant select on table public.v_parts_reconciliation to authenticated;
+grant select on table public.v_global_saved_menu_items to authenticated;
+grant select on table public.v_video_performance_summary to authenticated;
+grant select on table public.v_top_content_types_by_shop to authenticated;
+
+-- Reviews are intentionally public, and the base table already has a public
+-- SELECT RLS policy limited to published (`is_public = true`) reviews.
+revoke all on table public.shop_reviews_public from public, anon, authenticated;
+grant select on table public.shop_reviews_public to anon, authenticated;
+
+-- Shop public profiles are an intentionally sanitized public projection. The
+-- base `shops` table has no anon SELECT policy, so converting this one view to
+-- security_invoker would break the public shop-profile surface. Keep the
+-- projection behavior but remove every DML privilege and expose SELECT only.
+revoke all on table public.shop_public_profiles from public, anon, authenticated;
+grant select on table public.shop_public_profiles to anon, authenticated;

--- a/supabase/migrations/20260818160000_harden_security_definer_views.sql
+++ b/supabase/migrations/20260818160000_harden_security_definer_views.sql
@@ -46,8 +46,29 @@ alter view public.v_shift_rollups set (security_invoker = true);
 revoke all on table public.v_shift_rollups from public, anon, authenticated;
 grant select on table public.v_shift_rollups to authenticated;
 
--- Reviews are intentionally public, and the base table already has a public
--- SELECT RLS policy limited to published (`is_public = true`) reviews.
+-- Reviews are intentionally public. Production already has this policy, but
+-- the ordered clean-replay baseline does not, so create it only when absent.
+-- The policy is deliberately shared by anon and authenticated callers so the
+-- same published-review surface remains visible before and after sign-in.
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_catalog.pg_policies
+    where schemaname = 'public'
+      and tablename = 'shop_reviews'
+      and policyname = 'Public can read published reviews'
+  ) then
+    create policy "Public can read published reviews"
+      on public.shop_reviews
+      for select
+      to anon, authenticated
+      using (is_public = true);
+  end if;
+end
+$$;
+
+grant select on table public.shop_reviews to anon, authenticated;
 alter view public.shop_reviews_public set (security_invoker = true);
 revoke all on table public.shop_reviews_public from public, anon, authenticated;
 grant select on table public.shop_reviews_public to anon, authenticated;
@@ -156,6 +177,30 @@ begin
   ) then
     raise exception
       'security hardening failed: shop_reviews_public is not security-invoker';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_catalog.pg_policies
+    where schemaname = 'public'
+      and tablename = 'shop_reviews'
+      and policyname = 'Public can read published reviews'
+      and cmd = 'SELECT'
+      and roles @> array['anon', 'authenticated']::name[]
+      and qual = '(is_public = true)'
+  ) then
+    raise exception
+      'security hardening failed: published-review RLS policy is missing or invalid';
+  end if;
+
+  if not has_table_privilege('anon', 'public.shop_reviews', 'SELECT')
+     or not has_table_privilege(
+       'authenticated',
+       'public.shop_reviews',
+       'SELECT'
+     ) then
+    raise exception
+      'security hardening failed: published-review base SELECT grant is missing';
   end if;
 
   if not has_table_privilege('anon', 'public.shop_reviews_public', 'SELECT')

--- a/supabase/migrations/20260818160000_harden_security_definer_views.sql
+++ b/supabase/migrations/20260818160000_harden_security_definer_views.sql
@@ -1,43 +1,54 @@
 -- Production hardening: remove unintended anonymous/cross-tenant access through
 -- public views that currently execute with the view owner's privileges.
 --
--- Internal views become security-invoker so their base-table RLS policies are
--- enforced for the calling user. Public-facing views retain only the minimum
--- read grants required by their intended surface.
+-- Several of the audited views are production-only legacy objects that are
+-- intentionally not part of the clean-replay migration chain. Harden them when
+-- present without making a fresh database depend on unreconciled legacy schema.
+-- Baseline-owned views remain required and are hardened directly below.
 
-alter view public.ai_training_events_v set (security_invoker = true);
-alter view public.stock_balances set (security_invoker = true);
+do $$
+declare
+  v_relation text;
+begin
+  foreach v_relation in array array[
+    'ai_training_events_v',
+    'stock_balances',
+    'v_vehicle_service_history',
+    'v_parts_reconciliation',
+    'v_global_saved_menu_items',
+    'v_video_performance_summary',
+    'v_top_content_types_by_shop'
+  ]
+  loop
+    if to_regclass(format('public.%I', v_relation)) is null then
+      continue;
+    end if;
+
+    execute format(
+      'alter view public.%I set (security_invoker = true)',
+      v_relation
+    );
+    execute format(
+      'revoke all on table public.%I from public, anon, authenticated',
+      v_relation
+    );
+    execute format(
+      'grant select on table public.%I to authenticated',
+      v_relation
+    );
+  end loop;
+end
+$$;
+
+-- v_shift_rollups is owned by the ordered baseline and therefore must exist on
+-- both clean replay and production.
 alter view public.v_shift_rollups set (security_invoker = true);
-alter view public.v_vehicle_service_history set (security_invoker = true);
-alter view public.v_parts_reconciliation set (security_invoker = true);
-alter view public.v_global_saved_menu_items set (security_invoker = true);
-alter view public.v_video_performance_summary set (security_invoker = true);
-alter view public.v_top_content_types_by_shop set (security_invoker = true);
-alter view public.shop_reviews_public set (security_invoker = true);
-
--- Internal/authenticated views: never expose them to anon. Authenticated reads
--- are permitted, but security_invoker ensures the underlying RLS policies
--- determine which rows are visible.
-revoke all on table public.ai_training_events_v from public, anon, authenticated;
-revoke all on table public.stock_balances from public, anon, authenticated;
 revoke all on table public.v_shift_rollups from public, anon, authenticated;
-revoke all on table public.v_vehicle_service_history from public, anon, authenticated;
-revoke all on table public.v_parts_reconciliation from public, anon, authenticated;
-revoke all on table public.v_global_saved_menu_items from public, anon, authenticated;
-revoke all on table public.v_video_performance_summary from public, anon, authenticated;
-revoke all on table public.v_top_content_types_by_shop from public, anon, authenticated;
-
-grant select on table public.ai_training_events_v to authenticated;
-grant select on table public.stock_balances to authenticated;
 grant select on table public.v_shift_rollups to authenticated;
-grant select on table public.v_vehicle_service_history to authenticated;
-grant select on table public.v_parts_reconciliation to authenticated;
-grant select on table public.v_global_saved_menu_items to authenticated;
-grant select on table public.v_video_performance_summary to authenticated;
-grant select on table public.v_top_content_types_by_shop to authenticated;
 
 -- Reviews are intentionally public, and the base table already has a public
 -- SELECT RLS policy limited to published (`is_public = true`) reviews.
+alter view public.shop_reviews_public set (security_invoker = true);
 revoke all on table public.shop_reviews_public from public, anon, authenticated;
 grant select on table public.shop_reviews_public to anon, authenticated;
 
@@ -49,7 +60,8 @@ revoke all on table public.shop_public_profiles from public, anon, authenticated
 grant select on table public.shop_public_profiles to anon, authenticated;
 
 -- Fail the migration during clean replay if a future baseline/default grant
--- causes any of these boundaries to regress.
+-- causes any present boundary to regress. Production-only legacy views are
+-- checked when present and skipped when absent on clean replay.
 do $$
 declare
   v_relation text;
@@ -66,6 +78,10 @@ begin
     'v_top_content_types_by_shop'
   ]
   loop
+    if to_regclass(format('public.%I', v_relation)) is null then
+      continue;
+    end if;
+
     select c.reloptions
       into v_reloptions
     from pg_catalog.pg_class c

--- a/tests/security/p0-001-relation-boundaries.runtime.sql
+++ b/tests/security/p0-001-relation-boundaries.runtime.sql
@@ -74,6 +74,31 @@ where id in (
   '33000000-0000-4000-8000-000000000003'
 );
 
+insert into public.shop_reviews (
+  id,
+  shop_id,
+  reviewer_user_id,
+  rating,
+  comment,
+  is_public
+) values
+  (
+    'a1050000-0000-4000-8000-000000000001',
+    'a1000000-0000-4000-8000-000000000001',
+    '11000000-0000-4000-8000-000000000001',
+    5,
+    'Published P0-001 review',
+    true
+  ),
+  (
+    'a1050000-0000-4000-8000-000000000002',
+    'a1000000-0000-4000-8000-000000000001',
+    '33000000-0000-4000-8000-000000000003',
+    2,
+    'Unpublished P0-001 review',
+    false
+  );
+
 insert into public.parts (id, shop_id, name, part_number, sku)
 values
   (
@@ -432,6 +457,15 @@ create temp table p0_001_public_view_result (
 );
 grant insert, select on table p0_001_public_view_result to anon;
 
+create temp table p0_001_public_review_result (
+  caller_role text primary key,
+  visible_rows bigint not null,
+  published_visible boolean not null,
+  unpublished_visible boolean not null
+);
+grant insert, select on table p0_001_public_review_result
+  to anon, authenticated;
+
 create function pg_temp.expect_anon_select_denied(p_relation regclass)
 returns void
 language plpgsql
@@ -459,6 +493,17 @@ where id in (
   'a1000000-0000-4000-8000-000000000001',
   'b2000000-0000-4000-8000-000000000002'
 );
+insert into p0_001_public_review_result
+select
+  'anon',
+  count(*),
+  coalesce(bool_or(id = 'a1050000-0000-4000-8000-000000000001'), false),
+  coalesce(bool_or(id = 'a1050000-0000-4000-8000-000000000002'), false)
+from public.shop_reviews_public
+where id in (
+  'a1050000-0000-4000-8000-000000000001',
+  'a1050000-0000-4000-8000-000000000002'
+);
 select pg_temp.expect_anon_select_denied('public.apps');
 select pg_temp.expect_anon_select_denied('public.part_stock_summary');
 select pg_temp.expect_anon_select_denied('public.parts_barcodes');
@@ -466,6 +511,26 @@ select pg_temp.expect_anon_select_denied('public.shop_profiles');
 select pg_temp.expect_anon_select_denied('public.warranties');
 select pg_temp.expect_anon_select_denied('public.warranty_claims');
 select pg_temp.expect_anon_select_denied('public.widgets');
+reset role;
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config(
+  'request.jwt.claim.sub',
+  '22000000-0000-4000-8000-000000000002',
+  true
+);
+set local role authenticated;
+insert into p0_001_public_review_result
+select
+  'authenticated',
+  count(*),
+  coalesce(bool_or(id = 'a1050000-0000-4000-8000-000000000001'), false),
+  coalesce(bool_or(id = 'a1050000-0000-4000-8000-000000000002'), false)
+from public.shop_reviews_public
+where id in (
+  'a1050000-0000-4000-8000-000000000001',
+  'a1050000-0000-4000-8000-000000000002'
+);
 reset role;
 
 do $$
@@ -477,6 +542,21 @@ begin
   ) then
     raise exception
       'P0-001 runtime assertion failed: safe public shop view regressed';
+  end if;
+
+  if exists (
+    select 1
+    from p0_001_public_review_result
+    where visible_rows <> 1
+       or not published_visible
+       or unpublished_visible
+  )
+     or (
+       select count(*)
+       from p0_001_public_review_result
+     ) <> 2 then
+    raise exception
+      'P0-001 runtime assertion failed: public review visibility regressed';
   end if;
 end
 $$;


### PR DESCRIPTION
Production-hardening security fix, stacked on #1469 so the branch inherits the restored Vercel preview pipeline.

A read-only production audit confirmed that anonymous role access currently reaches data through owner-executed public views despite RLS on the underlying tables. Without returning row contents, the audit counted anonymous-visible rows in sensitive surfaces including AI training events, stock balances, workforce rollups, vehicle service history, and parts reconciliation.

This migration:
- switches internal views to `security_invoker = true` so underlying RLS is enforced;
- removes anon access to internal/authenticated-only views;
- reduces all affected view grants to SELECT-only;
- reconciles the clean-replay-only gap in the published-review RLS policy without replacing the matching production policy;
- keeps `shop_reviews_public` available to anonymous and authenticated readers while RLS restricts both roles to `is_public = true`;
- adds a P0 runtime fixture proving anonymous and signed-in cross-shop readers see the published review but not an unpublished review;
- deliberately keeps `shop_public_profiles` as a sanitized owner-executed projection because the base `shops` table has no anonymous SELECT policy, while stripping all DML privileges from the view.

No migration has been applied to production. Merge/apply requires explicit approval after CI and migration review. After #1469 merges, this PR should be retargeted to `main` before merge.