### PR TITLE
Disable Vercel preview builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,6 +224,11 @@ iteration and run when a PR becomes Ready. `Agent PR Checks` remains universal;
 migration diffs also require Supabase clean replay. Preserve check names and
 concurrency behavior unless the task explicitly redesigns CI.
 
+Vercel Git deployments are production-only for cost control. Keep
+`vercel.json` configured with `main: true` and the wildcard fallback set to
+`false`. Do not add preview branch allowlists or an `ignoreCommand` override
+unless the user explicitly requests preview deployments.
+
 Green CI is necessary but not sufficient. Before recommending merge, confirm
 the final diff, final head, unresolved findings, migration state, and deployment
 ordering. Never merge or enable auto-merge without explicit approval.

--- a/vercel.json
+++ b/vercel.json
@@ -29,12 +29,9 @@
       "schedule": "*/5 * * * *"
     }
   ],
-  "ignoreCommand": "exit 1",
   "git": {
     "deploymentEnabled": {
       "main": true,
-      "agent/*": true,
-      "codex/*": true,
       "*": false
     }
   }


### PR DESCRIPTION
## Outcome

Restores production-only Vercel Git deployments and makes the cost-control rule persistent.

## Changes

- removes the `ignoreCommand: "exit 1"` override that forced builds past the manually configured ignored-build behavior
- removes the `agent/*` and `codex/*` preview allowlists
- preserves production deployments for `main` with a wildcard `false` fallback
- records the production-only policy in `AGENTS.md` so agents do not re-enable previews without explicit instruction

## Validation

- `vercel.json` parses as valid JSON
- `git diff --check` passed
- after pushing this branch, Vercel created a canceled deployment record and did not run a preview build

## Database

No schema or migration changes.