### PR TITLE
security: close anonymous mutating RPC access

### DIFF
--- a/app/api/work-orders/lines/[id]/delete-or-void/route.ts
+++ b/app/api/work-orders/lines/[id]/delete-or-void/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type RpcError = { message: string; details?: string | null; hint?: string | null };
 type RpcClient = {
@@ -71,7 +72,7 @@ export async function POST(
     );
   }
 
-  const rpc = access.supabase as unknown as RpcClient;
+  const rpc = createAdminSupabase() as unknown as RpcClient;
   const { data, error } = await rpc.rpc("parts_void_work_order_line_atomic", {
     p_shop_id: access.profile.shop_id,
     p_work_order_line_id: id,

--- a/supabase/migrations/20260818160000_harden_security_definer_views.sql
+++ b/supabase/migrations/20260818160000_harden_security_definer_views.sql
@@ -47,3 +47,155 @@ grant select on table public.shop_reviews_public to anon, authenticated;
 -- projection behavior but remove every DML privilege and expose SELECT only.
 revoke all on table public.shop_public_profiles from public, anon, authenticated;
 grant select on table public.shop_public_profiles to anon, authenticated;
+
+-- Fail the migration during clean replay if a future baseline/default grant
+-- causes any of these boundaries to regress.
+do $$
+declare
+  v_relation text;
+  v_reloptions text[];
+begin
+  foreach v_relation in array array[
+    'ai_training_events_v',
+    'stock_balances',
+    'v_shift_rollups',
+    'v_vehicle_service_history',
+    'v_parts_reconciliation',
+    'v_global_saved_menu_items',
+    'v_video_performance_summary',
+    'v_top_content_types_by_shop'
+  ]
+  loop
+    select c.reloptions
+      into v_reloptions
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname = v_relation;
+
+    if not (
+      coalesce(v_reloptions, '{}'::text[])
+      @> array['security_invoker=true']
+    ) then
+      raise exception
+        'security hardening failed: public.% is not security-invoker',
+        v_relation;
+    end if;
+
+    if has_table_privilege('anon', 'public.' || v_relation, 'SELECT')
+       or has_table_privilege('anon', 'public.' || v_relation, 'INSERT')
+       or has_table_privilege('anon', 'public.' || v_relation, 'UPDATE')
+       or has_table_privilege('anon', 'public.' || v_relation, 'DELETE') then
+      raise exception
+        'security hardening failed: anon retains access to public.%',
+        v_relation;
+    end if;
+
+    if not has_table_privilege(
+      'authenticated',
+      'public.' || v_relation,
+      'SELECT'
+    )
+       or has_table_privilege(
+         'authenticated',
+         'public.' || v_relation,
+         'INSERT'
+       )
+       or has_table_privilege(
+         'authenticated',
+         'public.' || v_relation,
+         'UPDATE'
+       )
+       or has_table_privilege(
+         'authenticated',
+         'public.' || v_relation,
+         'DELETE'
+       ) then
+      raise exception
+        'security hardening failed: authenticated privilege contract changed for public.%',
+        v_relation;
+    end if;
+
+    if not has_table_privilege(
+      'service_role',
+      'public.' || v_relation,
+      'SELECT'
+    ) then
+      raise exception
+        'security hardening failed: service_role lost SELECT on public.%',
+        v_relation;
+    end if;
+  end loop;
+
+  select c.reloptions
+    into v_reloptions
+  from pg_catalog.pg_class c
+  join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+  where n.nspname = 'public'
+    and c.relname = 'shop_reviews_public';
+
+  if not (
+    coalesce(v_reloptions, '{}'::text[])
+    @> array['security_invoker=true']
+  ) then
+    raise exception
+      'security hardening failed: shop_reviews_public is not security-invoker';
+  end if;
+
+  if not has_table_privilege('anon', 'public.shop_reviews_public', 'SELECT')
+     or has_table_privilege('anon', 'public.shop_reviews_public', 'INSERT')
+     or has_table_privilege('anon', 'public.shop_reviews_public', 'UPDATE')
+     or has_table_privilege('anon', 'public.shop_reviews_public', 'DELETE')
+     or not has_table_privilege(
+       'authenticated',
+       'public.shop_reviews_public',
+       'SELECT'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_reviews_public',
+       'INSERT'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_reviews_public',
+       'UPDATE'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_reviews_public',
+       'DELETE'
+     ) then
+    raise exception
+      'security hardening failed: shop_reviews_public privilege contract changed';
+  end if;
+
+  if not has_table_privilege('anon', 'public.shop_public_profiles', 'SELECT')
+     or has_table_privilege('anon', 'public.shop_public_profiles', 'INSERT')
+     or has_table_privilege('anon', 'public.shop_public_profiles', 'UPDATE')
+     or has_table_privilege('anon', 'public.shop_public_profiles', 'DELETE')
+     or not has_table_privilege(
+       'authenticated',
+       'public.shop_public_profiles',
+       'SELECT'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_public_profiles',
+       'INSERT'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_public_profiles',
+       'UPDATE'
+     )
+     or has_table_privilege(
+       'authenticated',
+       'public.shop_public_profiles',
+       'DELETE'
+     ) then
+    raise exception
+      'security hardening failed: shop_public_profiles privilege contract changed';
+  end if;
+end
+$$;

--- a/supabase/migrations/20260818160000_harden_security_definer_views.sql
+++ b/supabase/migrations/20260818160000_harden_security_definer_views.sql
@@ -1,0 +1,49 @@
+-- Production hardening: remove unintended anonymous/cross-tenant access through
+-- public views that currently execute with the view owner's privileges.
+--
+-- Internal views become security-invoker so their base-table RLS policies are
+-- enforced for the calling user. Public-facing views retain only the minimum
+-- read grants required by their intended surface.
+
+alter view public.ai_training_events_v set (security_invoker = true);
+alter view public.stock_balances set (security_invoker = true);
+alter view public.v_shift_rollups set (security_invoker = true);
+alter view public.v_vehicle_service_history set (security_invoker = true);
+alter view public.v_parts_reconciliation set (security_invoker = true);
+alter view public.v_global_saved_menu_items set (security_invoker = true);
+alter view public.v_video_performance_summary set (security_invoker = true);
+alter view public.v_top_content_types_by_shop set (security_invoker = true);
+alter view public.shop_reviews_public set (security_invoker = true);
+
+-- Internal/authenticated views: never expose them to anon. Authenticated reads
+-- are permitted, but security_invoker ensures the underlying RLS policies
+-- determine which rows are visible.
+revoke all on table public.ai_training_events_v from public, anon, authenticated;
+revoke all on table public.stock_balances from public, anon, authenticated;
+revoke all on table public.v_shift_rollups from public, anon, authenticated;
+revoke all on table public.v_vehicle_service_history from public, anon, authenticated;
+revoke all on table public.v_parts_reconciliation from public, anon, authenticated;
+revoke all on table public.v_global_saved_menu_items from public, anon, authenticated;
+revoke all on table public.v_video_performance_summary from public, anon, authenticated;
+revoke all on table public.v_top_content_types_by_shop from public, anon, authenticated;
+
+grant select on table public.ai_training_events_v to authenticated;
+grant select on table public.stock_balances to authenticated;
+grant select on table public.v_shift_rollups to authenticated;
+grant select on table public.v_vehicle_service_history to authenticated;
+grant select on table public.v_parts_reconciliation to authenticated;
+grant select on table public.v_global_saved_menu_items to authenticated;
+grant select on table public.v_video_performance_summary to authenticated;
+grant select on table public.v_top_content_types_by_shop to authenticated;
+
+-- Reviews are intentionally public, and the base table already has a public
+-- SELECT RLS policy limited to published (`is_public = true`) reviews.
+revoke all on table public.shop_reviews_public from public, anon, authenticated;
+grant select on table public.shop_reviews_public to anon, authenticated;
+
+-- Shop public profiles are an intentionally sanitized public projection. The
+-- base `shops` table has no anon SELECT policy, so converting this one view to
+-- security_invoker would break the public shop-profile surface. Keep the
+-- projection behavior but remove every DML privilege and expose SELECT only.
+revoke all on table public.shop_public_profiles from public, anon, authenticated;
+grant select on table public.shop_public_profiles to anon, authenticated;

--- a/supabase/migrations/20260818160000_harden_security_definer_views.sql
+++ b/supabase/migrations/20260818160000_harden_security_definer_views.sql
@@ -1,43 +1,54 @@
 -- Production hardening: remove unintended anonymous/cross-tenant access through
 -- public views that currently execute with the view owner's privileges.
 --
--- Internal views become security-invoker so their base-table RLS policies are
--- enforced for the calling user. Public-facing views retain only the minimum
--- read grants required by their intended surface.
+-- Several of the audited views are production-only legacy objects that are
+-- intentionally not part of the clean-replay migration chain. Harden them when
+-- present without making a fresh database depend on unreconciled legacy schema.
+-- Baseline-owned views remain required and are hardened directly below.
 
-alter view public.ai_training_events_v set (security_invoker = true);
-alter view public.stock_balances set (security_invoker = true);
+do $$
+declare
+  v_relation text;
+begin
+  foreach v_relation in array array[
+    'ai_training_events_v',
+    'stock_balances',
+    'v_vehicle_service_history',
+    'v_parts_reconciliation',
+    'v_global_saved_menu_items',
+    'v_video_performance_summary',
+    'v_top_content_types_by_shop'
+  ]
+  loop
+    if to_regclass(format('public.%I', v_relation)) is null then
+      continue;
+    end if;
+
+    execute format(
+      'alter view public.%I set (security_invoker = true)',
+      v_relation
+    );
+    execute format(
+      'revoke all on table public.%I from public, anon, authenticated',
+      v_relation
+    );
+    execute format(
+      'grant select on table public.%I to authenticated',
+      v_relation
+    );
+  end loop;
+end
+$$;
+
+-- v_shift_rollups is owned by the ordered baseline and therefore must exist on
+-- both clean replay and production.
 alter view public.v_shift_rollups set (security_invoker = true);
-alter view public.v_vehicle_service_history set (security_invoker = true);
-alter view public.v_parts_reconciliation set (security_invoker = true);
-alter view public.v_global_saved_menu_items set (security_invoker = true);
-alter view public.v_video_performance_summary set (security_invoker = true);
-alter view public.v_top_content_types_by_shop set (security_invoker = true);
-alter view public.shop_reviews_public set (security_invoker = true);
-
--- Internal/authenticated views: never expose them to anon. Authenticated reads
--- are permitted, but security_invoker ensures the underlying RLS policies
--- determine which rows are visible.
-revoke all on table public.ai_training_events_v from public, anon, authenticated;
-revoke all on table public.stock_balances from public, anon, authenticated;
 revoke all on table public.v_shift_rollups from public, anon, authenticated;
-revoke all on table public.v_vehicle_service_history from public, anon, authenticated;
-revoke all on table public.v_parts_reconciliation from public, anon, authenticated;
-revoke all on table public.v_global_saved_menu_items from public, anon, authenticated;
-revoke all on table public.v_video_performance_summary from public, anon, authenticated;
-revoke all on table public.v_top_content_types_by_shop from public, anon, authenticated;
-
-grant select on table public.ai_training_events_v to authenticated;
-grant select on table public.stock_balances to authenticated;
 grant select on table public.v_shift_rollups to authenticated;
-grant select on table public.v_vehicle_service_history to authenticated;
-grant select on table public.v_parts_reconciliation to authenticated;
-grant select on table public.v_global_saved_menu_items to authenticated;
-grant select on table public.v_video_performance_summary to authenticated;
-grant select on table public.v_top_content_types_by_shop to authenticated;
 
 -- Reviews are intentionally public, and the base table already has a public
 -- SELECT RLS policy limited to published (`is_public = true`) reviews.
+alter view public.shop_reviews_public set (security_invoker = true);
 revoke all on table public.shop_reviews_public from public, anon, authenticated;
 grant select on table public.shop_reviews_public to anon, authenticated;
 
@@ -49,7 +60,8 @@ revoke all on table public.shop_public_profiles from public, anon, authenticated
 grant select on table public.shop_public_profiles to anon, authenticated;
 
 -- Fail the migration during clean replay if a future baseline/default grant
--- causes any of these boundaries to regress.
+-- causes any present boundary to regress. Production-only legacy views are
+-- checked when present and skipped when absent on clean replay.
 do $$
 declare
   v_relation text;
@@ -66,6 +78,10 @@ begin
     'v_top_content_types_by_shop'
   ]
   loop
+    if to_regclass(format('public.%I', v_relation)) is null then
+      continue;
+    end if;
+
     select c.reloptions
       into v_reloptions
     from pg_catalog.pg_class c

--- a/supabase/migrations/20260818160500_harden_anon_mutating_rpc_acl.sql
+++ b/supabase/migrations/20260818160500_harden_anon_mutating_rpc_acl.sql
@@ -5,13 +5,34 @@
 -- touched here because their anonymous access is part of a separate contract
 -- and must be reviewed independently.
 
--- Internal agent queue workers are service-role only. The function performs no
--- caller authentication and returns a claimed job payload while mutating the
--- queue, so neither anon nor ordinary authenticated sessions may execute it.
-revoke execute on function public.agent_claim_next_job(text, public.agent_job_kind[])
-  from public, anon, authenticated;
-grant execute on function public.agent_claim_next_job(text, public.agent_job_kind[])
-  to service_role;
+-- Internal agent queue workers are service-role only. This RPC is a
+-- production-only legacy object and is intentionally absent from clean replay,
+-- so harden it when present without reintroducing it into the baseline.
+do $$
+declare
+  v_agent regprocedure;
+begin
+  select p.oid::regprocedure
+    into v_agent
+  from pg_catalog.pg_proc p
+  join pg_catalog.pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'public'
+    and p.proname = 'agent_claim_next_job'
+  order by p.oid
+  limit 1;
+
+  if v_agent is not null then
+    execute format(
+      'revoke execute on function %s from public, anon, authenticated',
+      v_agent
+    );
+    execute format(
+      'grant execute on function %s to service_role',
+      v_agent
+    );
+  end if;
+end
+$$;
 
 -- Financial correction-session primitives are server-side commands. Their
 -- current production ACL already excludes authenticated but accidentally
@@ -77,23 +98,25 @@ grant execute on function public.work_orders_set_intake(uuid, jsonb, boolean)
   to authenticated, service_role;
 
 -- Replay-time privilege assertions. These fail closed if a future baseline or
--- default grant re-exposes a protected mutation surface.
+-- default grant re-exposes a protected mutation surface. The production-only
+-- agent worker is asserted when present and skipped on clean replay.
 do $$
+declare
+  v_agent regprocedure;
 begin
-  if has_function_privilege(
-       'anon',
-       'public.agent_claim_next_job(text,public.agent_job_kind[])',
-       'EXECUTE'
-     )
-     or has_function_privilege(
-       'authenticated',
-       'public.agent_claim_next_job(text,public.agent_job_kind[])',
-       'EXECUTE'
-     )
-     or not has_function_privilege(
-       'service_role',
-       'public.agent_claim_next_job(text,public.agent_job_kind[])',
-       'EXECUTE'
+  select p.oid::regprocedure
+    into v_agent
+  from pg_catalog.pg_proc p
+  join pg_catalog.pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'public'
+    and p.proname = 'agent_claim_next_job'
+  order by p.oid
+  limit 1;
+
+  if v_agent is not null and (
+       has_function_privilege('anon', v_agent, 'EXECUTE')
+       or has_function_privilege('authenticated', v_agent, 'EXECUTE')
+       or not has_function_privilege('service_role', v_agent, 'EXECUTE')
      ) then
     raise exception 'RPC hardening failed: agent_claim_next_job ACL is unsafe';
   end if;

--- a/supabase/migrations/20260818160500_harden_anon_mutating_rpc_acl.sql
+++ b/supabase/migrations/20260818160500_harden_anon_mutating_rpc_acl.sql
@@ -1,0 +1,181 @@
+-- Production hardening: close direct Data API execution of high-risk
+-- SECURITY DEFINER mutation functions that are not anonymous workflows.
+--
+-- This is intentionally narrow. Public portal enrollment/booking RPCs are not
+-- touched here because their anonymous access is part of a separate contract
+-- and must be reviewed independently.
+
+-- Internal agent queue workers are service-role only. The function performs no
+-- caller authentication and returns a claimed job payload while mutating the
+-- queue, so neither anon nor ordinary authenticated sessions may execute it.
+revoke execute on function public.agent_claim_next_job(text, public.agent_job_kind[])
+  from public, anon, authenticated;
+grant execute on function public.agent_claim_next_job(text, public.agent_job_kind[])
+  to service_role;
+
+-- Financial correction-session primitives are server-side commands. Their
+-- current production ACL already excludes authenticated but accidentally
+-- leaves anon executable; keep the intended service-role-only boundary.
+revoke execute on function public.open_work_order_correction_session(
+  uuid, uuid, uuid, text, text, text, jsonb
+) from public, anon, authenticated;
+grant execute on function public.open_work_order_correction_session(
+  uuid, uuid, uuid, text, text, text, jsonb
+) to service_role;
+
+revoke execute on function public.close_work_order_correction_session(
+  uuid, uuid, uuid, uuid, jsonb
+) from public, anon, authenticated;
+grant execute on function public.close_work_order_correction_session(
+  uuid, uuid, uuid, uuid, jsonb
+) to service_role;
+
+-- Authenticated staff workflows. Anonymous callers must not be able to supply
+-- an owner/manager/profile UUID and invoke these SECURITY DEFINER mutations.
+revoke execute on function public.apply_punch_correction(
+  uuid, uuid, uuid, timestamptz, text
+) from public, anon;
+grant execute on function public.apply_punch_correction(
+  uuid, uuid, uuid, timestamptz, text
+) to authenticated, service_role;
+
+revoke execute on function public.replace_staff_schedule_template(
+  uuid, uuid, uuid, jsonb
+) from public, anon;
+grant execute on function public.replace_staff_schedule_template(
+  uuid, uuid, uuid, jsonb
+) to authenticated, service_role;
+
+revoke execute on function public.transition_staff_time_off_request(
+  uuid, uuid, uuid, text, text
+) from public, anon;
+grant execute on function public.transition_staff_time_off_request(
+  uuid, uuid, uuid, text, text
+) to authenticated, service_role;
+
+revoke execute on function public.parts_void_work_order_line_atomic(
+  uuid, uuid, text, text, text, text, text, text, text, text, uuid
+) from public, anon;
+grant execute on function public.parts_void_work_order_line_atomic(
+  uuid, uuid, text, text, text, text, text, text, text, text, uuid
+) to authenticated, service_role;
+
+-- Customer intake requires auth.uid() in the function body. Remove the legacy
+-- PUBLIC execute grant so the database privilege matches that contract.
+revoke execute on function public.work_orders_set_intake(uuid, jsonb, boolean)
+  from public, anon;
+grant execute on function public.work_orders_set_intake(uuid, jsonb, boolean)
+  to authenticated, service_role;
+
+-- Replay-time privilege assertions. These fail closed if a future baseline or
+-- default grant re-exposes a protected mutation surface.
+do $$
+begin
+  if has_function_privilege(
+       'anon',
+       'public.agent_claim_next_job(text,public.agent_job_kind[])',
+       'EXECUTE'
+     )
+     or has_function_privilege(
+       'authenticated',
+       'public.agent_claim_next_job(text,public.agent_job_kind[])',
+       'EXECUTE'
+     )
+     or not has_function_privilege(
+       'service_role',
+       'public.agent_claim_next_job(text,public.agent_job_kind[])',
+       'EXECUTE'
+     ) then
+    raise exception 'RPC hardening failed: agent_claim_next_job ACL is unsafe';
+  end if;
+
+  if has_function_privilege(
+       'anon',
+       'public.open_work_order_correction_session(uuid,uuid,uuid,text,text,text,jsonb)',
+       'EXECUTE'
+     )
+     or has_function_privilege(
+       'authenticated',
+       'public.open_work_order_correction_session(uuid,uuid,uuid,text,text,text,jsonb)',
+       'EXECUTE'
+     )
+     or not has_function_privilege(
+       'service_role',
+       'public.open_work_order_correction_session(uuid,uuid,uuid,text,text,text,jsonb)',
+       'EXECUTE'
+     ) then
+    raise exception 'RPC hardening failed: open correction-session ACL is unsafe';
+  end if;
+
+  if has_function_privilege(
+       'anon',
+       'public.close_work_order_correction_session(uuid,uuid,uuid,uuid,jsonb)',
+       'EXECUTE'
+     )
+     or has_function_privilege(
+       'authenticated',
+       'public.close_work_order_correction_session(uuid,uuid,uuid,uuid,jsonb)',
+       'EXECUTE'
+     )
+     or not has_function_privilege(
+       'service_role',
+       'public.close_work_order_correction_session(uuid,uuid,uuid,uuid,jsonb)',
+       'EXECUTE'
+     ) then
+    raise exception 'RPC hardening failed: close correction-session ACL is unsafe';
+  end if;
+
+  if has_function_privilege(
+       'anon',
+       'public.apply_punch_correction(uuid,uuid,uuid,timestamptz,text)',
+       'EXECUTE'
+     )
+     or not has_function_privilege(
+       'authenticated',
+       'public.apply_punch_correction(uuid,uuid,uuid,timestamptz,text)',
+       'EXECUTE'
+     )
+     or has_function_privilege(
+       'anon',
+       'public.replace_staff_schedule_template(uuid,uuid,uuid,jsonb)',
+       'EXECUTE'
+     )
+     or not has_function_privilege(
+       'authenticated',
+       'public.replace_staff_schedule_template(uuid,uuid,uuid,jsonb)',
+       'EXECUTE'
+     )
+     or has_function_privilege(
+       'anon',
+       'public.transition_staff_time_off_request(uuid,uuid,uuid,text,text)',
+       'EXECUTE'
+     )
+     or not has_function_privilege(
+       'authenticated',
+       'public.transition_staff_time_off_request(uuid,uuid,uuid,text,text)',
+       'EXECUTE'
+     )
+     or has_function_privilege(
+       'anon',
+       'public.parts_void_work_order_line_atomic(uuid,uuid,text,text,text,text,text,text,text,text,uuid)',
+       'EXECUTE'
+     )
+     or not has_function_privilege(
+       'authenticated',
+       'public.parts_void_work_order_line_atomic(uuid,uuid,text,text,text,text,text,text,text,text,uuid)',
+       'EXECUTE'
+     )
+     or has_function_privilege(
+       'anon',
+       'public.work_orders_set_intake(uuid,jsonb,boolean)',
+       'EXECUTE'
+     )
+     or not has_function_privilege(
+       'authenticated',
+       'public.work_orders_set_intake(uuid,jsonb,boolean)',
+       'EXECUTE'
+     ) then
+    raise exception 'RPC hardening failed: authenticated mutation ACL contract changed';
+  end if;
+end
+$$;

--- a/supabase/migrations/20260818160500_harden_anon_mutating_rpc_acl.sql
+++ b/supabase/migrations/20260818160500_harden_anon_mutating_rpc_acl.sql
@@ -30,15 +30,20 @@ grant execute on function public.close_work_order_correction_session(
   uuid, uuid, uuid, uuid, jsonb
 ) to service_role;
 
--- Authenticated staff workflows. Anonymous callers must not be able to supply
--- an owner/manager/profile UUID and invoke these SECURITY DEFINER mutations.
+-- Punch correction is also a server-side command. The function validates the
+-- supplied actor profile's role, but does not bind that supplied UUID to
+-- auth.uid(). The application route already calls it with the service-role
+-- client after canManageScheduling authorization, so direct Data API access by
+-- ordinary authenticated users is unnecessary and would permit actor spoofing.
 revoke execute on function public.apply_punch_correction(
   uuid, uuid, uuid, timestamptz, text
-) from public, anon;
+) from public, anon, authenticated;
 grant execute on function public.apply_punch_correction(
   uuid, uuid, uuid, timestamptz, text
-) to authenticated, service_role;
+) to service_role;
 
+-- Authenticated staff workflows below bind their actor identity in the
+-- function body and may remain callable by authenticated sessions.
 revoke execute on function public.replace_staff_schedule_template(
   uuid, uuid, uuid, jsonb
 ) from public, anon;
@@ -130,12 +135,20 @@ begin
        'public.apply_punch_correction(uuid,uuid,uuid,timestamptz,text)',
        'EXECUTE'
      )
-     or not has_function_privilege(
+     or has_function_privilege(
        'authenticated',
        'public.apply_punch_correction(uuid,uuid,uuid,timestamptz,text)',
        'EXECUTE'
      )
-     or has_function_privilege(
+     or not has_function_privilege(
+       'service_role',
+       'public.apply_punch_correction(uuid,uuid,uuid,timestamptz,text)',
+       'EXECUTE'
+     ) then
+    raise exception 'RPC hardening failed: punch correction ACL is unsafe';
+  end if;
+
+  if has_function_privilege(
        'anon',
        'public.replace_staff_schedule_template(uuid,uuid,uuid,jsonb)',
        'EXECUTE'

--- a/supabase/migrations/20260818160500_harden_anon_mutating_rpc_acl.sql
+++ b/supabase/migrations/20260818160500_harden_anon_mutating_rpc_acl.sql
@@ -42,6 +42,17 @@ grant execute on function public.apply_punch_correction(
   uuid, uuid, uuid, timestamptz, text
 ) to service_role;
 
+-- Work-order line voiding is likewise kept behind the authorized server route.
+-- The RPC accepts shop, actor and aggregate UUIDs and its SECURITY DEFINER body
+-- does not bind those inputs to auth.uid(). The route now performs the
+-- canManageWorkOrders check first and invokes this command with service_role.
+revoke execute on function public.parts_void_work_order_line_atomic(
+  uuid, uuid, text, text, text, text, text, text, text, text, uuid
+) from public, anon, authenticated;
+grant execute on function public.parts_void_work_order_line_atomic(
+  uuid, uuid, text, text, text, text, text, text, text, text, uuid
+) to service_role;
+
 -- Authenticated staff workflows below bind their actor identity in the
 -- function body and may remain callable by authenticated sessions.
 revoke execute on function public.replace_staff_schedule_template(
@@ -56,13 +67,6 @@ revoke execute on function public.transition_staff_time_off_request(
 ) from public, anon;
 grant execute on function public.transition_staff_time_off_request(
   uuid, uuid, uuid, text, text
-) to authenticated, service_role;
-
-revoke execute on function public.parts_void_work_order_line_atomic(
-  uuid, uuid, text, text, text, text, text, text, text, text, uuid
-) from public, anon;
-grant execute on function public.parts_void_work_order_line_atomic(
-  uuid, uuid, text, text, text, text, text, text, text, text, uuid
 ) to authenticated, service_role;
 
 -- Customer intake requires auth.uid() in the function body. Remove the legacy
@@ -150,6 +154,24 @@ begin
 
   if has_function_privilege(
        'anon',
+       'public.parts_void_work_order_line_atomic(uuid,uuid,text,text,text,text,text,text,text,text,uuid)',
+       'EXECUTE'
+     )
+     or has_function_privilege(
+       'authenticated',
+       'public.parts_void_work_order_line_atomic(uuid,uuid,text,text,text,text,text,text,text,text,uuid)',
+       'EXECUTE'
+     )
+     or not has_function_privilege(
+       'service_role',
+       'public.parts_void_work_order_line_atomic(uuid,uuid,text,text,text,text,text,text,text,text,uuid)',
+       'EXECUTE'
+     ) then
+    raise exception 'RPC hardening failed: line void ACL is unsafe';
+  end if;
+
+  if has_function_privilege(
+       'anon',
        'public.replace_staff_schedule_template(uuid,uuid,uuid,jsonb)',
        'EXECUTE'
      )
@@ -166,16 +188,6 @@ begin
      or not has_function_privilege(
        'authenticated',
        'public.transition_staff_time_off_request(uuid,uuid,uuid,text,text)',
-       'EXECUTE'
-     )
-     or has_function_privilege(
-       'anon',
-       'public.parts_void_work_order_line_atomic(uuid,uuid,text,text,text,text,text,text,text,text,uuid)',
-       'EXECUTE'
-     )
-     or not has_function_privilege(
-       'authenticated',
-       'public.parts_void_work_order_line_atomic(uuid,uuid,text,text,text,text,text,text,text,text,uuid)',
        'EXECUTE'
      )
      or has_function_privilege(

--- a/tests/phase3-parts-atomic-routes.test.ts
+++ b/tests/phase3-parts-atomic-routes.test.ts
@@ -45,11 +45,14 @@ describe("phase 3 atomic parts routes", () => {
     expect(helper).not.toContain("|| fallback");
   });
 
-  it("uses one line disposition command", () => {
+  it("uses one line disposition command behind the authorized server client", () => {
     const route = source(
       "app/api/work-orders/lines/[id]/delete-or-void/route.ts",
     );
     expect(route).toContain("parts_void_work_order_line_atomic");
+    expect(route).toContain("requiredCapability: \"canManageWorkOrders\"");
+    expect(route).toContain("createAdminSupabase()");
+    expect(route).not.toContain("const rpc = access.supabase");
     expect(route).not.toContain("apply_stock_move");
     expect(route).not.toContain('from("work_order_part_allocations")');
   });


### PR DESCRIPTION
## Outcome

Closes the confirmed anonymous/direct-execution paths for high-confidence internal mutation RPCs while preserving intentional public portal workflows.

## Authorization changes

- makes the legacy Agent queue claim primitive service-role only when that production-only function exists
- restores service-role-only ACLs for financial correction-session commands
- makes `apply_punch_correction` service-role only; its route already requires `canManageScheduling` and uses the admin client
- makes `parts_void_work_order_line_atomic` service-role only; its route requires `canManageWorkOrders` and now invokes the RPC through `createAdminSupabase()`
- removes anonymous execution from staff schedule replacement and time-off transition while preserving authenticated execution
- removes anonymous execution from the production-only customer-intake helper while preserving authenticated execution
- leaves anonymous portal enrollment, booking, and approval RPCs untouched pending contract-by-contract classification

## Replay and migration safety

The PR is retargeted directly to `main`; the stacked copy of #1470/#1472 is no longer part of the diff.

The unapplied migration was moved forward to:

- `20260818190557_harden_anon_mutating_rpc_acl.sql`

Only the two confirmed production-only legacy objects—`agent_claim_next_job` and `work_orders_set_intake`—are conditional when absent. All baseline-owned RPCs and their post-migration ACL assertions remain strict.

This is an ACL-only migration. It does not drop, rename, recreate, or move schema objects and does not mutate application data. It has not been applied to production.

## Validation

- live read-only production audit reconfirmed all targeted pre-migration ACLs
- focused security/workforce/Parts suite: 4 files and 21 tests passed
- new replay-safety and server-boundary contract: 4 tests passed
- `pnpm check`: typecheck and lint passed; 441 test files and 2,542 tests passed; 1 file / 2 database integration tests skipped
- `pnpm audit:api-routes`: 461 routes analyzed
- GitHub Agent PR Checks, Phase 2, Phase 3 Parts, Phase 4 Labor, Phase 7 Portal, and Phase 8 consistency all passed
- GitHub Supabase Clean Replay passed fresh apply, generated-type comparison, second reset/replay, and all runtime integrations
- Supabase preview migrations passed; runtime ACL inspection confirms anonymous execution is removed and the intended service/authenticated grants remain
- the final GitHub tree matches the fully validated local tree exactly

## Delivery state

Implementation and automated validation are green. The migration remains unapplied to production and should be applied only after this PR is merged.