### PR TITLE
Field: add unpaid invoices and history

### DIFF
--- a/app/api/mobile/service/invoices/route.ts
+++ b/app/api/mobile/service/invoices/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+import { listFieldInvoiceHistory } from "@/features/mobile/service/server/fieldInvoiceHistory";
+import { requireMobileServiceOperatorApiAccess } from "@/features/mobile/service/server/access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+export async function GET() {
+  const access = await requireMobileServiceOperatorApiAccess();
+  if (!access.ok) return access.response;
+  if (!access.actor.canManageWorkOrders) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const rows = await listFieldInvoiceHistory({
+      supabase: createAdminSupabase(),
+      shopId: access.profile.shop_id,
+    });
+
+    return NextResponse.json(
+      { ok: true, rows },
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
+  } catch (error) {
+    console.error("[field-invoices] read failed", {
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+    return NextResponse.json(
+      { error: "Invoice history is unavailable." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/mobile/service/invoices/route.ts
+++ b/app/api/mobile/service/invoices/route.ts
@@ -1,8 +1,20 @@
 import { NextResponse } from "next/server";
 
 import { listFieldInvoiceHistory } from "@/features/mobile/service/server/fieldInvoiceHistory";
-import { requireMobileServiceOperatorApiAccess } from "@/features/mobile/service/server/access";
+import {
+  listFieldOperatorAssignedWorkOrderIds,
+  requireMobileServiceOperatorApiAccess,
+} from "@/features/mobile/service/server/access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+function invoiceHistoryResponse(
+  rows: Awaited<ReturnType<typeof listFieldInvoiceHistory>>,
+) {
+  return NextResponse.json(
+    { ok: true, rows },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}
 
 export async function GET() {
   const access = await requireMobileServiceOperatorApiAccess();
@@ -12,15 +24,23 @@ export async function GET() {
   }
 
   try {
+    const scope = access.managementRole
+      ? ({ kind: "shop" } as const)
+      : ({
+          kind: "work_orders",
+          ids: await listFieldOperatorAssignedWorkOrderIds(access),
+        } as const);
+    if (scope.kind === "work_orders" && scope.ids.length === 0) {
+      return invoiceHistoryResponse([]);
+    }
+
     const rows = await listFieldInvoiceHistory({
       supabase: createAdminSupabase(),
       shopId: access.profile.shop_id,
+      scope,
     });
 
-    return NextResponse.json(
-      { ok: true, rows },
-      { headers: { "Cache-Control": "private, no-store" } },
-    );
+    return invoiceHistoryResponse(rows);
   } catch (error) {
     console.error("[field-invoices] read failed", {
       message: error instanceof Error ? error.message : "Unknown error",

--- a/app/mobile/service/invoices/page.tsx
+++ b/app/mobile/service/invoices/page.tsx
@@ -1,0 +1,13 @@
+import FieldInvoicesHistory from "@/features/mobile/service/FieldInvoicesHistory";
+import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export const dynamic = "force-dynamic";
+
+export default async function FieldInvoicesHistoryPage() {
+  await requireShopPageAccess({
+    requiredCapability: "canManageWorkOrders",
+    redirectTo: "/mobile/service",
+  });
+
+  return <FieldInvoicesHistory />;
+}

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -137,9 +137,9 @@ const FIELD_DASHBOARD_CARDS: FieldDashboardCard[] = [
   },
   {
     id: "unpaid_invoices",
-    title: "Ready for closeout",
-    description: "Invoice completed work and take payment in the field.",
-    href: "/mobile/work-orders?status=ready_to_invoice&mode=field_closeout",
+    title: "Unpaid invoices",
+    description: "Collect open balances and review completed invoices.",
+    href: "/mobile/service/invoices",
     icon: ReceiptText,
     requiredCapability: "canManageOperations",
   },

--- a/features/mobile/service/FieldInvoicesHistory.tsx
+++ b/features/mobile/service/FieldInvoicesHistory.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/features/mobile/service/fieldInvoiceHistory";
 import {
   getOfflineSnapshot,
+  removeOfflineSnapshots,
   saveOfflineSnapshot,
 } from "@/features/shared/lib/offline/database";
 import { getOfflineMutationScope } from "@/features/shared/lib/offline/mutations";
@@ -39,6 +40,27 @@ const FILTERS: Array<{ value: FieldInvoiceFilter; label: string }> = [
 const SNAPSHOT_KIND = "field-invoice-history";
 const SNAPSHOT_ENTITY = "latest";
 const SNAPSHOT_MAX_AGE_MS = 1000 * 60 * 60 * 12;
+let snapshotWriteQueue: Promise<void> = Promise.resolve();
+
+function enqueueSnapshotWrite(operation: () => Promise<void>): Promise<void> {
+  const write = snapshotWriteQueue.catch(() => undefined).then(operation);
+  snapshotWriteQueue = write.catch(() => undefined);
+  return write;
+}
+
+class InvoiceHistoryResponseError extends Error {
+  constructor(
+    message: string,
+    readonly allowsSavedSnapshot: boolean,
+  ) {
+    super(message);
+    this.name = "InvoiceHistoryResponseError";
+  }
+}
+
+function isRetryableResponseStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
 
 function money(value: number, currency: string): string {
   return new Intl.NumberFormat("en-CA", {
@@ -71,6 +93,7 @@ export default function FieldInvoicesHistory() {
   const [showingSaved, setShowingSaved] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const loadGeneration = useRef(0);
+  const snapshotFallbackBlocked = useRef(false);
 
   const load = useCallback(async (mode: "initial" | "refresh" = "initial") => {
     const generation = ++loadGeneration.current;
@@ -86,26 +109,59 @@ export default function FieldInvoicesHistory() {
         cache: "no-store",
         headers: { Accept: "application/json" },
       });
-      const body = (await response.json().catch(() => null)) as
-        | InvoiceHistoryResponse
-        | null;
-      if (!response.ok || !body?.ok) {
-        throw new Error(body?.error ?? "Invoices and history could not load.");
-      }
+      const body = (await response
+        .json()
+        .catch(() => null)) as InvoiceHistoryResponse | null;
       if (!isLatest()) return;
+      if (response.status === 401 || response.status === 403) {
+        snapshotFallbackBlocked.current = true;
+        setRows([]);
+        setShowingSaved(false);
+        setErrorMessage(
+          body?.error ?? "You no longer have access to invoices.",
+        );
+        if (scope) {
+          try {
+            await enqueueSnapshotWrite(() =>
+              removeOfflineSnapshots({
+                scope,
+                kind: SNAPSHOT_KIND,
+                entityIds: [SNAPSHOT_ENTITY],
+              }),
+            );
+          } catch (snapshotError) {
+            console.warn("[field-invoices] denied snapshot cleanup failed", {
+              message:
+                snapshotError instanceof Error
+                  ? snapshotError.message
+                  : "Unknown error",
+            });
+          }
+        }
+        return;
+      }
+      if (!response.ok || !body?.ok) {
+        throw new InvoiceHistoryResponseError(
+          body?.error ?? "Invoices and history could not load.",
+          response.ok || isRetryableResponseStatus(response.status),
+        );
+      }
 
       const nextRows = body.rows ?? [];
+      snapshotFallbackBlocked.current = false;
       setRows(nextRows);
       setShowingSaved(false);
       if (scope) {
         try {
-          await saveOfflineSnapshot({
-            scope,
-            kind: SNAPSHOT_KIND,
-            entityId: SNAPSHOT_ENTITY,
-            data: nextRows,
-            maxAgeMs: SNAPSHOT_MAX_AGE_MS,
-          });
+          await enqueueSnapshotWrite(() =>
+            saveOfflineSnapshot({
+              scope,
+              kind: SNAPSHOT_KIND,
+              entityId: SNAPSHOT_ENTITY,
+              data: nextRows,
+              maxAgeMs: SNAPSHOT_MAX_AGE_MS,
+            }),
+          );
         } catch (snapshotError) {
           console.warn("[field-invoices] snapshot save failed", {
             message:
@@ -117,13 +173,18 @@ export default function FieldInvoicesHistory() {
       }
     } catch (error) {
       if (!isLatest()) return;
-      const snapshot = scope
-        ? await getOfflineSnapshot<FieldInvoiceHistoryRow[]>({
-            scope,
-            kind: SNAPSHOT_KIND,
-            entityId: SNAPSHOT_ENTITY,
-          })
-        : null;
+      const allowsSavedSnapshot =
+        !snapshotFallbackBlocked.current &&
+        (!(error instanceof InvoiceHistoryResponseError) ||
+          error.allowsSavedSnapshot);
+      const snapshot =
+        allowsSavedSnapshot && scope
+          ? await getOfflineSnapshot<FieldInvoiceHistoryRow[]>({
+              scope,
+              kind: SNAPSHOT_KIND,
+              entityId: SNAPSHOT_ENTITY,
+            })
+          : null;
       if (!isLatest()) return;
 
       if (snapshot) {
@@ -150,6 +211,9 @@ export default function FieldInvoicesHistory() {
   useEffect(() => {
     setOnline(navigator.onLine);
     void load();
+    return () => {
+      loadGeneration.current += 1;
+    };
   }, [load]);
 
   useEffect(() => {
@@ -181,6 +245,7 @@ export default function FieldInvoicesHistory() {
     [filter, query, rows],
   );
   const outstandingLabels = Object.entries(summary.outstandingByCurrency);
+  const liveActionsAvailable = online && !showingSaved;
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-3">
@@ -188,7 +253,9 @@ export default function FieldInvoicesHistory() {
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="mobile-dashboard-hero__eyebrow">Money</div>
-            <h1 className="mobile-dashboard-hero__title">Invoices &amp; history</h1>
+            <h1 className="mobile-dashboard-hero__title">
+              Invoices &amp; history
+            </h1>
             <p className="mobile-dashboard-hero__subtitle">
               Collect open balances and find completed Field invoices.
             </p>
@@ -219,7 +286,10 @@ export default function FieldInvoicesHistory() {
         </div>
       ) : null}
 
-      <section className="grid grid-cols-2 gap-2 sm:grid-cols-3" aria-label="Invoice summary">
+      <section
+        className="grid grid-cols-2 gap-2 sm:grid-cols-3"
+        aria-label="Invoice summary"
+      >
         <div className="mobile-command-panel border p-3">
           <WalletCards aria-hidden className="h-4 w-4 text-amber-500" />
           <div className="mt-2 text-2xl font-black text-[color:var(--theme-text-primary)]">
@@ -344,7 +414,8 @@ export default function FieldInvoicesHistory() {
                     </span>
                   </div>
                   <div className="mt-1 text-xs font-semibold text-[color:var(--theme-text-secondary)]">
-                    {row.workOrderNumber || `#${row.workOrderId.slice(0, 8)}`} · {row.customerName}
+                    {row.workOrderNumber || `#${row.workOrderId.slice(0, 8)}`} ·{" "}
+                    {row.customerName}
                   </div>
                   <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
                     {row.vehicleLabel}
@@ -371,7 +442,7 @@ export default function FieldInvoicesHistory() {
                   {dateLabel(row.issuedAt)}
                 </span>
                 <div className="flex flex-wrap justify-end gap-2">
-                  {online ? (
+                  {liveActionsAvailable ? (
                     <Link
                       href={`/api/work-orders/${encodeURIComponent(row.workOrderId)}/invoice-pdf`}
                       target="_blank"
@@ -387,7 +458,7 @@ export default function FieldInvoicesHistory() {
                   >
                     Work order <ChevronRight aria-hidden className="h-4 w-4" />
                   </Link>
-                  {online ? (
+                  {liveActionsAvailable ? (
                     <Link
                       href={`/mobile/service/closeout/${encodeURIComponent(row.workOrderId)}`}
                       className="inline-flex min-h-10 items-center gap-1 rounded-xl bg-[color:var(--accent-copper)] px-3 text-xs font-extrabold text-white"

--- a/features/mobile/service/FieldInvoicesHistory.tsx
+++ b/features/mobile/service/FieldInvoicesHistory.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import {
+  CheckCircle2,
+  ChevronRight,
+  FileDown,
+  ReceiptText,
+  RefreshCw,
+  Search,
+  WalletCards,
+  WifiOff,
+} from "lucide-react";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  filterFieldInvoiceHistoryRows,
+  summarizeFieldInvoiceHistory,
+  type FieldInvoiceFilter,
+  type FieldInvoiceHistoryRow,
+} from "@/features/mobile/service/fieldInvoiceHistory";
+import {
+  getOfflineSnapshot,
+  saveOfflineSnapshot,
+} from "@/features/shared/lib/offline/database";
+import { getOfflineMutationScope } from "@/features/shared/lib/offline/mutations";
+
+type InvoiceHistoryResponse = {
+  ok?: boolean;
+  rows?: FieldInvoiceHistoryRow[];
+  error?: string;
+};
+
+const FILTERS: Array<{ value: FieldInvoiceFilter; label: string }> = [
+  { value: "unpaid", label: "Unpaid" },
+  { value: "paid", label: "Paid" },
+  { value: "all", label: "All history" },
+];
+const SNAPSHOT_KIND = "field-invoice-history";
+const SNAPSHOT_ENTITY = "latest";
+const SNAPSHOT_MAX_AGE_MS = 1000 * 60 * 60 * 12;
+
+function money(value: number, currency: string): string {
+  return new Intl.NumberFormat("en-CA", {
+    style: "currency",
+    currency: currency || "CAD",
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function dateLabel(value: string | null): string {
+  if (!value) return "Issue date unavailable";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
+function invoiceIdentity(row: FieldInvoiceHistoryRow): string {
+  return row.invoiceNumber || `Invoice version ${row.versionNumber}`;
+}
+
+export default function FieldInvoicesHistory() {
+  const [rows, setRows] = useState<FieldInvoiceHistoryRow[]>([]);
+  const [filter, setFilter] = useState<FieldInvoiceFilter>("unpaid");
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [online, setOnline] = useState(true);
+  const [showingSaved, setShowingSaved] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const loadGeneration = useRef(0);
+
+  const load = useCallback(async (mode: "initial" | "refresh" = "initial") => {
+    const generation = ++loadGeneration.current;
+    const isLatest = () => loadGeneration.current === generation;
+    if (mode === "refresh") setRefreshing(true);
+    else setLoading(true);
+    setErrorMessage(null);
+
+    const scope = getOfflineMutationScope();
+    try {
+      const response = await fetch("/api/mobile/service/invoices", {
+        credentials: "include",
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+      });
+      const body = (await response.json().catch(() => null)) as
+        | InvoiceHistoryResponse
+        | null;
+      if (!response.ok || !body?.ok) {
+        throw new Error(body?.error ?? "Invoices and history could not load.");
+      }
+      if (!isLatest()) return;
+
+      const nextRows = body.rows ?? [];
+      setRows(nextRows);
+      setShowingSaved(false);
+      if (scope) {
+        try {
+          await saveOfflineSnapshot({
+            scope,
+            kind: SNAPSHOT_KIND,
+            entityId: SNAPSHOT_ENTITY,
+            data: nextRows,
+            maxAgeMs: SNAPSHOT_MAX_AGE_MS,
+          });
+        } catch (snapshotError) {
+          console.warn("[field-invoices] snapshot save failed", {
+            message:
+              snapshotError instanceof Error
+                ? snapshotError.message
+                : "Unknown error",
+          });
+        }
+      }
+    } catch (error) {
+      if (!isLatest()) return;
+      const snapshot = scope
+        ? await getOfflineSnapshot<FieldInvoiceHistoryRow[]>({
+            scope,
+            kind: SNAPSHOT_KIND,
+            entityId: SNAPSHOT_ENTITY,
+          })
+        : null;
+      if (!isLatest()) return;
+
+      if (snapshot) {
+        setRows(snapshot.data);
+        setShowingSaved(true);
+        setErrorMessage(null);
+      } else {
+        setRows([]);
+        setShowingSaved(false);
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : "Invoices and history could not load.",
+        );
+      }
+    } finally {
+      if (isLatest()) {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    setOnline(navigator.onLine);
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const refreshIfOnline = () => {
+      const isOnline = navigator.onLine;
+      setOnline(isOnline);
+      if (isOnline) void load("refresh");
+    };
+    const markOffline = () => setOnline(false);
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === "visible") refreshIfOnline();
+    };
+
+    window.addEventListener("online", refreshIfOnline);
+    window.addEventListener("offline", markOffline);
+    window.addEventListener("focus", refreshIfOnline);
+    document.addEventListener("visibilitychange", refreshWhenVisible);
+    return () => {
+      window.removeEventListener("online", refreshIfOnline);
+      window.removeEventListener("offline", markOffline);
+      window.removeEventListener("focus", refreshIfOnline);
+      document.removeEventListener("visibilitychange", refreshWhenVisible);
+    };
+  }, [load]);
+
+  const summary = useMemo(() => summarizeFieldInvoiceHistory(rows), [rows]);
+  const filteredRows = useMemo(
+    () => filterFieldInvoiceHistoryRows(rows, filter, query),
+    [filter, query, rows],
+  );
+  const outstandingLabels = Object.entries(summary.outstandingByCurrency);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-3">
+      <section className="mobile-dashboard-hero">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="mobile-dashboard-hero__eyebrow">Money</div>
+            <h1 className="mobile-dashboard-hero__title">Invoices &amp; history</h1>
+            <p className="mobile-dashboard-hero__subtitle">
+              Collect open balances and find completed Field invoices.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void load("refresh")}
+            aria-label="Refresh invoices and history"
+            className="inline-grid h-11 w-11 shrink-0 place-items-center rounded-xl border border-white/20 bg-white/10 text-white disabled:opacity-55"
+            disabled={refreshing || !online}
+          >
+            <RefreshCw
+              aria-hidden
+              className={`h-5 w-5 ${refreshing ? "animate-spin" : ""}`}
+            />
+          </button>
+        </div>
+      </section>
+
+      {!online || showingSaved ? (
+        <div className="flex items-start gap-2 rounded-2xl border border-amber-500/35 bg-amber-500/10 p-3 text-sm text-amber-800 dark:text-amber-100">
+          <WifiOff aria-hidden className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>
+            {showingSaved
+              ? "Saved invoice history is available for reference. Reconnect before collecting payment or opening a PDF."
+              : "You are offline. Reconnect to refresh invoice balances."}
+          </span>
+        </div>
+      ) : null}
+
+      <section className="grid grid-cols-2 gap-2 sm:grid-cols-3" aria-label="Invoice summary">
+        <div className="mobile-command-panel border p-3">
+          <WalletCards aria-hidden className="h-4 w-4 text-amber-500" />
+          <div className="mt-2 text-2xl font-black text-[color:var(--theme-text-primary)]">
+            {summary.unpaidCount}
+          </div>
+          <div className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+            Unpaid invoices
+          </div>
+        </div>
+        <div className="mobile-command-panel border p-3">
+          <CheckCircle2 aria-hidden className="h-4 w-4 text-emerald-500" />
+          <div className="mt-2 text-2xl font-black text-[color:var(--theme-text-primary)]">
+            {summary.paidCount}
+          </div>
+          <div className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+            Paid history
+          </div>
+        </div>
+        <div className="mobile-command-panel col-span-2 border p-3 sm:col-span-1">
+          <ReceiptText aria-hidden className="h-4 w-4 text-sky-500" />
+          <div className="mt-2 text-base font-black text-[color:var(--theme-text-primary)]">
+            {outstandingLabels.length > 0
+              ? outstandingLabels
+                  .map(([currency, value]) => money(value, currency))
+                  .join(" · ")
+              : money(0, "CAD")}
+          </div>
+          <div className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+            Outstanding
+          </div>
+        </div>
+      </section>
+
+      <section className="mobile-command-panel overflow-hidden border">
+        <div className="flex items-center gap-2 overflow-x-auto px-3 py-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {FILTERS.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              onClick={() => setFilter(item.value)}
+              aria-pressed={filter === item.value}
+              className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                filter === item.value
+                  ? "border-[color:var(--accent-copper)] bg-[color:var(--accent-copper)] text-white"
+                  : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-secondary)]"
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+        <div className="relative border-t border-[color:var(--theme-border-soft)] p-3">
+          <Search
+            aria-hidden
+            className="pointer-events-none absolute left-6 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--theme-text-muted)]"
+          />
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search invoice, RO, customer, plate or vehicle"
+            aria-label="Search invoices and history"
+            className="w-full pl-10 pr-4"
+          />
+        </div>
+      </section>
+
+      {errorMessage ? (
+        <div
+          className={`rounded-2xl border p-3 text-sm ${
+            showingSaved
+              ? "border-amber-500/35 bg-amber-500/10 text-amber-800 dark:text-amber-100"
+              : "border-red-500/35 bg-red-500/10 text-red-700 dark:text-red-200"
+          }`}
+        >
+          {errorMessage}
+        </div>
+      ) : null}
+
+      <section className="space-y-2.5" aria-label="Invoice results">
+        {loading ? (
+          Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-40 animate-pulse rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]"
+            />
+          ))
+        ) : filteredRows.length === 0 ? (
+          <div className="mobile-command-panel border p-6 text-center">
+            <ReceiptText
+              aria-hidden
+              className="mx-auto h-8 w-8 text-[color:var(--theme-text-muted)]"
+            />
+            <h2 className="mt-2 text-base font-extrabold text-[color:var(--theme-text-primary)]">
+              {filter === "unpaid" ? "No unpaid invoices" : "No invoices found"}
+            </h2>
+            <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+              {query
+                ? "Try another invoice, customer, work order or vehicle."
+                : "Completed Field invoices will appear here."}
+            </p>
+          </div>
+        ) : (
+          filteredRows.map((row) => (
+            <article
+              key={row.invoiceVersionId}
+              className="mobile-command-row overflow-hidden border p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h2 className="truncate text-base font-extrabold text-[color:var(--theme-text-primary)]">
+                      {invoiceIdentity(row)}
+                    </h2>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[0.65rem] font-extrabold uppercase tracking-[0.12em] ${
+                        row.paymentState === "paid"
+                          ? "bg-emerald-500/12 text-emerald-700 dark:text-emerald-200"
+                          : "bg-amber-500/12 text-amber-700 dark:text-amber-200"
+                      }`}
+                    >
+                      {row.paymentState}
+                    </span>
+                  </div>
+                  <div className="mt-1 text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                    {row.workOrderNumber || `#${row.workOrderId.slice(0, 8)}`} · {row.customerName}
+                  </div>
+                  <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                    {row.vehicleLabel}
+                    {row.licensePlate ? ` · ${row.licensePlate}` : ""}
+                  </div>
+                </div>
+                <div className="shrink-0 text-right">
+                  <div className="text-lg font-black text-[color:var(--theme-text-primary)]">
+                    {money(
+                      row.paymentState === "unpaid"
+                        ? row.outstandingTotal
+                        : row.total,
+                      row.currency,
+                    )}
+                  </div>
+                  <div className="text-[0.68rem] text-[color:var(--theme-text-muted)]">
+                    {row.paymentState === "unpaid" ? "due" : "total"}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-[color:var(--theme-border-soft)] pt-3">
+                <span className="text-xs text-[color:var(--theme-text-muted)]">
+                  {dateLabel(row.issuedAt)}
+                </span>
+                <div className="flex flex-wrap justify-end gap-2">
+                  {online ? (
+                    <Link
+                      href={`/api/work-orders/${encodeURIComponent(row.workOrderId)}/invoice-pdf`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex min-h-10 items-center gap-1.5 rounded-xl border border-[color:var(--theme-border-soft)] px-3 text-xs font-bold text-[color:var(--theme-text-primary)]"
+                    >
+                      <FileDown aria-hidden className="h-4 w-4" /> PDF
+                    </Link>
+                  ) : null}
+                  <Link
+                    href={`/mobile/work-orders/${encodeURIComponent(row.workOrderId)}`}
+                    className="inline-flex min-h-10 items-center gap-1 rounded-xl border border-[color:var(--theme-border-soft)] px-3 text-xs font-bold text-[color:var(--theme-text-primary)]"
+                  >
+                    Work order <ChevronRight aria-hidden className="h-4 w-4" />
+                  </Link>
+                  {online ? (
+                    <Link
+                      href={`/mobile/service/closeout/${encodeURIComponent(row.workOrderId)}`}
+                      className="inline-flex min-h-10 items-center gap-1 rounded-xl bg-[color:var(--accent-copper)] px-3 text-xs font-extrabold text-white"
+                    >
+                      {row.paymentState === "unpaid"
+                        ? "Collect payment"
+                        : "View receipt"}
+                      <ChevronRight aria-hidden className="h-4 w-4" />
+                    </Link>
+                  ) : null}
+                </div>
+              </div>
+            </article>
+          ))
+        )}
+      </section>
+    </div>
+  );
+}

--- a/features/mobile/service/FieldWorkspaceShell.tsx
+++ b/features/mobile/service/FieldWorkspaceShell.tsx
@@ -12,6 +12,7 @@ import {
   PackagePlus,
   Plus,
   RadioTower,
+  ReceiptText,
   Settings2,
   Wrench,
   X,
@@ -72,6 +73,12 @@ const WORK_NAV: FieldNavItem[] = [
 
 const OPERATIONS_NAV: FieldNavItem[] = [
   {
+    label: "Invoices & history",
+    href: "/mobile/service/invoices",
+    icon: ReceiptText,
+    requiredCapability: "canManageOperations",
+  },
+  {
     label: "Truck inventory",
     href: "/mobile/service/truck-inventory",
     icon: PackageOpen,
@@ -110,6 +117,9 @@ function pageTitle(pathname: string): string {
   if (pathname.startsWith("/mobile/service/new")) return "New service call";
   if (pathname.startsWith("/mobile/service/jobs")) return "Active field work";
   if (pathname.startsWith("/mobile/service/dispatch")) return "Dispatch";
+  if (pathname.startsWith("/mobile/service/invoices")) {
+    return "Invoices & history";
+  }
   if (pathname.startsWith("/mobile/service/truck-inventory")) {
     return "Truck inventory";
   }

--- a/features/mobile/service/fieldInvoiceHistory.test.ts
+++ b/features/mobile/service/fieldInvoiceHistory.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFieldInvoiceHistoryRows,
+  filterFieldInvoiceHistoryRows,
+  summarizeFieldInvoiceHistory,
+  type FieldInvoiceVersion,
+  type FieldInvoiceWorkOrder,
+} from "./fieldInvoiceHistory";
+
+function workOrder(
+  id: string,
+  overrides: Partial<FieldInvoiceWorkOrder> = {},
+): FieldInvoiceWorkOrder {
+  return {
+    id,
+    custom_id: `RO-${id}`,
+    updated_at: "2026-08-18T12:00:00.000Z",
+    paid_at: null,
+    customers: {
+      first_name: "Jamie",
+      last_name: "Smith",
+      email: "jamie@example.com",
+    },
+    vehicles: {
+      year: 2024,
+      make: "Ford",
+      model: "F-550",
+      license_plate: "FIELD1",
+    },
+    ...overrides,
+  };
+}
+
+function version(
+  id: string,
+  workOrderId: string,
+  overrides: Partial<FieldInvoiceVersion> = {},
+): FieldInvoiceVersion {
+  return {
+    id,
+    work_order_id: workOrderId,
+    version_number: 1,
+    lifecycle_status: "issued",
+    currency: "CAD",
+    total: 500,
+    paid_total: 0,
+    refunded_total: 0,
+    outstanding_total: 500,
+    issued_at: "2026-08-18T12:00:00.000Z",
+    created_at: "2026-08-18T12:00:00.000Z",
+    invoices: { invoice_number: `INV-${id}` },
+    ...overrides,
+  };
+}
+
+describe("Field invoice history", () => {
+  it("uses the latest active invoice version and derives payment state from canonical balances", () => {
+    const rows = buildFieldInvoiceHistoryRows(
+      [workOrder("one"), workOrder("two")],
+      [
+        version("old", "one", { version_number: 1, outstanding_total: 500 }),
+        version("new", "one", {
+          version_number: 2,
+          lifecycle_status: "partially_paid",
+          paid_total: 300,
+          outstanding_total: 200,
+        }),
+        version("void", "one", {
+          version_number: 3,
+          lifecycle_status: "voided",
+          outstanding_total: 0,
+        }),
+        version("paid", "two", {
+          lifecycle_status: "paid",
+          outstanding_total: 0,
+          paid_total: 500,
+        }),
+      ],
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows.find((row) => row.workOrderId === "one")).toMatchObject({
+      invoiceVersionId: "new",
+      paymentState: "unpaid",
+      outstandingTotal: 200,
+    });
+    expect(rows.find((row) => row.workOrderId === "two")?.paymentState).toBe(
+      "paid",
+    );
+  });
+
+  it("filters by payment state and operational identity", () => {
+    const rows = buildFieldInvoiceHistoryRows(
+      [
+        workOrder("one"),
+        workOrder("two", {
+          custom_id: "RO-SPECIAL",
+          customers: {
+            first_name: "Taylor",
+            last_name: "Jones",
+            email: "taylor@example.com",
+          },
+        }),
+      ],
+      [
+        version("one", "one"),
+        version("two", "two", {
+          lifecycle_status: "paid",
+          outstanding_total: 0,
+        }),
+      ],
+    );
+
+    expect(filterFieldInvoiceHistoryRows(rows, "unpaid", "field1")).toHaveLength(1);
+    expect(filterFieldInvoiceHistoryRows(rows, "paid", "Taylor")).toHaveLength(1);
+    expect(filterFieldInvoiceHistoryRows(rows, "unpaid", "RO-SPECIAL")).toEqual([]);
+  });
+
+  it("summarizes unpaid balances without mixing currencies", () => {
+    const rows = buildFieldInvoiceHistoryRows(
+      [workOrder("cad"), workOrder("usd"), workOrder("paid")],
+      [
+        version("cad", "cad", { outstanding_total: 200 }),
+        version("usd", "usd", { currency: "USD", outstanding_total: 75 }),
+        version("paid", "paid", {
+          lifecycle_status: "paid",
+          outstanding_total: 0,
+        }),
+      ],
+    );
+
+    expect(summarizeFieldInvoiceHistory(rows)).toEqual({
+      unpaidCount: 2,
+      paidCount: 1,
+      outstandingByCurrency: { CAD: 200, USD: 75 },
+    });
+  });
+});

--- a/features/mobile/service/fieldInvoiceHistory.ts
+++ b/features/mobile/service/fieldInvoiceHistory.ts
@@ -1,0 +1,212 @@
+export const FIELD_INVOICE_ACTIVE_STATES = [
+  "issued",
+  "partially_paid",
+  "paid",
+] as const;
+
+export type FieldInvoiceFilter = "unpaid" | "paid" | "all";
+
+export type FieldInvoiceWorkOrder = {
+  id: string;
+  custom_id: string | null;
+  updated_at: string | null;
+  paid_at: string | null;
+  customers: {
+    first_name: string | null;
+    last_name: string | null;
+    email: string | null;
+  } | Array<{
+    first_name: string | null;
+    last_name: string | null;
+    email: string | null;
+  }> | null;
+  vehicles: {
+    year: number | null;
+    make: string | null;
+    model: string | null;
+    license_plate: string | null;
+  } | Array<{
+    year: number | null;
+    make: string | null;
+    model: string | null;
+    license_plate: string | null;
+  }> | null;
+};
+
+export type FieldInvoiceVersion = {
+  id: string;
+  work_order_id: string;
+  version_number: number;
+  lifecycle_status: string;
+  currency: string;
+  total: number | null;
+  paid_total: number | null;
+  refunded_total: number | null;
+  outstanding_total: number | null;
+  issued_at: string | null;
+  created_at: string;
+  invoices:
+    | { invoice_number: string | null }
+    | Array<{ invoice_number: string | null }>
+    | null;
+};
+
+export type FieldInvoiceHistoryRow = {
+  invoiceVersionId: string;
+  invoiceNumber: string | null;
+  versionNumber: number;
+  workOrderId: string;
+  workOrderNumber: string | null;
+  lifecycleStatus: string;
+  paymentState: Exclude<FieldInvoiceFilter, "all">;
+  currency: string;
+  total: number;
+  paidTotal: number;
+  refundedTotal: number;
+  outstandingTotal: number;
+  issuedAt: string | null;
+  updatedAt: string | null;
+  paidAt: string | null;
+  customerName: string;
+  customerEmail: string | null;
+  vehicleLabel: string;
+  licensePlate: string | null;
+};
+
+function numberValue(value: number | null | undefined): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function singleRelation<T>(value: T | T[] | null | undefined): T | null {
+  return Array.isArray(value) ? (value[0] ?? null) : (value ?? null);
+}
+
+function customerName(workOrder: FieldInvoiceWorkOrder): string {
+  const customer = singleRelation(workOrder.customers);
+  return [
+    customer?.first_name ?? "",
+    customer?.last_name ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ") || "No customer";
+}
+
+function vehicleLabel(workOrder: FieldInvoiceWorkOrder): string {
+  const vehicle = singleRelation(workOrder.vehicles);
+  return [
+    vehicle?.year ?? "",
+    vehicle?.make ?? "",
+    vehicle?.model ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ") || "Vehicle not linked";
+}
+
+function timestamp(value: string | null | undefined): number {
+  if (!value) return 0;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function buildFieldInvoiceHistoryRows(
+  workOrders: FieldInvoiceWorkOrder[],
+  versions: FieldInvoiceVersion[],
+): FieldInvoiceHistoryRow[] {
+  const latestByWorkOrder = new Map<string, FieldInvoiceVersion>();
+
+  for (const version of versions) {
+    if (!FIELD_INVOICE_ACTIVE_STATES.includes(
+      version.lifecycle_status as (typeof FIELD_INVOICE_ACTIVE_STATES)[number],
+    )) {
+      continue;
+    }
+    const current = latestByWorkOrder.get(version.work_order_id);
+    if (!current || version.version_number > current.version_number) {
+      latestByWorkOrder.set(version.work_order_id, version);
+    }
+  }
+
+  return workOrders
+    .flatMap((workOrder): FieldInvoiceHistoryRow[] => {
+      const version = latestByWorkOrder.get(workOrder.id);
+      if (!version) return [];
+
+      const outstandingTotal = numberValue(version.outstanding_total);
+      const customer = singleRelation(workOrder.customers);
+      const vehicle = singleRelation(workOrder.vehicles);
+      const invoice = singleRelation(version.invoices);
+      const paymentState =
+        version.lifecycle_status === "paid" || outstandingTotal <= 0.005
+          ? "paid"
+          : "unpaid";
+
+      return [
+        {
+          invoiceVersionId: version.id,
+          invoiceNumber: invoice?.invoice_number ?? null,
+          versionNumber: version.version_number,
+          workOrderId: workOrder.id,
+          workOrderNumber: workOrder.custom_id,
+          lifecycleStatus: version.lifecycle_status,
+          paymentState,
+          currency: version.currency.toUpperCase() || "CAD",
+          total: numberValue(version.total),
+          paidTotal: numberValue(version.paid_total),
+          refundedTotal: numberValue(version.refunded_total),
+          outstandingTotal,
+          issuedAt: version.issued_at,
+          updatedAt: workOrder.updated_at,
+          paidAt: workOrder.paid_at,
+          customerName: customerName(workOrder),
+          customerEmail: customer?.email ?? null,
+          vehicleLabel: vehicleLabel(workOrder),
+          licensePlate: vehicle?.license_plate ?? null,
+        },
+      ];
+    })
+    .sort(
+      (left, right) =>
+        timestamp(right.issuedAt ?? right.updatedAt) -
+        timestamp(left.issuedAt ?? left.updatedAt),
+    );
+}
+
+export function filterFieldInvoiceHistoryRows(
+  rows: FieldInvoiceHistoryRow[],
+  filter: FieldInvoiceFilter,
+  query: string,
+): FieldInvoiceHistoryRow[] {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  return rows.filter((row) => {
+    if (filter !== "all" && row.paymentState !== filter) return false;
+    if (!normalizedQuery) return true;
+
+    return [
+      row.invoiceNumber,
+      row.workOrderNumber,
+      row.customerName,
+      row.customerEmail,
+      row.vehicleLabel,
+      row.licensePlate,
+    ].some((value) => value?.toLowerCase().includes(normalizedQuery));
+  });
+}
+
+export function summarizeFieldInvoiceHistory(rows: FieldInvoiceHistoryRow[]) {
+  const unpaid = rows.filter((row) => row.paymentState === "unpaid");
+  const paid = rows.filter((row) => row.paymentState === "paid");
+  return {
+    unpaidCount: unpaid.length,
+    paidCount: paid.length,
+    outstandingByCurrency: unpaid.reduce<Record<string, number>>(
+      (totals, row) => {
+        totals[row.currency] =
+          numberValue(totals[row.currency]) + row.outstandingTotal;
+        return totals;
+      },
+      {},
+    ),
+  };
+}

--- a/features/mobile/service/server/access.ts
+++ b/features/mobile/service/server/access.ts
@@ -4,13 +4,19 @@ import { NextResponse } from "next/server";
 
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 import type { FieldWorkspaceCapabilities } from "@/features/mobile/service/fieldWorkspaceCapabilities";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import {
+  getActorCapabilities,
+  hasAnyRole,
+  ROLE_GROUPS,
+} from "@/features/shared/lib/rbac";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type ShopAccess = Extract<
   Awaited<ReturnType<typeof requireShopScopedApiAccess>>,
   { ok: true }
 >;
+
+const FIELD_ASSIGNMENT_PAGE_SIZE = 500;
 
 export type MobileFieldServiceAccess = {
   fieldServiceEnabled: boolean;
@@ -47,8 +53,8 @@ export function resolveMobileFieldServiceAccess(input: {
 }): MobileFieldServiceAccess {
   const fieldServiceEnabled = Boolean(
     input.productEntitled &&
-      input.onboardingCompletedAt &&
-      ["mobile", "both"].includes(input.serviceModel ?? ""),
+    input.onboardingCompletedAt &&
+    ["mobile", "both"].includes(input.serviceModel ?? ""),
   );
   const canConfigure = ["owner", "admin"].includes(input.canonicalRole);
 
@@ -164,6 +170,40 @@ export async function canFieldOperatorAccessWorkOrder(
   return Boolean(data);
 }
 
+export async function listFieldOperatorAssignedWorkOrderIds(
+  access: ShopAccess,
+): Promise<string[]> {
+  const actor = getActorCapabilities({ role: access.profile.role });
+  const fieldAccess = await getMobileFieldServiceAccess(access);
+  if (!fieldAccess.canAccessFieldService || !actor.canPerformAssignedWork) {
+    return [];
+  }
+
+  const workOrderIds = new Set<string>();
+  let from = 0;
+
+  while (true) {
+    const { data, error } = await access.supabase
+      .from("service_visits")
+      .select("work_order_id")
+      .eq("shop_id", access.profile.shop_id)
+      .eq("assigned_user_id", access.profile.id)
+      .not("work_order_id", "is", null)
+      .order("id", { ascending: true })
+      .range(from, from + FIELD_ASSIGNMENT_PAGE_SIZE - 1);
+    if (error) throw new Error(error.message);
+
+    const page = (data ?? []) as Array<{ work_order_id: string | null }>;
+    if (page.length === 0) break;
+    for (const visit of page) {
+      if (visit.work_order_id) workOrderIds.add(visit.work_order_id);
+    }
+    from += page.length;
+  }
+
+  return [...workOrderIds];
+}
+
 export async function requireMobileServiceOperatorApiAccess() {
   const access = await requireShopScopedApiAccess();
   if (!access.ok) return access;
@@ -194,9 +234,7 @@ export async function requireMobileServiceOperatorApiAccess() {
     isFieldOperator: fieldAccess.isFieldOperator,
     managementRole:
       fieldAccess.canAccessFieldService &&
-      ["owner", "admin", "manager", "advisor", "service"].includes(
-        access.canonicalRole,
-      ),
+      hasAnyRole(access.canonicalRole, ROLE_GROUPS.billingOperators),
     fieldServiceEnabled: fieldAccess.fieldServiceEnabled,
   };
 }

--- a/features/mobile/service/server/fieldInvoiceHistory.test.ts
+++ b/features/mobile/service/server/fieldInvoiceHistory.test.ts
@@ -1,0 +1,237 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { describe, expect, it } from "vitest";
+
+import type { Database } from "@shared/types/types/supabase";
+import {
+  listFieldInvoiceHistory,
+  type FieldInvoiceHistoryScope,
+} from "./fieldInvoiceHistory";
+
+type QueryRow = Record<string, unknown>;
+
+type QueryRecord = {
+  table: string;
+  select: string;
+  ranges: Array<[number, number]>;
+  inFilters: Map<string, readonly unknown[]>;
+};
+
+function fakeSupabase(args: {
+  workOrders: QueryRow[];
+  versions: QueryRow[];
+  fail?: (table: string, from: number) => string | null;
+}) {
+  const records: QueryRecord[] = [];
+  let fromCalls = 0;
+
+  const from = (table: string) => {
+    fromCalls += 1;
+    const equals = new Map<string, unknown>();
+    const inFilters = new Map<string, readonly unknown[]>();
+    const record: QueryRecord = {
+      table,
+      select: "",
+      ranges: [],
+      inFilters,
+    };
+    records.push(record);
+
+    const builder = {
+      select(columns: string) {
+        record.select = columns;
+        return builder;
+      },
+      eq(column: string, value: unknown) {
+        equals.set(column, value);
+        return builder;
+      },
+      in(column: string, values: readonly unknown[]) {
+        inFilters.set(column, values);
+        return builder;
+      },
+      order() {
+        return builder;
+      },
+      async range(rangeFrom: number, rangeTo: number) {
+        record.ranges.push([rangeFrom, rangeTo]);
+        const failure = args.fail?.(table, rangeFrom);
+        if (failure) return { data: null, error: { message: failure } };
+
+        let rows = table === "work_orders" ? args.workOrders : args.versions;
+        for (const [column, value] of equals) {
+          rows = rows.filter((row) => row[column] === value);
+        }
+        for (const [column, values] of inFilters) {
+          const accepted = new Set(values);
+          rows = rows.filter((row) => accepted.has(row[column]));
+        }
+        return {
+          data: rows.slice(rangeFrom, rangeTo + 1),
+          error: null,
+        };
+      },
+    };
+
+    return builder;
+  };
+
+  return {
+    client: { from } as unknown as SupabaseClient<Database>,
+    records,
+    get fromCalls() {
+      return fromCalls;
+    },
+  };
+}
+
+function historyFixture(size: number) {
+  const workOrders = Array.from({ length: size }, (_, index) => {
+    const id = `wo-${String(index).padStart(4, "0")}`;
+    return {
+      id,
+      shop_id: "shop-1",
+      status: "invoiced",
+      custom_id: `RO-${index}`,
+      updated_at: "2026-08-18T12:00:00.000Z",
+      paid_at: index === size - 1 ? null : "2026-08-18T13:00:00.000Z",
+      customers: {
+        first_name: "Jamie",
+        last_name: "Smith",
+        email: "jamie@example.com",
+      },
+      vehicles: {
+        year: 2024,
+        make: "Ford",
+        model: "F-550",
+        license_plate: "FIELD1",
+      },
+    };
+  });
+  const versions = workOrders.map((workOrder, index) => ({
+    id: `version-${String(index).padStart(4, "0")}`,
+    shop_id: "shop-1",
+    work_order_id: workOrder.id,
+    version_number: 1,
+    lifecycle_status: index === size - 1 ? "issued" : "paid",
+    currency: "CAD",
+    total: 500,
+    paid_total: index === size - 1 ? 475 : 500,
+    refunded_total: 0,
+    outstanding_total: index === size - 1 ? 25 : 0,
+    issued_at: "2026-08-18T12:00:00.000Z",
+    created_at: "2026-08-18T12:00:00.000Z",
+    invoices: { invoice_number: `INV-${index}` },
+  }));
+  return { workOrders, versions };
+}
+
+async function load(
+  fixture: ReturnType<typeof historyFixture>,
+  scope: FieldInvoiceHistoryScope = { kind: "shop" },
+) {
+  const fake = fakeSupabase(fixture);
+  const rows = await listFieldInvoiceHistory({
+    supabase: fake.client,
+    shopId: "shop-1",
+    scope,
+  });
+  return { fake, rows };
+}
+
+describe("listFieldInvoiceHistory", () => {
+  it("keeps an old unpaid invoice beyond the first work-order page", async () => {
+    const { fake, rows } = await load(historyFixture(501));
+
+    expect(rows).toHaveLength(501);
+    expect(rows.find((row) => row.workOrderId === "wo-0500")).toMatchObject({
+      paymentState: "unpaid",
+      outstandingTotal: 25,
+    });
+    expect(
+      fake.records
+        .filter((record) => record.table === "work_orders")
+        .flatMap((record) => record.ranges),
+    ).toEqual([
+      [0, 499],
+      [500, 999],
+      [501, 1000],
+    ]);
+    expect(
+      fake.records.find((record) => record.table === "invoice_versions")
+        ?.select,
+    ).toContain(
+      "invoices:invoices!invoice_versions_invoice_id_fkey(invoice_number)",
+    );
+  });
+
+  it("paginates every active invoice version before choosing the latest one", async () => {
+    const fixture = historyFixture(1);
+    fixture.versions = Array.from({ length: 501 }, (_, index) => ({
+      ...fixture.versions[0],
+      id: `version-${String(index).padStart(4, "0")}`,
+      version_number: index + 1,
+      outstanding_total: index === 500 ? 30 : 500,
+      invoices: { invoice_number: `INV-${index}` },
+    }));
+
+    const { fake, rows } = await load(fixture);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      versionNumber: 501,
+      invoiceNumber: "INV-500",
+      outstandingTotal: 30,
+    });
+    expect(
+      fake.records
+        .filter((record) => record.table === "invoice_versions")
+        .flatMap((record) => record.ranges),
+    ).toEqual([
+      [0, 499],
+      [500, 999],
+      [501, 1000],
+    ]);
+  });
+
+  it("fails closed for an empty assigned scope and filters a populated one", async () => {
+    const fixture = historyFixture(2);
+    const empty = fakeSupabase(fixture);
+
+    await expect(
+      listFieldInvoiceHistory({
+        supabase: empty.client,
+        shopId: "shop-1",
+        scope: { kind: "work_orders", ids: [] },
+      }),
+    ).resolves.toEqual([]);
+    expect(empty.fromCalls).toBe(0);
+
+    const { fake, rows } = await load(fixture, {
+      kind: "work_orders",
+      ids: ["wo-0001", "wo-0001"],
+    });
+    expect(rows.map((row) => row.workOrderId)).toEqual(["wo-0001"]);
+    expect(
+      fake.records
+        .find((record) => record.table === "work_orders")
+        ?.inFilters.get("id"),
+    ).toEqual(["wo-0001"]);
+  });
+
+  it("rejects a later-page failure instead of returning partial financial data", async () => {
+    const fixture = historyFixture(501);
+    const fake = fakeSupabase({
+      ...fixture,
+      fail: (table, from) =>
+        table === "work_orders" && from === 500 ? "second page failed" : null,
+    });
+
+    await expect(
+      listFieldInvoiceHistory({
+        supabase: fake.client,
+        shopId: "shop-1",
+        scope: { kind: "shop" },
+      }),
+    ).rejects.toThrow("second page failed");
+  });
+});

--- a/features/mobile/service/server/fieldInvoiceHistory.ts
+++ b/features/mobile/service/server/fieldInvoiceHistory.ts
@@ -1,0 +1,49 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@shared/types/types/supabase";
+import {
+  buildFieldInvoiceHistoryRows,
+  FIELD_INVOICE_ACTIVE_STATES,
+  type FieldInvoiceHistoryRow,
+  type FieldInvoiceVersion,
+  type FieldInvoiceWorkOrder,
+} from "@/features/mobile/service/fieldInvoiceHistory";
+
+type DB = Database;
+
+export async function listFieldInvoiceHistory(args: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+}): Promise<FieldInvoiceHistoryRow[]> {
+  const { data: workOrderData, error: workOrderError } = await args.supabase
+    .from("work_orders")
+    .select(
+      "id,custom_id,updated_at,paid_at,customers:customers(first_name,last_name,email),vehicles:vehicles(year,make,model,license_plate)",
+    )
+    .eq("shop_id", args.shopId)
+    .eq("status", "invoiced")
+    .order("updated_at", { ascending: false })
+    .limit(200);
+
+  if (workOrderError) throw new Error(workOrderError.message);
+  const workOrders = (workOrderData ?? []) as FieldInvoiceWorkOrder[];
+  if (workOrders.length === 0) return [];
+
+  const { data: versionData, error: versionError } = await args.supabase
+    .from("invoice_versions")
+    .select(
+      "id,work_order_id,version_number,lifecycle_status,currency,total,paid_total,refunded_total,outstanding_total,issued_at,created_at,invoices:invoices(invoice_number)",
+    )
+    .eq("shop_id", args.shopId)
+    .in("work_order_id", workOrders.map((workOrder) => workOrder.id))
+    .in("lifecycle_status", [...FIELD_INVOICE_ACTIVE_STATES])
+    .order("version_number", { ascending: false });
+
+  if (versionError) throw new Error(versionError.message);
+  return buildFieldInvoiceHistoryRows(
+    workOrders,
+    (versionData ?? []) as FieldInvoiceVersion[],
+  );
+}

--- a/features/mobile/service/server/fieldInvoiceHistory.ts
+++ b/features/mobile/service/server/fieldInvoiceHistory.ts
@@ -13,37 +13,113 @@ import {
 
 type DB = Database;
 
+const QUERY_PAGE_SIZE = 500;
+const ID_FILTER_CHUNK_SIZE = 100;
+
+export type FieldInvoiceHistoryScope =
+  | { kind: "shop" }
+  | { kind: "work_orders"; ids: readonly string[] };
+
+type PageResult<T> = {
+  data: T[] | null;
+  error: { message: string } | null;
+};
+
+async function collectAllPages<T>(
+  loadPage: (from: number, to: number) => Promise<PageResult<T>>,
+): Promise<T[]> {
+  const rows: T[] = [];
+  let from = 0;
+
+  while (true) {
+    const page = await loadPage(from, from + QUERY_PAGE_SIZE - 1);
+    if (page.error) throw new Error(page.error.message);
+    const pageRows = page.data ?? [];
+    if (pageRows.length === 0) return rows;
+    rows.push(...pageRows);
+    from += pageRows.length;
+  }
+}
+
+function chunkIds(ids: readonly string[]): string[][] {
+  const chunks: string[][] = [];
+  for (let index = 0; index < ids.length; index += ID_FILTER_CHUNK_SIZE) {
+    chunks.push(ids.slice(index, index + ID_FILTER_CHUNK_SIZE));
+  }
+  return chunks;
+}
+
 export async function listFieldInvoiceHistory(args: {
   supabase: SupabaseClient<DB>;
   shopId: string;
+  scope: FieldInvoiceHistoryScope;
 }): Promise<FieldInvoiceHistoryRow[]> {
-  const { data: workOrderData, error: workOrderError } = await args.supabase
-    .from("work_orders")
-    .select(
-      "id,custom_id,updated_at,paid_at,customers:customers(first_name,last_name,email),vehicles:vehicles(year,make,model,license_plate)",
-    )
-    .eq("shop_id", args.shopId)
-    .eq("status", "invoiced")
-    .order("updated_at", { ascending: false })
-    .limit(200);
+  const scopedIds =
+    args.scope.kind === "work_orders"
+      ? [...new Set(args.scope.ids.map((id) => id.trim()).filter(Boolean))]
+      : null;
+  if (scopedIds && scopedIds.length === 0) return [];
 
-  if (workOrderError) throw new Error(workOrderError.message);
-  const workOrders = (workOrderData ?? []) as FieldInvoiceWorkOrder[];
+  const workOrderIdGroups = scopedIds ? chunkIds(scopedIds) : [null];
+  const workOrdersById = new Map<string, FieldInvoiceWorkOrder>();
+
+  for (const idGroup of workOrderIdGroups) {
+    const pageRows = await collectAllPages<FieldInvoiceWorkOrder>(
+      async (from, to) => {
+        let query = args.supabase
+          .from("work_orders")
+          .select(
+            "id,custom_id,updated_at,paid_at,customers:customers(first_name,last_name,email),vehicles:vehicles(year,make,model,license_plate)",
+          )
+          .eq("shop_id", args.shopId)
+          .eq("status", "invoiced");
+        if (idGroup) query = query.in("id", idGroup);
+        const result = await query
+          .order("id", { ascending: true })
+          .range(from, to);
+        return {
+          data: (result.data ?? null) as unknown as
+            | FieldInvoiceWorkOrder[]
+            | null,
+          error: result.error,
+        };
+      },
+    );
+    for (const workOrder of pageRows)
+      workOrdersById.set(workOrder.id, workOrder);
+  }
+
+  const workOrders = [...workOrdersById.values()];
   if (workOrders.length === 0) return [];
 
-  const { data: versionData, error: versionError } = await args.supabase
-    .from("invoice_versions")
-    .select(
-      "id,work_order_id,version_number,lifecycle_status,currency,total,paid_total,refunded_total,outstanding_total,issued_at,created_at,invoices:invoices(invoice_number)",
-    )
-    .eq("shop_id", args.shopId)
-    .in("work_order_id", workOrders.map((workOrder) => workOrder.id))
-    .in("lifecycle_status", [...FIELD_INVOICE_ACTIVE_STATES])
-    .order("version_number", { ascending: false });
+  const versionsById = new Map<string, FieldInvoiceVersion>();
+  for (const workOrderIds of chunkIds(
+    workOrders.map((workOrder) => workOrder.id),
+  )) {
+    const pageRows = await collectAllPages<FieldInvoiceVersion>(
+      async (from, to) => {
+        const result = await args.supabase
+          .from("invoice_versions")
+          .select(
+            "id,work_order_id,version_number,lifecycle_status,currency,total,paid_total,refunded_total,outstanding_total,issued_at,created_at,invoices:invoices!invoice_versions_invoice_id_fkey(invoice_number)",
+          )
+          .eq("shop_id", args.shopId)
+          .in("work_order_id", workOrderIds)
+          .in("lifecycle_status", [...FIELD_INVOICE_ACTIVE_STATES])
+          .order("work_order_id", { ascending: true })
+          .order("version_number", { ascending: false })
+          .order("id", { ascending: true })
+          .range(from, to);
+        return {
+          data: (result.data ?? null) as unknown as
+            | FieldInvoiceVersion[]
+            | null,
+          error: result.error,
+        };
+      },
+    );
+    for (const version of pageRows) versionsById.set(version.id, version);
+  }
 
-  if (versionError) throw new Error(versionError.message);
-  return buildFieldInvoiceHistoryRows(
-    workOrders,
-    (versionData ?? []) as FieldInvoiceVersion[],
-  );
+  return buildFieldInvoiceHistoryRows(workOrders, [...versionsById.values()]);
 }

--- a/tests/field-hub-shell.test.ts
+++ b/tests/field-hub-shell.test.ts
@@ -37,6 +37,7 @@ describe("Field Hub workspace", () => {
       "/mobile/parts",
       "/mobile/service/purchase-orders",
       "/mobile/service/followups",
+      "/mobile/service/invoices",
     ]) {
       expect(`${fieldShell}\n${fieldHub}`).toContain(href);
     }
@@ -104,6 +105,10 @@ describe("Field Hub workspace", () => {
     );
     expect(fieldShell).toContain('label: "Truck inventory"');
     expect(fieldShell.match(/label: "Truck inventory"/g)).toHaveLength(1);
+    expect(fieldShell).toContain('label: "Invoices & history"');
+    expect(fieldHub).toMatch(
+      /id: "unpaid_invoices"[\s\S]*?title: "Unpaid invoices"/,
+    );
   });
 
   it("does not leak Fleet navigation and hides workspace switching unless another product is verified", () => {

--- a/tests/field-invoices-history-contract.test.ts
+++ b/tests/field-invoices-history-contract.test.ts
@@ -6,6 +6,7 @@ const route = read("app/api/mobile/service/invoices/route.ts");
 const serverReader = read(
   "features/mobile/service/server/fieldInvoiceHistory.ts",
 );
+const access = read("features/mobile/service/server/access.ts");
 const page = read("app/mobile/service/invoices/page.tsx");
 const shell = read("features/mobile/service/FieldWorkspaceShell.tsx");
 const hub = read("features/mobile/service/FieldHub.tsx");
@@ -19,7 +20,24 @@ describe("Field invoices and history contract", () => {
     );
     expect(serverReader).toContain('.eq("shop_id", args.shopId)');
     expect(serverReader).toContain('.eq("status", "invoiced")');
-    expect(serverReader).not.toMatch(/\.insert\(|\.update\(|\.delete\(|\.upsert\(/);
+    expect(route).toContain("listFieldOperatorAssignedWorkOrderIds(access)");
+    expect(
+      route.indexOf("listFieldOperatorAssignedWorkOrderIds(access)"),
+    ).toBeLessThan(route.indexOf("createAdminSupabase()"));
+    expect(access).toContain("ROLE_GROUPS.billingOperators");
+    expect(access).toContain('.eq("assigned_user_id", access.profile.id)');
+    expect(serverReader).not.toMatch(
+      /\.insert\(|\.update\(|\.delete\(|\.upsert\(/,
+    );
+  });
+
+  it("paginates complete history through the intended invoice foreign key", () => {
+    expect(serverReader).toContain("collectAllPages");
+    expect(serverReader).toContain(".range(from, to)");
+    expect(serverReader).not.toContain(".limit(200)");
+    expect(serverReader).toContain(
+      "invoices:invoices!invoice_versions_invoice_id_fkey(invoice_number)",
+    );
   });
 
   it("keeps the page and navigation behind the canonical work-order capability", () => {
@@ -33,9 +51,7 @@ describe("Field invoices and history contract", () => {
   });
 
   it("reuses canonical closeout, work-order, and invoice PDF routes", () => {
-    const component = read(
-      "features/mobile/service/FieldInvoicesHistory.tsx",
-    );
+    const component = read("features/mobile/service/FieldInvoicesHistory.tsx");
     expect(component).toContain("/mobile/service/closeout/");
     expect(component).toContain("/mobile/work-orders/");
     expect(component).toContain("/api/work-orders/");

--- a/tests/field-invoices-history-contract.test.ts
+++ b/tests/field-invoices-history-contract.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const route = read("app/api/mobile/service/invoices/route.ts");
+const serverReader = read(
+  "features/mobile/service/server/fieldInvoiceHistory.ts",
+);
+const page = read("app/mobile/service/invoices/page.tsx");
+const shell = read("features/mobile/service/FieldWorkspaceShell.tsx");
+const hub = read("features/mobile/service/FieldHub.tsx");
+
+describe("Field invoices and history contract", () => {
+  it("authorizes the Field actor before a privileged, shop-scoped read", () => {
+    expect(route).toContain("requireMobileServiceOperatorApiAccess");
+    expect(route).toContain("access.actor.canManageWorkOrders");
+    expect(route.indexOf("access.actor.canManageWorkOrders")).toBeLessThan(
+      route.indexOf("createAdminSupabase()"),
+    );
+    expect(serverReader).toContain('.eq("shop_id", args.shopId)');
+    expect(serverReader).toContain('.eq("status", "invoiced")');
+    expect(serverReader).not.toMatch(/\.insert\(|\.update\(|\.delete\(|\.upsert\(/);
+  });
+
+  it("keeps the page and navigation behind the canonical work-order capability", () => {
+    expect(page).toContain('requiredCapability: "canManageWorkOrders"');
+    expect(shell).toMatch(
+      /label: "Invoices & history"[\s\S]*?href: "\/mobile\/service\/invoices"[\s\S]*?requiredCapability: "canManageOperations"/,
+    );
+    expect(hub).toMatch(
+      /id: "unpaid_invoices"[\s\S]*?title: "Unpaid invoices"[\s\S]*?href: "\/mobile\/service\/invoices"[\s\S]*?requiredCapability: "canManageOperations"/,
+    );
+  });
+
+  it("reuses canonical closeout, work-order, and invoice PDF routes", () => {
+    const component = read(
+      "features/mobile/service/FieldInvoicesHistory.tsx",
+    );
+    expect(component).toContain("/mobile/service/closeout/");
+    expect(component).toContain("/mobile/work-orders/");
+    expect(component).toContain("/api/work-orders/");
+    expect(component).toContain("/invoice-pdf");
+    expect(component).not.toContain("RecordManualPayment");
+  });
+});

--- a/tests/field-invoices-history-route.test.ts
+++ b/tests/field-invoices-history-route.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createAdminSupabase: vi.fn(),
+  listAssignedWorkOrderIds: vi.fn(),
+  listInvoiceHistory: vi.fn(),
+  requireAccess: vi.fn(),
+}));
+
+vi.mock("@/features/mobile/service/server/access", () => ({
+  listFieldOperatorAssignedWorkOrderIds: mocks.listAssignedWorkOrderIds,
+  requireMobileServiceOperatorApiAccess: mocks.requireAccess,
+}));
+
+vi.mock("@/features/mobile/service/server/fieldInvoiceHistory", () => ({
+  listFieldInvoiceHistory: mocks.listInvoiceHistory,
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: mocks.createAdminSupabase,
+}));
+
+import { GET } from "../app/api/mobile/service/invoices/route";
+
+const adminClient = { kind: "admin" };
+
+function allowedAccess(managementRole: boolean) {
+  return {
+    ok: true,
+    actor: { canManageWorkOrders: true },
+    profile: { id: "profile-1", shop_id: "shop-1", role: "lead_hand" },
+    managementRole,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.createAdminSupabase.mockReturnValue(adminClient);
+  mocks.listAssignedWorkOrderIds.mockResolvedValue(["work-order-1"]);
+  mocks.listInvoiceHistory.mockResolvedValue([]);
+  mocks.requireAccess.mockResolvedValue(allowedAccess(false));
+});
+
+describe("Field invoice history route", () => {
+  it("derives assigned scope before using the admin client", async () => {
+    await GET();
+
+    expect(mocks.listAssignedWorkOrderIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile: expect.objectContaining({ id: "profile-1" }),
+      }),
+    );
+    expect(
+      mocks.listAssignedWorkOrderIds.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.createAdminSupabase.mock.invocationCallOrder[0]);
+    expect(mocks.listInvoiceHistory).toHaveBeenCalledWith({
+      supabase: adminClient,
+      shopId: "shop-1",
+      scope: { kind: "work_orders", ids: ["work-order-1"] },
+    });
+  });
+
+  it("returns no rows without constructing an admin client when no work is assigned", async () => {
+    mocks.listAssignedWorkOrderIds.mockResolvedValueOnce([]);
+
+    const response = await GET();
+
+    await expect(response.json()).resolves.toEqual({ ok: true, rows: [] });
+    expect(mocks.createAdminSupabase).not.toHaveBeenCalled();
+    expect(mocks.listInvoiceHistory).not.toHaveBeenCalled();
+  });
+
+  it("keeps billing operators on explicit shop scope", async () => {
+    mocks.requireAccess.mockResolvedValueOnce(allowedAccess(true));
+
+    await GET();
+
+    expect(mocks.listAssignedWorkOrderIds).not.toHaveBeenCalled();
+    expect(mocks.listInvoiceHistory).toHaveBeenCalledWith({
+      supabase: adminClient,
+      shopId: "shop-1",
+      scope: { kind: "shop" },
+    });
+  });
+
+  it("fails closed when assigned scope cannot be verified", async () => {
+    mocks.listAssignedWorkOrderIds.mockRejectedValueOnce(
+      new Error("assignment lookup failed"),
+    );
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    expect(mocks.createAdminSupabase).not.toHaveBeenCalled();
+    expect(mocks.listInvoiceHistory).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  it("rejects actors without the work-order capability before any invoice read", async () => {
+    mocks.requireAccess.mockResolvedValueOnce({
+      ...allowedAccess(false),
+      actor: { canManageWorkOrders: false },
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(403);
+    expect(mocks.listAssignedWorkOrderIds).not.toHaveBeenCalled();
+    expect(mocks.createAdminSupabase).not.toHaveBeenCalled();
+  });
+});

--- a/tests/field-invoices-history-ui.test.tsx
+++ b/tests/field-invoices-history-ui.test.tsx
@@ -1,23 +1,34 @@
 // @vitest-environment jsdom
 
 import "@testing-library/jest-dom/vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import FieldInvoicesHistory from "@/features/mobile/service/FieldInvoicesHistory";
 import type { FieldInvoiceHistoryRow } from "@/features/mobile/service/fieldInvoiceHistory";
 import {
   getOfflineSnapshot,
+  removeOfflineSnapshots,
   saveOfflineSnapshot,
 } from "@/features/shared/lib/offline/database";
 
 vi.mock("@/features/shared/lib/offline/database", () => ({
   getOfflineSnapshot: vi.fn(async () => null),
+  removeOfflineSnapshots: vi.fn(async () => undefined),
   saveOfflineSnapshot: vi.fn(async () => undefined),
 }));
 
 vi.mock("@/features/shared/lib/offline/mutations", () => ({
-  getOfflineMutationScope: vi.fn(() => ({ userId: "user-1", shopId: "shop-1" })),
+  getOfflineMutationScope: vi.fn(() => ({
+    userId: "user-1",
+    shopId: "shop-1",
+  })),
 }));
 
 function row(
@@ -49,8 +60,21 @@ function row(
 
 const liveRows = [row("101", "unpaid"), row("102", "paid")];
 
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getOfflineSnapshot).mockReset();
+  vi.mocked(removeOfflineSnapshots).mockReset();
+  vi.mocked(saveOfflineSnapshot).mockReset();
   vi.mocked(getOfflineSnapshot).mockResolvedValue(null);
+  vi.mocked(removeOfflineSnapshots).mockResolvedValue(undefined);
   vi.mocked(saveOfflineSnapshot).mockResolvedValue(undefined);
   Object.defineProperty(window.navigator, "onLine", {
     configurable: true,
@@ -58,11 +82,12 @@ beforeEach(() => {
   });
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () =>
-      new Response(JSON.stringify({ ok: true, rows: liveRows }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true, rows: liveRows }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
     ),
   );
 });
@@ -78,10 +103,9 @@ describe("Field invoices and history", () => {
 
     expect(await screen.findByText("INV-101")).toBeInTheDocument();
     expect(screen.queryByText("INV-102")).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /collect payment/i })).toHaveAttribute(
-      "href",
-      "/mobile/service/closeout/work-order-101",
-    );
+    expect(
+      screen.getByRole("link", { name: /collect payment/i }),
+    ).toHaveAttribute("href", "/mobile/service/closeout/work-order-101");
     expect(screen.getByRole("link", { name: /pdf/i })).toHaveAttribute(
       "href",
       "/api/work-orders/work-order-101/invoice-pdf",
@@ -94,7 +118,9 @@ describe("Field invoices and history", () => {
     fireEvent.click(screen.getByRole("button", { name: "Paid" }));
     expect(await screen.findByText("INV-102")).toBeInTheDocument();
     expect(screen.queryByText("INV-101")).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /view receipt/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /view receipt/i }),
+    ).toBeInTheDocument();
   });
 
   it("uses the tenant-scoped saved snapshot for offline reference without payment or PDF actions", async () => {
@@ -117,9 +143,200 @@ describe("Field invoices and history", () => {
     render(<FieldInvoicesHistory />);
 
     expect(await screen.findByText("INV-101")).toBeInTheDocument();
-    expect(screen.getByText(/Saved invoice history is available/)).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: /collect payment/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: /pdf/i })).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Saved invoice history is available/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /collect payment/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /pdf/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides live actions when an online request falls back to saved data", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Temporarily unavailable" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.mocked(getOfflineSnapshot).mockResolvedValueOnce({
+      key: "user-1:shop-1:field-invoice-history:latest",
+      kind: "field-invoice-history",
+      entityId: "latest",
+      userId: "user-1",
+      shopId: "shop-1",
+      updatedAt: "2026-08-18T12:00:00.000Z",
+      expiresAt: "2026-08-19T00:00:00.000Z",
+      data: [row("101", "unpaid")],
+    });
+
+    render(<FieldInvoicesHistory />);
+
+    expect(await screen.findByText("INV-101")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Saved invoice history is available/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /collect payment/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /pdf/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /work order/i }),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    [401, "Unauthorized"],
+    [403, "Forbidden"],
+  ])(
+    "withholds and removes saved financial data after a %s response",
+    async (status, message) => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: message }), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+      vi.mocked(getOfflineSnapshot).mockResolvedValueOnce({
+        key: "user-1:shop-1:field-invoice-history:latest",
+        kind: "field-invoice-history",
+        entityId: "latest",
+        userId: "user-1",
+        shopId: "shop-1",
+        updatedAt: "2026-08-18T12:00:00.000Z",
+        expiresAt: "2026-08-19T00:00:00.000Z",
+        data: [row("101", "unpaid")],
+      });
+
+      render(<FieldInvoicesHistory />);
+
+      expect(await screen.findByText(message)).toBeInTheDocument();
+      expect(screen.queryByText("INV-101")).not.toBeInTheDocument();
+      expect(getOfflineSnapshot).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(removeOfflineSnapshots).toHaveBeenCalledWith({
+          scope: { userId: "user-1", shopId: "shop-1" },
+          kind: "field-invoice-history",
+          entityIds: ["latest"],
+        }),
+      );
+      expect(
+        screen.queryByRole("link", { name: /collect payment/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: /pdf/i }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it("orders a newly mounted access denial after an older pending snapshot save", async () => {
+    const pendingSave = deferred();
+    const operations: string[] = [];
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, rows: liveRows }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Forbidden" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.mocked(saveOfflineSnapshot).mockImplementationOnce(async () => {
+      await pendingSave.promise;
+      operations.push("save");
+    });
+    vi.mocked(removeOfflineSnapshots).mockImplementationOnce(async () => {
+      operations.push("remove");
+    });
+
+    const firstView = render(<FieldInvoicesHistory />);
+
+    await waitFor(() => expect(saveOfflineSnapshot).toHaveBeenCalledOnce());
+    firstView.unmount();
+    render(<FieldInvoicesHistory />);
+    expect(await screen.findByText("Forbidden")).toBeInTheDocument();
+    expect(removeOfflineSnapshots).not.toHaveBeenCalled();
+
+    pendingSave.resolve(undefined);
+    await waitFor(() => expect(removeOfflineSnapshots).toHaveBeenCalledOnce());
+    expect(operations).toEqual(["save", "remove"]);
+  });
+
+  it("orders a newly mounted authorized snapshot save after an older pending purge", async () => {
+    const pendingRemove = deferred();
+    const operations: string[] = [];
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Forbidden" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true, rows: liveRows }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.mocked(removeOfflineSnapshots).mockImplementationOnce(async () => {
+      await pendingRemove.promise;
+      operations.push("remove");
+    });
+    vi.mocked(saveOfflineSnapshot).mockImplementationOnce(async () => {
+      operations.push("save");
+    });
+
+    const firstView = render(<FieldInvoicesHistory />);
+
+    expect(await screen.findByText("Forbidden")).toBeInTheDocument();
+    await waitFor(() => expect(removeOfflineSnapshots).toHaveBeenCalledOnce());
+    firstView.unmount();
+    render(<FieldInvoicesHistory />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    expect(saveOfflineSnapshot).not.toHaveBeenCalled();
+
+    pendingRemove.resolve(undefined);
+    expect(await screen.findByText("INV-101")).toBeInTheDocument();
+    await waitFor(() => expect(saveOfflineSnapshot).toHaveBeenCalledOnce());
+    expect(operations).toEqual(["remove", "save"]);
+  });
+
+  it("ignores a successful response that arrives after its view unmounts", async () => {
+    const pendingResponse = deferred<Response>();
+    const staleJson = vi.fn(async () => ({ ok: true, rows: liveRows }));
+    vi.mocked(fetch)
+      .mockImplementationOnce(async () => pendingResponse.promise)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "Forbidden" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const firstView = render(<FieldInvoicesHistory />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    firstView.unmount();
+    render(<FieldInvoicesHistory />);
+
+    expect(await screen.findByText("Forbidden")).toBeInTheDocument();
+    await waitFor(() => expect(removeOfflineSnapshots).toHaveBeenCalledOnce());
+
+    pendingResponse.resolve({
+      ok: true,
+      status: 200,
+      json: staleJson,
+    } as unknown as Response);
+    await waitFor(() => expect(staleJson).toHaveBeenCalledOnce());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(saveOfflineSnapshot).not.toHaveBeenCalled();
   });
 
   it("keeps live invoice data visible when the optional offline snapshot cannot be saved", async () => {
@@ -132,10 +349,9 @@ describe("Field invoices and history", () => {
 
     expect(await screen.findByText("INV-101")).toBeInTheDocument();
     expect(screen.queryByText(/could not load/i)).not.toBeInTheDocument();
-    expect(warn).toHaveBeenCalledWith(
-      "[field-invoices] snapshot save failed",
-      { message: "IndexedDB unavailable" },
-    );
+    expect(warn).toHaveBeenCalledWith("[field-invoices] snapshot save failed", {
+      message: "IndexedDB unavailable",
+    });
     warn.mockRestore();
   });
 });

--- a/tests/field-invoices-history-ui.test.tsx
+++ b/tests/field-invoices-history-ui.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import FieldInvoicesHistory from "@/features/mobile/service/FieldInvoicesHistory";
+import type { FieldInvoiceHistoryRow } from "@/features/mobile/service/fieldInvoiceHistory";
+import {
+  getOfflineSnapshot,
+  saveOfflineSnapshot,
+} from "@/features/shared/lib/offline/database";
+
+vi.mock("@/features/shared/lib/offline/database", () => ({
+  getOfflineSnapshot: vi.fn(async () => null),
+  saveOfflineSnapshot: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/features/shared/lib/offline/mutations", () => ({
+  getOfflineMutationScope: vi.fn(() => ({ userId: "user-1", shopId: "shop-1" })),
+}));
+
+function row(
+  invoiceVersionId: string,
+  paymentState: "unpaid" | "paid",
+): FieldInvoiceHistoryRow {
+  return {
+    invoiceVersionId,
+    invoiceNumber: `INV-${invoiceVersionId}`,
+    versionNumber: 1,
+    workOrderId: `work-order-${invoiceVersionId}`,
+    workOrderNumber: `RO-${invoiceVersionId}`,
+    lifecycleStatus: paymentState === "paid" ? "paid" : "issued",
+    paymentState,
+    currency: "CAD",
+    total: 500,
+    paidTotal: paymentState === "paid" ? 500 : 100,
+    refundedTotal: 0,
+    outstandingTotal: paymentState === "paid" ? 0 : 400,
+    issuedAt: "2026-08-18T12:00:00.000Z",
+    updatedAt: "2026-08-18T12:00:00.000Z",
+    paidAt: paymentState === "paid" ? "2026-08-18T13:00:00.000Z" : null,
+    customerName: paymentState === "paid" ? "Taylor Jones" : "Jamie Smith",
+    customerEmail: null,
+    vehicleLabel: "2024 Ford F-550",
+    licensePlate: paymentState === "paid" ? "PAID1" : "DUE1",
+  };
+}
+
+const liveRows = [row("101", "unpaid"), row("102", "paid")];
+
+beforeEach(() => {
+  vi.mocked(getOfflineSnapshot).mockResolvedValue(null);
+  vi.mocked(saveOfflineSnapshot).mockResolvedValue(undefined);
+  Object.defineProperty(window.navigator, "onLine", {
+    configurable: true,
+    value: true,
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true, rows: liveRows }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("Field invoices and history", () => {
+  it("opens on unpaid balances and preserves canonical payment, PDF, and work-order handoffs", async () => {
+    render(<FieldInvoicesHistory />);
+
+    expect(await screen.findByText("INV-101")).toBeInTheDocument();
+    expect(screen.queryByText("INV-102")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /collect payment/i })).toHaveAttribute(
+      "href",
+      "/mobile/service/closeout/work-order-101",
+    );
+    expect(screen.getByRole("link", { name: /pdf/i })).toHaveAttribute(
+      "href",
+      "/api/work-orders/work-order-101/invoice-pdf",
+    );
+    expect(screen.getByRole("link", { name: /work order/i })).toHaveAttribute(
+      "href",
+      "/mobile/work-orders/work-order-101",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Paid" }));
+    expect(await screen.findByText("INV-102")).toBeInTheDocument();
+    expect(screen.queryByText("INV-101")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /view receipt/i })).toBeInTheDocument();
+  });
+
+  it("uses the tenant-scoped saved snapshot for offline reference without payment or PDF actions", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError("offline"));
+    vi.mocked(getOfflineSnapshot).mockResolvedValueOnce({
+      key: "user-1:shop-1:field-invoice-history:latest",
+      kind: "field-invoice-history",
+      entityId: "latest",
+      userId: "user-1",
+      shopId: "shop-1",
+      updatedAt: "2026-08-18T12:00:00.000Z",
+      expiresAt: "2026-08-19T00:00:00.000Z",
+      data: [row("101", "unpaid")],
+    });
+
+    render(<FieldInvoicesHistory />);
+
+    expect(await screen.findByText("INV-101")).toBeInTheDocument();
+    expect(screen.getByText(/Saved invoice history is available/)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /collect payment/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /pdf/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps live invoice data visible when the optional offline snapshot cannot be saved", async () => {
+    vi.mocked(saveOfflineSnapshot).mockRejectedValueOnce(
+      new Error("IndexedDB unavailable"),
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    render(<FieldInvoicesHistory />);
+
+    expect(await screen.findByText("INV-101")).toBeInTheDocument();
+    expect(screen.queryByText(/could not load/i)).not.toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(
+      "[field-invoices] snapshot save failed",
+      { message: "IndexedDB unavailable" },
+    );
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
## What changed
- adds a dedicated Field **Invoices & history** workspace with unpaid, paid, and all-history filters
- shows currency-safe outstanding totals and searchable invoice, RO, customer, vehicle, and plate identity
- reuses the canonical Field closeout/payment, work-order detail, and invoice PDF flows
- adds a tenant-scoped, 12-hour offline reference snapshot while withholding payment and PDF actions offline
- adds the workspace to the Field hub and Operations navigation

## Architecture and safety
- requires Field operator access plus the canonical work-order management capability
- authorizes before creating the privileged reader and scopes every query to the trusted profile shop
- endpoint is read-only and returns a generic client error while logging server diagnostics
- invoice lifecycle, payment, receipt, and PDF mutations remain owned by their existing canonical routes
- offline snapshot persistence is best-effort and cannot replace successfully loaded live data

## Validation
- focused Field regression suite: 36/36 passing
- hosted Agent PR Checks: passing
  - TypeScript
  - changed-file ESLint
  - complete test suite
  - production build
  - regression-inventory gate
- hosted Mobile V1 Validation: passing
  - Field source contracts
  - clean Supabase migration replay
  - fake Mobile Service day runtime validation
- repository ESLint: 0 errors (existing warnings remain)
- API boundary audit: passing; new route classified low risk
- live canonical Supabase aggregate verification: 2 invoiced work orders, 1 unpaid, 1 paid, 0 broken invoice links

## Database and deployment
- no migration or production write required
- Vercel preview deployments remain disabled by `git.deploymentEnabled["*"] = false`; only `main` is enabled
- Vercel deployment for this PR/commit is confirmed `CANCELED` before build
