### PR TITLE
Fix embedded Field queue refresh recovery

### DIFF
--- a/features/mobile/work-orders/MobileWorkOrderQueue.tsx
+++ b/features/mobile/work-orders/MobileWorkOrderQueue.tsx
@@ -10,7 +10,7 @@ import {
   X,
 } from "lucide-react";
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   getOfflineSnapshot,
@@ -188,9 +188,13 @@ export default function MobileWorkOrderQueue({
   const [lineSignals, setLineSignals] = useState<Record<string, WorkOrderSignal>>(
     {},
   );
+  const loadGenerationRef = useRef(0);
 
   const load = useCallback(
     async (mode: "initial" | "refresh" = "initial") => {
+      const loadGeneration = ++loadGenerationRef.current;
+      const isLatestLoad = () => loadGenerationRef.current === loadGeneration;
+
       if (mode === "refresh") setRefreshing(true);
       else setLoading(true);
       setErrorMessage(null);
@@ -204,6 +208,7 @@ export default function MobileWorkOrderQueue({
             kind: "mobile-work-order-list",
             entityId: status || "active",
           });
+          if (!isLatestLoad()) return;
           if (cached) {
             setRows(cached.data.rows);
             setLineSignals(cached.data.signals);
@@ -216,6 +221,7 @@ export default function MobileWorkOrderQueue({
         }
 
         const { data: auth } = await supabase.auth.getUser();
+        if (!isLatestLoad()) return;
         if (!auth.user) {
           setErrorMessage("Unauthorized");
           setRows([]);
@@ -227,6 +233,7 @@ export default function MobileWorkOrderQueue({
           .select("role, shop_id")
           .eq("id", auth.user.id)
           .maybeSingle();
+        if (!isLatestLoad()) return;
 
         const actor = getActorCapabilities({ role: me?.role ?? null });
         const canViewAssignedWork =
@@ -268,6 +275,7 @@ export default function MobileWorkOrderQueue({
         }
 
         const { data, error } = await query;
+        if (!isLatestLoad()) return;
         if (error) {
           setErrorMessage(error.message);
           setRows([]);
@@ -286,6 +294,7 @@ export default function MobileWorkOrderQueue({
             )
             .eq("shop_id", me.shop_id)
             .in("work_order_id", workOrderIds);
+          if (!isLatestLoad()) return;
 
           (linesData ?? []).forEach((line) => {
             const item = line as WorkOrderLineSummary;
@@ -310,6 +319,7 @@ export default function MobileWorkOrderQueue({
           });
         }
 
+        if (!isLatestLoad()) return;
         setLineSignals(signals);
         setRows(list);
         await saveOfflineSnapshot({
@@ -323,8 +333,10 @@ export default function MobileWorkOrderQueue({
           },
         });
       } finally {
-        setLoading(false);
-        setRefreshing(false);
+        if (isLatestLoad()) {
+          setLoading(false);
+          setRefreshing(false);
+        }
       }
     },
     [status, supabase],

--- a/features/mobile/work-orders/MobileWorkOrderQueue.tsx
+++ b/features/mobile/work-orders/MobileWorkOrderQueue.tsx
@@ -353,6 +353,25 @@ export default function MobileWorkOrderQueue({
     };
   }, [load, supabase]);
 
+  useEffect(() => {
+    const refreshIfOnline = () => {
+      if (navigator.onLine) void load("refresh");
+    };
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === "visible") refreshIfOnline();
+    };
+
+    window.addEventListener("online", refreshIfOnline);
+    window.addEventListener("focus", refreshIfOnline);
+    document.addEventListener("visibilitychange", refreshWhenVisible);
+
+    return () => {
+      window.removeEventListener("online", refreshIfOnline);
+      window.removeEventListener("focus", refreshIfOnline);
+      document.removeEventListener("visibilitychange", refreshWhenVisible);
+    };
+  }, [load]);
+
   const filteredRows = useMemo(() => {
     const search = queryText.trim().toLowerCase();
     if (!search) return rows;
@@ -395,106 +414,123 @@ export default function MobileWorkOrderQueue({
   return (
     <div className="mobile-work-order-queue">
       {!embedded ? (
-      <section className="mobile-dashboard-hero">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <div className="mobile-dashboard-hero__eyebrow">
-              {assignedOnly ? "Technician queue" : "Shop operations"}
+        <section className="mobile-dashboard-hero">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="mobile-dashboard-hero__eyebrow">
+                {assignedOnly ? "Technician queue" : "Shop operations"}
+              </div>
+              <h1 className="mobile-dashboard-hero__title">
+                {assignedOnly ? "My work orders" : "Work orders"}
+              </h1>
+              <p className="mobile-dashboard-hero__subtitle">
+                {assignedOnly
+                  ? `${activeCount} active work order${activeCount === 1 ? "" : "s"} assigned to you.`
+                  : `${activeCount} active work order${activeCount === 1 ? "" : "s"} in the current shop flow.`}
+              </p>
             </div>
-            <h1 className="mobile-dashboard-hero__title">
-              {assignedOnly ? "My work orders" : "Work orders"}
-            </h1>
-            <p className="mobile-dashboard-hero__subtitle">
-              {assignedOnly
-                ? `${activeCount} active work order${activeCount === 1 ? "" : "s"} assigned to you.`
-                : `${activeCount} active work order${activeCount === 1 ? "" : "s"} in the current shop flow.`}
-            </p>
+            <div className="flex shrink-0 gap-2">
+              <button
+                type="button"
+                onClick={() => setSearchOpen((current) => !current)}
+                aria-label={searchOpen ? "Close search" : "Search work orders"}
+                className="inline-grid h-11 w-11 place-items-center rounded-xl border border-white/20 bg-white/10 text-white"
+              >
+                {searchOpen ? (
+                  <X className="h-5 w-5" />
+                ) : (
+                  <Search className="h-5 w-5" />
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={() => void load("refresh")}
+                aria-label="Refresh work orders"
+                className="inline-grid h-11 w-11 place-items-center rounded-xl border border-white/20 bg-white/10 text-white disabled:opacity-55"
+                disabled={refreshing}
+              >
+                <RefreshCw
+                  className={`h-5 w-5 ${refreshing ? "animate-spin" : ""}`}
+                />
+              </button>
+            </div>
           </div>
-          <div className="flex shrink-0 gap-2">
-            <button
-              type="button"
-              onClick={() => setSearchOpen((current) => !current)}
-              aria-label={searchOpen ? "Close search" : "Search work orders"}
-              className="inline-grid h-11 w-11 place-items-center rounded-xl border border-white/20 bg-white/10 text-white"
-            >
-              {searchOpen ? (
-                <X className="h-5 w-5" />
-              ) : (
-                <Search className="h-5 w-5" />
-              )}
-            </button>
-            <button
-              type="button"
-              onClick={() => void load("refresh")}
-              aria-label="Refresh work orders"
-              className="inline-grid h-11 w-11 place-items-center rounded-xl border border-white/20 bg-white/10 text-white disabled:opacity-55"
-              disabled={refreshing}
-            >
-              <RefreshCw
-                className={`h-5 w-5 ${refreshing ? "animate-spin" : ""}`}
-              />
-            </button>
-          </div>
-        </div>
 
-        {searchOpen ? (
-          <div className="relative mt-4">
-            <Search
-              aria-hidden
-              className="pointer-events-none absolute left-3 top-1/2 h-4.5 w-4.5 -translate-y-1/2 text-slate-400"
-            />
-            <input
-              autoFocus
-              value={queryText}
-              onChange={(event) => setQueryText(event.target.value)}
-              placeholder="Search RO, customer, plate or vehicle"
-              className="w-full pl-10 pr-4"
-            />
-          </div>
-        ) : null}
-      </section>
+          {searchOpen ? (
+            <div className="relative mt-4">
+              <Search
+                aria-hidden
+                className="pointer-events-none absolute left-3 top-1/2 h-4.5 w-4.5 -translate-y-1/2 text-slate-400"
+              />
+              <input
+                autoFocus
+                value={queryText}
+                onChange={(event) => setQueryText(event.target.value)}
+                placeholder="Search RO, customer, plate or vehicle"
+                className="w-full pl-10 pr-4"
+              />
+            </div>
+          ) : null}
+        </section>
       ) : null}
 
       <section className="mt-3 overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] shadow-[var(--mobile-shadow)]">
         {!lockStatus ? (
-        <div className="flex items-center gap-2 overflow-x-auto px-3 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          <Filter
-            aria-hidden
-            className="h-4 w-4 shrink-0 text-[color:var(--theme-text-muted)]"
-          />
-          {FILTERS.map((filter) => {
-            const active = status === filter.value;
-            return (
-              <button
-                key={filter.value || "active"}
-                type="button"
-                onClick={() => setStatus(filter.value)}
-                className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
-                  active
-                    ? "border-[color:var(--accent-copper)] bg-[color:var(--accent-copper)] text-white"
-                    : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-secondary)]"
-                }`}
-              >
-                {filter.label}
-              </button>
-            );
-          })}
-        </div>
+          <div className="flex items-center gap-2 overflow-x-auto px-3 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            <Filter
+              aria-hidden
+              className="h-4 w-4 shrink-0 text-[color:var(--theme-text-muted)]"
+            />
+            {FILTERS.map((filter) => {
+              const active = status === filter.value;
+              return (
+                <button
+                  key={filter.value || "active"}
+                  type="button"
+                  onClick={() => setStatus(filter.value)}
+                  className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                    active
+                      ? "border-[color:var(--accent-copper)] bg-[color:var(--accent-copper)] text-white"
+                      : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-secondary)]"
+                  }`}
+                >
+                  {filter.label}
+                </button>
+              );
+            })}
+          </div>
         ) : null}
         <div className="flex items-center justify-between border-t border-[color:var(--theme-border-soft)] px-4 py-2.5 text-xs text-[color:var(--theme-text-secondary)]">
           <span>
             {filteredRows.length} work order
             {filteredRows.length === 1 ? "" : "s"}
           </span>
-          {!assignedOnly ? (
-            <Link
-              href="/mobile/work-orders/create"
-              className="inline-flex items-center gap-1.5 font-bold text-[color:var(--accent-copper)]"
-            >
-              <Plus aria-hidden className="h-4 w-4" />
-              Create
-            </Link>
-          ) : null}
+          <div className="flex items-center gap-3">
+            {embedded ? (
+              <button
+                type="button"
+                onClick={() => void load("refresh")}
+                aria-label="Refresh active repairs"
+                className="inline-flex items-center gap-1.5 font-bold text-[color:var(--accent-copper)] disabled:opacity-55"
+                disabled={refreshing}
+              >
+                <RefreshCw
+                  aria-hidden
+                  className={`h-4 w-4 ${refreshing ? "animate-spin" : ""}`}
+                />
+                Refresh
+              </button>
+            ) : null}
+            {!assignedOnly ? (
+              <Link
+                href="/mobile/work-orders/create"
+                className="inline-flex items-center gap-1.5 font-bold text-[color:var(--accent-copper)]"
+              >
+                <Plus aria-hidden className="h-4 w-4" />
+                Create
+              </Link>
+            ) : null}
+          </div>
         </div>
       </section>
 

--- a/tests/field-active-work.test.ts
+++ b/tests/field-active-work.test.ts
@@ -49,17 +49,4 @@ describe("Field active-work cockpit", () => {
       expect(cockpit).toContain(`href: "${href}"`);
     }
   });
-
-  it("keeps manual and automatic recovery paths in the embedded repair queue", () => {
-    expect(workOrderQueue).toContain('aria-label="Refresh active repairs"');
-    expect(workOrderQueue).toContain(
-      'window.addEventListener("online", refreshIfOnline)',
-    );
-    expect(workOrderQueue).toContain(
-      'window.addEventListener("focus", refreshIfOnline)',
-    );
-    expect(workOrderQueue).toContain(
-      'document.addEventListener("visibilitychange", refreshWhenVisible)',
-    );
-  });
 });

--- a/tests/field-active-work.test.ts
+++ b/tests/field-active-work.test.ts
@@ -49,4 +49,17 @@ describe("Field active-work cockpit", () => {
       expect(cockpit).toContain(`href: "${href}"`);
     }
   });
+
+  it("keeps manual and automatic recovery paths in the embedded repair queue", () => {
+    expect(workOrderQueue).toContain('aria-label="Refresh active repairs"');
+    expect(workOrderQueue).toContain(
+      'window.addEventListener("online", refreshIfOnline)',
+    );
+    expect(workOrderQueue).toContain(
+      'window.addEventListener("focus", refreshIfOnline)',
+    );
+    expect(workOrderQueue).toContain(
+      'document.addEventListener("visibilitychange", refreshWhenVisible)',
+    );
+  });
 });

--- a/tests/mobile-work-order-queue-recovery.test.tsx
+++ b/tests/mobile-work-order-queue-recovery.test.tsx
@@ -1,0 +1,208 @@
+import React from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import MobileWorkOrderQueue from "@/features/mobile/work-orders/MobileWorkOrderQueue";
+
+type WorkOrderResult = {
+  data: Array<Record<string, unknown>>;
+  error: null;
+};
+
+const mocks = vi.hoisted(() => ({
+  authGetUser: vi.fn(async () => ({
+    data: { user: { id: "00000000-0000-4000-8000-000000000001" } },
+    error: null,
+  })),
+  defaultWorkOrderResult: { data: [], error: null } as WorkOrderResult,
+  workOrderRequestCount: 0,
+  workOrderResults: [] as Array<Promise<WorkOrderResult>>,
+}));
+
+vi.mock("@/features/shared/lib/offline/database", () => ({
+  getOfflineSnapshot: vi.fn(async () => null),
+  saveOfflineSnapshot: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/features/shared/lib/offline/mutations", () => ({
+  getOfflineMutationScope: vi.fn(() => null),
+  setOfflineMutationScope: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/rbac", () => ({
+  getActorCapabilities: vi.fn(() => ({
+    canManageWorkOrders: true,
+    canPerformAssignedWork: false,
+    canViewShopWideData: true,
+  })),
+}));
+
+vi.mock("@/features/shared/lib/supabase/client", () => {
+  const chain = (result: Promise<unknown>) => {
+    const builder: Record<string, unknown> = {};
+    for (const method of ["eq", "in", "limit", "order", "select"]) {
+      builder[method] = vi.fn(() => builder);
+    }
+    builder.maybeSingle = vi.fn(() => result);
+    builder.then = (
+      onFulfilled: (value: unknown) => unknown,
+      onRejected?: (reason: unknown) => unknown,
+    ) => result.then(onFulfilled, onRejected);
+    return builder;
+  };
+
+  const channel = {
+    on: vi.fn(),
+    subscribe: vi.fn(),
+  };
+  channel.on.mockReturnValue(channel);
+  channel.subscribe.mockReturnValue(channel);
+
+  return {
+    createBrowserSupabase: () => ({
+      auth: { getUser: mocks.authGetUser },
+      channel: vi.fn(() => channel),
+      from: vi.fn((table: string) => {
+        if (table === "profiles") {
+          return chain(
+            Promise.resolve({
+              data: {
+                role: "manager",
+                shop_id: "00000000-0000-4000-8000-000000000002",
+              },
+              error: null,
+            }),
+          );
+        }
+        if (table === "work_order_lines") {
+          return chain(Promise.resolve({ data: [], error: null }));
+        }
+        if (table === "work_orders") {
+          mocks.workOrderRequestCount += 1;
+          return chain(
+            mocks.workOrderResults.shift() ??
+              Promise.resolve(mocks.defaultWorkOrderResult),
+          );
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+      removeChannel: vi.fn(async () => undefined),
+    }),
+  };
+});
+
+function workOrder(customId: string): Record<string, unknown> {
+  return {
+    id: `00000000-0000-4000-8000-${customId.padEnd(12, "0").slice(0, 12)}`,
+    custom_id: customId,
+    status: "in_progress",
+    created_at: "2026-08-18T20:00:00.000Z",
+    customers: {
+      first_name: "Jamie",
+      last_name: "Smith",
+      phone: "555-0100",
+    },
+    vehicles: {
+      year: 2024,
+      make: "Ford",
+      model: "F-550",
+      license_plate: "FIELD1",
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function renderEmbeddedQueue() {
+  return render(
+    <MobileWorkOrderQueue initialStatus="in_progress" embedded lockStatus />,
+  );
+}
+
+describe("MobileWorkOrderQueue recovery", () => {
+  beforeEach(() => {
+    mocks.authGetUser.mockClear();
+    mocks.workOrderRequestCount = 0;
+    mocks.workOrderResults.length = 0;
+    mocks.defaultWorkOrderResult = {
+      data: [workOrder("WO-INITIAL")],
+      error: null,
+    };
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+  });
+
+  it("reloads from the embedded button and each browser recovery signal", async () => {
+    renderEmbeddedQueue();
+    await screen.findByText(/WO-INITIAL/);
+    expect(mocks.workOrderRequestCount).toBe(1);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh active repairs" }),
+    );
+    await waitFor(() => expect(mocks.workOrderRequestCount).toBe(2));
+
+    act(() => window.dispatchEvent(new Event("online")));
+    await waitFor(() => expect(mocks.workOrderRequestCount).toBe(3));
+
+    act(() => window.dispatchEvent(new Event("focus")));
+    await waitFor(() => expect(mocks.workOrderRequestCount).toBe(4));
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    await waitFor(() => expect(mocks.workOrderRequestCount).toBe(5));
+  });
+
+  it("does not let an older refresh overwrite the latest queue response", async () => {
+    const olderRefresh = deferred<WorkOrderResult>();
+    const latestRefresh = deferred<WorkOrderResult>();
+    mocks.workOrderResults.push(
+      Promise.resolve({ data: [workOrder("WO-INITIAL")], error: null }),
+      olderRefresh.promise,
+      latestRefresh.promise,
+    );
+
+    renderEmbeddedQueue();
+    await screen.findByText(/WO-INITIAL/);
+
+    act(() => window.dispatchEvent(new Event("focus")));
+    await waitFor(() => expect(mocks.workOrderRequestCount).toBe(2));
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    await waitFor(() => expect(mocks.workOrderRequestCount).toBe(3));
+
+    await act(async () => {
+      latestRefresh.resolve({
+        data: [workOrder("WO-LATEST")],
+        error: null,
+      });
+      await latestRefresh.promise;
+    });
+    await screen.findByText(/WO-LATEST/);
+
+    await act(async () => {
+      olderRefresh.resolve({ data: [workOrder("WO-STALE")], error: null });
+      await olderRefresh.promise;
+    });
+
+    expect(screen.getByText(/WO-LATEST/)).toBeInTheDocument();
+    expect(screen.queryByText(/WO-STALE/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What changed

- restores a visible refresh action when the canonical work-order queue is embedded in the Field active-work cockpit
- retries the queue when connectivity returns, the browser window regains focus, or the tab becomes visible
- makes async queue loads generation-safe so only the newest request may publish rows, errors, access state, or loading indicators
- replaces the source-scanning recovery assertion with rendered behavior tests for the button, reconnect, focus, visibility, and out-of-order responses
- keeps retries online-only and preserves the existing offline snapshot behavior

## Why

Codex correctly identified that PR #1474 hid the queue hero—and therefore its only refresh control—on `/mobile/service/jobs`. An initial request failure or an empty offline launch could leave the operator with no recovery path short of reloading or leaving the cockpit.

The first #1475 review also identified that focus and visibility recovery could overlap and let an older response overwrite newer queue state. The request-generation guard now makes stale loads unable to mutate the visible queue or clear the current loading state.

## Scope and safety

This is a forward-only UI recovery fix. It changes no schema, migration, RLS policy, RPC, tenant boundary, or data writer.

## Validation

- `pnpm typecheck`
- ESLint on the changed component and tests
- 5 focused Field/mobile test files: 26 tests passed
- rendered recovery tests exercise all four triggers and out-of-order request completion
- `git diff --check`