### PR TITLE
Align Field phone navigation with build plan

### DIFF
--- a/features/mobile/service/FieldWorkspaceShell.tsx
+++ b/features/mobile/service/FieldWorkspaceShell.tsx
@@ -347,13 +347,13 @@ export default function FieldWorkspaceShell({ children }: { children: ReactNode 
         </Link>
         {workspaceCapabilities.canManageScheduling ? (
           <Link
-            href="/mobile/service/dispatch"
+            href="/mobile/appointments"
             data-active={
-              pathname.startsWith("/mobile/service/dispatch") ? "true" : "false"
+              pathname.startsWith("/mobile/appointments") ? "true" : "false"
             }
           >
-            <RadioTower aria-hidden className="h-5 w-5" />
-            <span>Dispatch</span>
+            <CalendarDays aria-hidden className="h-5 w-5" />
+            <span>Schedule</span>
           </Link>
         ) : (
           <Link

--- a/tests/field-active-work.test.ts
+++ b/tests/field-active-work.test.ts
@@ -31,7 +31,7 @@ describe("Field active-work cockpit", () => {
   });
 
   it("keeps the service lifecycle and repair queue valid when embedded in one page landmark", () => {
-    expect(serviceShell).toContain("<div\n      className={`${");
+    expect(serviceShell).toMatch(/<div\r?\n\s+className=\{`\$\{/);
     expect(workOrderQueue).toContain(
       '<div className="mobile-work-order-queue">',
     );

--- a/tests/field-service-call-dispatch.test.ts
+++ b/tests/field-service-call-dispatch.test.ts
@@ -11,14 +11,16 @@ const visitApi = read("app/api/dispatch/visits/[id]/route.ts");
 const intakeApi = read("app/api/mobile/service/intake/route.ts");
 
 describe("Field service-call dispatch", () => {
-  it("gives scheduling-capable Field operators a native Dispatch destination", () => {
+  it("keeps Dispatch available without replacing Schedule in the phone bar", () => {
     expect(fieldShell).toMatch(
       /label: "Dispatch"[\s\S]*?href: "\/mobile\/service\/dispatch"[\s\S]*?requiredCapability: "canManageScheduling"/,
     );
     expect(fieldHub).toMatch(
       /id: "dispatch_queue"[\s\S]*?href: "\/mobile\/service\/dispatch"[\s\S]*?requiredCapability: "canManageScheduling"/,
     );
-    expect(fieldShell).toContain("<span>Dispatch</span>");
+    expect(fieldShell).toMatch(
+      /canManageScheduling \? \([\s\S]*?href="\/mobile\/appointments"[\s\S]*?<CalendarDays[\s\S]*?<span>Schedule<\/span>/,
+    );
   });
 
   it("server-guards the Field dispatch page and reuses the canonical board", () => {


### PR DESCRIPTION
## Outcome

Restores the build-plan phone navigation contract while preserving the new canonical Dispatch surface.

## Changes

- restores the scheduling-capable phone bar to `Today / Schedule / New / Work / More`
- keeps Dispatch available in the Field sidebar/drawer and dashboard command card
- makes the active-work source assertion tolerant of Windows and Unix line endings
- updates the dispatch contract test to protect both Schedule and Dispatch destinations

## Validation

- 47 focused Field tests passed across 7 test files
- targeted ESLint passed
- TypeScript `--noEmit` passed
- `git diff --check` passed
- formal diff review found no tenant, auth, data-write, accessibility, or routing regressions

## Database

No schema or migration changes.