### PR TITLE
Build Field active-work cockpit

### DIFF
--- a/app/mobile/field-hub.css
+++ b/app/mobile/field-hub.css
@@ -5,7 +5,11 @@
   --field-copper: var(--accent-copper, #c66a2b);
   min-height: 100dvh;
   background:
-    radial-gradient(circle at 80% 0%, rgba(41, 182, 246, 0.08), transparent 30rem),
+    radial-gradient(
+      circle at 80% 0%,
+      rgba(41, 182, 246, 0.08),
+      transparent 30rem
+    ),
     var(--theme-surface-page);
   color: var(--theme-text-primary);
 }
@@ -155,7 +159,11 @@
   border-bottom: 1px solid rgba(137, 178, 234, 0.2);
   padding: env(safe-area-inset-top, 0px) 0.75rem 0;
   background:
-    radial-gradient(circle at 88% -55%, rgba(41, 182, 246, 0.28), transparent 12rem),
+    radial-gradient(
+      circle at 88% -55%,
+      rgba(41, 182, 246, 0.28),
+      transparent 12rem
+    ),
     linear-gradient(145deg, var(--field-chrome), var(--field-chrome-deep));
   color: white;
   box-shadow: 0 12px 28px rgba(3, 13, 32, 0.18);
@@ -365,8 +373,16 @@
   border-radius: 1.5rem;
   padding: 1.2rem;
   background:
-    radial-gradient(circle at 88% 8%, rgba(41, 182, 246, 0.26), transparent 18rem),
-    radial-gradient(circle at 12% 140%, rgba(23, 71, 255, 0.33), transparent 20rem),
+    radial-gradient(
+      circle at 88% 8%,
+      rgba(41, 182, 246, 0.26),
+      transparent 18rem
+    ),
+    radial-gradient(
+      circle at 12% 140%,
+      rgba(23, 71, 255, 0.33),
+      transparent 20rem
+    ),
     linear-gradient(145deg, #07172f, #030b1c);
   color: white;
   box-shadow: 0 22px 55px rgba(3, 13, 32, 0.22);
@@ -443,15 +459,23 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 0.55rem;
-  border: 1px solid color-mix(in srgb, var(--accent-copper) 25%, var(--theme-border-soft));
+  border: 1px solid
+    color-mix(in srgb, var(--accent-copper) 25%, var(--theme-border-soft));
   border-radius: 1rem;
   padding: 0.72rem;
-  background: color-mix(in srgb, var(--accent-copper) 7%, var(--theme-surface-page));
+  background: color-mix(
+    in srgb,
+    var(--accent-copper) 7%,
+    var(--theme-surface-page)
+  );
   color: var(--theme-text-primary);
   font-size: 0.72rem;
   font-weight: 800;
   line-height: 1.2;
-  transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
+  transition:
+    border-color 140ms ease,
+    transform 140ms ease,
+    box-shadow 140ms ease;
 }
 
 .field-hub-action svg {
@@ -460,7 +484,11 @@
 
 .field-hub-action:hover {
   transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--accent-copper) 65%, var(--theme-border-soft));
+  border-color: color-mix(
+    in srgb,
+    var(--accent-copper) 65%,
+    var(--theme-border-soft)
+  );
   box-shadow: 0 12px 26px rgba(3, 13, 32, 0.1);
 }
 
@@ -551,12 +579,19 @@
   padding: 0.7rem;
   background: var(--theme-surface-page);
   color: var(--theme-text-primary);
-  transition: border-color 140ms ease, transform 140ms ease, box-shadow 140ms ease;
+  transition:
+    border-color 140ms ease,
+    transform 140ms ease,
+    box-shadow 140ms ease;
 }
 
 a.field-hub-module:hover {
   transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--accent-copper) 55%, var(--theme-border-soft));
+  border-color: color-mix(
+    in srgb,
+    var(--accent-copper) 55%,
+    var(--theme-border-soft)
+  );
   box-shadow: 0 12px 28px rgba(3, 13, 32, 0.09);
 }
 
@@ -794,6 +829,136 @@ a.field-hub-module:hover {
   color: var(--theme-text-on-accent);
 }
 
+.field-active-work {
+  display: grid;
+  width: min(100%, 78rem);
+  gap: 1rem;
+  margin-inline: auto;
+  padding: 0.75rem 0.75rem 2rem;
+  color: var(--theme-text-primary);
+}
+
+.field-active-work__hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(91, 154, 255, 0.2);
+  border-radius: 1.5rem;
+  padding: 1.25rem;
+  background:
+    radial-gradient(
+      circle at 92% 0,
+      rgba(41, 182, 246, 0.2),
+      transparent 22rem
+    ),
+    linear-gradient(140deg, var(--field-chrome), var(--field-chrome-deep));
+  color: white;
+  box-shadow: 0 20px 45px rgba(3, 13, 32, 0.16);
+}
+
+.field-active-work__eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #7dd3fc;
+  font-size: 0.66rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.field-active-work__hero h1 {
+  margin-top: 0.4rem;
+  font-size: clamp(1.75rem, 5vw, 2.65rem);
+  font-weight: 900;
+  letter-spacing: -0.045em;
+  line-height: 1;
+}
+
+.field-active-work__hero p {
+  max-width: 46rem;
+  margin-top: 0.65rem;
+  color: #cbd5e1;
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.field-active-work__all-link {
+  display: inline-flex;
+  min-height: 2.75rem;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 0.85rem;
+  padding-inline: 0.9rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: white;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.field-active-work__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.field-active-work__actions a {
+  display: flex;
+  min-height: 3.25rem;
+  align-items: center;
+  gap: 0.55rem;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 1rem;
+  padding: 0.75rem;
+  background: var(--theme-surface-panel);
+  color: var(--theme-text-primary);
+  font-size: 0.76rem;
+  font-weight: 800;
+  box-shadow: var(--mobile-shadow);
+}
+
+.field-active-work__actions svg {
+  color: var(--accent-copper);
+}
+
+.field-active-work__section {
+  min-width: 0;
+  border: 1px solid var(--theme-border-soft);
+  border-radius: 1.35rem;
+  padding: 0.85rem;
+  background: color-mix(in srgb, var(--theme-surface-panel) 92%, transparent);
+  box-shadow: var(--mobile-shadow);
+}
+
+.field-active-work__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  padding-inline: 0.15rem;
+}
+
+.field-active-work__heading h2 {
+  margin-top: 0.2rem;
+  font-size: 1.05rem;
+  font-weight: 900;
+  letter-spacing: -0.025em;
+}
+
+.field-active-work__heading > span {
+  max-width: 9rem;
+  color: var(--theme-text-muted);
+  font-size: 0.65rem;
+  font-weight: 700;
+  line-height: 1.35;
+  text-align: right;
+}
+
 @media (min-width: 36rem) {
   .field-hub {
     padding: 1rem 1rem 2.5rem;
@@ -814,6 +979,21 @@ a.field-hub-module:hover {
   .field-hub-module-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .field-active-work {
+    padding: 1rem 1rem 2.5rem;
+  }
+
+  .field-active-work__hero {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem;
+  }
+
+  .field-active-work__actions {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 }
 
 @media (min-width: 64rem) {
@@ -831,7 +1011,11 @@ a.field-hub-module:hover {
     flex-direction: column;
     border-right: 1px solid rgba(124, 166, 235, 0.18);
     background:
-      radial-gradient(circle at 0 0, rgba(23, 71, 255, 0.19), transparent 20rem),
+      radial-gradient(
+        circle at 0 0,
+        rgba(23, 71, 255, 0.19),
+        transparent 20rem
+      ),
       linear-gradient(180deg, var(--field-chrome), var(--field-chrome-deep));
     box-shadow: 16px 0 45px rgba(3, 13, 32, 0.11);
   }
@@ -880,6 +1064,17 @@ a.field-hub-module:hover {
 
   .field-hub-module-grid {
     grid-template-columns: 1fr;
+  }
+
+  .field-active-work {
+    grid-template-columns: minmax(0, 1.15fr) minmax(23rem, 0.85fr);
+    align-items: start;
+    padding: 1.25rem 1.5rem 3rem;
+  }
+
+  .field-active-work__hero,
+  .field-active-work__actions {
+    grid-column: 1 / -1;
   }
 }
 

--- a/app/mobile/service/jobs/page.tsx
+++ b/app/mobile/service/jobs/page.tsx
@@ -1,0 +1,5 @@
+import FieldActiveWork from "@/features/mobile/service/FieldActiveWork";
+
+export default function FieldActiveWorkPage() {
+  return <FieldActiveWork />;
+}

--- a/features/mobile/service/FieldActiveWork.tsx
+++ b/features/mobile/service/FieldActiveWork.tsx
@@ -1,0 +1,100 @@
+import {
+  ArrowRight,
+  Boxes,
+  BriefcaseBusiness,
+  ClipboardCheck,
+  Plus,
+  Wrench,
+} from "lucide-react";
+import Link from "next/link";
+
+import MobileWorkOrderQueue from "@/features/mobile/work-orders/MobileWorkOrderQueue";
+import MobileServiceShell from "./MobileServiceShell";
+
+const FIELD_JOB_ACTIONS = [
+  {
+    label: "New service call",
+    href: "/mobile/service/new",
+    icon: Plus,
+  },
+  {
+    label: "Truck parts",
+    href: "/mobile/service/truck-inventory",
+    icon: Boxes,
+  },
+  {
+    label: "Inspections",
+    href: "/mobile/inspections",
+    icon: ClipboardCheck,
+  },
+  {
+    label: "All work orders",
+    href: "/mobile/work-orders",
+    icon: BriefcaseBusiness,
+  },
+] as const;
+
+export default function FieldActiveWork() {
+  return (
+    <main className="field-active-work">
+      <section className="field-active-work__hero">
+        <div>
+          <div className="field-active-work__eyebrow">
+            <Wrench aria-hidden className="h-3.5 w-3.5" /> Field execution
+          </div>
+          <h1>Active field work</h1>
+          <p>
+            Move the service call, repair record, inspection, parts and closeout
+            forward from one Field workspace.
+          </p>
+        </div>
+        <Link
+          href="/mobile/work-orders"
+          className="field-active-work__all-link"
+        >
+          All work <ArrowRight aria-hidden className="h-4 w-4" />
+        </Link>
+      </section>
+
+      <nav
+        className="field-active-work__actions"
+        aria-label="Active work actions"
+      >
+        {FIELD_JOB_ACTIONS.map(({ label, href, icon: Icon }) => (
+          <Link key={href} href={href}>
+            <Icon aria-hidden className="h-4.5 w-4.5" />
+            <span>{label}</span>
+          </Link>
+        ))}
+      </nav>
+
+      <section
+        className="field-active-work__section"
+        aria-labelledby="field-call-heading"
+      >
+        <div className="field-active-work__heading">
+          <div>
+            <div className="field-active-work__eyebrow">Service call</div>
+            <h2 id="field-call-heading">Your active and next stop</h2>
+          </div>
+          <span>Offline-safe status updates</span>
+        </div>
+        <MobileServiceShell embedded />
+      </section>
+
+      <section
+        className="field-active-work__section"
+        aria-labelledby="field-repairs-heading"
+      >
+        <div className="field-active-work__heading">
+          <div>
+            <div className="field-active-work__eyebrow">Repair flow</div>
+            <h2 id="field-repairs-heading">Jobs in progress</h2>
+          </div>
+          <span>Canonical work-order records</span>
+        </div>
+        <MobileWorkOrderQueue initialStatus="in_progress" embedded lockStatus />
+      </section>
+    </main>
+  );
+}

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -109,7 +109,7 @@ const FIELD_DASHBOARD_CARDS: FieldDashboardCard[] = [
     id: "jobs_in_progress",
     title: "Jobs in progress",
     description: "Return to active repairs and service calls.",
-    href: "/mobile/work-orders?status=in_progress",
+    href: "/mobile/service/jobs",
     icon: Wrench,
   },
   {
@@ -164,7 +164,6 @@ const FIELD_DASHBOARD_CARDS: FieldDashboardCard[] = [
 function serializeLayout(layout: FieldDashboardLayoutItem[]): string {
   return JSON.stringify(layout);
 }
-
 function readCachedLayout(
   cacheKey: string,
   scope: OfflineMutationScope,

--- a/features/mobile/service/FieldWorkspaceShell.tsx
+++ b/features/mobile/service/FieldWorkspaceShell.tsx
@@ -108,6 +108,7 @@ function pageTitle(pathname: string): string {
     return "Purchase orders";
   }
   if (pathname.startsWith("/mobile/service/new")) return "New service call";
+  if (pathname.startsWith("/mobile/service/jobs")) return "Active field work";
   if (pathname.startsWith("/mobile/service/dispatch")) return "Dispatch";
   if (pathname.startsWith("/mobile/service/truck-inventory")) {
     return "Truck inventory";
@@ -370,8 +371,13 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
           <span>New</span>
         </Link>
         <Link
-          href="/mobile/work-orders"
-          data-active={pathname.startsWith("/mobile/work-orders") ? "true" : "false"}
+          href="/mobile/service/jobs"
+          data-active={
+            pathname.startsWith("/mobile/service/jobs") ||
+            pathname.startsWith("/mobile/work-orders")
+              ? "true"
+              : "false"
+          }
         >
           <BriefcaseBusiness aria-hidden className="h-5 w-5" />
           <span>Work</span>

--- a/features/mobile/service/MobileServiceShell.tsx
+++ b/features/mobile/service/MobileServiceShell.tsx
@@ -51,7 +51,6 @@ type PendingCloseout = {
 function pendingCloseoutKey(userId: string, shopId: string): string {
   return `${PENDING_CLOSEOUT_CACHE_KEY}:${userId}:${shopId}`;
 }
-
 type VisitAction = {
   label: string;
   icon: typeof Navigation;
@@ -837,7 +836,7 @@ export default function MobileServiceShell({
   );
 
   return (
-    <main
+    <div
       className={`${
         embedded
           ? "w-full space-y-4 text-[color:var(--theme-text-primary)]"
@@ -995,6 +994,6 @@ export default function MobileServiceShell({
           </div>
         </section>
       )}
-    </main>
+    </div>
   );
 }

--- a/features/mobile/work-orders/MobileWorkOrderQueue.tsx
+++ b/features/mobile/work-orders/MobileWorkOrderQueue.tsx
@@ -121,7 +121,6 @@ function statusKey(raw: string | null | undefined): StatusKey {
     .replaceAll(" ", "_") as StatusKey;
   return key in STATUS_LABEL ? key : "awaiting";
 }
-
 function cleanText(value: string | null | undefined): string {
   return String(value ?? "")
     .trim()
@@ -168,9 +167,13 @@ function primarySignal(signal: WorkOrderSignal): string | null {
 export default function MobileWorkOrderQueue({
   initialStatus = "",
   readyToInvoiceCloseout = false,
+  embedded = false,
+  lockStatus = false,
 }: {
   initialStatus?: string;
   readyToInvoiceCloseout?: boolean;
+  embedded?: boolean;
+  lockStatus?: boolean;
 }) {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [rows, setRows] = useState<Row[]>([]);
@@ -390,7 +393,8 @@ export default function MobileWorkOrderQueue({
   );
 
   return (
-    <main className="mobile-work-order-queue">
+    <div className="mobile-work-order-queue">
+      {!embedded ? (
       <section className="mobile-dashboard-hero">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
@@ -449,8 +453,10 @@ export default function MobileWorkOrderQueue({
           </div>
         ) : null}
       </section>
+      ) : null}
 
       <section className="mt-3 overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] shadow-[var(--mobile-shadow)]">
+        {!lockStatus ? (
         <div className="flex items-center gap-2 overflow-x-auto px-3 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <Filter
             aria-hidden
@@ -474,6 +480,7 @@ export default function MobileWorkOrderQueue({
             );
           })}
         </div>
+        ) : null}
         <div className="flex items-center justify-between border-t border-[color:var(--theme-border-soft)] px-4 py-2.5 text-xs text-[color:var(--theme-text-secondary)]">
           <span>
             {filteredRows.length} work order
@@ -592,6 +599,6 @@ export default function MobileWorkOrderQueue({
           })
         )}
       </section>
-    </main>
+    </div>
   );
 }

--- a/tests/field-active-work.test.ts
+++ b/tests/field-active-work.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const route = read("app/mobile/service/jobs/page.tsx");
+const cockpit = read("features/mobile/service/FieldActiveWork.tsx");
+const hub = read("features/mobile/service/FieldHub.tsx");
+const fieldShell = read("features/mobile/service/FieldWorkspaceShell.tsx");
+const serviceShell = read("features/mobile/service/MobileServiceShell.tsx");
+const workOrderQueue = read(
+  "features/mobile/work-orders/MobileWorkOrderQueue.tsx",
+);
+
+describe("Field active-work cockpit", () => {
+  it("routes the Jobs in progress card into the dedicated Field execution surface", () => {
+    expect(hub).toMatch(
+      /id: "jobs_in_progress"[\s\S]*?href: "\/mobile\/service\/jobs"/,
+    );
+    expect(route).toContain("<FieldActiveWork />");
+    expect(fieldShell).toContain('href="/mobile/service/jobs"');
+    expect(fieldShell).toContain('return "Active field work"');
+  });
+
+  it("composes canonical service-visit and work-order readers without direct data writes", () => {
+    expect(cockpit).toContain("<MobileServiceShell embedded />");
+    expect(cockpit).toContain(
+      '<MobileWorkOrderQueue initialStatus="in_progress" embedded lockStatus />',
+    );
+    expect(cockpit).not.toContain('.from("');
+    expect(cockpit).not.toContain("supabase");
+  });
+
+  it("keeps the service lifecycle and repair queue valid when embedded in one page landmark", () => {
+    expect(serviceShell).toContain("<div\n      className={`${");
+    expect(workOrderQueue).toContain(
+      '<div className="mobile-work-order-queue">',
+    );
+    expect(workOrderQueue).toContain("lockStatus?: boolean");
+    expect(workOrderQueue).toContain("!lockStatus ?");
+  });
+
+  it("keeps adjacent job tools on existing Field and mobile routes", () => {
+    for (const href of [
+      "/mobile/service/new",
+      "/mobile/service/truck-inventory",
+      "/mobile/inspections",
+      "/mobile/work-orders",
+    ]) {
+      expect(cockpit).toContain(`href: "${href}"`);
+    }
+  });
+});


### PR DESCRIPTION
## Outcome

Adds the next ProFixIQ Field phase: a dedicated active-work cockpit that keeps the assigned service-call lifecycle and canonical in-progress repair records in one Field-native surface.

## What changed

- routes the Field dashboard’s **Jobs in progress** card to `/mobile/service/jobs`
- combines the existing offline-safe active/next Service Visit workflow with the canonical in-progress work-order queue
- adds direct handoffs to service-call intake, inspections, truck inventory, and the full work-order list
- keeps the Field bottom **Work** action anchored to the new cockpit while preserving the canonical work-order detail routes
- supports embedded service and work-order views without creating nested page landmarks
- adds responsive Field styling and focused routing/composition regression coverage

## Architecture and safety

- no database migration
- no new tables, views, RPCs, or state machines
- no direct data writes from the new cockpit
- reuses the existing Service Visit API, work-order reader, offline queue/replay, inspection routes, truck inventory commands, and closeout flow
- based on current `main` after #1473

## Validation

- TypeScript: passed
- changed-file ESLint: passed
- focused Field suite: 4 files / 24 tests passed
- `git diff --check`: passed
- React quality review: removed an unnecessary client boundary and confirmed the composed canonical component boundaries
