### PR TITLE
Fix parts import candidate column queries

### DIFF
--- a/app/parts/page.tsx
+++ b/app/parts/page.tsx
@@ -237,7 +237,7 @@ export default function PartsDashboardPage(): JSX.Element {
         supabase.from("shop_parts_import_staging").select("status"),
         supabase
           .from("shop_parts_import_match_candidates")
-          .select("staging_id, candidate_part_id"),
+          .select("staging_row_id, candidate_part_id"),
       ]);
 
       const partsRows = (partsRes.data ?? []) as TrustExtendedPart[];
@@ -263,7 +263,7 @@ export default function PartsDashboardPage(): JSX.Element {
       ).length;
       const candidateCounts: Record<string, number> = {};
       for (const row of candidateRes.data ?? []) {
-        const key = String(row.staging_id ?? row.candidate_part_id ?? "");
+        const key = String(row.staging_row_id ?? row.candidate_part_id ?? "");
         if (key) candidateCounts[key] = (candidateCounts[key] ?? 0) + 1;
       }
       setTrustSummary({

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -180,7 +180,7 @@ export default function ReceivingInboxPage(): JSX.Element {
           .eq("shop_id", sid),
         supabase
           .from("shop_parts_import_match_candidates")
-          .select("staging_id, candidate_part_id")
+          .select("staging_row_id, candidate_part_id")
           .in("candidate_part_id", partIds)
           .eq("shop_id", sid),
       ]);

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/features/parts/lib/status-display";
 import {
   buildPartTrustMeta,
+  countAmbiguousStagingRowsByPart,
   trustBadgeTone,
   trustLevelLabel,
   trustReasonTone,
@@ -214,24 +215,12 @@ export default function ReceivingInboxPage(): JSX.Element {
               .eq("shop_id", sid)
           ).data ?? []
         : [];
-      const candidatesByStagingRow = new Map<string, Set<string>>();
-      for (const row of completeCandidateRows) {
-        const stagingRowId = String(row.staging_row_id ?? "");
-        const candidatePartId = String(row.candidate_part_id ?? "");
-        if (!stagingRowId || !candidatePartId) continue;
-        const candidates =
-          candidatesByStagingRow.get(stagingRowId) ?? new Set<string>();
-        candidates.add(candidatePartId);
-        candidatesByStagingRow.set(stagingRowId, candidates);
-      }
-      const ambiguousCountByPartId: Record<string, number> = {};
-      for (const candidates of candidatesByStagingRow.values()) {
-        if (candidates.size <= 1) continue;
-        for (const candidatePartId of candidates) {
-          ambiguousCountByPartId[candidatePartId] =
-            (ambiguousCountByPartId[candidatePartId] ?? 0) + 1;
-        }
-      }
+      const ambiguousCountByPartId = countAmbiguousStagingRowsByPart(
+        completeCandidateRows.map((row) => ({
+          stagingRowId: row.staging_row_id,
+          candidatePartId: row.candidate_part_id,
+        })),
+      );
 
       const tMap: Record<string, PartTrustMeta> = {};
       for (const pid of partIds) {

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -198,11 +198,40 @@ export default function ReceivingInboxPage(): JSX.Element {
           pendingCount[String(r.matched_part_id)] = (pendingCount[String(r.matched_part_id)] ?? 0) + 1;
         }
       });
-      const candCount: Record<string, number> = {};
-      (candRes.data ?? []).forEach((r) => {
-        const id = String(r.candidate_part_id);
-        candCount[id] = (candCount[id] ?? 0) + 1;
-      });
+      const candidateStagingRowIds = [
+        ...new Set(
+          (candRes.data ?? [])
+            .map((row) => String(row.staging_row_id ?? ""))
+            .filter(Boolean),
+        ),
+      ];
+      const completeCandidateRows = candidateStagingRowIds.length
+        ? (
+            await supabase
+              .from("shop_parts_import_match_candidates")
+              .select("staging_row_id, candidate_part_id")
+              .in("staging_row_id", candidateStagingRowIds)
+              .eq("shop_id", sid)
+          ).data ?? []
+        : [];
+      const candidatesByStagingRow = new Map<string, Set<string>>();
+      for (const row of completeCandidateRows) {
+        const stagingRowId = String(row.staging_row_id ?? "");
+        const candidatePartId = String(row.candidate_part_id ?? "");
+        if (!stagingRowId || !candidatePartId) continue;
+        const candidates =
+          candidatesByStagingRow.get(stagingRowId) ?? new Set<string>();
+        candidates.add(candidatePartId);
+        candidatesByStagingRow.set(stagingRowId, candidates);
+      }
+      const ambiguousCountByPartId: Record<string, number> = {};
+      for (const candidates of candidatesByStagingRow.values()) {
+        if (candidates.size <= 1) continue;
+        for (const candidatePartId of candidates) {
+          ambiguousCountByPartId[candidatePartId] =
+            (ambiguousCountByPartId[candidatePartId] ?? 0) + 1;
+        }
+      }
 
       const tMap: Record<string, PartTrustMeta> = {};
       for (const pid of partIds) {
@@ -215,7 +244,7 @@ export default function ReceivingInboxPage(): JSX.Element {
           sourceIntakeId: p?.source_intake_id ?? null,
           importConfidence: extended?.import_confidence ?? null,
           aliasCount: aliasCount[pid] ?? 0,
-          ambiguousCandidateCount: (candCount[pid] ?? 0) > 1 ? candCount[pid] : 0,
+          ambiguousCandidateCount: ambiguousCountByPartId[pid] ?? 0,
           pendingStagingCount: pendingCount[pid] ?? 0,
         });
       }

--- a/features/parts/lib/trust-signals.ts
+++ b/features/parts/lib/trust-signals.ts
@@ -5,6 +5,34 @@ export type PartTrustMeta = {
   reasons: string[];
 };
 
+export function countAmbiguousStagingRowsByPart(
+  rows: ReadonlyArray<{
+    stagingRowId: string | null | undefined;
+    candidatePartId: string | null | undefined;
+  }>,
+): Record<string, number> {
+  const candidatesByStagingRow = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const stagingRowId = String(row.stagingRowId ?? "");
+    const candidatePartId = String(row.candidatePartId ?? "");
+    if (!stagingRowId || !candidatePartId) continue;
+    const candidates =
+      candidatesByStagingRow.get(stagingRowId) ?? new Set<string>();
+    candidates.add(candidatePartId);
+    candidatesByStagingRow.set(stagingRowId, candidates);
+  }
+
+  const ambiguousCountByPartId: Record<string, number> = {};
+  for (const candidates of candidatesByStagingRow.values()) {
+    if (candidates.size <= 1) continue;
+    for (const candidatePartId of candidates) {
+      ambiguousCountByPartId[candidatePartId] =
+        (ambiguousCountByPartId[candidatePartId] ?? 0) + 1;
+    }
+  }
+  return ambiguousCountByPartId;
+}
+
 const TRUST_REASON = {
   missingSku: "Missing SKU",
   missingPartNumber: "Missing part number",

--- a/scripts/regression-inventory/baseline.json
+++ b/scripts/regression-inventory/baseline.json
@@ -233,26 +233,6 @@
       "expiresOn": "2026-09-06"
     },
     {
-      "fingerprint": "b5ab30b194047e169693",
-      "rule": "missing-column",
-      "severity": "error",
-      "domain": "parts",
-      "file": "app/parts/page.tsx",
-      "subject": "shop_parts_import_match_candidates.staging_id",
-      "message": "select references missing column shop_parts_import_match_candidates.staging_id",
-      "expiresOn": "2026-09-06"
-    },
-    {
-      "fingerprint": "79b17e3dc7bc8b802735",
-      "rule": "missing-column",
-      "severity": "error",
-      "domain": "parts",
-      "file": "app/parts/receiving/page.tsx",
-      "subject": "shop_parts_import_match_candidates.staging_id",
-      "message": "select references missing column shop_parts_import_match_candidates.staging_id",
-      "expiresOn": "2026-09-06"
-    },
-    {
       "fingerprint": "85da6576aee2f976fb03",
       "rule": "missing-column",
       "severity": "error",

--- a/tests/parts-inventory-csv-import.test.ts
+++ b/tests/parts-inventory-csv-import.test.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { buildPartTrustMeta } from "@/features/parts/lib/trust-signals";
+import {
+  buildPartTrustMeta,
+  countAmbiguousStagingRowsByPart,
+} from "@/features/parts/lib/trust-signals";
 
 const inventorySource = () => readFileSync("app/parts/inventory/page.tsx", "utf8");
 
@@ -48,6 +51,30 @@ describe("parts inventory trust classification", () => {
 
   it("name-only or missing identity is low trust", () => {
     expect(buildPartTrustMeta({ name: "Mystery clip" }).level).toBe("low");
+  });
+});
+
+describe("parts import candidate ambiguity", () => {
+  it("does not mark repeated single-candidate staging rows as ambiguous", () => {
+    expect(
+      countAmbiguousStagingRowsByPart([
+        { stagingRowId: "row-1", candidatePartId: "part-1" },
+        { stagingRowId: "row-2", candidatePartId: "part-1" },
+      ]),
+    ).toEqual({});
+  });
+
+  it("marks every part belonging to a multi-candidate staging row", () => {
+    expect(
+      countAmbiguousStagingRowsByPart([
+        { stagingRowId: "row-1", candidatePartId: "part-1" },
+        { stagingRowId: "row-1", candidatePartId: "part-2" },
+        { stagingRowId: "row-2", candidatePartId: "part-1" },
+      ]),
+    ).toEqual({
+      "part-1": 1,
+      "part-2": 1,
+    });
   });
 });
 


### PR DESCRIPTION
## What changed

- update the Parts dashboard match-candidate query to use the canonical `staging_row_id` column
- update Receiving to fetch complete candidate sets for relevant staging rows before calculating ambiguity
- count ambiguity per staging row and associate it with each candidate part
- remove the two now-resolved missing-column entries from the regression baseline
- add executable regression coverage for repeated single candidates and true multi-candidate staging rows

## Root cause

The Parts dashboard and Receiving queried `shop_parts_import_match_candidates.staging_id`, but the production schema defines the foreign key as `staging_row_id`. The resulting Supabase errors were swallowed by optional client-side trust queries. Receiving also counted candidate rows per part, which could not distinguish repeated single-candidate staging rows from genuinely ambiguous multi-candidate rows.

## Impact

Restores parts trust and ambiguity signals on `/parts` and `/parts/receiving` without a database migration, while preventing false-positive and false-negative ambiguity labels.

## Validation

- branch created from production/main SHA `1309f241f9bbe52dc0d0c93a97833601e08c5b2c`
- original exact-head typecheck, lint, 2,580 tests, and production build passed
- removed only the two baseline fingerprints resolved by this hotfix
- added unit coverage for both candidate-grouping edge cases
- fresh exact-head CI is running