### PR TITLE
Shop Vehicle Workspace — Foundation and Canonical Read Model

### DIFF
--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -237,6 +237,20 @@ jobs:
             -f tests/security/p0-004-vehicle-recall-fetch.runtime.sql \
             2>&1 | tee p0-004-vehicle-recall-fetch-runtime.log
 
+      - name: Execute Vehicle Workspace tenant-boundary integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/vehicle-workspace-tenant.runtime.sql \
+            2>&1 | tee vehicle-workspace-tenant-runtime.log
+
       - name: Execute P0 AI route governance integration
         shell: bash
         env:
@@ -463,6 +477,7 @@ jobs:
             p0-002-rpc-privileges-runtime.log
             p0-002-stock-move-signature-compat-runtime.log
             p0-004-vehicle-recall-fetch-runtime.log
+            vehicle-workspace-tenant-runtime.log
             p0-005-ai-route-governance-runtime.log
             p0-006-stripe-identity-runtime.log
             p0-007-financial-outbox-runtime.log

--- a/app/api/portal/bookings/route.ts
+++ b/app/api/portal/bookings/route.ts
@@ -1,6 +1,10 @@
 // app/api/portal/bookings/route.ts
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
@@ -9,6 +13,9 @@ import {
 } from "@/features/portal/server/createPortalBooking";
 
 export const runtime = "nodejs";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 type Db = Database;
 type BookingPayload = {
@@ -113,32 +120,38 @@ async function loadSchedulerEvents(
 }
 
 export async function GET(req: Request): Promise<Response> {
-  const supabase = createServerSupabaseRoute();
   const url = new URL(req.url);
   const shopSlug = url.searchParams.get("shop") ?? "";
   const start = url.searchParams.get("start") ?? "";
   const end = url.searchParams.get("end") ?? "";
   const status = url.searchParams.get("status") ?? "";
+  const bookingId = url.searchParams.get("bookingId")?.trim() ?? "";
+  const scope = url.searchParams.get("scope")?.trim() ?? "";
+  const shopContextOnly = scope === "shop";
   const pendingQueue = status === "pending";
 
-  if (!shopSlug || (!pendingQueue && (!start || !end))) {
+  if (scope && !shopContextOnly) {
+    return bad("Unsupported scope");
+  }
+  if (bookingId && !UUID_PATTERN.test(bookingId)) {
+    return bad("Invalid booking id");
+  }
+  if (
+    !shopContextOnly &&
+    (!shopSlug || (!bookingId && !pendingQueue && (!start || !end)))
+  ) {
     return bad("Missing shop or date range");
   }
 
-  const {
-    data: { user },
-    error: authErr,
-  } = await supabase.auth.getUser();
-  if (authErr || !user) return bad("Not authenticated", 401);
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
 
-  const { data: profile, error: profErr } = await supabase
-    .from("profiles")
-    .select("shop_id, role")
-    .eq("id", user.id)
-    .single();
-  if (profErr || !profile?.shop_id) return bad("Profile / shop not found", 403);
+  const { profile, supabase } = access;
 
-  const actor = getActorCapabilities({ role: profile.role });
+  const actor = getActorCapabilities({ role: access.canonicalRole });
+  if (bookingId && !actor.canManageScheduling) {
+    return bad("Not allowed", 403);
+  }
   if (
     !actor.isKnownRole ||
     (!actor.canManageScheduling && !actor.canViewShopWideData)
@@ -146,14 +159,26 @@ export async function GET(req: Request): Promise<Response> {
     return bad("Not allowed", 403);
   }
 
-  const { data: shop, error: shopErr } = await supabase
+  // The service client is used only after canonical staff authorization and is
+  // pinned to the actor's resolved tenant. This keeps linked legacy profiles
+  // working even where the shops self-read policy still keys on profiles.id.
+  let shopQuery = createAdminSupabase()
     .from("shops")
-    .select("id, slug")
-    .eq("slug", shopSlug)
-    .single();
+    .select("id, name, slug, accepts_online_booking")
+    .eq("id", profile.shop_id);
+
+  if (!shopContextOnly) {
+    shopQuery = shopQuery.eq("slug", shopSlug);
+  }
+
+  const { data: shop, error: shopErr } = await shopQuery.maybeSingle();
   if (shopErr || !shop) return bad("Shop not found", 404);
-  if (shop.id !== profile.shop_id) {
-    return bad("You cannot view bookings for this shop", 403);
+
+  if (shopContextOnly) {
+    return NextResponse.json(
+      { shop },
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
   }
 
   let bookingsQuery = supabase
@@ -169,7 +194,9 @@ export async function GET(req: Request): Promise<Response> {
     .eq("shop_id", shop.id)
     .order("starts_at", { ascending: true });
 
-  if (pendingQueue) {
+  if (bookingId) {
+    bookingsQuery = bookingsQuery.eq("id", bookingId).limit(1);
+  } else if (pendingQueue) {
     bookingsQuery = bookingsQuery.eq("status", "pending");
   } else {
     const startIso = new Date(`${start}T00:00:00.000Z`).toISOString();
@@ -189,6 +216,10 @@ export async function GET(req: Request): Promise<Response> {
       code: rowsErr?.code,
     });
     return bad(rowsErr?.message || "Failed to load bookings", 500);
+  }
+
+  if (bookingId && rows.length === 0) {
+    return bad("Appointment not found", 404);
   }
 
   const bookings = rows as unknown as BookingRow[];

--- a/app/api/vehicles/search/route.ts
+++ b/app/api/vehicles/search/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import {
+  requireShopScopedApiAccess,
+} from "@/features/shared/lib/server/admin-access";
+import { VEHICLE_WORKSPACE_READER_ROLES } from "@/features/vehicles/lib/vehicleWorkspace";
+import { searchShopVehicleRecords } from "@/features/vehicles/server/searchShopVehicleRecords";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: VEHICLE_WORKSPACE_READER_ROLES,
+  });
+  if (!access.ok) return access.response;
+
+  try {
+    const response = await searchShopVehicleRecords({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id,
+      role: access.canonicalRole,
+      query: new URL(request.url).searchParams.get("q"),
+    });
+    return NextResponse.json(response, {
+      headers: { "Cache-Control": "private, no-store" },
+    });
+  } catch (error) {
+    console.error("[vehicle-workspace] vehicle search failed", {
+      shopId: access.profile.shop_id,
+      userId: access.authUserId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: "Unable to search vehicle records" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/dashboard/appointments/page.tsx
+++ b/app/dashboard/appointments/page.tsx
@@ -38,8 +38,16 @@ import FullCalendarModal from "./FullCalendarModal";
 import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
 
-type ShopRow = Database["public"]["Tables"]["shops"]["Row"];
+type ShopRow = Pick<
+  Database["public"]["Tables"]["shops"]["Row"],
+  "id" | "name" | "slug" | "accepts_online_booking"
+>;
 type CustomerRow = Database["public"]["Tables"]["customers"]["Row"];
+
+type ShopContextResponse = {
+  shop?: ShopRow | null;
+  error?: string;
+};
 
 export type Booking = {
   id: string;
@@ -198,6 +206,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const search = useSearchParams();
   const router = useRouter();
+  const requestedBookingId = search.get("bookingId")?.trim() ?? "";
 
   const [shops, setShops] = useState<ShopRow[]>([]);
   const [shopSlug, setShopSlug] = useState<string>(search.get("shop") || "");
@@ -245,50 +254,46 @@ export default function PortalAppointmentsPage(): JSX.Element {
   // depend on whether that shop currently accepts public online bookings.
   useEffect(() => {
     let mounted = true;
+    const controller = new AbortController();
 
     (async () => {
-      const { data: auth } = await supabase.auth.getUser();
-      const userId = auth.user?.id;
-      if (!userId) {
-        if (mounted) toast.error("Sign in to manage appointments.");
-        return;
-      }
+      try {
+        const response = await fetch("/api/portal/bookings?scope=shop", {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        const context = (await response.json().catch(() => null)) as
+          | ShopContextResponse
+          | null;
+        if (!response.ok) {
+          throw new Error(context?.error || "Unable to load your shop.");
+        }
 
-      const { data: profile, error: profileError } = await supabase
-        .from("profiles")
-        .select("shop_id")
-        .eq("id", userId)
-        .maybeSingle<{ shop_id: string | null }>();
+        const shop = context?.shop ?? null;
+        if (!shop?.id || !shop.slug) {
+          throw new Error("Your profile is not linked to a shop.");
+        }
+        if (!mounted) return;
 
-      if (profileError || !profile?.shop_id) {
-        if (mounted) toast.error("Your profile is not linked to a shop.");
-        return;
-      }
-
-      const { data, error } = await supabase
-        .from("shops")
-        .select("id,name,slug,accepts_online_booking")
-        .eq("id", profile.shop_id)
-        .maybeSingle();
-
-      if (!mounted) return;
-
-      if (error) {
-        // eslint-disable-next-line no-console
-        console.error(error);
-        toast.error("Unable to load shops.");
-        return;
-      }
-
-      const rows = data ? [data as ShopRow] : [];
-      setShops(rows);
-
-      if (rows.length > 0) {
-        const authorizedSlug = rows[0].slug as string;
+        setShops([shop]);
+        const authorizedSlug = shop.slug;
         setShopSlug(authorizedSlug);
-        if (shopSlug !== authorizedSlug) {
+        if (search.get("shop") !== authorizedSlug) {
+          const canonicalQuery = new URLSearchParams(search.toString());
+          canonicalQuery.set("shop", authorizedSlug);
           router.replace(
-            `/dashboard/appointments?shop=${encodeURIComponent(authorizedSlug)}`,
+            `/dashboard/appointments?${canonicalQuery.toString()}`,
+          );
+        }
+      } catch (caught: unknown) {
+        if (caught instanceof DOMException && caught.name === "AbortError") {
+          return;
+        }
+        if (mounted) {
+          toast.error(
+            caught instanceof Error
+              ? caught.message
+              : "Unable to load your shop.",
           );
         }
       }
@@ -296,13 +301,67 @@ export default function PortalAppointmentsPage(): JSX.Element {
 
     return () => {
       mounted = false;
+      controller.abort();
     };
-  }, [supabase, router, shopSlug]);
+  }, [router, search]);
 
   const selectedShop = useMemo(
     () => shops.find((s) => (s.slug as string | null) === shopSlug) ?? null,
     [shops, shopSlug],
   );
+
+  // Resolve appointment deep links only after the actor's canonical shop is
+  // known. The guarded staff endpoint applies both capability and tenant/RLS
+  // checks before returning the exact booking.
+  useEffect(() => {
+    if (!selectedShop || !requestedBookingId) return;
+
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const authorizedSlug = selectedShop.slug as string;
+        const response = await fetch(
+          `/api/portal/bookings?shop=${encodeURIComponent(authorizedSlug)}&bookingId=${encodeURIComponent(requestedBookingId)}`,
+          { cache: "no-store", signal: controller.signal },
+        );
+        const body = (await response.json().catch(() => null)) as
+          | Booking[]
+          | { error?: string }
+          | null;
+        if (!response.ok) {
+          throw new Error(
+            body && !Array.isArray(body)
+              ? body.error || "Unable to open appointment."
+              : "Unable to open appointment.",
+          );
+        }
+
+        const booking = Array.isArray(body) ? body[0] : null;
+        if (!booking) throw new Error("Appointment not found.");
+
+        const appointmentDate = new Date(booking.starts_at);
+        if (Number.isNaN(appointmentDate.getTime())) {
+          throw new Error("Appointment has an invalid start date.");
+        }
+        appointmentDate.setHours(0, 0, 0, 0);
+        setWeekStart(appointmentDate);
+        setEditing(booking);
+        setCreatingDate(null);
+        setPanelMode("edit");
+      } catch (caught: unknown) {
+        if (caught instanceof DOMException && caught.name === "AbortError") {
+          return;
+        }
+        toast.error(
+          caught instanceof Error
+            ? caught.message
+            : "Unable to open appointment.",
+        );
+      }
+    })();
+
+    return () => controller.abort();
+  }, [requestedBookingId, selectedShop]);
 
   // load customers for selected shop
   useEffect(() => {

--- a/app/vehicles/[id]/page.tsx
+++ b/app/vehicles/[id]/page.tsx
@@ -1,0 +1,53 @@
+import { unstable_noStore as noStore } from "next/cache";
+import { notFound } from "next/navigation";
+
+import VehicleWorkspace from "@/features/vehicles/components/VehicleWorkspace";
+import { VEHICLE_WORKSPACE_READER_ROLES } from "@/features/vehicles/lib/vehicleWorkspace";
+import {
+  loadVehicleWorkspaceSnapshot,
+  vehicleWorkspaceCreateWorkOrderHref,
+} from "@/features/vehicles/server/loadVehicleWorkspaceSnapshot";
+import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type VehicleWorkspacePageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function VehicleWorkspacePage({
+  params,
+}: VehicleWorkspacePageProps) {
+  noStore();
+
+  const { profile, canonicalRole } = await requireShopPageAccess({
+    allowRoles: VEHICLE_WORKSPACE_READER_ROLES,
+  });
+  const { id } = await params;
+  if (!UUID_PATTERN.test(id)) notFound();
+
+  // Keep the authenticated cookie-backed client here. The read model relies on
+  // database RLS in addition to its explicit shop filters and role redaction.
+  const snapshot = await loadVehicleWorkspaceSnapshot({
+    supabase: createServerSupabaseRSC(),
+    shopId: profile.shop_id,
+    role: canonicalRole,
+    vehicleId: id,
+  });
+
+  // Malformed, cross-shop, missing, and unassigned-work access all have the same
+  // public result so callers cannot use this route to enumerate vehicle IDs.
+  if (!snapshot) notFound();
+
+  return (
+    <VehicleWorkspace
+      snapshot={snapshot}
+      createWorkOrderHref={vehicleWorkspaceCreateWorkOrderHref(snapshot)}
+    />
+  );
+}

--- a/app/vehicles/page.tsx
+++ b/app/vehicles/page.tsx
@@ -1,1 +1,23 @@
-export { default } from "@/features/vehicles/app/vehicles/page";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import VehicleFilesPage from "@/features/vehicles/app/vehicles/page";
+import { VEHICLE_WORKSPACE_READER_ROLES } from "@/features/vehicles/lib/vehicleWorkspace";
+import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export default async function VehiclesPage() {
+  const { canonicalRole } = await requireShopPageAccess({
+    allowRoles: VEHICLE_WORKSPACE_READER_ROLES,
+  });
+
+  return (
+    <VehicleFilesPage
+      canManageVehicles={[
+        "owner",
+        "admin",
+        "manager",
+        "advisor",
+      ].includes(canonicalRole)}
+    />
+  );
+}

--- a/docs/shop-vehicle-workspace-foundation.md
+++ b/docs/shop-vehicle-workspace-foundation.md
@@ -1,0 +1,147 @@
+# Shop Vehicle Workspace — Foundation and Canonical Read Model
+
+Status: first vertical slice implementation
+Audit date: 2026-08-19
+
+## Milestone
+
+The foundation proves one narrow flow without replacing existing records pages:
+
+1. Search a customer, company, contact value, vehicle identifier, or work-order number.
+2. Resolve every match to its canonical `vehicles.id` without choosing a first vehicle.
+3. Open a role-shaped, server-side Vehicle Workspace.
+4. Start the existing Create Work Order flow with the canonical customer and vehicle IDs preselected.
+
+The workspace is a read model. It does not persist copied history, balances, findings,
+maintenance results, documents, or lifecycle state.
+
+## Repository audit findings
+
+- The Shop shell has no authoritative database-backed global record search today. The tab
+  bar search only filters device-local open tabs, while Customer and Vehicle Files previously
+  loaded records into the browser and filtered them locally. This slice upgrades the existing
+  `/vehicles` records entrance instead of adding a second search silo.
+- The old vehicle search opened a customer route, and that route could default to the first
+  vehicle. The new result and workspace always carry the matched canonical `vehicles.id`.
+- Create Work Order is the only existing action with a complete customer-and-vehicle prefill
+  contract and same-shop relationship validation. Booking, Estimate, and Message have partial
+  backend or form support but no complete query-handoff contract, so they are not advertised
+  as working quick actions in this PR.
+
+## Canonical relationship contract
+
+| Domain | Canonical source | Vehicle relationship and workspace rule |
+| --- | --- | --- |
+| Customer or business account | `customers.id` | `vehicles.customer_id` is the nullable current-account relationship. Commercial settings remain account-owned. |
+| Vehicle | `vehicles.id` | The only workspace key. Sources that carry `shop_id` are explicitly shop-scoped; relation-only sources are limited to RLS-visible canonical vehicle/WO IDs. |
+| Appointment | `bookings.id` | Direct `vehicle_id`; optional `customer_id` and `work_order_id`. Return every current appointment. Scheduling-authorized roles deep-link by source ID into the existing appointment UI; other cards retain the source ID without offering an unauthorized navigation. |
+| Work order | `work_orders.id` | Direct `vehicle_id`. Return every non-terminal record rather than selecting one; dated timeline events retain the WO `odometer_km` reading when present. |
+| Repair line | `work_order_lines.id` | Connected through both `work_order_id` and `vehicle_id`. The line remains the repair source. |
+| Installed part | `work_order_parts.id` | Connected through `work_order_id`, with an optional focused `work_order_line_id`. Timeline evidence includes only active rows whose net `quantity_consumed - quantity_returned` is positive, retains the canonical part-row ID, and never projects price or cost. |
+| Parts request | `part_requests.id` | Connected through `work_order_id`. Active-now cards are queried only for roles accepted by the existing Parts Requests layout, exclude terminal request states, and retain the request ID and canonical detail route. |
+| Inspection | `inspections.id` | Direct `vehicle_id`, optional WO/line IDs. Canonical findings remain in `inspections.summary`; a workspace finding retains the inspection ID. |
+| Estimate and approval | `work_orders.id`, `work_order_quote_lines.id` | An estimate is a pre-authorization work order; nonempty canonical quote-line decisions become approval timeline events that retain their quote-line IDs and source line IDs. |
+| Deferred work | `work_order_quote_lines.id` or independently deferred `work_order_lines.id` | Linked quote/repair representations are not rendered twice. AI recommendation tables are not operational truth. |
+| Invoice | `invoices.id`, with issued truth in `invoice_versions.id` | Vehicle attribution exists only through `invoice.work_order_id -> work_orders.vehicle_id`. Account-wide invoices are never assigned to a vehicle. |
+| Payment | `payments.id` and append-only `payment_events.id` | Included only when its WO resolves to the vehicle and the actor can view financials. |
+| Vehicle/repair media | `vehicle_media.id`, `work_order_media.id` | Counts and links only; no blob or metadata copying. |
+| Imported history | `history.id` | Query by `vehicle_id`, not current customer. Skip a history mirror when its canonical live WO is already rendered; retain imported odometer readings and differing historical customer IDs as evidence. |
+| Maintenance | `maintenance_rules`, `maintenance_services`, completed repair lines; `maintenance_suggestions.work_order_id` is a deterministic cache | Show only non-suppressed, due evidence with a recorded `whyDue`, service code, and source WO. Never turn generated prose into unexplained maintenance truth. |
+
+## Ownership and ambiguity rules
+
+- A vehicle with no current account has a valid workspace. Customer-dependent actions are unavailable.
+- A customer search returns all matching vehicles. For account-authorized roles, an account with no vehicles remains an account result and does not get a fabricated workspace.
+- Multiple active WOs, appointments, inspections, deferred items, and vehicle-related invoices remain arrays.
+- A historical WO whose `customer_id` differs from `vehicles.customer_id` stays linked to its historical source. The workspace does not infer a prior-owner ledger that the schema does not have.
+- Inactive/archived/merged accounts and archived/duplicate/inactive vehicle status are visible warnings.
+- Duplicate VINs are possible because normalized VIN lookup is not a unique ownership constraint. Search deduplicates only by canonical `vehicles.id`.
+- A WO match without a canonical `vehicle_id` is unresolved; it is never attached using denormalized vehicle text.
+- Failed/recommended inspection findings remain dated source evidence. The workspace does not claim they are unresolved when no canonical repair-to-finding resolution link exists.
+
+## Authorization contract
+
+The page and search API use the cookie-backed authenticated Supabase client, so RLS is
+always in the query path. They do not use a service-role client.
+
+The server projection reuses current application capabilities:
+
+| Data/action | Authority or safe-link rule |
+| --- | --- |
+| Financial summary | `getActorCapabilities(role).canViewFinancials` (currently owner/admin/manager) |
+| Parts requests | Existing `/parts/requests` layout roles (owner/admin/manager/parts) |
+| Open legacy account page | Existing Vehicle/Customer Files roles (owner/admin/manager/advisor); broader contact viewers get plain contact shortcuts without a mutation-capable account link |
+| Open work-order-family detail | Existing dynamic WO roles (owner/admin/manager/advisor/mechanic/lead_hand/foreman); service and parts retain source IDs without links |
+| Open estimate or quote detail | `ESTIMATE_VIEW_ROLES`; mechanics retain estimate and decision evidence without links |
+| Open inspection detail | Owner/admin/manager/advisor/lead_hand/foreman; service, parts, and mechanics retain evidence without links until the legacy inspection payload is role-shaped |
+| Open imported-history detail | Financial viewers only until the legacy detail page has a role-shaped projection; other roles retain the history source ID without a link |
+| Open appointment detail | `canManageScheduling`; other workspace readers retain the booking ID without a link |
+| Create WO | `ROLE_GROUPS.workOrderCreators` |
+| Appointment action contract (deferred) | `canManageScheduling` |
+| Estimate action contract (deferred) | `estimateActorForRole(role).canCreate` |
+| Customer messaging contract (deferred) | `isCustomerMessagingRole(role)` |
+| Mechanic workspace | At least one RLS-visible assigned WO for the vehicle; otherwise return the same not-found result as an unknown/cross-shop ID |
+
+Once that assigned-WO anchor exists, the mechanic receives the vehicle-level service context
+already allowed by the current table policies. Tightening that context to only the assigned WO
+would be a separate authorization-policy change, not an implicit workspace rule.
+
+Restricted projections do not query invoices or payments and do not select account contact
+fields. The route does not accept a request-provided shop, role, customer, or permission value.
+
+### Existing database-policy compatibility gate
+
+The audit found a pre-existing mismatch between TypeScript capabilities and direct table
+access: several invoice, payment, invoice-version, payment-event, and customer-settings
+policies permit broader same-shop access than `canViewFinancials` does. The new workspace
+does not widen that access and does not expose those fields to restricted roles, but React or
+server projection alone cannot make a broader direct-table claim true.
+
+Tightening those policies requires a separate forward security migration after product owners
+choose the exact advisor/service/billing role matrix and affected legacy billing flows are
+compatibility-tested. Until then, the workspace payload and cross-tenant direct access can be
+certified; a claim that every restricted same-shop actor is blocked from every legacy financial
+table cannot.
+
+The audit also found that imported `history` rows with `work_order_id is null` are excluded by
+the current WO-based history select policy. The read model does not bypass RLS to fill that gap.
+A forward policy change needs a role-aware vehicle/customer tenant rule before those orphaned
+imports can be certified as complete workspace history.
+
+## First-PR scope
+
+Included:
+
+- one bounded, server-backed search contract mounted in the existing `/vehicles` entry;
+- guarded `/vehicles/[vehicleId]` workspace;
+- Vehicle header, Active now, Needs attention, and Recent timeline;
+- canonical source IDs on every operational item, with canonical links only
+  when the destination page authorizes the current role;
+- explicit ambiguity/warning cards;
+- role-shaped account and financial projection;
+- the existing `/work-orders/create?customerId=...&vehicleId=...` handoff.
+
+Deliberately deferred:
+
+- Book, Estimate, and Message quick actions, because their existing UIs do not yet consume a durable customer+vehicle prefill contract;
+- any replacement or removal of Customers, Vehicles, History, Invoice, Inspection, Appointment, or Work Order pages;
+- a new workspace table, rewritten migration, lifecycle-state change, or production mutation;
+- Field/Fleet behavior, sidebar redesign, and AI-written operational truth;
+- performance indexes until production-like query plans justify a forward migration.
+
+For odometer display, dated work-order readings take precedence over the undated
+`vehicles.mileage` master field; the vehicle field is the fallback when no WO reading exists.
+The current schema has no `vehicles.updated_at`, so claiming a stricter cross-source timestamp
+ordering would invent recency that the data cannot prove.
+Engine hours remain a current vehicle-header value because the audited sources do not provide
+dated engine-hour evidence suitable for a historical timeline.
+
+## Verification gates
+
+- search deduplicates by vehicle ID and preserves all matched vehicles for a multi-vehicle account;
+- snapshot queries use authenticated `shop_id` scope, and mechanics require an assigned-WO anchor;
+- a malformed, unassigned, missing, or cross-shop vehicle produces no workspace disclosure;
+- invoice/payment queries do not execute for restricted roles;
+- authorized source references open the canonical WO, estimate, invoice, inspection, or history page, while restricted roles retain the same source IDs as non-links;
+- Create Work Order passes both canonical IDs and the existing destination validates them;
+- focused tests, integration tests, type-check, lint, build, responsive browser checks, and regression inventory pass before merge.

--- a/features/shared/components/tabs/TabsBar.tsx
+++ b/features/shared/components/tabs/TabsBar.tsx
@@ -3,6 +3,7 @@
 import { AnimatePresence, motion } from "framer-motion";
 import {
   CalendarDays,
+  Car,
   ClipboardCheck,
   LayoutDashboard,
   MoreHorizontal,
@@ -46,6 +47,7 @@ function KindIcon({
   if (kind === "inspection") return <ClipboardCheck {...props} />;
   if (kind === "invoice") return <ReceiptText {...props} />;
   if (kind === "customer") return <UserRound {...props} />;
+  if (kind === "vehicle") return <Car {...props} />;
   if (kind === "appointment") return <CalendarDays {...props} />;
   return <Wrench {...props} />;
 }

--- a/features/shared/components/tabs/openWork.ts
+++ b/features/shared/components/tabs/openWork.ts
@@ -4,6 +4,7 @@ export type OpenWorkKind =
   | "inspection"
   | "invoice"
   | "customer"
+  | "vehicle"
   | "appointment";
 
 export type OpenWorkItem = {
@@ -213,6 +214,16 @@ export function resolveOpenWork(
       mobileHref: `/mobile/customers/${encodeURIComponent(segments[1])}`,
       title: `Customer · ${shortId(segments[1])}`,
       kind: "customer",
+      lastOpenedAt: now,
+    };
+  }
+
+  if (segments[0] === "vehicles" && segments[1]) {
+    return {
+      key: `vehicle:${segments[1]}`,
+      href: path,
+      title: `Vehicle · ${shortId(segments[1])}`,
+      kind: "vehicle",
       lastOpenedAt: now,
     };
   }

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -183,7 +183,34 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/vehicles": {
     title: () => "Vehicle Files",
     icon: "🚗",
-    roles: ["owner", "admin", "manager", "advisor"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "service",
+      "parts",
+      "mechanic",
+      "lead_hand",
+      "foreman",
+    ],
+  },
+  "/vehicles/[id]": {
+    title: (href) =>
+      `Vehicle · ${href.split("/").pop()?.slice(0, 8) ?? "…"}`,
+    icon: "🚗",
+    persist: { keyParams: ["id"] },
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "service",
+      "parts",
+      "mechanic",
+      "lead_hand",
+      "foreman",
+    ],
   },
 
   "/quote-review/[id]": {

--- a/features/vehicles/app/vehicles/page.tsx
+++ b/features/vehicles/app/vehicles/page.tsx
@@ -1,330 +1,453 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { useEffect, useState } from "react";
+
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
-import { VehicleCsvImportCard } from "@/features/vehicles/components/VehicleCsvImportCard";
 import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
-import type { Database } from "@shared/types/types/supabase";
-
-type DB = Database;
-type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
-type Customer = DB["public"]["Tables"]["customers"]["Row"];
-
-type CustomerSummary = Pick<
-  Customer,
-  | "id"
-  | "business_name"
-  | "name"
-  | "first_name"
-  | "last_name"
-  | "email"
-  | "phone"
-  | "phone_number"
->;
-
-type VehicleSearchRow = Pick<
-  Vehicle,
-  | "id"
-  | "shop_id"
-  | "customer_id"
-  | "unit_number"
-  | "vin"
-  | "license_plate"
-  | "year"
-  | "make"
-  | "model"
-  | "created_at"
-> & {
-  customers?: CustomerSummary | null;
-};
+import { VehicleCsvImportCard } from "@/features/vehicles/components/VehicleCsvImportCard";
+import {
+  vehicleIdentityLabel,
+  type VehicleWorkspacePermissions,
+  type VehicleWorkspaceSearchCard,
+  type VehicleWorkspaceSearchResponse,
+} from "@/features/vehicles/lib/vehicleWorkspace";
 
 const CARD_BASE =
   "rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-panel-bg-soft)] shadow-[var(--theme-shadow-medium)] backdrop-blur-xl";
 const CARD_INNER =
   "rounded-xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-item-bg)]";
+const ACTION_CLASS =
+  "inline-flex min-h-10 items-center justify-center rounded-lg border px-3 py-2 text-xs font-semibold transition focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]";
 
-function customerDisplayName(
-  c: CustomerSummary | null | undefined,
-): string | null {
-  if (!c) return null;
-  const businessName = c.business_name?.trim();
-  if (businessName) return businessName;
-  const name = c.name?.trim();
-  if (name) return name;
-  const person = [c.first_name ?? "", c.last_name ?? ""]
-    .filter(Boolean)
-    .join(" ")
-    .trim();
-  if (person) return person;
-  return c.email ?? c.phone ?? c.phone_number ?? null;
+type VehicleFilesPageProps = {
+  canManageVehicles: boolean;
+};
+
+function vinSuffix(vin: string | null): string | null {
+  const normalized = vin?.trim();
+  return normalized ? normalized.slice(-8) : null;
 }
 
-function vehicleYearMakeModel(
-  v: Pick<Vehicle, "year" | "make" | "model">,
-): string {
-  return [v.year != null ? String(v.year) : "", v.make ?? "", v.model ?? ""]
-    .filter(Boolean)
-    .join(" ");
+function formatMoney(amount: number, currency: string | null | undefined): string {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: currency || "CAD",
+    maximumFractionDigits: 2,
+  }).format(amount);
 }
 
-function vehicleDisplayLabel(v: VehicleSearchRow): string {
-  const unitNumber = v.unit_number?.trim();
-  if (unitNumber) return unitNumber;
-  const ymm = vehicleYearMakeModel(v).trim();
-  if (ymm) return ymm;
-  const plate = v.license_plate?.trim();
-  if (plate) return plate;
-  return v.vin?.trim() || "Vehicle";
-}
-
-function vehicleSearchHaystack(v: VehicleSearchRow): string {
-  return [
-    v.unit_number,
-    v.vin,
-    v.license_plate,
-    v.year != null ? String(v.year) : null,
-    v.make,
-    v.model,
-    customerDisplayName(v.customers),
-  ]
-    .filter(
-      (value): value is string =>
-        typeof value === "string" && value.trim().length > 0,
-    )
-    .join(" ")
-    .toLowerCase();
-}
-
-function sortVehicleRows(rows: VehicleSearchRow[]): VehicleSearchRow[] {
-  return [...rows].sort((a, b) =>
-    vehicleDisplayLabel(a).localeCompare(vehicleDisplayLabel(b), undefined, {
-      numeric: true,
-      sensitivity: "base",
-    }),
-  );
-}
-
-export default function VehicleFilesPage() {
-  const router = useRouter();
-  const vehicleGuidedQuery = usePersistentGuidedOnboardingQuery("vehicles");
-  const supabase = useMemo(() => createBrowserSupabase(), []);
-  const [query, setQuery] = useState("");
-  const [loading, setLoading] = useState(true);
-  const [allRows, setAllRows] = useState<VehicleSearchRow[]>([]);
-  const [visibleRows, setVisibleRows] = useState<VehicleSearchRow[]>([]);
-
-  const getOrLinkShopId = useCallback(
-    async (userId: string): Promise<string | null> => {
-      const byUserId = await supabase
-        .from("profiles")
-        .select("shop_id")
-        .eq("user_id", userId)
-        .maybeSingle();
-
-      if (byUserId.error) throw byUserId.error;
-      if (byUserId.data?.shop_id) return byUserId.data.shop_id;
-
-      const byId = await supabase
-        .from("profiles")
-        .select("shop_id")
-        .eq("id", userId)
-        .maybeSingle();
-
-      if (byId.error) throw byId.error;
-      if (byId.data?.shop_id) return byId.data.shop_id;
-
-      const ownedShop = await supabase
-        .from("shops")
-        .select("id")
-        .eq("owner_id", userId)
-        .maybeSingle();
-
-      if (ownedShop.error) throw ownedShop.error;
-      return ownedShop.data?.id ?? null;
-    },
-    [supabase],
-  );
-
-  const loadVehicles = useCallback(async () => {
-    setLoading(true);
-    try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-
-      if (!user?.id) {
-        setAllRows([]);
-        setVisibleRows([]);
-        return;
-      }
-
-      const shopId = await getOrLinkShopId(user.id);
-      if (!shopId) {
-        setAllRows([]);
-        setVisibleRows([]);
-        return;
-      }
-
-      const { data, error } = await supabase
-        .from("vehicles")
-        .select(
-          "id, shop_id, customer_id, unit_number, vin, license_plate, year, make, model, created_at, customers(id, business_name, name, first_name, last_name, email, phone, phone_number)",
-        )
-        .eq("shop_id", shopId);
-
-      if (error) {
-        setAllRows([]);
-        setVisibleRows([]);
-        return;
-      }
-
-      const rows = (
-        (data ?? []) as Array<
-          VehicleSearchRow & {
-            customers?: CustomerSummary | CustomerSummary[] | null;
-          }
-        >
-      ).map((row) => ({
-        ...row,
-        customers: Array.isArray(row.customers)
-          ? (row.customers[0] ?? null)
-          : (row.customers ?? null),
-      }));
-      const sortedRows = sortVehicleRows(rows);
-      setAllRows(sortedRows);
-      setVisibleRows(sortedRows.slice(0, 20));
-    } catch {
-      setAllRows([]);
-      setVisibleRows([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [getOrLinkShopId, supabase]);
-
-  useEffect(() => {
-    void loadVehicles();
-  }, [loadVehicles]);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      const q = query.trim().toLowerCase();
-      const rows = q
-        ? allRows.filter((row) => vehicleSearchHaystack(row).includes(q))
-        : allRows;
-      setVisibleRows(sortVehicleRows(rows).slice(0, 20));
-    }, 150);
-
-    return () => window.clearTimeout(timer);
-  }, [allRows, query]);
+function VehicleResultCard({
+  card,
+  permissions,
+}: {
+  card: VehicleWorkspaceSearchCard;
+  permissions: VehicleWorkspacePermissions;
+}) {
+  const identities = [
+    card.vehicle.unitNumber ? `Unit ${card.vehicle.unitNumber}` : null,
+    card.vehicle.licensePlate ? `Plate ${card.vehicle.licensePlate}` : null,
+    vinSuffix(card.vehicle.vin) ? `VIN •${vinSuffix(card.vehicle.vin)}` : null,
+  ].filter(Boolean);
+  const outstandingLabel =
+    card.currency === null
+      ? "Multiple/unknown currencies"
+      : card.outstandingAmount !== undefined && card.currency
+        ? formatMoney(card.outstandingAmount, card.currency)
+        : null;
 
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-5 text-[color:var(--theme-text-primary)]">
+    <article className={`${CARD_INNER} p-4`} data-vehicle-id={card.vehicle.id}>
+      <div className="flex min-w-0 flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="break-words text-base font-semibold text-[color:var(--theme-text-primary)]">
+              {vehicleIdentityLabel(card.vehicle)}
+            </h3>
+            {card.vehicle.status ? (
+              <span className="rounded-full border border-[color:var(--theme-border-soft)] px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
+                {card.vehicle.status}
+              </span>
+            ) : null}
+          </div>
+
+          <p className="mt-1 break-all text-xs text-[color:var(--theme-text-secondary)]">
+            {identities.length
+              ? identities.join(" · ")
+              : "No plate, VIN, or unit recorded"}
+          </p>
+          <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+            Account: {card.currentAccount?.displayName ?? "No current account"}
+          </p>
+
+          <dl className="mt-3 grid gap-2 text-xs sm:grid-cols-2 xl:grid-cols-4">
+            <div>
+              <dt className="text-[color:var(--theme-text-muted)]">Latest odometer</dt>
+              <dd className="mt-0.5 text-[color:var(--theme-text-primary)]">
+                {card.latestOdometer ?? "Not recorded"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[color:var(--theme-text-muted)]">Active now</dt>
+              <dd className="mt-0.5 text-[color:var(--theme-text-primary)]">
+                {card.activeWork.length
+                  ? `${card.activeWork.length} open record${card.activeWork.length === 1 ? "" : "s"}`
+                  : "No active work"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[color:var(--theme-text-muted)]">Next appointment</dt>
+              <dd className="mt-0.5 text-[color:var(--theme-text-primary)]">
+                {card.nextAppointment
+                  ? new Date(card.nextAppointment.startsAt).toLocaleString()
+                  : "None scheduled"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[color:var(--theme-text-muted)]">Needs attention</dt>
+              <dd className="mt-0.5 text-[color:var(--theme-text-primary)]">
+                {card.attentionCount} open/deferred
+              </dd>
+            </div>
+          </dl>
+
+          {card.activeWork.length ? (
+            <ul className="mt-3 flex flex-wrap gap-2" aria-label="Active records">
+              {card.activeWork.map((work) => {
+                const canOpen = work.kind === "estimate"
+                  ? permissions.canViewEstimates
+                  : permissions.canOpenWorkOrders;
+                const content = (
+                  <>
+                    {work.title} · {work.status.replaceAll("_", " ")}
+                  </>
+                );
+                const className =
+                  "inline-flex min-h-8 items-center rounded-full border border-[color:var(--theme-border-soft)] px-2.5 py-1 text-[11px] text-[color:var(--theme-text-secondary)]";
+
+                return (
+                  <li
+                    key={`${work.reference.sourceType}:${work.reference.sourceId}`}
+                  >
+                    {canOpen ? (
+                      <Link
+                        href={work.reference.href}
+                        data-source-id={work.reference.sourceId}
+                        data-source-type={work.reference.sourceType}
+                        className={`${className} hover:border-[var(--accent-copper-soft)] hover:text-[color:var(--theme-text-primary)]`}
+                      >
+                        {content}
+                      </Link>
+                    ) : (
+                      <span
+                        data-source-id={work.reference.sourceId}
+                        data-source-type={work.reference.sourceType}
+                        className={className}
+                      >
+                        {content}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+        </div>
+
+        <div className="flex shrink-0 flex-col gap-3 lg:items-end">
+          {outstandingLabel ? (
+            <div className="text-left lg:text-right">
+              <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                Vehicle-related outstanding
+              </div>
+              <div className="mt-0.5 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                {outstandingLabel}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex flex-wrap gap-2 lg:justify-end">
+            <Link
+              href={card.workspaceHref}
+              className={`${ACTION_CLASS} border-[var(--accent-copper-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-primary)] hover:border-[var(--accent-copper)]`}
+            >
+              Open Workspace
+            </Link>
+            {card.createWorkOrderHref ? (
+              <Link
+                href={card.createWorkOrderHref}
+                className={`${ACTION_CLASS} border-emerald-500/35 bg-emerald-500/10 text-emerald-700 hover:border-emerald-500/70 dark:text-emerald-200`}
+              >
+                Create Work Order
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function AccountWithoutVehicleCard({
+  account,
+  canOpen,
+}: {
+  account: VehicleWorkspaceSearchResponse["accountsWithoutVehicles"][number];
+  canOpen: boolean;
+}) {
+  const content = (
+    <>
+      <span className="min-w-0">
+        <span className="block truncate font-semibold text-[color:var(--theme-text-primary)]">
+          {account.displayName}
+        </span>
+        <span className="block text-xs text-[color:var(--theme-text-muted)]">
+          {account.accountType} account · no vehicle
+        </span>
+      </span>
+      <span aria-hidden="true">{canOpen ? "→" : "No vehicle"}</span>
+    </>
+  );
+  const className = `${CARD_INNER} flex min-h-14 items-center justify-between gap-3 p-3 text-sm`;
+
+  return canOpen ? (
+    <Link
+      href={`/customers/${account.id}`}
+      className={`${className} hover:border-[var(--accent-copper-soft)]`}
+    >
+      {content}
+    </Link>
+  ) : (
+    <article className={className}>{content}</article>
+  );
+}
+
+export default function VehicleFilesPage({
+  canManageVehicles,
+}: VehicleFilesPageProps) {
+  const router = useRouter();
+  const vehicleGuidedQuery = usePersistentGuidedOnboardingQuery("vehicles");
+  const [query, setQuery] = useState("");
+  const [result, setResult] =
+    useState<VehicleWorkspaceSearchResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timer = window.setTimeout(async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams();
+        if (query.trim()) params.set("q", query.trim());
+        const response = await fetch(
+          `/api/vehicles/search?${params.toString()}`,
+          {
+            cache: "no-store",
+            signal: controller.signal,
+          },
+        );
+        if (!response.ok) {
+          const body = (await response.json().catch(() => null)) as
+            | { error?: string }
+            | null;
+          throw new Error(body?.error || "Vehicle search is unavailable.");
+        }
+        setResult((await response.json()) as VehicleWorkspaceSearchResponse);
+      } catch (cause) {
+        if (controller.signal.aborted) return;
+        setResult(null);
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : "Vehicle search is unavailable.",
+        );
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    }, 250);
+
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [query]);
+
+  const vehicleCount =
+    result?.groups.reduce(
+      (count, group) => count + group.vehicles.length,
+      0,
+    ) ?? 0;
+  const visibleAccountsWithoutVehicles =
+    result?.permissions.canViewAccountContact
+      ? result.accountsWithoutVehicles
+      : [];
+  const noResults =
+    !loading &&
+    !error &&
+    vehicleCount === 0 &&
+    visibleAccountsWithoutVehicles.length === 0;
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-5 text-[color:var(--theme-text-primary)] sm:px-6">
       <GuidedPageStepPanel />
 
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <button
           type="button"
           onClick={() => router.back()}
-          className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--theme-text-primary)] hover:border-[var(--accent-copper-soft)]/70 hover:text-[color:var(--theme-text-primary)]"
+          className="min-h-10 rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--theme-text-primary)] hover:border-[var(--accent-copper-soft)]/70"
         >
           ← Back
         </button>
-        <div className="text-xs text-[color:var(--theme-text-muted)]">Vehicles</div>
+        <div className="text-xs text-[color:var(--theme-text-muted)]">Shop records</div>
       </div>
 
-      <VehicleCsvImportCard guidedQuery={vehicleGuidedQuery} />
+      {canManageVehicles ? (
+        <VehicleCsvImportCard guidedQuery={vehicleGuidedQuery} />
+      ) : null}
 
-      <div className={`${CARD_BASE} p-4`}>
+      <section
+        className={`${CARD_BASE} p-4`}
+        aria-labelledby="vehicle-search-heading"
+      >
         <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h1
+              id="vehicle-search-heading"
               className="text-2xl font-semibold text-[color:var(--theme-text-primary)]"
               style={{ fontFamily: "var(--font-blackops), system-ui" }}
             >
               Vehicle Files
             </h1>
-            <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-              Search by unit, VIN, plate, year, make, model, or customer.
+            <p className="mt-1 max-w-2xl text-xs text-[color:var(--theme-text-secondary)]">
+              Search by customer or company, phone, email, VIN, licence plate,
+              unit, year/make/model, or work-order number.
             </p>
           </div>
 
           <div className="flex flex-col gap-2 sm:w-[680px] sm:flex-row">
-            <button
-              type="button"
-              onClick={() => router.push("/customers/directory")}
-              className="rounded-xl border border-[var(--accent-copper-soft)]/55 bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] hover:border-[var(--accent-copper)] hover:bg-[color:var(--theme-surface-inset)]"
-              title="Select a customer file to add a vehicle."
-            >
-              + Create Vehicle
-            </button>
+            {canManageVehicles ? (
+              <button
+                type="button"
+                onClick={() => router.push("/customers/directory")}
+                className="min-h-11 rounded-xl border border-[var(--accent-copper-soft)]/55 bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] hover:border-[var(--accent-copper)] hover:bg-[color:var(--theme-surface-inset)]"
+                title="Select a customer file to add a vehicle."
+              >
+                + Create Vehicle
+              </button>
+            ) : null}
+            <label className="sr-only" htmlFor="vehicle-record-search">
+              Search customer and vehicle records
+            </label>
             <input
+              id="vehicle-record-search"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search vehicles..."
-              className="w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
+              placeholder="Customer, phone, VIN, plate, unit, or WO…"
+              autoComplete="off"
+              className="min-h-11 w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
             />
           </div>
         </div>
 
-        <div className="mt-4">
-          {visibleRows.length === 0 ? (
-            <div className={`${CARD_INNER} p-3 text-sm text-[color:var(--theme-text-secondary)]`}>
-              {loading
-                ? "Loading vehicles…"
-                : allRows.length === 0
-                  ? "No vehicles found yet."
-                  : "No vehicles match your search."}
+        <div className="mt-4" aria-live="polite">
+          {loading && !result ? (
+            <div
+              className={`${CARD_INNER} p-4 text-sm text-[color:var(--theme-text-secondary)]`}
+            >
+              Searching canonical customer, vehicle, and work-order records…
             </div>
-          ) : (
-            <div className="space-y-2">
-              {visibleRows.map((vehicle) => {
-                const customerName = customerDisplayName(vehicle.customers);
-                const yearMakeModel =
-                  vehicleYearMakeModel(vehicle) || "Vehicle";
+          ) : null}
 
-                return (
-                  <button
-                    key={vehicle.id}
-                    type="button"
-                    onClick={() => {
-                      if (vehicle.customer_id)
-                        router.push(`/customers/${vehicle.customer_id}`);
-                    }}
-                    className={`${CARD_INNER} w-full p-3 text-left hover:border-[var(--accent-copper-soft)]/65`}
-                  >
-                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                          {yearMakeModel}
-                        </div>
-                        <div className="mt-0.5 truncate text-[11px] text-[color:var(--theme-text-secondary)]">
-                          {vehicle.unit_number?.trim()
-                            ? `Unit ${vehicle.unit_number}`
-                            : "No unit number"}
-                        </div>
-                        <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-secondary)]">
-                          VIN: {vehicle.vin?.trim() || "—"} · Plate:{" "}
-                          {vehicle.license_plate?.trim() || "—"}
-                        </div>
-                      </div>
-                      <div className="text-left text-[11px] text-[color:var(--theme-text-secondary)] sm:text-right">
-                        <div className="text-[color:var(--theme-text-secondary)]">
-                          {customerName ?? "No linked customer"}
-                        </div>
-                        <div className="mt-0.5 text-[color:var(--theme-text-muted)]">
-                          {vehicleDisplayLabel(vehicle)}
-                        </div>
-                      </div>
-                    </div>
-                  </button>
-                );
-              })}
+          {error ? (
+            <div className="rounded-xl border border-rose-500/35 bg-rose-500/10 p-4 text-sm text-rose-700 dark:text-rose-200">
+              {error}
             </div>
-          )}
+          ) : null}
+
+          {noResults ? (
+            <div
+              className={`${CARD_INNER} p-4 text-sm text-[color:var(--theme-text-secondary)]`}
+            >
+              {query.trim()
+                ? "No customer, vehicle, or work-order record matches this search."
+                : "No vehicles found yet."}
+            </div>
+          ) : null}
+
+          {result ? (
+            <div
+              className="space-y-5 opacity-100 transition-opacity"
+              data-loading={loading}
+            >
+              {result.groups.map((group, index) => (
+                <section
+                  key={group.account?.id ?? `unassigned-${index}`}
+                  aria-labelledby={`account-group-${group.account?.id ?? index}`}
+                >
+                  <div className="mb-2 flex flex-wrap items-center justify-between gap-2 px-1">
+                    <div>
+                      <h2
+                        id={`account-group-${group.account?.id ?? index}`}
+                        className="text-sm font-semibold text-[color:var(--theme-text-primary)]"
+                      >
+                        {group.account?.displayName ??
+                          "Vehicles without a current account"}
+                      </h2>
+                      <p className="text-[11px] text-[color:var(--theme-text-muted)]">
+                        {group.account
+                          ? `${group.account.accountType} account · ${group.vehicles.length} vehicle${group.vehicles.length === 1 ? "" : "s"}`
+                          : `${group.vehicles.length} unassigned vehicle${group.vehicles.length === 1 ? "" : "s"}`}
+                      </p>
+                    </div>
+                    {group.account &&
+                    result.permissions.canOpenAccount ? (
+                      <Link
+                        href={`/customers/${group.account.id}`}
+                        className="inline-flex min-h-9 items-center rounded-lg border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs text-[color:var(--theme-text-secondary)] hover:border-[var(--accent-copper-soft)] hover:text-[color:var(--theme-text-primary)]"
+                      >
+                        Open account
+                      </Link>
+                    ) : null}
+                  </div>
+                  <div className="space-y-2">
+                    {group.vehicles.map((card) => (
+                      <VehicleResultCard
+                        key={card.vehicle.id}
+                        card={card}
+                        permissions={result.permissions}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))}
+
+              {visibleAccountsWithoutVehicles.length ? (
+                <section aria-labelledby="accounts-without-vehicles-heading">
+                  <h2
+                    id="accounts-without-vehicles-heading"
+                    className="mb-2 px-1 text-sm font-semibold text-[color:var(--theme-text-primary)]"
+                  >
+                    Matching accounts without vehicles
+                  </h2>
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    {visibleAccountsWithoutVehicles.map((account) => (
+                      <AccountWithoutVehicleCard
+                        key={account.id}
+                        account={account}
+                        canOpen={result.permissions.canOpenAccount}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+            </div>
+          ) : null}
         </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/features/vehicles/components/VehicleWorkspace.tsx
+++ b/features/vehicles/components/VehicleWorkspace.tsx
@@ -1,0 +1,820 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import type {
+  ActiveWorkSummary,
+  AppointmentSummary,
+  VehicleAttentionItem,
+  VehicleTimelineEvent,
+  VehicleWorkspacePermissions,
+  VehicleWorkspaceReference,
+  VehicleWorkspaceSnapshot,
+} from "@/features/vehicles/lib/vehicleWorkspace";
+
+type VehicleWorkspaceProps = {
+  snapshot: VehicleWorkspaceSnapshot;
+  createWorkOrderHref: string | null;
+};
+
+const PANEL =
+  "rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-panel-bg-soft,var(--theme-surface-page))] shadow-[var(--theme-shadow-medium)] backdrop-blur-xl";
+const ITEM =
+  "rounded-xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-item-bg,var(--theme-surface-inset))]";
+const EYEBROW =
+  "text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]";
+const LINK_FOCUS =
+  "focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-copper-soft,#fdba74)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--theme-surface-page)]";
+
+function textOrDash(value: string | number | null | undefined): string {
+  if (value == null) return "—";
+  const normalized = String(value).trim();
+  return normalized || "—";
+}
+
+function humanize(value: string): string {
+  return value.replaceAll("_", " ").replaceAll("-", " ");
+}
+
+function formatDateTime(value: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat("en-CA", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function formatCurrency(
+  value: number,
+  currency: string | null | undefined,
+): string {
+  try {
+    return new Intl.NumberFormat(currency === "USD" ? "en-US" : "en-CA", {
+      style: "currency",
+      currency: currency || "CAD",
+    }).format(value);
+  } catch {
+    return `${value.toFixed(2)} ${currency || "CAD"}`;
+  }
+}
+
+function vehicleTitle(snapshot: VehicleWorkspaceSnapshot): string {
+  const { identity } = snapshot;
+  return (
+    [identity.year, identity.make, identity.model, identity.submodel]
+      .filter(Boolean)
+      .join(" ") || "Vehicle"
+  );
+}
+
+function StatusPill({ value }: { value: string }) {
+  return (
+    <span className="inline-flex max-w-full rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.15em] text-[color:var(--theme-text-secondary)]">
+      {humanize(value)}
+    </span>
+  );
+}
+
+function SourceFooter({
+  label,
+  canOpen = true,
+}: {
+  label: string;
+  canOpen?: boolean;
+}) {
+  return (
+    <span className="mt-3 flex items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] pt-3 text-xs text-[color:var(--theme-text-muted)]">
+      <span className="min-w-0 truncate">Source: {label}</span>
+      <span aria-hidden="true" className="shrink-0 text-[color:var(--accent-copper-light,#fdba74)]">
+        {canOpen ? "Open →" : "Source retained"}
+      </span>
+    </span>
+  );
+}
+
+function EmptyState({ children }: { children: ReactNode }) {
+  return (
+    <p className={`${ITEM} px-4 py-5 text-sm text-[color:var(--theme-text-muted)]`}>
+      {children}
+    </p>
+  );
+}
+
+const WORK_ORDER_SOURCE_TYPES = new Set<
+  VehicleWorkspaceReference["sourceType"]
+>([
+  "maintenance_suggestion",
+  "work_order",
+  "work_order_line",
+  "work_order_media",
+  "work_order_part",
+]);
+
+function canOpenReference(
+  reference: VehicleWorkspaceReference,
+  permissions: VehicleWorkspacePermissions,
+): boolean {
+  if (reference.sourceType === "history") {
+    return permissions.canViewFinancials;
+  }
+  if (
+    reference.sourceType === "invoice" ||
+    reference.sourceType === "payment"
+  ) {
+    return permissions.canViewFinancials;
+  }
+  if (reference.sourceType === "inspection") {
+    return permissions.canOpenInspections;
+  }
+  if (reference.sourceType === "work_order_quote_line") {
+    return permissions.canViewEstimates;
+  }
+  if (WORK_ORDER_SOURCE_TYPES.has(reference.sourceType)) {
+    return permissions.canOpenWorkOrders;
+  }
+  return true;
+}
+
+function canOpenActiveWork(
+  item: ActiveWorkSummary,
+  permissions: VehicleWorkspacePermissions,
+): boolean {
+  if (item.kind === "estimate") return permissions.canViewEstimates;
+  return canOpenReference(item.reference, permissions);
+}
+
+function canOpenTimelineEvent(
+  event: VehicleTimelineEvent,
+  permissions: VehicleWorkspacePermissions,
+): boolean {
+  if (event.kind === "appointment" && !permissions.canBookAppointment) {
+    return false;
+  }
+  if (event.kind === "estimate") return permissions.canViewEstimates;
+  if (event.kind === "approval" && !permissions.canViewEstimates) return false;
+  return canOpenReference(event.reference, permissions);
+}
+
+function ActiveWorkCard({
+  item,
+  canOpen,
+}: {
+  item: ActiveWorkSummary;
+  canOpen: boolean;
+}) {
+  const content = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className={EYEBROW}>{humanize(item.kind)}</p>
+          <h3 className="mt-1 font-semibold">{item.title}</h3>
+        </div>
+        <StatusPill value={item.status} />
+      </div>
+      {item.detail ? (
+        <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+          {item.detail}
+        </p>
+      ) : null}
+      <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-[color:var(--theme-text-muted)]">
+        <span>{formatDateTime(item.occurredAt) || "Date not recorded"}</span>
+        {typeof item.amount === "number" ? (
+          <strong className="text-[color:var(--theme-text-primary)]">
+            {formatCurrency(item.amount, item.currency)}
+          </strong>
+        ) : null}
+      </div>
+      <SourceFooter label={item.reference.sourceLabel} canOpen={canOpen} />
+    </>
+  );
+
+  return (
+    <li>
+      {canOpen ? (
+        <Link
+          href={item.reference.href}
+          data-source-id={item.reference.sourceId}
+          data-source-type={item.reference.sourceType}
+          className={`${ITEM} ${LINK_FOCUS} block h-full p-4 transition hover:border-[color:var(--accent-copper-soft,#fdba74)] hover:bg-[color:var(--theme-surface-subtle)]`}
+        >
+          {content}
+        </Link>
+      ) : (
+        <div
+          data-source-id={item.reference.sourceId}
+          data-source-type={item.reference.sourceType}
+          className={`${ITEM} block h-full p-4`}
+        >
+          {content}
+        </div>
+      )}
+    </li>
+  );
+}
+
+function AppointmentCard({
+  appointment,
+  canOpen,
+}: {
+  appointment: AppointmentSummary;
+  canOpen: boolean;
+}) {
+  const startsAt = formatDateTime(appointment.startsAt);
+  const endsAt = formatDateTime(appointment.endsAt);
+  const content = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className={EYEBROW}>Appointment</p>
+          <h3 className="mt-1 font-semibold text-[color:var(--theme-text-primary)]">
+            {appointment.title}
+          </h3>
+        </div>
+        <StatusPill value={appointment.status} />
+      </div>
+      <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+        {startsAt || "Start time not recorded"}
+        {endsAt ? ` – ${endsAt}` : ""}
+      </p>
+      {appointment.detail ? (
+        <p className="mt-2 line-clamp-2 text-sm text-[color:var(--theme-text-muted)]">
+          {appointment.detail}
+        </p>
+      ) : null}
+      <SourceFooter
+        label={appointment.reference.sourceLabel}
+        canOpen={canOpen}
+      />
+    </>
+  );
+
+  return (
+    <li>
+      {canOpen ? (
+        <Link
+          href={appointment.reference.href}
+          data-source-id={appointment.reference.sourceId}
+          data-source-type={appointment.reference.sourceType}
+          className={`${ITEM} ${LINK_FOCUS} block h-full p-4 transition hover:border-[color:var(--accent-copper-soft,#fdba74)] hover:bg-[color:var(--theme-surface-subtle)]`}
+        >
+          {content}
+        </Link>
+      ) : (
+        <div
+          data-source-id={appointment.reference.sourceId}
+          data-source-type={appointment.reference.sourceType}
+          className={`${ITEM} block h-full p-4`}
+        >
+          {content}
+        </div>
+      )}
+    </li>
+  );
+}
+
+function AttentionCard({
+  item,
+  canOpen,
+}: {
+  item: VehicleAttentionItem;
+  canOpen: boolean;
+}) {
+  const severityClass =
+    item.severity === "urgent"
+      ? "border-rose-500/50 bg-rose-500/10"
+      : item.severity === "warning"
+        ? "border-amber-500/50 bg-amber-500/10"
+        : "border-sky-500/40 bg-sky-500/10";
+
+  const content = (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className={EYEBROW}>{humanize(item.kind)}</p>
+          <h3 className="mt-1 font-semibold text-[color:var(--theme-text-primary)]">
+            {item.title}
+          </h3>
+        </div>
+        <span className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+          {item.severity}
+        </span>
+      </div>
+      <p className="mt-2 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+        {item.explanation}
+      </p>
+      <SourceFooter label={item.reference.sourceLabel} canOpen={canOpen} />
+    </>
+  );
+
+  return (
+    <li>
+      {canOpen ? (
+        <Link
+          href={item.reference.href}
+          data-source-id={item.reference.sourceId}
+          data-source-type={item.reference.sourceType}
+          className={`${LINK_FOCUS} block h-full rounded-xl border p-4 transition hover:brightness-110 ${severityClass}`}
+        >
+          {content}
+        </Link>
+      ) : (
+        <div
+          data-source-id={item.reference.sourceId}
+          data-source-type={item.reference.sourceType}
+          className={`block h-full rounded-xl border p-4 ${severityClass}`}
+        >
+          {content}
+        </div>
+      )}
+    </li>
+  );
+}
+
+function TimelineEvent({
+  event,
+  canOpen,
+}: {
+  event: VehicleTimelineEvent;
+  canOpen: boolean;
+}) {
+  const content = (
+    <>
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+        <div className="min-w-0">
+          <p className={EYEBROW}>{humanize(event.kind)}</p>
+          <h3 className="mt-1 font-semibold text-[color:var(--theme-text-primary)]">
+            {event.title}
+          </h3>
+        </div>
+        <time
+          dateTime={event.occurredAt}
+          className="shrink-0 text-xs text-[color:var(--theme-text-muted)]"
+        >
+          {formatDateTime(event.occurredAt) || "Date not recorded"}
+        </time>
+      </div>
+      {event.detail ? (
+        <p className="mt-2 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+          {event.detail}
+        </p>
+      ) : null}
+      <SourceFooter label={event.reference.sourceLabel} canOpen={canOpen} />
+    </>
+  );
+
+  return (
+    <li className="relative pl-7 before:absolute before:left-[7px] before:top-3 before:h-full before:w-px before:bg-[color:var(--theme-border-soft)] last:before:hidden">
+      <span
+        aria-hidden="true"
+        className="absolute left-0 top-2 h-[15px] w-[15px] rounded-full border-2 border-[color:var(--accent-copper-soft,#fdba74)] bg-[color:var(--theme-surface-page)]"
+      />
+      {canOpen ? (
+        <Link
+          href={event.reference.href}
+          data-source-id={event.reference.sourceId}
+          data-source-type={event.reference.sourceType}
+          className={`${ITEM} ${LINK_FOCUS} block p-4 transition hover:border-[color:var(--accent-copper-soft,#fdba74)]`}
+        >
+          {content}
+        </Link>
+      ) : (
+        <div
+          data-source-id={event.reference.sourceId}
+          data-source-type={event.reference.sourceType}
+          className={`${ITEM} block p-4`}
+        >
+          {content}
+        </div>
+      )}
+    </li>
+  );
+}
+
+export function VehicleWorkspace({
+  snapshot,
+  createWorkOrderHref,
+}: VehicleWorkspaceProps) {
+  const { identity, currentAccount } = snapshot;
+  const visibleTimeline = snapshot.recentTimeline.slice(0, 8);
+  const olderTimeline = snapshot.recentTimeline.slice(8);
+  const identifierRows = [
+    identity.unitNumber ? ["Unit", identity.unitNumber] : null,
+    identity.licensePlate ? ["Plate", identity.licensePlate] : null,
+    identity.vin ? ["VIN", identity.vin] : null,
+  ].filter((row): row is [string, string] => Boolean(row));
+
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-4 text-[color:var(--theme-text-primary)] sm:px-6 sm:py-6 lg:px-8">
+      <header className={`${PANEL} sticky top-2 z-20 overflow-hidden p-4 sm:p-5`}>
+        <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className={EYEBROW}>Vehicle workspace</p>
+              {identity.status ? <StatusPill value={identity.status} /> : null}
+            </div>
+            <h1 className="mt-2 text-2xl font-bold tracking-tight sm:text-3xl">
+              {vehicleTitle(snapshot)}
+            </h1>
+            <dl className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-sm">
+              {identifierRows.map(([label, value]) => (
+                <div key={label} className="flex min-w-0 gap-2">
+                  <dt className="text-[color:var(--theme-text-muted)]">{label}</dt>
+                  <dd className="max-w-[22rem] break-all font-medium text-[color:var(--theme-text-secondary)]">
+                    {value}
+                  </dd>
+                </div>
+              ))}
+              {identity.mileage ? (
+                <div className="flex gap-2">
+                  <dt className="text-[color:var(--theme-text-muted)]">Odometer</dt>
+                  <dd className="font-medium text-[color:var(--theme-text-secondary)]">
+                    {identity.mileage} {identity.odometerUnit || ""}
+                  </dd>
+                </div>
+              ) : null}
+              {identity.engineHours != null ? (
+                <div className="flex gap-2">
+                  <dt className="text-[color:var(--theme-text-muted)]">Engine hours</dt>
+                  <dd className="font-medium text-[color:var(--theme-text-secondary)]">
+                    {identity.engineHours}
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+          </div>
+
+          <div className="flex min-w-0 flex-col gap-3 xl:items-end">
+            {currentAccount ? (
+              <div className="min-w-0 xl:text-right">
+                <p className={EYEBROW}>Current account</p>
+                {snapshot.permissions.canOpenAccount ? (
+                  <Link
+                    href={`/customers/${encodeURIComponent(currentAccount.id)}`}
+                    className={`${LINK_FOCUS} mt-1 inline-block max-w-full truncate font-semibold text-[color:var(--accent-copper-light,#fdba74)] hover:underline`}
+                  >
+                    {currentAccount.displayName}
+                  </Link>
+                ) : (
+                  <p className="mt-1 max-w-full truncate font-semibold text-[color:var(--theme-text-primary)]">
+                    {currentAccount.displayName}
+                  </p>
+                )}
+                {snapshot.permissions.canViewAccountContact &&
+                (currentAccount.email || currentAccount.phone) ? (
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-[color:var(--theme-text-muted)] xl:justify-end">
+                    {currentAccount.phone ? (
+                      <a
+                        href={`tel:${currentAccount.phone}`}
+                        className={`${LINK_FOCUS} hover:text-[color:var(--theme-text-primary)] hover:underline`}
+                      >
+                        {currentAccount.phone}
+                      </a>
+                    ) : null}
+                    {currentAccount.email ? (
+                      <a
+                        href={`mailto:${currentAccount.email}`}
+                        className={`${LINK_FOCUS} break-all hover:text-[color:var(--theme-text-primary)] hover:underline`}
+                      >
+                        {currentAccount.email}
+                      </a>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-sm text-[color:var(--theme-text-muted)]">
+                No current account
+              </p>
+            )}
+            <nav
+              aria-label="Vehicle actions"
+              className="flex flex-wrap gap-2 xl:justify-end"
+            >
+              {currentAccount &&
+              snapshot.permissions.canOpenAccount ? (
+                <Link
+                  href={`/customers/${encodeURIComponent(currentAccount.id)}`}
+                  className={`${LINK_FOCUS} rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3.5 py-2 text-sm font-semibold transition hover:bg-[color:var(--theme-surface-subtle)]`}
+                >
+                  Open Account
+                </Link>
+              ) : null}
+              {snapshot.permissions.canCreateWorkOrder && createWorkOrderHref ? (
+                <Link
+                  href={createWorkOrderHref}
+                  className={`${LINK_FOCUS} rounded-lg border border-[color:var(--accent-copper-soft,#fdba74)] bg-[color:var(--accent-copper,#c47a3a)] px-3.5 py-2 text-sm font-semibold text-white transition hover:brightness-110`}
+                >
+                  Create Work Order
+                </Link>
+              ) : null}
+            </nav>
+          </div>
+        </div>
+
+        {snapshot.conflicts.length > 0 ? (
+          <div
+            role="alert"
+            aria-label="Vehicle record conflicts"
+            className="mt-5 rounded-xl border border-amber-500/50 bg-amber-500/10 p-4"
+          >
+            <p className="text-xs font-bold uppercase tracking-[0.18em] text-amber-800 dark:text-amber-200">
+              Review record conflicts
+            </p>
+            <ul className="mt-2 space-y-2">
+              {snapshot.conflicts.map((conflict) => (
+                <li key={`${conflict.kind}:${conflict.sourceIds.join(":")}`}>
+                  <p className="text-sm font-semibold">{conflict.title}</p>
+                  <p className="text-sm text-[color:var(--theme-text-secondary)]">
+                    {conflict.detail}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </header>
+
+      <section
+        aria-labelledby="active-now-heading"
+        className={`${PANEL} p-4 sm:p-5`}
+      >
+        <div className="flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <p className={EYEBROW}>Current condition</p>
+            <h2 id="active-now-heading" className="mt-1 text-xl font-bold">
+              Active now
+            </h2>
+          </div>
+          <p className="text-xs text-[color:var(--theme-text-muted)]">
+            {snapshot.activeWork.length} active record
+            {snapshot.activeWork.length === 1 ? "" : "s"}
+            {snapshot.upcomingAppointments.length
+              ? ` · ${snapshot.upcomingAppointments.length} upcoming`
+              : ""}
+          </p>
+        </div>
+
+        {snapshot.activeWork.length || snapshot.upcomingAppointments.length ? (
+          <ul className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {snapshot.activeWork.map((item) => (
+              <ActiveWorkCard
+                key={`${item.reference.sourceType}:${item.reference.sourceId}`}
+                item={item}
+                canOpen={canOpenActiveWork(item, snapshot.permissions)}
+              />
+            ))}
+            {snapshot.upcomingAppointments.map((appointment) => (
+              <AppointmentCard
+                key={`${appointment.reference.sourceType}:${appointment.reference.sourceId}`}
+                appointment={appointment}
+                canOpen={snapshot.permissions.canBookAppointment}
+              />
+            ))}
+          </ul>
+        ) : (
+          <div className="mt-4">
+            <EmptyState>
+              No active work or upcoming appointments are visible for this
+              vehicle.
+            </EmptyState>
+          </div>
+        )}
+      </section>
+
+      <section
+        aria-labelledby="attention-heading"
+        className={`${PANEL} p-4 sm:p-5`}
+      >
+        <div className="flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <p className={EYEBROW}>Evidence-backed items</p>
+            <h2 id="attention-heading" className="mt-1 text-xl font-bold">
+              Needs attention
+            </h2>
+          </div>
+          <p className="text-xs text-[color:var(--theme-text-muted)]">
+            {snapshot.attentionItems.length} evidence item
+            {snapshot.attentionItems.length === 1 ? "" : "s"}
+          </p>
+        </div>
+        {snapshot.attentionItems.length ? (
+          <ul className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {snapshot.attentionItems.map((item) => (
+              <AttentionCard
+                key={`${item.reference.sourceType}:${item.reference.sourceId}:${item.kind}`}
+                item={item}
+                canOpen={canOpenReference(item.reference, snapshot.permissions)}
+              />
+            ))}
+          </ul>
+        ) : (
+          <div className="mt-4">
+            <EmptyState>
+              No evidence-backed attention items are visible.
+            </EmptyState>
+          </div>
+        )}
+      </section>
+
+      <section
+        aria-labelledby="timeline-heading"
+        className={`${PANEL} p-4 sm:p-5`}
+      >
+        <div className="flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <p className={EYEBROW}>Canonical record stream</p>
+            <h2 id="timeline-heading" className="mt-1 text-xl font-bold">
+              Recent timeline
+            </h2>
+          </div>
+          <p className="text-xs text-[color:var(--theme-text-muted)]">
+            Most recent first
+          </p>
+        </div>
+        {visibleTimeline.length ? (
+          <>
+            <ol className="mt-5 space-y-3">
+              {visibleTimeline.map((event) => (
+                <TimelineEvent
+                  key={`${event.reference.sourceType}:${event.reference.sourceId}:${event.kind}`}
+                  event={event}
+                  canOpen={canOpenTimelineEvent(event, snapshot.permissions)}
+                />
+              ))}
+            </ol>
+            {olderTimeline.length ? (
+              <details className={`${ITEM} mt-4 p-4`}>
+                <summary
+                  className={`${LINK_FOCUS} cursor-pointer text-sm font-semibold text-[color:var(--accent-copper-light,#fdba74)]`}
+                >
+                  Show {olderTimeline.length} older event
+                  {olderTimeline.length === 1 ? "" : "s"}
+                </summary>
+                <ol className="mt-5 space-y-3">
+                  {olderTimeline.map((event) => (
+                    <TimelineEvent
+                      key={`${event.reference.sourceType}:${event.reference.sourceId}:${event.kind}`}
+                      event={event}
+                      canOpen={canOpenTimelineEvent(event, snapshot.permissions)}
+                    />
+                  ))}
+                </ol>
+              </details>
+            ) : null}
+          </>
+        ) : (
+          <div className="mt-4">
+            <EmptyState>No timeline events are visible for this vehicle.</EmptyState>
+          </div>
+        )}
+      </section>
+
+      <aside
+        aria-label="Vehicle workspace summaries"
+        className="grid gap-4 lg:grid-cols-3"
+      >
+        {snapshot.financialSummary.visible ? (
+          <section
+            className={`${PANEL} p-4`}
+            aria-labelledby="financial-summary-heading"
+          >
+            <p className={EYEBROW}>Authorized view</p>
+            <h2 id="financial-summary-heading" className="mt-1 font-bold">
+              Vehicle financials
+            </h2>
+            <dl className="mt-3 grid grid-cols-2 gap-3 text-sm">
+              <div>
+                <dt className="text-[color:var(--theme-text-muted)]">
+                  Outstanding
+                </dt>
+                <dd className="mt-1 font-semibold">
+                  {snapshot.financialSummary.invoiceCount === 0
+                    ? "No invoices"
+                    : !snapshot.financialSummary.currency ||
+                        snapshot.financialSummary.outstandingAmount === null
+                      ? "Multiple currencies"
+                      : formatCurrency(
+                        snapshot.financialSummary.outstandingAmount,
+                        snapshot.financialSummary.currency,
+                      )}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[color:var(--theme-text-muted)]">Paid</dt>
+                <dd className="mt-1 font-semibold">
+                  {snapshot.financialSummary.invoiceCount === 0
+                    ? "No invoices"
+                    : !snapshot.financialSummary.currency ||
+                        snapshot.financialSummary.paidAmount === null
+                      ? "Multiple currencies"
+                      : formatCurrency(
+                        snapshot.financialSummary.paidAmount,
+                        snapshot.financialSummary.currency,
+                      )}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-[color:var(--theme-text-muted)]">Invoices</dt>
+                <dd className="mt-1 font-semibold">
+                  {snapshot.financialSummary.invoiceCount}
+                </dd>
+              </div>
+            </dl>
+          </section>
+        ) : null}
+
+        <section
+          className={`${PANEL} p-4`}
+          aria-labelledby="document-summary-heading"
+        >
+          <p className={EYEBROW}>Attached evidence</p>
+          <h2 id="document-summary-heading" className="mt-1 font-bold">
+            Documents
+          </h2>
+          <dl className="mt-3 grid grid-cols-3 gap-2 text-center text-sm">
+            <div className={`${ITEM} p-2`}>
+              <dt className="text-xs text-[color:var(--theme-text-muted)]">
+                Vehicle
+              </dt>
+              <dd className="mt-1 font-semibold">
+                {snapshot.documentSummary.vehicleMediaCount}
+              </dd>
+            </div>
+            <div className={`${ITEM} p-2`}>
+              <dt className="text-xs text-[color:var(--theme-text-muted)]">
+                Work order
+              </dt>
+              <dd className="mt-1 font-semibold">
+                {snapshot.documentSummary.workOrderMediaCount}
+              </dd>
+            </div>
+            <div className={`${ITEM} p-2`}>
+              <dt className="text-xs text-[color:var(--theme-text-muted)]">
+                Inspection
+              </dt>
+              <dd className="mt-1 font-semibold">
+                {snapshot.documentSummary.inspectionReportCount}
+              </dd>
+            </div>
+          </dl>
+          {snapshot.documentSummary.latestReference ? (
+            canOpenReference(
+              snapshot.documentSummary.latestReference,
+              snapshot.permissions,
+            ) ? (
+              <Link
+                href={snapshot.documentSummary.latestReference.href}
+                data-source-id={snapshot.documentSummary.latestReference.sourceId}
+                data-source-type={snapshot.documentSummary.latestReference.sourceType}
+                className={`${LINK_FOCUS} mt-3 inline-flex text-sm font-semibold text-[color:var(--accent-copper-light,#fdba74)] hover:underline`}
+              >
+                Open {snapshot.documentSummary.latestReference.sourceLabel} →
+              </Link>
+            ) : (
+              <p
+                data-source-id={snapshot.documentSummary.latestReference.sourceId}
+                data-source-type={snapshot.documentSummary.latestReference.sourceType}
+                className="mt-3 text-sm font-semibold text-[color:var(--theme-text-muted)]"
+              >
+                Source retained: {snapshot.documentSummary.latestReference.sourceLabel}
+              </p>
+            )
+          ) : null}
+        </section>
+
+        {snapshot.permissions.canViewRelatedVehicles &&
+        snapshot.relatedVehicles.length ? (
+          <section
+            className={`${PANEL} p-4`}
+            aria-labelledby="related-vehicles-heading"
+          >
+            <p className={EYEBROW}>Current account</p>
+            <h2 id="related-vehicles-heading" className="mt-1 font-bold">
+              Related vehicles
+            </h2>
+            <ul className="mt-3 divide-y divide-[color:var(--theme-border-soft)]">
+              {snapshot.relatedVehicles.slice(0, 6).map((vehicle) => (
+                <li key={vehicle.id}>
+                  <Link
+                    href={vehicle.href}
+                    className={`${LINK_FOCUS} flex items-center justify-between gap-3 py-2 text-sm hover:text-[color:var(--accent-copper-light,#fdba74)]`}
+                  >
+                    <span className="min-w-0 truncate font-medium">
+                      {vehicle.label}
+                    </span>
+                    <span className="shrink-0 text-xs text-[color:var(--theme-text-muted)]">
+                      {textOrDash(vehicle.status)} →
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+      </aside>
+    </main>
+  );
+}
+
+export default VehicleWorkspace;

--- a/features/vehicles/lib/vehicleWorkspace.ts
+++ b/features/vehicles/lib/vehicleWorkspace.ts
@@ -1,0 +1,268 @@
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+
+export const VEHICLE_WORKSPACE_READER_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "service",
+  "parts",
+  "mechanic",
+  "lead_hand",
+  "foreman",
+] as const satisfies readonly CanonicalRole[];
+
+export type VehicleWorkspaceSourceType =
+  | "appointment"
+  | "history"
+  | "inspection"
+  | "invoice"
+  | "maintenance_suggestion"
+  | "part_request"
+  | "payment"
+  | "vehicle_media"
+  | "work_order"
+  | "work_order_line"
+  | "work_order_media"
+  | "work_order_part"
+  | "work_order_quote_line";
+
+export type VehicleWorkspaceReference = {
+  sourceType: VehicleWorkspaceSourceType;
+  sourceId: string;
+  sourceLabel: string;
+  href: string;
+};
+
+export type VehicleWorkspacePermissions = {
+  canViewAccountContact: boolean;
+  canOpenAccount: boolean;
+  canViewFinancials: boolean;
+  canViewEstimates: boolean;
+  canOpenInspections: boolean;
+  canOpenWorkOrders: boolean;
+  canViewPartRequests: boolean;
+  canCreateWorkOrder: boolean;
+  canBookAppointment: boolean;
+  canCreateEstimate: boolean;
+  canMessageCustomer: boolean;
+  canViewRelatedVehicles: boolean;
+  isAssignedWorkOnly: boolean;
+};
+
+export type VehicleIdentity = {
+  id: string;
+  year: number | null;
+  make: string | null;
+  model: string | null;
+  submodel: string | null;
+  vin: string | null;
+  licensePlate: string | null;
+  unitNumber: string | null;
+  mileage: string | null;
+  odometerUnit: string | null;
+  engineHours: number | null;
+  status: string | null;
+};
+
+export type CustomerAccountSummary = {
+  id: string;
+  displayName: string;
+  accountType: string;
+  active: boolean;
+  email?: string | null;
+  phone?: string | null;
+  archivedAt: string | null;
+  mergedIntoCustomerId: string | null;
+};
+
+export type ActiveWorkSummary = {
+  kind:
+    | "estimate"
+    | "inspection"
+    | "invoice"
+    | "part_request"
+    | "work_order";
+  title: string;
+  status: string;
+  detail: string | null;
+  occurredAt: string | null;
+  amount?: number;
+  currency?: string;
+  reference: VehicleWorkspaceReference;
+};
+
+export type AppointmentSummary = {
+  title: string;
+  status: string;
+  startsAt: string;
+  endsAt: string;
+  detail: string | null;
+  reference: VehicleWorkspaceReference;
+};
+
+export type VehicleAttentionItem = {
+  kind:
+    | "deferred_work"
+    | "failed_inspection"
+    | "maintenance_due"
+    | "unresolved_concern"
+    | "waiting_parts";
+  title: string;
+  explanation: string;
+  severity: "info" | "warning" | "urgent";
+  occurredAt: string | null;
+  reference: VehicleWorkspaceReference;
+};
+
+export type VehicleTimelineEvent = {
+  kind:
+    | "approval"
+    | "appointment"
+    | "estimate"
+    | "history"
+    | "inspection"
+    | "invoice"
+    | "part"
+    | "payment"
+    | "repair"
+    | "work_order";
+  title: string;
+  detail: string | null;
+  occurredAt: string;
+  reference: VehicleWorkspaceReference;
+};
+
+export type VehicleFinancialSummary =
+  | { visible: false }
+  | {
+      visible: true;
+      currency: string | null;
+      invoiceCount: number;
+      outstandingAmount: number | null;
+      paidAmount: number | null;
+    };
+
+export type VehicleDocumentSummary = {
+  vehicleMediaCount: number;
+  workOrderMediaCount: number;
+  inspectionReportCount: number;
+  latestReference: VehicleWorkspaceReference | null;
+};
+
+export type RelatedVehicleSummary = {
+  id: string;
+  label: string;
+  status: string | null;
+  href: string;
+};
+
+export type VehicleWorkspaceConflict = {
+  kind:
+    | "archived_account"
+    | "historical_owner"
+    | "missing_current_account"
+    | "multiple_active_work_orders"
+    | "vehicle_status";
+  title: string;
+  detail: string;
+  sourceIds: string[];
+};
+
+export type VehicleWorkspaceSnapshot = {
+  identity: VehicleIdentity;
+  currentAccount: CustomerAccountSummary | null;
+  permissions: VehicleWorkspacePermissions;
+  activeWork: ActiveWorkSummary[];
+  upcomingAppointments: AppointmentSummary[];
+  attentionItems: VehicleAttentionItem[];
+  recentTimeline: VehicleTimelineEvent[];
+  financialSummary: VehicleFinancialSummary;
+  documentSummary: VehicleDocumentSummary;
+  relatedVehicles: RelatedVehicleSummary[];
+  conflicts: VehicleWorkspaceConflict[];
+};
+
+export type VehicleWorkspaceSearchCard = {
+  vehicle: VehicleIdentity;
+  currentAccount: Pick<CustomerAccountSummary, "id" | "displayName"> | null;
+  latestOdometer: string | null;
+  activeWork: Pick<
+    ActiveWorkSummary,
+    "kind" | "title" | "status" | "reference"
+  >[];
+  nextAppointment: AppointmentSummary | null;
+  attentionCount: number;
+  outstandingAmount?: number;
+  currency?: string | null;
+  workspaceHref: string;
+  createWorkOrderHref: string | null;
+};
+
+export type VehicleWorkspaceSearchGroup = {
+  account: Pick<
+    CustomerAccountSummary,
+    "id" | "displayName" | "accountType" | "active"
+  > | null;
+  matchedAccount: boolean;
+  vehicles: VehicleWorkspaceSearchCard[];
+};
+
+export type VehicleWorkspaceSearchResponse = {
+  query: string;
+  groups: VehicleWorkspaceSearchGroup[];
+  accountsWithoutVehicles: Array<
+    Pick<CustomerAccountSummary, "id" | "displayName" | "accountType" | "active">
+  >;
+  permissions: VehicleWorkspacePermissions;
+};
+
+export function customerAccountDisplayName(input: {
+  business_name?: string | null;
+  name?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  phone_number?: string | null;
+}): string {
+  const person = [input.first_name, input.last_name]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join(" ")
+    .trim();
+
+  return (
+    input.business_name?.trim() ||
+    input.name?.trim() ||
+    person ||
+    input.email?.trim() ||
+    input.phone?.trim() ||
+    input.phone_number?.trim() ||
+    "Unnamed account"
+  );
+}
+
+export function vehicleIdentityLabel(
+  vehicle: Pick<VehicleIdentity, "year" | "make" | "model" | "unitNumber">,
+): string {
+  const description = [vehicle.year, vehicle.make, vehicle.model]
+    .filter(Boolean)
+    .join(" ");
+  const unit = vehicle.unitNumber?.trim();
+  return [description || "Vehicle", unit ? `Unit ${unit}` : null]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export function createWorkOrderHandoffHref(input: {
+  customerId: string | null;
+  vehicleId: string;
+}): string | null {
+  if (!input.customerId) return null;
+  const query = new URLSearchParams({
+    autostart: "1",
+    customerId: input.customerId,
+    vehicleId: input.vehicleId,
+  });
+  return `/work-orders/create?${query.toString()}`;
+}

--- a/features/vehicles/server/loadVehicleWorkspaceSnapshot.ts
+++ b/features/vehicles/server/loadVehicleWorkspaceSnapshot.ts
@@ -1,0 +1,1418 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database, Json } from "@shared/types/types/supabase";
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
+import type { MaintenanceSuggestionItem } from "@/features/maintenance/server/types";
+import {
+  createWorkOrderHandoffHref,
+  customerAccountDisplayName,
+  vehicleIdentityLabel,
+  type ActiveWorkSummary,
+  type AppointmentSummary,
+  type CustomerAccountSummary,
+  type RelatedVehicleSummary,
+  type VehicleAttentionItem,
+  type VehicleDocumentSummary,
+  type VehicleFinancialSummary,
+  type VehicleIdentity,
+  type VehicleTimelineEvent,
+  type VehicleWorkspaceConflict,
+  type VehicleWorkspaceReference,
+  type VehicleWorkspaceSnapshot,
+} from "@/features/vehicles/lib/vehicleWorkspace";
+import { vehicleWorkspacePermissionsForRole } from "@/features/vehicles/server/vehicleWorkspacePermissions";
+
+type DB = Database;
+type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
+type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type WorkOrderPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"];
+type QuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type BookingRow = DB["public"]["Tables"]["bookings"]["Row"];
+type InspectionRow = DB["public"]["Tables"]["inspections"]["Row"];
+type HistoryRow = DB["public"]["Tables"]["history"]["Row"];
+type InvoiceRow = DB["public"]["Tables"]["invoices"]["Row"];
+type PaymentRow = DB["public"]["Tables"]["payments"]["Row"];
+type PartRequestRow = DB["public"]["Tables"]["part_requests"]["Row"];
+type VehicleMediaRow = DB["public"]["Tables"]["vehicle_media"]["Row"];
+type WorkOrderMediaRow = DB["public"]["Tables"]["work_order_media"]["Row"];
+type MaintenanceSuggestionRow =
+  DB["public"]["Tables"]["maintenance_suggestions"]["Row"];
+
+type WorkspaceVehicleRow = Pick<
+  VehicleRow,
+  | "id"
+  | "shop_id"
+  | "customer_id"
+  | "year"
+  | "make"
+  | "model"
+  | "submodel"
+  | "vin"
+  | "license_plate"
+  | "unit_number"
+  | "mileage"
+  | "odometer_unit"
+  | "engine_hours"
+  | "status"
+>;
+
+type WorkspaceCustomerRow = Pick<
+  CustomerRow,
+  | "id"
+  | "account_type"
+  | "active"
+  | "business_name"
+  | "name"
+  | "first_name"
+  | "last_name"
+  | "email"
+  | "phone"
+  | "phone_number"
+  | "archived_at"
+  | "merged_into_customer_id"
+>;
+
+type WorkspaceWorkOrderRow = Pick<
+  WorkOrderRow,
+  | "id"
+  | "customer_id"
+  | "vehicle_id"
+  | "custom_id"
+  | "status"
+  | "record_type"
+  | "approval_state"
+  | "estimate_number"
+  | "estimate_status"
+  | "scheduled_at"
+  | "odometer_km"
+  | "created_at"
+  | "updated_at"
+>;
+
+type WorkspaceWorkOrderLineRow = Pick<
+  WorkOrderLineRow,
+  | "id"
+  | "work_order_id"
+  | "description"
+  | "complaint"
+  | "correction"
+  | "hold_reason"
+  | "status"
+  | "line_status"
+  | "approval_state"
+  | "urgency"
+  | "voided_at"
+  | "created_at"
+  | "updated_at"
+>;
+
+type WorkspaceWorkOrderPartRow = Pick<
+  WorkOrderPartRow,
+  | "id"
+  | "work_order_id"
+  | "work_order_line_id"
+  | "description_snapshot"
+  | "manufacturer_snapshot"
+  | "part_number_snapshot"
+  | "sku_snapshot"
+  | "quantity_consumed"
+  | "quantity_returned"
+  | "is_active"
+  | "created_at"
+  | "updated_at"
+>;
+
+type WorkspaceQuoteLineRow = Pick<
+  QuoteLineRow,
+  | "id"
+  | "work_order_id"
+  | "work_order_line_id"
+  | "source_work_order_line_id"
+  | "description"
+  | "title"
+  | "status"
+  | "decision"
+  | "defer_reason"
+  | "decline_reason"
+  | "approved_at"
+  | "deferred_at"
+  | "declined_at"
+  | "created_at"
+  | "updated_at"
+>;
+
+type WorkspaceBookingRow = Pick<
+  BookingRow,
+  | "id"
+  | "work_order_id"
+  | "starts_at"
+  | "ends_at"
+  | "status"
+  | "notes"
+  | "created_at"
+>;
+
+type WorkspaceInspectionRow = Pick<
+  InspectionRow,
+  | "id"
+  | "work_order_id"
+  | "work_order_line_id"
+  | "inspection_type"
+  | "status"
+  | "completed"
+  | "summary"
+  | "created_at"
+  | "started_at"
+  | "finalized_at"
+  | "updated_at"
+  | "pdf_url"
+  | "pdf_storage_path"
+>;
+
+type WorkspaceHistoryRow = Pick<
+  HistoryRow,
+  | "id"
+  | "customer_id"
+  | "work_order_id"
+  | "work_order_number"
+  | "historical_status"
+  | "description"
+  | "odometer"
+  | "service_date"
+  | "opened_at"
+  | "closed_at"
+  | "source_system"
+>;
+
+type WorkspaceInvoiceRow = Pick<
+  InvoiceRow,
+  | "id"
+  | "work_order_id"
+  | "invoice_number"
+  | "status"
+  | "currency"
+  | "total"
+  | "outstanding_total"
+  | "paid_total"
+  | "created_at"
+  | "issued_at"
+  | "paid_at"
+  | "updated_at"
+>;
+
+type WorkspacePaymentRow = Pick<
+  PaymentRow,
+  | "id"
+  | "work_order_id"
+  | "status"
+  | "amount"
+  | "currency"
+  | "paid_at"
+  | "created_at"
+>;
+
+type WorkspacePartRequestRow = Pick<
+  PartRequestRow,
+  "id" | "work_order_id" | "status" | "notes" | "created_at"
+>;
+
+type WorkspaceVehicleMediaRow = Pick<
+  VehicleMediaRow,
+  "id" | "type" | "filename" | "created_at"
+>;
+
+type WorkspaceWorkOrderMediaRow = Pick<
+  WorkOrderMediaRow,
+  "id" | "work_order_id" | "kind" | "file_name" | "created_at"
+>;
+
+const TERMINAL_WORK_ORDER_STATUSES = new Set([
+  "archived",
+  "canceled",
+  "cancelled",
+  "closed",
+  "completed",
+  "invoiced",
+  "paid",
+  "void",
+  "voided",
+]);
+const OPEN_INSPECTION_STATUSES = new Set([
+  "not_started",
+  "in_progress",
+  "paused",
+  "draft",
+  "open",
+]);
+const TERMINAL_APPOINTMENT_STATUSES = new Set([
+  "canceled",
+  "cancelled",
+  "completed",
+]);
+const TERMINAL_PART_REQUEST_STATUSES = new Set([
+  "canceled",
+  "cancelled",
+  "fulfilled",
+  "rejected",
+  "returned",
+]);
+const ACTIVE_ESTIMATE_STATUSES = new Set([
+  "draft",
+  "waiting_for_parts",
+  "ready_for_advisor",
+  "sent",
+  "partially_approved",
+]);
+const DEFERRED_LINE_STATES = new Set([
+  "deferred",
+  "declined",
+  "customer_deferred",
+  "customer_declined",
+]);
+const WAITING_PARTS_LINE_STATES = new Set([
+  "awaiting_parts",
+  "on_hold",
+  "parts_needed",
+  "waiting_parts",
+]);
+const PENDING_CONCERN_STATES = new Set([
+  "awaiting",
+  "awaiting_approval",
+  "pending",
+]);
+const QUOTE_DECISION_STATES = new Set([
+  "approved",
+  "declined",
+  "deferred",
+  "customer_approved",
+  "customer_declined",
+  "customer_deferred",
+]);
+const TERMINAL_LINE_STATES = new Set([
+  "canceled",
+  "cancelled",
+  "completed",
+  "invoiced",
+  "ready_to_invoice",
+  "voided",
+]);
+
+function text(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizedOperationalState(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function quoteLineIsDeferred(row: WorkspaceQuoteLineRow): boolean {
+  return DEFERRED_LINE_STATES.has(
+    normalizedOperationalState(row.decision ?? row.status),
+  );
+}
+
+function workOrderIsEstimate(row: WorkspaceWorkOrderRow): boolean {
+  return row.record_type === "estimate" || Boolean(row.estimate_number);
+}
+
+function estimateIsActionable(row: WorkspaceWorkOrderRow): boolean {
+  return (
+    workOrderIsEstimate(row) &&
+    ACTIVE_ESTIMATE_STATUSES.has(
+      normalizedOperationalState(row.estimate_status),
+    )
+  );
+}
+
+function workOrderIsTerminal(row: WorkspaceWorkOrderRow): boolean {
+  return (
+    TERMINAL_WORK_ORDER_STATUSES.has(normalizedOperationalState(row.status)) ||
+    TERMINAL_WORK_ORDER_STATUSES.has(normalizeWorkOrderStatus(row.status))
+  );
+}
+
+function dateValue(...values: Array<string | null | undefined>): string {
+  return values.find((value): value is string => Boolean(value)) ?? new Date(0).toISOString();
+}
+
+function latestWorkOrderOdometer(
+  workOrders: WorkspaceWorkOrderRow[],
+): number | null {
+  const newestReading = [...workOrders]
+    .filter(
+      (row) =>
+        row.odometer_km !== null &&
+        Number.isFinite(Number(row.odometer_km)),
+    )
+    .sort(
+      (a, b) =>
+        new Date(dateValue(b.updated_at, b.created_at)).getTime() -
+        new Date(dateValue(a.updated_at, a.created_at)).getTime(),
+    )[0];
+  return newestReading?.odometer_km ?? null;
+}
+
+function workspaceVehicleIdentity(
+  row: WorkspaceVehicleRow,
+  workOrders: WorkspaceWorkOrderRow[] = [],
+): VehicleIdentity {
+  // vehicles.mileage has no source timestamp. A dated canonical WO reading is
+  // therefore the newest provable value; the vehicle master value is fallback.
+  const workOrderOdometer = latestWorkOrderOdometer(workOrders);
+  return {
+    id: row.id,
+    year: row.year,
+    make: row.make,
+    model: row.model,
+    submodel: row.submodel,
+    vin: row.vin,
+    licensePlate: row.license_plate,
+    unitNumber: row.unit_number,
+    mileage:
+      workOrderOdometer === null ? row.mileage : String(workOrderOdometer),
+    odometerUnit:
+      workOrderOdometer === null ? row.odometer_unit : "km",
+    engineHours: row.engine_hours,
+    status: row.status,
+  };
+}
+
+function workOrderLabel(row: WorkspaceWorkOrderRow): string {
+  return row.custom_id ? `WO-${row.custom_id.replace(/^wo-?/i, "")}` : `WO ${row.id.slice(0, 8)}`;
+}
+
+function workOrderReference(row: WorkspaceWorkOrderRow): VehicleWorkspaceReference {
+  const isEstimate = workOrderIsEstimate(row);
+  const sourceLabel = isEstimate
+    ? row.estimate_number
+      ? `Estimate ${row.estimate_number}`
+      : `Estimate ${row.id.slice(0, 8)}`
+    : workOrderLabel(row);
+  return {
+    sourceType: "work_order",
+    sourceId: row.id,
+    sourceLabel,
+    href: isEstimate ? `/estimates/${row.id}` : `/work-orders/${row.id}`,
+  };
+}
+
+function lineReference(row: WorkspaceWorkOrderLineRow): VehicleWorkspaceReference {
+  return {
+    sourceType: "work_order_line",
+    sourceId: row.id,
+    sourceLabel: `Repair line ${row.id.slice(0, 8)}`,
+    href: `/work-orders/${row.work_order_id}/focused-job/${row.id}`,
+  };
+}
+
+function quoteLineReference(
+  row: WorkspaceQuoteLineRow,
+): VehicleWorkspaceReference {
+  return {
+    sourceType: "work_order_quote_line",
+    sourceId: row.id,
+    sourceLabel: `Estimate item ${row.id.slice(0, 8)}`,
+    href: `/estimates/${row.work_order_id}`,
+  };
+}
+
+function workOrderPartReference(
+  row: WorkspaceWorkOrderPartRow,
+): VehicleWorkspaceReference {
+  return {
+    sourceType: "work_order_part",
+    sourceId: row.id,
+    sourceLabel: `Installed part ${row.id.slice(0, 8)}`,
+    href: row.work_order_line_id
+      ? `/work-orders/${row.work_order_id}/focused-job/${row.work_order_line_id}`
+      : `/work-orders/${row.work_order_id}`,
+  };
+}
+
+function workOrderPartLabel(row: WorkspaceWorkOrderPartRow): string {
+  const manufacturerAndNumber = [
+    text(row.manufacturer_snapshot),
+    text(row.part_number_snapshot),
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    text(row.description_snapshot) ??
+    text(manufacturerAndNumber) ??
+    text(row.sku_snapshot) ??
+    `Part ${row.id.slice(0, 8)}`
+  );
+}
+
+function installedPartQuantity(row: WorkspaceWorkOrderPartRow): number {
+  return Number(row.quantity_consumed ?? 0) - Number(row.quantity_returned ?? 0);
+}
+
+function inspectionReference(row: WorkspaceInspectionRow): VehicleWorkspaceReference {
+  return {
+    sourceType: "inspection",
+    sourceId: row.id,
+    sourceLabel: row.inspection_type?.trim() || `Inspection ${row.id.slice(0, 8)}`,
+    href: `/inspections/${row.id}`,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+type InspectionFinding = {
+  key: string;
+  label: string;
+  section: string | null;
+  status: "fail" | "recommend";
+  note: string | null;
+  measurement: string | null;
+};
+
+function findingFromRecord(
+  value: unknown,
+  index: number,
+  fallbackSection: string | null,
+): InspectionFinding | null {
+  if (!isRecord(value)) return null;
+  const normalizedStatus = String(value.status ?? "").trim().toLowerCase();
+  if (normalizedStatus !== "fail" && normalizedStatus !== "recommend") return null;
+
+  const label = text(value.item) ?? text(value.name) ?? text(value.label) ?? `Finding ${index + 1}`;
+  const section = text(value.section) ?? fallbackSection;
+  const rawValue = text(value.value);
+  const unit = text(value.unit);
+
+  return {
+    key: `${section ?? "inspection"}:${label}:${index}`,
+    label,
+    section,
+    status: normalizedStatus,
+    note: text(value.note) ?? text(value.notes),
+    measurement: rawValue ? `${rawValue}${unit ? ` ${unit}` : ""}` : null,
+  };
+}
+
+export function extractInspectionFindings(summary: Json | null): InspectionFinding[] {
+  if (!isRecord(summary)) return [];
+  const findings: InspectionFinding[] = [];
+
+  if (Array.isArray(summary.items)) {
+    summary.items.forEach((item, index) => {
+      const finding = findingFromRecord(item, index, null);
+      if (finding) findings.push(finding);
+    });
+  }
+
+  if (Array.isArray(summary.sections)) {
+    summary.sections.forEach((sectionValue) => {
+      if (!isRecord(sectionValue) || !Array.isArray(sectionValue.items)) return;
+      const section = text(sectionValue.title) ?? text(sectionValue.name);
+      sectionValue.items.forEach((item, index) => {
+        const finding = findingFromRecord(item, index, section);
+        if (finding) findings.push(finding);
+      });
+    });
+  }
+
+  return findings;
+}
+
+function isMaintenanceSuggestionItem(value: unknown): value is MaintenanceSuggestionItem {
+  return (
+    isRecord(value) &&
+    typeof value.label === "string" &&
+    typeof value.serviceCode === "string" &&
+    value.dueNow === true &&
+    value.suppressed !== true &&
+    typeof value.whyDue === "string" &&
+    value.whyDue.trim().length > 0
+  );
+}
+
+function maintenanceItems(row: MaintenanceSuggestionRow): MaintenanceSuggestionItem[] {
+  return Array.isArray(row.suggestions)
+    ? row.suggestions.filter(isMaintenanceSuggestionItem)
+    : [];
+}
+
+function buildAttentionItems(input: {
+  workOrdersById: Map<string, WorkspaceWorkOrderRow>;
+  lines: WorkspaceWorkOrderLineRow[];
+  quoteLines: WorkspaceQuoteLineRow[];
+  inspections: WorkspaceInspectionRow[];
+  maintenance: MaintenanceSuggestionRow[];
+}): VehicleAttentionItem[] {
+  const items: VehicleAttentionItem[] = [];
+  const representedLineIds = new Set(
+    input.quoteLines
+      .filter(quoteLineIsDeferred)
+      .flatMap((line) =>
+        [line.work_order_line_id, line.source_work_order_line_id].filter(
+          (id): id is string => Boolean(id),
+        ),
+      ),
+  );
+
+  for (const quoteLine of input.quoteLines) {
+    const status = normalizedOperationalState(
+      quoteLine.decision ?? quoteLine.status,
+    );
+    if (!quoteLineIsDeferred(quoteLine)) continue;
+    const workOrder = input.workOrdersById.get(quoteLine.work_order_id);
+    const reason = quoteLine.defer_reason ?? quoteLine.decline_reason;
+    items.push({
+      kind: "deferred_work",
+      title: quoteLine.title?.trim() || quoteLine.description.trim(),
+      explanation: [
+        status.includes("defer") ? "Deferred" : "Declined",
+        workOrder ? `from ${workOrderLabel(workOrder)}` : null,
+        text(reason),
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      severity: "warning",
+      occurredAt: quoteLine.deferred_at ?? quoteLine.declined_at ?? quoteLine.updated_at,
+      reference: quoteLineReference(quoteLine),
+    });
+  }
+
+  for (const line of input.lines) {
+    if (representedLineIds.has(line.id)) continue;
+    if (line.voided_at) continue;
+    const states = [line.line_status, line.status, line.approval_state]
+      .map(normalizedOperationalState)
+      .filter(Boolean);
+    if (states.some((state) => TERMINAL_LINE_STATES.has(state))) continue;
+    const isDeferred = states.some((state) => DEFERRED_LINE_STATES.has(state));
+    const isWaitingParts =
+      !isDeferred &&
+      (states.some((state) => WAITING_PARTS_LINE_STATES.has(state)) ||
+        Boolean(text(line.hold_reason)));
+    const isConcern =
+      !isDeferred &&
+      !isWaitingParts &&
+      states.some((state) => PENDING_CONCERN_STATES.has(state)) &&
+      Boolean(text(line.complaint));
+    if (!isDeferred && !isWaitingParts && !isConcern) continue;
+    const workOrder = input.workOrdersById.get(line.work_order_id);
+    const title = text(line.description) ?? text(line.complaint) ?? "Repair item";
+    items.push({
+      kind: isDeferred
+        ? "deferred_work"
+        : isWaitingParts
+          ? "waiting_parts"
+          : "unresolved_concern",
+      title,
+      explanation: [
+        isWaitingParts ? text(line.hold_reason) ?? "Waiting for parts" : null,
+        workOrder ? `Recorded on ${workOrderLabel(workOrder)}` : "Recorded repair line",
+        isConcern ? text(line.complaint) : null,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      severity: isWaitingParts || isDeferred ? "warning" : "info",
+      occurredAt: line.updated_at ?? line.created_at,
+      reference: lineReference(line),
+    });
+  }
+
+  for (const inspection of input.inspections) {
+    for (const finding of extractInspectionFindings(inspection.summary)) {
+      const detail = [
+        finding.measurement,
+        finding.note,
+        `recorded during ${inspectionReference(inspection).sourceLabel}`,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+      items.push({
+        kind: "failed_inspection",
+        title: [finding.section, finding.label].filter(Boolean).join(" — "),
+        explanation: detail,
+        severity: finding.status === "fail" ? "urgent" : "warning",
+        occurredAt: dateValue(
+          inspection.finalized_at,
+          inspection.updated_at,
+          inspection.created_at,
+        ),
+        reference: inspectionReference(inspection),
+      });
+    }
+  }
+
+  for (const suggestionRow of input.maintenance) {
+    const workOrder = input.workOrdersById.get(suggestionRow.work_order_id);
+    for (const suggestion of maintenanceItems(suggestionRow)) {
+      items.push({
+        kind: "maintenance_due",
+        title: suggestion.label,
+        explanation: [
+          suggestion.whyDue,
+          workOrder ? `evaluated for ${workOrderLabel(workOrder)}` : null,
+          suggestion.serviceCode ? `service ${suggestion.serviceCode}` : null,
+        ]
+          .filter(Boolean)
+          .join(" · "),
+        severity: suggestion.isCritical || suggestion.overdue ? "urgent" : "warning",
+        occurredAt: suggestionRow.updated_at,
+        reference: {
+          sourceType: "maintenance_suggestion",
+          sourceId: suggestionRow.work_order_id,
+          sourceLabel: `Maintenance evidence for ${workOrder ? workOrderLabel(workOrder) : suggestionRow.work_order_id.slice(0, 8)}`,
+          href: `/work-orders/${suggestionRow.work_order_id}`,
+        },
+      });
+    }
+  }
+
+  return items.sort(
+    (a, b) =>
+      new Date(b.occurredAt ?? 0).getTime() - new Date(a.occurredAt ?? 0).getTime(),
+  );
+}
+
+function buildTimeline(input: {
+  workOrders: WorkspaceWorkOrderRow[];
+  bookings: WorkspaceBookingRow[];
+  inspections: WorkspaceInspectionRow[];
+  lines: WorkspaceWorkOrderLineRow[];
+  parts: WorkspaceWorkOrderPartRow[];
+  quoteLines: WorkspaceQuoteLineRow[];
+  history: WorkspaceHistoryRow[];
+  invoices: WorkspaceInvoiceRow[];
+  payments: WorkspacePaymentRow[];
+}): VehicleTimelineEvent[] {
+  const events: VehicleTimelineEvent[] = [];
+  const workOrderIds = new Set(input.workOrders.map((row) => row.id));
+
+  for (const row of input.workOrders) {
+    const isEstimate = workOrderIsEstimate(row);
+    const odometer =
+      row.odometer_km === null ? null : `Odometer: ${row.odometer_km} km`;
+    events.push({
+      kind: isEstimate ? "estimate" : "work_order",
+      title:
+        isEstimate
+          ? row.estimate_number
+            ? `Estimate ${row.estimate_number}`
+            : `Estimate ${row.id.slice(0, 8)}`
+          : workOrderLabel(row),
+      detail:
+        [isEstimate ? row.estimate_status : row.status, odometer]
+          .filter(Boolean)
+          .join(" · ") || null,
+      occurredAt: dateValue(row.updated_at, row.created_at),
+      reference: workOrderReference(row),
+    });
+  }
+
+  for (const row of input.bookings) {
+    events.push({
+      kind: "appointment",
+      title: "Appointment",
+      detail: [row.status, text(row.notes)].filter(Boolean).join(" · ") || null,
+      occurredAt: row.starts_at,
+      reference: {
+        sourceType: "appointment",
+        sourceId: row.id,
+        sourceLabel: `Appointment ${row.id.slice(0, 8)}`,
+        href: `/dashboard/appointments?bookingId=${encodeURIComponent(row.id)}`,
+      },
+    });
+  }
+
+  for (const row of input.inspections) {
+    events.push({
+      kind: "inspection",
+      title: inspectionReference(row).sourceLabel,
+      detail: row.status,
+      occurredAt: dateValue(row.finalized_at, row.updated_at, row.started_at, row.created_at),
+      reference: inspectionReference(row),
+    });
+  }
+
+  for (const row of input.lines) {
+    const status = String(row.line_status ?? row.status).toLowerCase();
+    if (!["completed", "ready_to_invoice", "invoiced"].includes(status)) continue;
+    events.push({
+      kind: "repair",
+      title: text(row.description) ?? text(row.correction) ?? "Repair completed",
+      detail: status.replaceAll("_", " "),
+      occurredAt: dateValue(row.updated_at, row.created_at),
+      reference: lineReference(row),
+    });
+  }
+
+  for (const row of input.parts) {
+    const quantity = installedPartQuantity(row);
+    if (
+      !row.is_active ||
+      !workOrderIds.has(row.work_order_id) ||
+      !Number.isFinite(quantity) ||
+      quantity <= 0
+    ) {
+      continue;
+    }
+    events.push({
+      kind: "part",
+      title: workOrderPartLabel(row),
+      detail: `Installed quantity: ${quantity}`,
+      occurredAt: dateValue(row.updated_at, row.created_at),
+      reference: workOrderPartReference(row),
+    });
+  }
+
+  for (const row of input.quoteLines) {
+    const decision = normalizedOperationalState(row.decision);
+    if (!QUOTE_DECISION_STATES.has(decision)) continue;
+    const decisionAt = decision.includes("approved")
+      ? row.approved_at
+      : decision.includes("declined")
+        ? row.declined_at
+        : row.deferred_at;
+    events.push({
+      kind: "approval",
+      title:
+        text(row.title) ?? text(row.description) ?? "Estimate item decision",
+      detail: `Decision: ${decision.replaceAll("_", " ")}`,
+      occurredAt: dateValue(decisionAt, row.updated_at, row.created_at),
+      reference: quoteLineReference(row),
+    });
+  }
+
+  for (const row of input.history) {
+    if (row.work_order_id && workOrderIds.has(row.work_order_id)) continue;
+    events.push({
+      kind: "history",
+      title: row.work_order_number ? `Historical WO ${row.work_order_number}` : "Imported service history",
+      detail: [
+        row.description,
+        row.historical_status,
+        row.source_system,
+        row.odometer === null ? null : `Odometer: ${row.odometer}`,
+      ]
+        .filter(Boolean)
+        .join(" · ") || null,
+      occurredAt: dateValue(row.closed_at, row.opened_at, row.service_date),
+      reference: {
+        sourceType: "history",
+        sourceId: row.id,
+        sourceLabel: `History ${row.id.slice(0, 8)}`,
+        href: `/work-orders/history/${row.id}`,
+      },
+    });
+  }
+
+  for (const row of input.invoices) {
+    if (!row.work_order_id) continue;
+    events.push({
+      kind: "invoice",
+      title: row.invoice_number ? `Invoice ${row.invoice_number}` : `Invoice ${row.id.slice(0, 8)}`,
+      detail: row.status,
+      occurredAt: dateValue(row.paid_at, row.issued_at, row.updated_at, row.created_at),
+      reference: {
+        sourceType: "invoice",
+        sourceId: row.id,
+        sourceLabel: row.invoice_number ? `Invoice ${row.invoice_number}` : `Invoice ${row.id.slice(0, 8)}`,
+        href: `/work-orders/invoice/${row.work_order_id}`,
+      },
+    });
+  }
+
+  for (const row of input.payments) {
+    if (!row.work_order_id) continue;
+    events.push({
+      kind: "payment",
+      title: "Payment recorded",
+      detail: row.status,
+      occurredAt: dateValue(row.paid_at, row.created_at),
+      reference: {
+        sourceType: "payment",
+        sourceId: row.id,
+        sourceLabel: `Payment ${row.id.slice(0, 8)}`,
+        href: `/work-orders/invoice/${row.work_order_id}`,
+      },
+    });
+  }
+
+  return events
+    .sort((a, b) => new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime())
+    .slice(0, 20);
+}
+
+function buildFinancialSummary(invoices: WorkspaceInvoiceRow[]): VehicleFinancialSummary {
+  if (invoices.length === 0) {
+    return {
+      visible: true,
+      currency: null,
+      invoiceCount: 0,
+      outstandingAmount: null,
+      paidAmount: null,
+    };
+  }
+
+  const currencies = new Set(
+    invoices.map((row) => text(row.currency)?.toUpperCase() ?? null),
+  );
+  const singleCurrency =
+    currencies.size === 1 ? [...currencies][0] : null;
+  if (!singleCurrency) {
+    return {
+      visible: true,
+      currency: null,
+      invoiceCount: invoices.length,
+      outstandingAmount: null,
+      paidAmount: null,
+    };
+  }
+
+  return {
+    visible: true,
+    currency: singleCurrency,
+    invoiceCount: invoices.length,
+    outstandingAmount: invoices.reduce((sum, row) => sum + Number(row.outstanding_total ?? 0), 0),
+    paidAmount: invoices.reduce((sum, row) => sum + Number(row.paid_total ?? 0), 0),
+  };
+}
+
+function buildDocumentSummary(input: {
+  vehicleMedia: WorkspaceVehicleMediaRow[];
+  workOrderMedia: WorkspaceWorkOrderMediaRow[];
+  inspections: WorkspaceInspectionRow[];
+}): VehicleDocumentSummary {
+  const reports = input.inspections.filter(
+    (row) => Boolean(row.pdf_url || row.pdf_storage_path),
+  );
+  const newestWorkOrderMedia = [...input.workOrderMedia].sort(
+    (a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
+  )[0];
+
+  return {
+    vehicleMediaCount: input.vehicleMedia.length,
+    workOrderMediaCount: input.workOrderMedia.length,
+    inspectionReportCount: reports.length,
+    latestReference: newestWorkOrderMedia
+      ? {
+          sourceType: "work_order_media",
+          sourceId: newestWorkOrderMedia.id,
+          sourceLabel:
+            text(newestWorkOrderMedia.file_name) ??
+            text(newestWorkOrderMedia.kind) ??
+            `Work-order file ${newestWorkOrderMedia.id.slice(0, 8)}`,
+          href: `/work-orders/${newestWorkOrderMedia.work_order_id}`,
+        }
+      : reports[0]
+        ? inspectionReference(reports[0])
+        : null,
+  };
+}
+
+function buildConflicts(input: {
+  vehicle: WorkspaceVehicleRow;
+  account: WorkspaceCustomerRow | null;
+  workOrders: WorkspaceWorkOrderRow[];
+  history: WorkspaceHistoryRow[];
+}): VehicleWorkspaceConflict[] {
+  const conflicts: VehicleWorkspaceConflict[] = [];
+  const activeWorkOrders = input.workOrders.filter(
+    (row) =>
+      !workOrderIsEstimate(row) &&
+      !workOrderIsTerminal(row),
+  );
+
+  if (!input.vehicle.customer_id || !input.account) {
+    conflicts.push({
+      kind: "missing_current_account",
+      title: input.vehicle.customer_id
+        ? "Linked account is unavailable"
+        : "No current account",
+      detail: input.vehicle.customer_id
+        ? "The vehicle has an account ID, but that canonical account is missing or not visible."
+        : "This vehicle is not currently linked to a customer or business account.",
+      sourceIds: [input.vehicle.id, input.vehicle.customer_id].filter(
+        (id): id is string => Boolean(id),
+      ),
+    });
+  }
+
+  if (input.account && (!input.account.active || input.account.archived_at || input.account.merged_into_customer_id)) {
+    conflicts.push({
+      kind: "archived_account",
+      title: "Current account needs review",
+      detail: input.account.merged_into_customer_id
+        ? "The linked account has been merged into another account."
+        : "The linked account is inactive or archived.",
+      sourceIds: [input.account.id, input.account.merged_into_customer_id].filter(
+        (id): id is string => Boolean(id),
+      ),
+    });
+  }
+
+  if (activeWorkOrders.length > 1) {
+    conflicts.push({
+      kind: "multiple_active_work_orders",
+      title: `${activeWorkOrders.length} active work orders`,
+      detail: "No work order was selected automatically; each open record is shown separately.",
+      sourceIds: activeWorkOrders.map((row) => row.id),
+    });
+  }
+
+  const historicalAccountIds = new Set(
+    [...input.workOrders, ...input.history]
+      .map((row) => row.customer_id)
+      .filter((id): id is string => Boolean(id) && id !== input.vehicle.customer_id),
+  );
+  if (historicalAccountIds.size > 0) {
+    conflicts.push({
+      kind: "historical_owner",
+      title: "Historical service uses another account",
+      detail:
+        "One or more canonical work orders reference a different account. The workspace preserves those historical links and does not infer ownership history.",
+      sourceIds: [...historicalAccountIds],
+    });
+  }
+
+  const vehicleStatus = String(input.vehicle.status ?? "").trim().toLowerCase();
+  if (["archived", "merged", "duplicate", "inactive"].includes(vehicleStatus)) {
+    conflicts.push({
+      kind: "vehicle_status",
+      title: `Vehicle status: ${vehicleStatus}`,
+      detail: "Review this vehicle record before starting new work.",
+      sourceIds: [input.vehicle.id],
+    });
+  }
+
+  return conflicts;
+}
+
+function throwQueryError(error: { message: string } | null, context: string): void {
+  if (error) throw new Error(`${context}: ${error.message}`);
+}
+
+export async function loadVehicleWorkspaceSnapshot(input: {
+  supabase: SupabaseClient<Database>;
+  shopId: string;
+  role: CanonicalRole;
+  vehicleId: string;
+  now?: Date;
+}): Promise<VehicleWorkspaceSnapshot | null> {
+  const permissions = vehicleWorkspacePermissionsForRole(input.role);
+  const now = input.now ?? new Date();
+  const vehicleResult = await input.supabase
+    .from("vehicles")
+    .select(
+      "id,shop_id,customer_id,year,make,model,submodel,vin,license_plate,unit_number,mileage,odometer_unit,engine_hours,status",
+    )
+    .eq("shop_id", input.shopId)
+    .eq("id", input.vehicleId)
+    .maybeSingle();
+  throwQueryError(vehicleResult.error, "Unable to load vehicle");
+  if (!vehicleResult.data) return null;
+  const vehicle = vehicleResult.data as WorkspaceVehicleRow;
+
+  const workOrdersResult = await input.supabase
+    .from("work_orders")
+    .select(
+      "id,customer_id,vehicle_id,custom_id,status,record_type,approval_state,estimate_number,estimate_status,scheduled_at,odometer_km,created_at,updated_at",
+    )
+    .eq("shop_id", input.shopId)
+    .eq("vehicle_id", input.vehicleId)
+    .order("updated_at", { ascending: false, nullsFirst: false })
+    .limit(100);
+  throwQueryError(workOrdersResult.error, "Unable to load work orders");
+  const workOrders = (workOrdersResult.data ?? []) as WorkspaceWorkOrderRow[];
+
+  // Work-order RLS is the canonical assignment boundary for mechanics. A same-shop
+  // vehicle row alone must never grant a mechanic access to unrelated history.
+  if (permissions.isAssignedWorkOnly && workOrders.length === 0) return null;
+
+  const workOrderIds = workOrders.map((row) => row.id);
+  const customerId = vehicle.customer_id;
+  const emptyRows = Promise.resolve({ data: [], error: null });
+
+  const accountQuery = customerId
+    ? permissions.canViewAccountContact
+      ? input.supabase
+          .from("customers")
+          .select(
+            "id,account_type,active,business_name,name,first_name,last_name,email,phone,phone_number,archived_at,merged_into_customer_id",
+          )
+          .eq("shop_id", input.shopId)
+          .eq("id", customerId)
+          .maybeSingle()
+      : input.supabase
+          .from("customers")
+          .select(
+            "id,account_type,active,business_name,name,first_name,last_name,archived_at,merged_into_customer_id",
+          )
+          .eq("shop_id", input.shopId)
+          .eq("id", customerId)
+          .maybeSingle()
+    : Promise.resolve({ data: null, error: null });
+
+  const [
+    accountResult,
+    bookingsResult,
+    inspectionsResult,
+    linesResult,
+    partsResult,
+    quoteLinesResult,
+    maintenanceResult,
+    historyResult,
+    relatedVehiclesResult,
+    vehicleMediaResult,
+    workOrderMediaResult,
+    partRequestsResult,
+    invoicesResult,
+    paymentsResult,
+  ] = await Promise.all([
+    accountQuery,
+    input.supabase
+      .from("bookings")
+      .select("id,work_order_id,starts_at,ends_at,status,notes,created_at")
+      .eq("shop_id", input.shopId)
+      .eq("vehicle_id", input.vehicleId)
+      .order("starts_at", { ascending: false })
+      .limit(40),
+    input.supabase
+      .from("inspections")
+      .select(
+        "id,work_order_id,work_order_line_id,inspection_type,status,completed,summary,created_at,started_at,finalized_at,updated_at,pdf_url,pdf_storage_path",
+      )
+      .eq("shop_id", input.shopId)
+      .eq("vehicle_id", input.vehicleId)
+      .order("updated_at", { ascending: false, nullsFirst: false })
+      .limit(40),
+    workOrderIds.length
+      ? input.supabase
+          .from("work_order_lines")
+          .select(
+            "id,work_order_id,description,complaint,correction,hold_reason,status,line_status,approval_state,urgency,voided_at,created_at,updated_at",
+          )
+          .eq("shop_id", input.shopId)
+          .in("work_order_id", workOrderIds)
+          .limit(300)
+      : emptyRows,
+    workOrderIds.length
+      ? input.supabase
+          .from("work_order_parts")
+          .select(
+            "id,work_order_id,work_order_line_id,description_snapshot,manufacturer_snapshot,part_number_snapshot,sku_snapshot,quantity_consumed,quantity_returned,is_active,created_at,updated_at",
+          )
+          .eq("shop_id", input.shopId)
+          .eq("is_active", true)
+          .in("work_order_id", workOrderIds)
+          .limit(300)
+      : emptyRows,
+    workOrderIds.length
+      ? input.supabase
+          .from("work_order_quote_lines")
+          .select(
+            "id,work_order_id,work_order_line_id,source_work_order_line_id,description,title,status,decision,defer_reason,decline_reason,approved_at,deferred_at,declined_at,created_at,updated_at",
+          )
+          .eq("shop_id", input.shopId)
+          .in("work_order_id", workOrderIds)
+          .limit(300)
+      : emptyRows,
+    workOrderIds.length
+      ? input.supabase
+          .from("maintenance_suggestions")
+          .select("work_order_id,vehicle_id,status,suggestions,created_at,updated_at,error_message,mileage_km")
+          .eq("vehicle_id", input.vehicleId)
+          .in("work_order_id", workOrderIds)
+          .eq("status", "ready")
+      : emptyRows,
+    input.supabase
+      .from("history")
+      .select(
+        "id,customer_id,work_order_id,work_order_number,historical_status,description,odometer,service_date,opened_at,closed_at,source_system",
+      )
+      .eq("vehicle_id", input.vehicleId)
+      .order("service_date", { ascending: false })
+      .limit(50),
+    customerId && permissions.canViewRelatedVehicles
+      ? input.supabase
+          .from("vehicles")
+          .select("id,year,make,model,unit_number,status")
+          .eq("shop_id", input.shopId)
+          .eq("customer_id", customerId)
+          .neq("id", input.vehicleId)
+          .limit(20)
+      : emptyRows,
+    input.supabase
+      .from("vehicle_media")
+      .select("id,type,filename,created_at")
+      .eq("shop_id", input.shopId)
+      .eq("vehicle_id", input.vehicleId)
+      .limit(100),
+    workOrderIds.length
+      ? input.supabase
+          .from("work_order_media")
+          .select("id,work_order_id,kind,file_name,created_at")
+          .eq("shop_id", input.shopId)
+          .in("work_order_id", workOrderIds)
+          .limit(100)
+      : emptyRows,
+    permissions.canViewPartRequests && workOrderIds.length
+      ? input.supabase
+          .from("part_requests")
+          .select("id,work_order_id,status,notes,created_at")
+          .eq("shop_id", input.shopId)
+          .in("work_order_id", workOrderIds)
+          .order("created_at", { ascending: false })
+          .limit(100)
+      : emptyRows,
+    permissions.canViewFinancials && workOrderIds.length
+      ? input.supabase
+          .from("invoices")
+          .select(
+            "id,work_order_id,invoice_number,status,currency,total,outstanding_total,paid_total,created_at,issued_at,paid_at,updated_at",
+          )
+          .eq("shop_id", input.shopId)
+          .in("work_order_id", workOrderIds)
+          .order("updated_at", { ascending: false })
+      : emptyRows,
+    permissions.canViewFinancials && workOrderIds.length
+      ? input.supabase
+          .from("payments")
+          .select("id,work_order_id,status,amount,currency,paid_at,created_at")
+          .eq("shop_id", input.shopId)
+          .in("work_order_id", workOrderIds)
+          .order("created_at", { ascending: false })
+          .limit(100)
+      : emptyRows,
+  ]);
+
+  for (const [result, context] of [
+    [accountResult, "account"],
+    [bookingsResult, "appointments"],
+    [inspectionsResult, "inspections"],
+    [linesResult, "repair lines"],
+    [partsResult, "installed parts"],
+    [quoteLinesResult, "estimate items"],
+    [maintenanceResult, "maintenance evidence"],
+    [historyResult, "history"],
+    [relatedVehiclesResult, "related vehicles"],
+    [vehicleMediaResult, "vehicle media"],
+    [workOrderMediaResult, "work-order media"],
+    [partRequestsResult, "parts requests"],
+    [invoicesResult, "invoices"],
+    [paymentsResult, "payments"],
+  ] as const) {
+    throwQueryError(result.error, `Unable to load ${context}`);
+  }
+
+  const accountRow = (accountResult.data ?? null) as WorkspaceCustomerRow | null;
+  const bookings = (bookingsResult.data ?? []) as WorkspaceBookingRow[];
+  const inspections = (inspectionsResult.data ?? []) as WorkspaceInspectionRow[];
+  const lines = (linesResult.data ?? []) as WorkspaceWorkOrderLineRow[];
+  const parts = (partsResult.data ?? []) as WorkspaceWorkOrderPartRow[];
+  const quoteLines = (quoteLinesResult.data ?? []) as WorkspaceQuoteLineRow[];
+  const maintenance = (maintenanceResult.data ?? []) as MaintenanceSuggestionRow[];
+  const history = (historyResult.data ?? []) as WorkspaceHistoryRow[];
+  const vehicleMedia = (vehicleMediaResult.data ?? []) as WorkspaceVehicleMediaRow[];
+  const workOrderMedia = (workOrderMediaResult.data ?? []) as WorkspaceWorkOrderMediaRow[];
+  const partRequests = (partRequestsResult.data ?? []) as WorkspacePartRequestRow[];
+  const invoices = (invoicesResult.data ?? []) as WorkspaceInvoiceRow[];
+  const payments = (paymentsResult.data ?? []) as WorkspacePaymentRow[];
+  const workOrdersById = new Map(workOrders.map((row) => [row.id, row]));
+
+  const currentAccount: CustomerAccountSummary | null = accountRow
+    ? {
+        id: accountRow.id,
+        displayName: customerAccountDisplayName(accountRow),
+        accountType: accountRow.account_type,
+        active: accountRow.active,
+        ...(permissions.canViewAccountContact
+          ? {
+              email: accountRow.email ?? null,
+              phone: accountRow.phone ?? accountRow.phone_number ?? null,
+            }
+          : {}),
+        archivedAt: accountRow.archived_at,
+        mergedIntoCustomerId: accountRow.merged_into_customer_id,
+      }
+    : null;
+
+  const upcomingAppointments: AppointmentSummary[] = bookings
+    .filter(
+      (row) =>
+        new Date(row.ends_at).getTime() >= now.getTime() &&
+        !TERMINAL_APPOINTMENT_STATUSES.has(
+          normalizedOperationalState(row.status),
+        ),
+    )
+    .sort((a, b) => new Date(a.starts_at).getTime() - new Date(b.starts_at).getTime())
+    .map((row) => ({
+      title: "Appointment",
+      status: row.status,
+      startsAt: row.starts_at,
+      endsAt: row.ends_at,
+      detail: text(row.notes),
+      reference: {
+        sourceType: "appointment",
+        sourceId: row.id,
+        sourceLabel: `Appointment ${row.id.slice(0, 8)}`,
+        href: `/dashboard/appointments?bookingId=${encodeURIComponent(row.id)}`,
+      },
+    }));
+
+  const activeWork: ActiveWorkSummary[] = [];
+  for (const row of workOrders) {
+    const isEstimate = workOrderIsEstimate(row);
+    if (workOrderIsTerminal(row) || (isEstimate && !estimateIsActionable(row))) {
+      continue;
+    }
+    activeWork.push({
+      kind: isEstimate ? "estimate" : "work_order",
+      title: isEstimate
+        ? row.estimate_number
+          ? `Estimate ${row.estimate_number}`
+          : `Estimate ${row.id.slice(0, 8)}`
+        : workOrderLabel(row),
+      status: isEstimate ? row.estimate_status ?? row.status : row.status,
+      detail: row.approval_state,
+      occurredAt: row.updated_at ?? row.created_at,
+      reference: workOrderReference(row),
+    });
+  }
+  for (const row of inspections) {
+    const status = normalizedOperationalState(row.status);
+    if (row.completed || !OPEN_INSPECTION_STATUSES.has(status)) continue;
+    activeWork.push({
+      kind: "inspection",
+      title: inspectionReference(row).sourceLabel,
+      status: row.status,
+      detail: null,
+      occurredAt: row.updated_at ?? row.created_at,
+      reference: inspectionReference(row),
+    });
+  }
+  for (const row of invoices) {
+    if (Number(row.outstanding_total) <= 0) continue;
+    activeWork.push({
+      kind: "invoice",
+      title: row.invoice_number ? `Invoice ${row.invoice_number}` : `Invoice ${row.id.slice(0, 8)}`,
+      status: row.status,
+      detail: "Vehicle-related balance",
+      occurredAt: row.updated_at,
+      amount: Number(row.outstanding_total),
+      currency: row.currency,
+      reference: {
+        sourceType: "invoice",
+        sourceId: row.id,
+        sourceLabel: row.invoice_number ? `Invoice ${row.invoice_number}` : `Invoice ${row.id.slice(0, 8)}`,
+        href: row.work_order_id ? `/work-orders/invoice/${row.work_order_id}` : "/billing",
+      },
+    });
+  }
+  for (const row of partRequests) {
+    if (TERMINAL_PART_REQUEST_STATUSES.has(normalizedOperationalState(row.status))) {
+      continue;
+    }
+    const workOrder = row.work_order_id
+      ? workOrdersById.get(row.work_order_id)
+      : null;
+    activeWork.push({
+      kind: "part_request",
+      title: "Parts request",
+      status: row.status,
+      detail: text(row.notes) ?? (workOrder ? workOrderLabel(workOrder) : null),
+      occurredAt: row.created_at,
+      reference: {
+        sourceType: "part_request",
+        sourceId: row.id,
+        sourceLabel: `Parts request ${row.id.slice(0, 8)}`,
+        href: `/parts/requests/${row.id}`,
+      },
+    });
+  }
+
+  const relatedVehicles = (relatedVehiclesResult.data ?? []).map((row) => {
+    const identity = workspaceVehicleIdentity({
+      ...vehicle,
+      id: row.id,
+      year: row.year,
+      make: row.make,
+      model: row.model,
+      unit_number: row.unit_number,
+      status: row.status,
+    });
+    return {
+      id: row.id,
+      label: vehicleIdentityLabel(identity),
+      status: row.status,
+      href: `/vehicles/${row.id}`,
+    } satisfies RelatedVehicleSummary;
+  });
+
+  return {
+    identity: workspaceVehicleIdentity(vehicle, workOrders),
+    currentAccount,
+    permissions,
+    activeWork: activeWork.sort(
+      (a, b) => new Date(b.occurredAt ?? 0).getTime() - new Date(a.occurredAt ?? 0).getTime(),
+    ),
+    upcomingAppointments,
+    attentionItems: buildAttentionItems({
+      workOrdersById,
+      lines,
+      quoteLines,
+      inspections,
+      maintenance,
+    }),
+    recentTimeline: buildTimeline({
+      workOrders,
+      bookings,
+      inspections,
+      lines,
+      parts,
+      quoteLines,
+      history,
+      invoices,
+      payments,
+    }),
+    financialSummary: permissions.canViewFinancials
+      ? buildFinancialSummary(invoices)
+      : { visible: false },
+    documentSummary: buildDocumentSummary({
+      vehicleMedia,
+      workOrderMedia,
+      inspections,
+    }),
+    relatedVehicles,
+    conflicts: buildConflicts({
+      vehicle,
+      account: accountRow,
+      workOrders,
+      history,
+    }),
+  };
+}
+
+export function vehicleWorkspaceCreateWorkOrderHref(
+  snapshot: VehicleWorkspaceSnapshot,
+): string | null {
+  if (!snapshot.permissions.canCreateWorkOrder) return null;
+  if (
+    snapshot.conflicts.some((conflict) =>
+      ["archived_account", "vehicle_status"].includes(conflict.kind),
+    )
+  ) {
+    return null;
+  }
+  return createWorkOrderHandoffHref({
+    customerId: snapshot.currentAccount?.id ?? null,
+    vehicleId: snapshot.identity.id,
+  });
+}

--- a/features/vehicles/server/searchShopVehicleRecords.ts
+++ b/features/vehicles/server/searchShopVehicleRecords.ts
@@ -1,0 +1,928 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
+import {
+  createWorkOrderHandoffHref,
+  customerAccountDisplayName,
+  type AppointmentSummary,
+  type CustomerAccountSummary,
+  type VehicleIdentity,
+  type VehicleWorkspaceSearchResponse,
+} from "@/features/vehicles/lib/vehicleWorkspace";
+import { vehicleWorkspacePermissionsForRole } from "@/features/vehicles/server/vehicleWorkspacePermissions";
+
+type ShopSupabase = SupabaseClient<Database>;
+type VehicleRow = Database["public"]["Tables"]["vehicles"]["Row"];
+type CustomerRow = Database["public"]["Tables"]["customers"]["Row"];
+type WorkOrderRow = Database["public"]["Tables"]["work_orders"]["Row"];
+type BookingRow = Database["public"]["Tables"]["bookings"]["Row"];
+type WorkOrderLineRow =
+  Database["public"]["Tables"]["work_order_lines"]["Row"];
+type InvoiceRow = Database["public"]["Tables"]["invoices"]["Row"];
+
+type SearchCustomerRow = Pick<
+  CustomerRow,
+  | "id"
+  | "account_type"
+  | "active"
+  | "business_name"
+  | "name"
+  | "first_name"
+  | "last_name"
+  | "identity_name"
+  | "archived_at"
+  | "merged_into_customer_id"
+> &
+  Partial<
+    Pick<
+      CustomerRow,
+      | "email"
+      | "phone"
+      | "phone_number"
+      | "identity_email"
+      | "identity_phone"
+    >
+  >;
+
+type SearchVehicleRow = Pick<
+  VehicleRow,
+  | "id"
+  | "customer_id"
+  | "year"
+  | "make"
+  | "model"
+  | "submodel"
+  | "vin"
+  | "license_plate"
+  | "unit_number"
+  | "mileage"
+  | "odometer_unit"
+  | "engine_hours"
+  | "status"
+  | "created_at"
+>;
+
+type SearchWorkOrderRow = Pick<
+  WorkOrderRow,
+  | "id"
+  | "custom_id"
+  | "status"
+  | "record_type"
+  | "estimate_number"
+  | "estimate_status"
+  | "customer_id"
+  | "customer_name"
+  | "vehicle_id"
+  | "vehicle_year"
+  | "vehicle_make"
+  | "vehicle_model"
+  | "vehicle_submodel"
+  | "vehicle_vin"
+  | "vehicle_license_plate"
+  | "vehicle_unit_number"
+  | "vehicle_mileage"
+  | "odometer_km"
+  | "created_at"
+  | "updated_at"
+>;
+
+type SearchBookingRow = Pick<
+  BookingRow,
+  | "id"
+  | "vehicle_id"
+  | "work_order_id"
+  | "status"
+  | "starts_at"
+  | "ends_at"
+  | "notes"
+>;
+
+type SearchLineRow = Pick<
+  WorkOrderLineRow,
+  | "id"
+  | "vehicle_id"
+  | "work_order_id"
+  | "status"
+  | "line_status"
+  | "approval_state"
+  | "hold_reason"
+  | "voided_at"
+>;
+
+type SearchQuoteLineRow = Pick<
+  Database["public"]["Tables"]["work_order_quote_lines"]["Row"],
+  | "id"
+  | "vehicle_id"
+  | "work_order_id"
+  | "work_order_line_id"
+  | "source_work_order_line_id"
+  | "status"
+  | "decision"
+>;
+
+type SearchInvoiceRow = Pick<
+  InvoiceRow,
+  "id" | "work_order_id" | "outstanding_total" | "currency"
+>;
+
+const DEFAULT_RESULT_LIMIT = 20;
+const MAX_RESULT_LIMIT = 30;
+const SEARCH_SCAN_LIMIT = 120;
+const MECHANIC_SCOPE_LIMIT = 1_000;
+const SUMMARY_ROW_LIMIT = 1_000;
+const TERMINAL_WORK_ORDER_STATUSES = new Set([
+  "archived",
+  "closed",
+  "completed",
+  "cancelled",
+  "canceled",
+  "invoiced",
+  "paid",
+  "void",
+  "voided",
+]);
+const ACTIVE_ESTIMATE_STATUSES = new Set([
+  "draft",
+  "waiting_for_parts",
+  "ready_for_advisor",
+  "sent",
+  "partially_approved",
+]);
+const ATTENTION_STATES = new Set([
+  "declined",
+  "deferred",
+  "on_hold",
+  "waiting_parts",
+  "awaiting_parts",
+  "parts_needed",
+]);
+const TERMINAL_LINE_STATES = new Set([
+  "canceled",
+  "cancelled",
+  "completed",
+  "invoiced",
+  "ready_to_invoice",
+  "voided",
+]);
+const TERMINAL_APPOINTMENT_STATUSES = new Set([
+  "cancelled",
+  "canceled",
+  "completed",
+]);
+const BLOCKED_CREATE_WORK_ORDER_VEHICLE_STATUSES = new Set([
+  "archived",
+  "merged",
+  "duplicate",
+  "inactive",
+]);
+
+const VEHICLE_COLUMNS =
+  "id,customer_id,year,make,model,submodel,vin,license_plate,unit_number,mileage,odometer_unit,engine_hours,status,created_at";
+const CUSTOMER_COLUMNS =
+  "id,account_type,active,business_name,name,first_name,last_name,email,phone,phone_number,identity_name,identity_email,identity_phone,archived_at,merged_into_customer_id";
+const CUSTOMER_SAFE_COLUMNS =
+  "id,account_type,active,business_name,name,first_name,last_name,identity_name,archived_at,merged_into_customer_id";
+const WORK_ORDER_COLUMNS =
+  "id,custom_id,status,record_type,estimate_number,estimate_status,customer_id,customer_name,vehicle_id,vehicle_year,vehicle_make,vehicle_model,vehicle_submodel,vehicle_vin,vehicle_license_plate,vehicle_unit_number,vehicle_mileage,odometer_km,created_at,updated_at";
+
+function normalizedState(value: string | null | undefined): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+export function sanitizeVehicleWorkspaceSearchQuery(value: unknown): string {
+  return String(value ?? "")
+    .replace(/[^a-zA-Z0-9@.+ _'-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 120);
+}
+
+function searchTerms(query: string): string[] {
+  return Array.from(
+    new Set(query.toLowerCase().match(/[a-z0-9]+/g) ?? []),
+  ).slice(0, 10);
+}
+
+function workOrderSearchTerms(terms: string[]): string[] {
+  if (terms[0] === "wo") return terms.slice(1);
+  if (terms.length === 1) {
+    const compactMatch = /^wo(\d+)$/.exec(terms[0]);
+    if (compactMatch) return [compactMatch[1]];
+  }
+  return terms;
+}
+
+function searchableText(values: unknown[]): string {
+  return values
+    .filter((value) => value !== null && value !== undefined)
+    .map((value) => String(value).toLowerCase())
+    .join(" ");
+}
+
+function matchesEveryTerm(values: unknown[], terms: string[]): boolean {
+  const text = searchableText(values);
+  const compact = text.replace(/[^a-z0-9]/g, "");
+  return terms.every(
+    (term) => text.includes(term) || compact.includes(term.replace(/[^a-z0-9]/g, "")),
+  );
+}
+
+function ilikeCandidateFilters(field: string, term: string): string[] {
+  const filters = [`${field}.ilike.%${term}%`];
+  // Candidate queries need to tolerate separators in stored VINs, plates, and
+  // phone numbers (for example, ABC-123 vs ABC123). The term is already reduced
+  // to [a-z0-9] by searchTerms(), and the exact compact comparison above remains
+  // the final match check, so this broader pattern cannot create a result match.
+  if (term.length >= 4) {
+    filters.push(`${field}.ilike.%${term.split("").join("%")}%`);
+  }
+  return filters;
+}
+
+function vehicleFilterForTerm(term: string): string {
+  const filters = [
+    ...ilikeCandidateFilters("vin", term),
+    ...ilikeCandidateFilters("license_plate", term),
+    `unit_number.ilike.%${term}%`,
+    `make.ilike.%${term}%`,
+    `model.ilike.%${term}%`,
+    `submodel.ilike.%${term}%`,
+  ];
+  if (/^\d{4}$/.test(term)) filters.push(`year.eq.${term}`);
+  return filters.join(",");
+}
+
+function customerFilterForTerm(term: string, includeContact: boolean): string {
+  const fields = ["business_name", "name", "first_name", "last_name", "identity_name"];
+  const filters = fields.map((field) => `${field}.ilike.%${term}%`);
+  if (includeContact) {
+    filters.push(
+      `email.ilike.%${term}%`,
+      `identity_email.ilike.%${term}%`,
+      ...ilikeCandidateFilters("phone", term),
+      ...ilikeCandidateFilters("phone_number", term),
+      ...ilikeCandidateFilters("identity_phone", term),
+    );
+  }
+  return filters.join(",");
+}
+
+function workOrderFilterForTerm(term: string): string {
+  const filters = [
+    ...ilikeCandidateFilters("custom_id", term),
+    `customer_name.ilike.%${term}%`,
+    ...ilikeCandidateFilters("vehicle_vin", term),
+    ...ilikeCandidateFilters("vehicle_license_plate", term),
+    `vehicle_unit_number.ilike.%${term}%`,
+    `vehicle_make.ilike.%${term}%`,
+    `vehicle_model.ilike.%${term}%`,
+    `vehicle_submodel.ilike.%${term}%`,
+  ];
+  if (/^\d{4}$/.test(term)) filters.push(`vehicle_year.eq.${term}`);
+  return filters.join(",");
+}
+
+function vehicleMatches(row: SearchVehicleRow, terms: string[]): boolean {
+  return matchesEveryTerm(
+    [
+      row.year,
+      row.make,
+      row.model,
+      row.submodel,
+      row.vin,
+      row.license_plate,
+      row.unit_number,
+    ],
+    terms,
+  );
+}
+
+function customerMatches(row: SearchCustomerRow, terms: string[]): boolean {
+  return matchesEveryTerm(
+    [
+      row.business_name,
+      row.name,
+      row.first_name,
+      row.last_name,
+      row.email,
+      row.phone,
+      row.phone_number,
+      row.identity_name,
+      row.identity_email,
+      row.identity_phone,
+    ],
+    terms,
+  );
+}
+
+function workOrderMatches(row: SearchWorkOrderRow, terms: string[]): boolean {
+  return matchesEveryTerm(
+    [
+      row.custom_id,
+      row.customer_name,
+      row.vehicle_year,
+      row.vehicle_make,
+      row.vehicle_model,
+      row.vehicle_submodel,
+      row.vehicle_vin,
+      row.vehicle_license_plate,
+      row.vehicle_unit_number,
+    ],
+    terms,
+  );
+}
+
+function toVehicleIdentity(row: SearchVehicleRow): VehicleIdentity {
+  return {
+    id: row.id,
+    year: row.year,
+    make: row.make,
+    model: row.model,
+    submodel: row.submodel,
+    vin: row.vin,
+    licensePlate: row.license_plate,
+    unitNumber: row.unit_number,
+    mileage: row.mileage,
+    odometerUnit: row.odometer_unit,
+    engineHours: row.engine_hours,
+    status: row.status,
+  };
+}
+
+function toAccountSummary(
+  row: SearchCustomerRow,
+): Pick<CustomerAccountSummary, "id" | "displayName" | "accountType" | "active"> {
+  return {
+    id: row.id,
+    displayName: customerAccountDisplayName(row),
+    accountType: row.account_type,
+    active: row.active,
+  };
+}
+
+function workOrderTitle(row: SearchWorkOrderRow): string {
+  const isEstimate = workOrderIsEstimate(row);
+  if (isEstimate) {
+    return row.estimate_number
+      ? `Estimate ${row.estimate_number}`
+      : `Estimate ${row.id.slice(0, 8)}`;
+  }
+  return row.custom_id
+    ? `WO-${row.custom_id.replace(/^wo-?/i, "")}`
+    : `WO ${row.id.slice(0, 8)}`;
+}
+
+function workOrderHref(row: SearchWorkOrderRow): string {
+  return workOrderIsEstimate(row)
+    ? `/estimates/${row.id}`
+    : `/work-orders/${row.id}`;
+}
+
+function workOrderDisplayStatus(row: SearchWorkOrderRow): string {
+  const isEstimate = workOrderIsEstimate(row);
+  return isEstimate ? row.estimate_status ?? row.status : row.status;
+}
+
+function workOrderIsEstimate(row: SearchWorkOrderRow): boolean {
+  return row.record_type === "estimate" || Boolean(row.estimate_number);
+}
+
+function workOrderEvidenceTime(row: SearchWorkOrderRow): number {
+  const value = Date.parse(row.updated_at ?? row.created_at ?? "");
+  return Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
+}
+
+function latestOdometerWorkOrder(
+  rows: SearchWorkOrderRow[],
+): SearchWorkOrderRow | null {
+  return rows.reduce<SearchWorkOrderRow | null>((latest, row) => {
+    if (row.odometer_km === null || !Number.isFinite(Number(row.odometer_km))) {
+      return latest;
+    }
+    if (!latest || workOrderEvidenceTime(row) > workOrderEvidenceTime(latest)) {
+      return row;
+    }
+    return latest;
+  }, null);
+}
+
+function workOrderIsActive(row: SearchWorkOrderRow): boolean {
+  if (
+    TERMINAL_WORK_ORDER_STATUSES.has(normalizedState(row.status)) ||
+    TERMINAL_WORK_ORDER_STATUSES.has(normalizeWorkOrderStatus(row.status))
+  ) {
+    return false;
+  }
+  const isEstimate = workOrderIsEstimate(row);
+  return (
+    !isEstimate ||
+    ACTIVE_ESTIMATE_STATUSES.has(normalizedState(row.estimate_status))
+  );
+}
+
+function appointmentSummary(row: SearchBookingRow): AppointmentSummary {
+  return {
+    title: "Appointment",
+    status: row.status,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    detail: row.notes?.trim() || null,
+    reference: {
+      sourceType: "appointment",
+      sourceId: row.id,
+      sourceLabel: `Appointment ${row.id.slice(0, 8)}`,
+      href: `/dashboard/appointments?bookingId=${encodeURIComponent(row.id)}`,
+    },
+  };
+}
+
+function lineNeedsAttention(row: SearchLineRow): boolean {
+  if (row.voided_at) return false;
+  const states = [row.status, row.line_status, row.approval_state].map(
+    normalizedState,
+  );
+  if (states.some((state) => TERMINAL_LINE_STATES.has(state))) return false;
+  return (
+    states.some((state) => ATTENTION_STATES.has(state)) ||
+    Boolean(row.hold_reason?.trim())
+  );
+}
+
+function quoteLineNeedsAttention(row: SearchQuoteLineRow): boolean {
+  const state = normalizedState(row.decision ?? row.status);
+  return [
+    "deferred",
+    "declined",
+    "customer_deferred",
+    "customer_declined",
+  ].includes(state);
+}
+
+function assertQuerySucceeded(
+  label: string,
+  error: { message: string } | null,
+): void {
+  if (error) throw new Error(`${label}: ${error.message}`);
+}
+
+export async function searchShopVehicleRecords(input: {
+  supabase: ShopSupabase;
+  shopId: string;
+  role: CanonicalRole;
+  query: unknown;
+  limit?: number;
+  now?: Date;
+}): Promise<VehicleWorkspaceSearchResponse> {
+  const query = sanitizeVehicleWorkspaceSearchQuery(input.query);
+  const terms = searchTerms(query);
+  const permissions = vehicleWorkspacePermissionsForRole(input.role);
+  const canSearchAccountContact = permissions.canViewAccountContact;
+  const limit = Math.min(
+    Math.max(Math.trunc(input.limit ?? DEFAULT_RESULT_LIMIT), 1),
+    MAX_RESULT_LIMIT,
+  );
+
+  const isMechanic = permissions.isAssignedWorkOnly;
+  let visibleMechanicWorkOrders: SearchWorkOrderRow[] = [];
+  let allowedMechanicVehicleRows: SearchVehicleRow[] = [];
+
+  if (isMechanic) {
+    const { data, error } = await input.supabase
+      .from("work_orders")
+      .select(WORK_ORDER_COLUMNS)
+      .eq("shop_id", input.shopId)
+      .order("updated_at", { ascending: false, nullsFirst: false })
+      .limit(MECHANIC_SCOPE_LIMIT);
+    assertQuerySucceeded("Unable to resolve assigned work orders", error);
+    visibleMechanicWorkOrders = (data ?? []) as SearchWorkOrderRow[];
+
+    const allowedVehicleIds = Array.from(
+      new Set(
+        visibleMechanicWorkOrders
+          .map((row) => row.vehicle_id)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+    if (allowedVehicleIds.length) {
+      const { data: vehicleData, error: vehicleError } = await input.supabase
+        .from("vehicles")
+        .select(VEHICLE_COLUMNS)
+        .eq("shop_id", input.shopId)
+        .in("id", allowedVehicleIds)
+        .order("created_at", { ascending: false, nullsFirst: false })
+        .limit(MECHANIC_SCOPE_LIMIT);
+      assertQuerySucceeded("Unable to resolve assigned vehicles", vehicleError);
+      allowedMechanicVehicleRows = (vehicleData ?? []) as SearchVehicleRow[];
+    }
+  }
+
+  let directVehicleMatches: SearchVehicleRow[];
+  if (isMechanic) {
+    directVehicleMatches = allowedMechanicVehicleRows.filter((row) =>
+      vehicleMatches(row, terms),
+    );
+  } else {
+    let vehicleQuery = input.supabase
+      .from("vehicles")
+      .select(VEHICLE_COLUMNS)
+      .eq("shop_id", input.shopId);
+    for (const term of terms) {
+      vehicleQuery = vehicleQuery.or(vehicleFilterForTerm(term));
+    }
+    const { data, error } = await vehicleQuery
+      .order("created_at", { ascending: false, nullsFirst: false })
+      .limit(SEARCH_SCAN_LIMIT);
+    assertQuerySucceeded("Unable to search vehicles", error);
+    directVehicleMatches = ((data ?? []) as SearchVehicleRow[]).filter((row) =>
+      vehicleMatches(row, terms),
+    );
+  }
+
+  const normalizedWorkOrderTerms = workOrderSearchTerms(terms);
+  let matchedWorkOrders: SearchWorkOrderRow[];
+  if (!terms.length) {
+    matchedWorkOrders = [];
+  } else if (isMechanic) {
+    matchedWorkOrders = visibleMechanicWorkOrders.filter((row) =>
+      workOrderMatches(row, normalizedWorkOrderTerms),
+    );
+  } else {
+    let workOrderQuery = input.supabase
+      .from("work_orders")
+      .select(WORK_ORDER_COLUMNS)
+      .eq("shop_id", input.shopId);
+    for (const term of normalizedWorkOrderTerms) {
+      workOrderQuery = workOrderQuery.or(workOrderFilterForTerm(term));
+    }
+    const { data, error } = await workOrderQuery
+      .order("updated_at", { ascending: false, nullsFirst: false })
+      .limit(SEARCH_SCAN_LIMIT);
+    assertQuerySucceeded("Unable to search work orders", error);
+    matchedWorkOrders = ((data ?? []) as SearchWorkOrderRow[]).filter((row) =>
+      workOrderMatches(row, normalizedWorkOrderTerms),
+    );
+  }
+
+  let matchedCustomers: SearchCustomerRow[] = [];
+  const mechanicCustomerIds = Array.from(
+    new Set(
+      allowedMechanicVehicleRows
+        .map((row) => row.customer_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+  if (terms.length && (!isMechanic || mechanicCustomerIds.length)) {
+    let customerRows: SearchCustomerRow[];
+    if (canSearchAccountContact) {
+      let customerQuery = input.supabase
+        .from("customers")
+        .select(CUSTOMER_COLUMNS)
+        .eq("shop_id", input.shopId);
+      if (isMechanic) {
+        customerQuery = customerQuery.in("id", mechanicCustomerIds);
+      }
+      for (const term of terms) {
+        customerQuery = customerQuery.or(customerFilterForTerm(term, true));
+      }
+      const { data, error } = await customerQuery.limit(SEARCH_SCAN_LIMIT);
+      assertQuerySucceeded("Unable to search customer accounts", error);
+      customerRows = (data ?? []) as SearchCustomerRow[];
+    } else {
+      let customerQuery = input.supabase
+        .from("customers")
+        .select(CUSTOMER_SAFE_COLUMNS)
+        .eq("shop_id", input.shopId);
+      if (isMechanic) {
+        customerQuery = customerQuery.in("id", mechanicCustomerIds);
+      }
+      for (const term of terms) {
+        customerQuery = customerQuery.or(customerFilterForTerm(term, false));
+      }
+      const { data, error } = await customerQuery.limit(SEARCH_SCAN_LIMIT);
+      assertQuerySucceeded("Unable to search customer accounts", error);
+      customerRows = (data ?? []) as SearchCustomerRow[];
+    }
+    matchedCustomers = customerRows.filter((row) =>
+      customerMatches(row, terms),
+    );
+  }
+
+  const matchedCustomerIds = new Set(matchedCustomers.map((row) => row.id));
+  let expandedCustomerVehicles: SearchVehicleRow[] = [];
+  if (matchedCustomerIds.size) {
+    if (isMechanic) {
+      expandedCustomerVehicles = allowedMechanicVehicleRows.filter(
+        (row) => row.customer_id && matchedCustomerIds.has(row.customer_id),
+      );
+    } else {
+      const { data, error } = await input.supabase
+        .from("vehicles")
+        .select(VEHICLE_COLUMNS)
+        .eq("shop_id", input.shopId)
+        .in("customer_id", Array.from(matchedCustomerIds))
+        .order("created_at", { ascending: false, nullsFirst: false })
+        .limit(SUMMARY_ROW_LIMIT);
+      assertQuerySucceeded("Unable to expand customer vehicles", error);
+      expandedCustomerVehicles = (data ?? []) as SearchVehicleRow[];
+    }
+  }
+
+  const candidateVehicleIds = new Map<string, true>();
+  for (const row of directVehicleMatches) candidateVehicleIds.set(row.id, true);
+  for (const row of matchedWorkOrders) {
+    if (row.vehicle_id) candidateVehicleIds.set(row.vehicle_id, true);
+  }
+  for (const row of expandedCustomerVehicles) candidateVehicleIds.set(row.id, true);
+
+  const boundedVehicleIds = Array.from(candidateVehicleIds.keys()).slice(0, limit);
+  let vehicles: SearchVehicleRow[] = [];
+  if (boundedVehicleIds.length) {
+    const { data, error } = await input.supabase
+      .from("vehicles")
+      .select(VEHICLE_COLUMNS)
+      .eq("shop_id", input.shopId)
+      .in("id", boundedVehicleIds);
+    assertQuerySucceeded("Unable to load canonical vehicles", error);
+    const byId = new Map(
+      ((data ?? []) as SearchVehicleRow[]).map((row) => [row.id, row]),
+    );
+    vehicles = boundedVehicleIds
+      .map((id) => byId.get(id))
+      .filter((row): row is SearchVehicleRow => Boolean(row));
+  }
+
+  const currentCustomerIds = Array.from(
+    new Set(
+      vehicles
+        .map((row) => row.customer_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+  const accountsById = new Map<string, SearchCustomerRow>();
+  if (currentCustomerIds.length) {
+    const { data, error } = await input.supabase
+      .from("customers")
+      .select(CUSTOMER_SAFE_COLUMNS)
+      .eq("shop_id", input.shopId)
+      .in("id", currentCustomerIds);
+    assertQuerySucceeded("Unable to load current accounts", error);
+    for (const row of (data ?? []) as SearchCustomerRow[]) accountsById.set(row.id, row);
+  }
+
+  let workOrders: SearchWorkOrderRow[] = [];
+  if (boundedVehicleIds.length) {
+    const { data, error } = await input.supabase
+      .from("work_orders")
+      .select(WORK_ORDER_COLUMNS)
+      .eq("shop_id", input.shopId)
+      .in("vehicle_id", boundedVehicleIds)
+      .order("updated_at", { ascending: false, nullsFirst: false })
+      .limit(SUMMARY_ROW_LIMIT);
+    assertQuerySucceeded("Unable to load vehicle work orders", error);
+    workOrders = (data ?? []) as SearchWorkOrderRow[];
+  }
+
+  let bookings: SearchBookingRow[] = [];
+  if (boundedVehicleIds.length) {
+    const { data, error } = await input.supabase
+      .from("bookings")
+      .select("id,vehicle_id,work_order_id,status,starts_at,ends_at,notes")
+      .eq("shop_id", input.shopId)
+      .in("vehicle_id", boundedVehicleIds)
+      .gte("ends_at", (input.now ?? new Date()).toISOString())
+      .order("starts_at", { ascending: true })
+      .limit(SUMMARY_ROW_LIMIT);
+    assertQuerySucceeded("Unable to load vehicle appointments", error);
+    bookings = ((data ?? []) as SearchBookingRow[]).filter(
+      (row) => !TERMINAL_APPOINTMENT_STATUSES.has(normalizedState(row.status)),
+    );
+  }
+
+  const workOrderVehicleById = new Map(
+    workOrders
+      .filter(
+        (row): row is SearchWorkOrderRow & { vehicle_id: string } =>
+          Boolean(row.vehicle_id),
+      )
+      .map((row) => [row.id, row.vehicle_id]),
+  );
+  const workOrderIds = Array.from(workOrderVehicleById.keys());
+
+  let attentionLines: SearchLineRow[] = [];
+  let attentionQuoteLines: SearchQuoteLineRow[] = [];
+  if (boundedVehicleIds.length) {
+    const references = [`vehicle_id.in.(${boundedVehicleIds.join(",")})`];
+    if (workOrderIds.length) {
+      references.push(`work_order_id.in.(${workOrderIds.join(",")})`);
+    }
+    const { data, error } = await input.supabase
+      .from("work_order_lines")
+      .select(
+        "id,vehicle_id,work_order_id,status,line_status,approval_state,hold_reason,voided_at",
+      )
+      .eq("shop_id", input.shopId)
+      .or(references.join(","))
+      .limit(SUMMARY_ROW_LIMIT);
+    assertQuerySucceeded("Unable to load vehicle attention items", error);
+    attentionLines = ((data ?? []) as SearchLineRow[]).filter(lineNeedsAttention);
+
+    const { data: quoteLineData, error: quoteLineError } = await input.supabase
+      .from("work_order_quote_lines")
+      .select(
+        "id,vehicle_id,work_order_id,work_order_line_id,source_work_order_line_id,status,decision",
+      )
+      .eq("shop_id", input.shopId)
+      .or(references.join(","))
+      .limit(SUMMARY_ROW_LIMIT);
+    assertQuerySucceeded(
+      "Unable to load deferred vehicle estimate items",
+      quoteLineError,
+    );
+    attentionQuoteLines = ((quoteLineData ?? []) as SearchQuoteLineRow[]).filter(
+      quoteLineNeedsAttention,
+    );
+  }
+
+  let invoices: SearchInvoiceRow[] = [];
+  if (permissions.canViewFinancials && workOrderIds.length) {
+    const { data, error } = await input.supabase
+      .from("invoices")
+      .select("id,work_order_id,outstanding_total,currency")
+      .eq("shop_id", input.shopId)
+      .in("work_order_id", workOrderIds)
+      .gt("outstanding_total", 0)
+      .limit(SUMMARY_ROW_LIMIT);
+    assertQuerySucceeded("Unable to load vehicle balances", error);
+    invoices = (data ?? []) as SearchInvoiceRow[];
+  }
+
+  const activeWorkOrdersByVehicle = new Map<string, SearchWorkOrderRow[]>();
+  for (const row of workOrders) {
+    if (!row.vehicle_id || !workOrderIsActive(row)) continue;
+    const rows = activeWorkOrdersByVehicle.get(row.vehicle_id) ?? [];
+    rows.push(row);
+    activeWorkOrdersByVehicle.set(row.vehicle_id, rows);
+  }
+
+  const appointmentByVehicle = new Map<string, SearchBookingRow>();
+  for (const row of bookings) {
+    if (row.vehicle_id && !appointmentByVehicle.has(row.vehicle_id)) {
+      appointmentByVehicle.set(row.vehicle_id, row);
+    }
+  }
+
+  const attentionCountByVehicle = new Map<string, number>();
+  const representedLineIds = new Set(
+    attentionQuoteLines.flatMap((row) =>
+      [row.work_order_line_id, row.source_work_order_line_id].filter(
+        (id): id is string => Boolean(id),
+      ),
+    ),
+  );
+  for (const row of attentionQuoteLines) {
+    const vehicleId = row.vehicle_id ?? workOrderVehicleById.get(row.work_order_id);
+    if (!vehicleId) continue;
+    attentionCountByVehicle.set(
+      vehicleId,
+      (attentionCountByVehicle.get(vehicleId) ?? 0) + 1,
+    );
+  }
+  for (const row of attentionLines) {
+    if (representedLineIds.has(row.id)) continue;
+    const vehicleId = row.vehicle_id ?? workOrderVehicleById.get(row.work_order_id);
+    if (!vehicleId) continue;
+    attentionCountByVehicle.set(
+      vehicleId,
+      (attentionCountByVehicle.get(vehicleId) ?? 0) + 1,
+    );
+  }
+
+  const invoicesByVehicle = new Map<string, SearchInvoiceRow[]>();
+  for (const row of invoices) {
+    if (!row.work_order_id) continue;
+    const vehicleId = workOrderVehicleById.get(row.work_order_id);
+    if (!vehicleId) continue;
+    const rows = invoicesByVehicle.get(vehicleId) ?? [];
+    rows.push(row);
+    invoicesByVehicle.set(vehicleId, rows);
+  }
+
+  const groupMap = new Map<
+    string,
+    VehicleWorkspaceSearchResponse["groups"][number]
+  >();
+  for (const vehicle of vehicles) {
+    const accountRow = vehicle.customer_id
+      ? accountsById.get(vehicle.customer_id) ?? null
+      : null;
+    const groupKey = accountRow?.id ?? "__orphan__";
+    let group = groupMap.get(groupKey);
+    if (!group) {
+      group = {
+        account: accountRow ? toAccountSummary(accountRow) : null,
+        matchedAccount: Boolean(accountRow && matchedCustomerIds.has(accountRow.id)),
+        vehicles: [],
+      };
+      groupMap.set(groupKey, group);
+    }
+
+    const vehicleWorkOrders = workOrders.filter(
+      (row) => row.vehicle_id === vehicle.id,
+    );
+    const latestWorkOrderOdometer = latestOdometerWorkOrder(vehicleWorkOrders);
+    const workOrderOdometer = latestWorkOrderOdometer
+      ? String(latestWorkOrderOdometer.odometer_km)
+      : null;
+    // vehicles.mileage has no update timestamp in the canonical schema. Prefer
+    // the newest timestamped WO evidence and use the vehicle value only when no
+    // WO has an odometer reading.
+    const odometer = workOrderOdometer ?? vehicle.mileage;
+    const vehicleInvoices = invoicesByVehicle.get(vehicle.id) ?? [];
+    const currencies = new Set(
+      vehicleInvoices.map((row) => row.currency?.trim().toUpperCase() || null),
+    );
+    const singleCurrency =
+      currencies.size === 1 ? Array.from(currencies)[0] : null;
+    const canPresentOutstandingAmount =
+      vehicleInvoices.length > 0 && singleCurrency !== null;
+    let createWorkOrderHref: string | null = null;
+    if (
+      permissions.canCreateWorkOrder &&
+      accountRow?.active &&
+      !accountRow.archived_at &&
+      !accountRow.merged_into_customer_id &&
+      !BLOCKED_CREATE_WORK_ORDER_VEHICLE_STATUSES.has(
+        normalizedState(vehicle.status),
+      )
+    ) {
+      createWorkOrderHref = createWorkOrderHandoffHref({
+        customerId: accountRow.id,
+        vehicleId: vehicle.id,
+      });
+    }
+
+    group.vehicles.push({
+      vehicle: toVehicleIdentity(vehicle),
+      currentAccount: accountRow
+        ? { id: accountRow.id, displayName: customerAccountDisplayName(accountRow) }
+        : null,
+      latestOdometer: odometer,
+      activeWork: (activeWorkOrdersByVehicle.get(vehicle.id) ?? []).map((row) => ({
+        kind: workOrderIsEstimate(row) ? "estimate" : "work_order",
+        title: workOrderTitle(row),
+        status: workOrderDisplayStatus(row),
+        reference: {
+          sourceType: "work_order",
+          sourceId: row.id,
+          sourceLabel: workOrderTitle(row),
+          href: workOrderHref(row),
+        },
+      })),
+      nextAppointment: appointmentByVehicle.has(vehicle.id)
+        ? appointmentSummary(appointmentByVehicle.get(vehicle.id)!)
+        : null,
+      attentionCount: attentionCountByVehicle.get(vehicle.id) ?? 0,
+      ...(permissions.canViewFinancials && vehicleInvoices.length > 0
+        ? canPresentOutstandingAmount
+          ? {
+              outstandingAmount: vehicleInvoices.reduce(
+                (total, row) => total + Number(row.outstanding_total ?? 0),
+                0,
+              ),
+              currency: singleCurrency,
+            }
+          : { currency: null }
+        : {}),
+      workspaceHref: `/vehicles/${vehicle.id}`,
+      createWorkOrderHref,
+    });
+  }
+
+  const expandedCustomerIds = new Set(
+    expandedCustomerVehicles
+      .map((row) => row.customer_id)
+      .filter((id): id is string => Boolean(id)),
+  );
+  // Restricted roles may use safe account names to expand vehicle-scoped cards,
+  // but an unmatched account ID must never become an account-only response.
+  const accountsWithoutVehicles =
+    isMechanic || !permissions.canViewAccountContact
+      ? []
+      : matchedCustomers
+          .filter((row) => !expandedCustomerIds.has(row.id))
+          .map(toAccountSummary);
+
+  return {
+    query,
+    groups: Array.from(groupMap.values()),
+    accountsWithoutVehicles,
+    permissions,
+  };
+}

--- a/features/vehicles/server/vehicleWorkspacePermissions.ts
+++ b/features/vehicles/server/vehicleWorkspacePermissions.ts
@@ -1,0 +1,83 @@
+import "server-only";
+
+import { isCustomerMessagingRole } from "@/features/ai/lib/chat/authorization";
+import {
+  ESTIMATE_VIEW_ROLES,
+  estimateActorForRole,
+} from "@/features/estimates/lib/access";
+import {
+  getActorCapabilities,
+  ROLE_GROUPS,
+  type CanonicalRole,
+} from "@/features/shared/lib/rbac";
+import type { VehicleWorkspacePermissions } from "@/features/vehicles/lib/vehicleWorkspace";
+
+const LEGACY_ACCOUNT_PAGE_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+] as const satisfies readonly CanonicalRole[];
+
+const PART_REQUEST_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "parts",
+] as const satisfies readonly CanonicalRole[];
+
+const INSPECTION_OPEN_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "lead_hand",
+  "foreman",
+] as const satisfies readonly CanonicalRole[];
+
+const WORK_ORDER_OPEN_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "mechanic",
+  "lead_hand",
+  "foreman",
+] as const satisfies readonly CanonicalRole[];
+
+export function vehicleWorkspacePermissionsForRole(
+  role: CanonicalRole,
+): VehicleWorkspacePermissions {
+  const capabilities = getActorCapabilities({ role });
+  const isWorkOrderCreator = (
+    ROLE_GROUPS.workOrderCreators as readonly CanonicalRole[]
+  ).includes(role);
+
+  return {
+    canViewAccountContact:
+      capabilities.canManageWorkOrders || capabilities.canManageScheduling,
+    canOpenAccount: (LEGACY_ACCOUNT_PAGE_ROLES as readonly CanonicalRole[]).includes(
+      role,
+    ),
+    canViewFinancials: capabilities.canViewFinancials,
+    canViewEstimates: (ESTIMATE_VIEW_ROLES as readonly CanonicalRole[]).includes(
+      role,
+    ),
+    canOpenInspections: (
+      INSPECTION_OPEN_ROLES as readonly CanonicalRole[]
+    ).includes(role),
+    canOpenWorkOrders: (
+      WORK_ORDER_OPEN_ROLES as readonly CanonicalRole[]
+    ).includes(role),
+    canViewPartRequests: (PART_REQUEST_ROLES as readonly CanonicalRole[]).includes(
+      role,
+    ),
+    canCreateWorkOrder: isWorkOrderCreator,
+    canBookAppointment: capabilities.canManageScheduling,
+    canCreateEstimate: estimateActorForRole(role).canCreate,
+    canMessageCustomer: isCustomerMessagingRole(role),
+    canViewRelatedVehicles:
+      capabilities.canViewShopWideData || capabilities.canManageWorkOrders,
+    isAssignedWorkOnly: role === "mechanic",
+  };
+}

--- a/tests/appointment-deep-link-contract.test.ts
+++ b/tests/appointment-deep-link-contract.test.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const SHOP_ID = "a4100000-0000-4000-8000-000000000001";
+
+const routeMocks = vi.hoisted(() => ({
+  requireApiAccess: vi.fn(),
+  createAdminSupabase: vi.fn(),
+  createServerSupabaseRoute: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: routeMocks.requireApiAccess,
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: routeMocks.createAdminSupabase,
+  createServerSupabaseRoute: routeMocks.createServerSupabaseRoute,
+}));
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const appointmentsPage = read("app/dashboard/appointments/page.tsx");
+const staffBookingsRoute = read("app/api/portal/bookings/route.ts");
+const workspaceLoader = read(
+  "features/vehicles/server/loadVehicleWorkspaceSnapshot.ts",
+);
+const workspaceSearch = read(
+  "features/vehicles/server/searchShopVehicleRecords.ts",
+);
+
+describe("vehicle workspace appointment deep links", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("retains each canonical booking id in workspace appointment links", () => {
+    const canonicalHref =
+      "`/dashboard/appointments?bookingId=${encodeURIComponent(row.id)}`";
+
+    expect(workspaceLoader.split(canonicalHref)).toHaveLength(3);
+    expect(workspaceSearch).toContain(canonicalHref);
+  });
+
+  it("preserves the booking id while canonicalizing the authorized shop", () => {
+    expect(appointmentsPage).toContain('search.get("bookingId")');
+    expect(appointmentsPage).toContain(
+      "new URLSearchParams(search.toString())",
+    );
+    expect(appointmentsPage).toContain(
+      'canonicalQuery.set("shop", authorizedSlug)',
+    );
+  });
+
+  it("loads the exact tenant-scoped booking before opening the edit panel", () => {
+    expect(staffBookingsRoute).toContain(
+      "if (bookingId && !actor.canManageScheduling)",
+    );
+    expect(staffBookingsRoute).toContain('.eq("shop_id", shop.id)');
+    expect(staffBookingsRoute).toContain(
+      '.eq("id", bookingId).limit(1)',
+    );
+    expect(staffBookingsRoute).toContain(
+      'return bad("Appointment not found", 404)',
+    );
+
+    expect(appointmentsPage).toContain(
+      "&bookingId=${encodeURIComponent(requestedBookingId)}",
+    );
+    expect(appointmentsPage).toContain("setWeekStart(appointmentDate)");
+    expect(appointmentsPage).toContain('setPanelMode("edit")');
+  });
+
+  it("bootstraps the shop through the canonical server profile guard", () => {
+    expect(staffBookingsRoute).toContain(
+      "await requireShopScopedApiAccess()",
+    );
+    expect(staffBookingsRoute).toContain('.eq("id", profile.shop_id)');
+    expect(appointmentsPage).toContain(
+      'fetch("/api/portal/bookings?scope=shop"',
+    );
+    expect(appointmentsPage).not.toContain('.from("profiles")');
+  });
+
+  it("returns only the canonical linked profile's shop context", async () => {
+    const shopBuilder = {
+      select: vi.fn(),
+      eq: vi.fn(),
+      maybeSingle: vi.fn(),
+    };
+    shopBuilder.select.mockReturnValue(shopBuilder);
+    shopBuilder.eq.mockReturnValue(shopBuilder);
+    shopBuilder.maybeSingle.mockResolvedValue({
+      data: {
+        id: SHOP_ID,
+        name: "Linked Profile Shop",
+        slug: "linked-profile-shop",
+        accepts_online_booking: false,
+      },
+      error: null,
+    });
+    const from = vi.fn(() => shopBuilder);
+    routeMocks.createAdminSupabase.mockReturnValue({ from });
+    routeMocks.requireApiAccess.mockResolvedValue({
+      ok: true,
+      profile: {
+        id: "canonical-profile-id",
+        shop_id: SHOP_ID,
+        role: "advisor",
+      },
+      canonicalRole: "advisor",
+      authUserId: "linked-auth-user-id",
+      supabase: { from: vi.fn(), rpc: vi.fn() },
+    });
+
+    const { GET } = await import("../app/api/portal/bookings/route");
+    const response = await GET(
+      new Request(
+        "https://profixiq.test/api/portal/bookings?scope=shop&shop=forged-shop",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(routeMocks.requireApiAccess).toHaveBeenCalledTimes(1);
+    expect(from).toHaveBeenCalledWith("shops");
+    expect(shopBuilder.eq).toHaveBeenCalledWith("id", SHOP_ID);
+    expect(shopBuilder.eq).not.toHaveBeenCalledWith("slug", "forged-shop");
+    await expect(response.json()).resolves.toEqual({
+      shop: {
+        id: SHOP_ID,
+        name: "Linked Profile Shop",
+        slug: "linked-profile-shop",
+        accepts_online_booking: false,
+      },
+    });
+  });
+
+  it("does not use the service client when canonical access is denied", async () => {
+    routeMocks.requireApiAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
+
+    const { GET } = await import("../app/api/portal/bookings/route");
+    const response = await GET(
+      new Request("https://profixiq.test/api/portal/bookings?scope=shop"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(routeMocks.createAdminSupabase).not.toHaveBeenCalled();
+  });
+});

--- a/tests/guided-onboarding-page-panels.test.tsx
+++ b/tests/guided-onboarding-page-panels.test.tsx
@@ -326,25 +326,22 @@ describe("guided onboarding page panels", () => {
     expect(source).not.toContain("Start typing to search customers.");
   });
 
-  it("builds Vehicle Files with default and live-search behavior capped to 20 shop-scoped rows", () => {
+  it("builds Vehicle Files on the guarded canonical server-search contract", () => {
     const source = read("features/vehicles/app/vehicles/page.tsx");
+    const route = read("app/vehicles/page.tsx");
 
     expect(source).toContain("Vehicle Files");
-    expect(source).toContain(
-      "Search by unit, VIN, plate, year, make, model, or customer.",
-    );
-    expect(source).toContain('placeholder="Search vehicles..."');
+    expect(source).toContain("Search by customer or company, phone, email, VIN");
+    expect(source).toContain('placeholder="Customer, phone, VIN, plate, unit, or WO…"');
     expect(source).toContain("+ Create Vehicle");
     expect(source).toContain("GuidedPageStepPanel");
     expect(source).toContain('"No vehicles found yet."');
-    expect(source).toContain('"No vehicles match your search."');
-    expect(source).toContain('.eq("shop_id", shopId)');
-    expect(source).toContain("setVisibleRows(sortedRows.slice(0, 20))");
-    expect(source).toContain(
-      "setVisibleRows(sortVehicleRows(rows).slice(0, 20))",
-    );
-    expect(source).toContain("vehicleSearchHaystack");
-    expect(source).not.toContain("Start typing to search vehicles.");
+    expect(source).toContain("/api/vehicles/search?");
+    expect(source).toContain("Open Workspace");
+    expect(source).toContain("Create Work Order");
+    expect(source).not.toContain("createBrowserSupabase");
+    expect(route).toContain("requireShopPageAccess");
+    expect(route).toContain("VEHICLE_WORKSPACE_READER_ROLES");
   });
 
   it("does not introduce legacy guided onboarding or auth helper regressions", () => {

--- a/tests/open-work-tray.test.ts
+++ b/tests/open-work-tray.test.ts
@@ -83,6 +83,10 @@ describe("Open Work route identity", () => {
       key: "customer:customer-123",
       kind: "customer",
     });
+    expect(resolveOpenWork("/vehicles/vehicle-123")).toMatchObject({
+      key: "vehicle:vehicle-123",
+      kind: "vehicle",
+    });
   });
 });
 

--- a/tests/security/vehicle-workspace-tenant.runtime.sql
+++ b/tests/security/vehicle-workspace-tenant.runtime.sql
@@ -1,0 +1,282 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values
+  (
+    '68100000-0000-4000-8000-000000000001',
+    'vehicle-workspace-owner-a@example.test',
+    '{"full_name":"Vehicle Workspace Owner A"}'::jsonb
+  ),
+  (
+    '68100000-0000-4000-8000-000000000002',
+    'vehicle-workspace-owner-b@example.test',
+    '{"full_name":"Vehicle Workspace Owner B"}'::jsonb
+  ),
+  (
+    '68100000-0000-4000-8000-000000000003',
+    'vehicle-workspace-mechanic-a@example.test',
+    '{"full_name":"Vehicle Workspace Mechanic A"}'::jsonb
+  )
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name)
+values
+  (
+    '68100000-0000-4000-8000-000000000001',
+    '68100000-0000-4000-8000-000000000001',
+    'owner',
+    'Vehicle Workspace Owner A'
+  ),
+  (
+    '68100000-0000-4000-8000-000000000002',
+    '68100000-0000-4000-8000-000000000002',
+    'owner',
+    'Vehicle Workspace Owner B'
+  ),
+  (
+    '68100000-0000-4000-8000-000000000003',
+    '68100000-0000-4000-8000-000000000003',
+    'mechanic',
+    'Vehicle Workspace Mechanic A'
+  )
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name;
+
+insert into public.shops (id, owner_id, business_name, name, user_limit)
+values
+  (
+    '68200000-0000-4000-8000-000000000001',
+    '68100000-0000-4000-8000-000000000001',
+    'Vehicle Workspace Shop A',
+    'Vehicle Workspace Shop A',
+    5
+  ),
+  (
+    '68200000-0000-4000-8000-000000000002',
+    '68100000-0000-4000-8000-000000000002',
+    'Vehicle Workspace Shop B',
+    'Vehicle Workspace Shop B',
+    5
+  )
+on conflict (id) do nothing;
+
+update public.profiles
+set shop_id = case
+  when id in (
+    '68100000-0000-4000-8000-000000000001'::uuid,
+    '68100000-0000-4000-8000-000000000003'::uuid
+  ) then '68200000-0000-4000-8000-000000000001'::uuid
+  else '68200000-0000-4000-8000-000000000002'::uuid
+end
+where id in (
+  '68100000-0000-4000-8000-000000000001',
+  '68100000-0000-4000-8000-000000000002',
+  '68100000-0000-4000-8000-000000000003'
+);
+
+insert into public.customers (id, shop_id, user_id, name)
+values
+  (
+    '68600000-0000-4000-8000-000000000001',
+    '68200000-0000-4000-8000-000000000001',
+    '68100000-0000-4000-8000-000000000001',
+    'Vehicle Workspace Customer A'
+  ),
+  (
+    '68600000-0000-4000-8000-000000000002',
+    '68200000-0000-4000-8000-000000000002',
+    '68100000-0000-4000-8000-000000000002',
+    'Vehicle Workspace Customer B'
+  );
+
+insert into public.vehicles (
+  id, shop_id, user_id, customer_id, vin, license_plate, unit_number, year, make, model
+)
+values
+  (
+    '68300000-0000-4000-8000-000000000001',
+    '68200000-0000-4000-8000-000000000001',
+    '68100000-0000-4000-8000-000000000001',
+    '68600000-0000-4000-8000-000000000001',
+    '1FTBW1X80NKA10001',
+    'WS-A-1',
+    'A-1',
+    2022,
+    'Ford',
+    'Transit'
+  ),
+  (
+    '68300000-0000-4000-8000-000000000002',
+    '68200000-0000-4000-8000-000000000002',
+    '68100000-0000-4000-8000-000000000002',
+    '68600000-0000-4000-8000-000000000002',
+    '1FTBW1X80NKA10002',
+    'WS-B-1',
+    'B-1',
+    2022,
+    'Ford',
+    'Transit'
+  );
+
+insert into public.work_orders (
+  id, shop_id, customer_id, vehicle_id, custom_id, status, record_type
+)
+values
+  (
+    '68400000-0000-4000-8000-000000000001',
+    '68200000-0000-4000-8000-000000000001',
+    '68600000-0000-4000-8000-000000000001',
+    '68300000-0000-4000-8000-000000000001',
+    'WS-A-1001',
+    'in_progress',
+    'work_order'
+  ),
+  (
+    '68400000-0000-4000-8000-000000000002',
+    '68200000-0000-4000-8000-000000000002',
+    '68600000-0000-4000-8000-000000000002',
+    '68300000-0000-4000-8000-000000000002',
+    'WS-B-1001',
+    'in_progress',
+    'work_order'
+  );
+
+insert into public.invoices (
+  id, shop_id, work_order_id, invoice_number, status, issued_at, currency
+)
+values
+  (
+    '68500000-0000-4000-8000-000000000001',
+    '68200000-0000-4000-8000-000000000001',
+    '68400000-0000-4000-8000-000000000001',
+    'WS-A-INV-1',
+    'issued',
+    now(),
+    'CAD'
+  ),
+  (
+    '68500000-0000-4000-8000-000000000002',
+    '68200000-0000-4000-8000-000000000002',
+    '68400000-0000-4000-8000-000000000002',
+    'WS-B-INV-1',
+    'issued',
+    now(),
+    'CAD'
+  );
+
+-- Shop A may resolve its canonical records but cannot enumerate Shop B by a
+-- guessed vehicle, WO, or invoice ID.
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"68100000-0000-4000-8000-000000000001","role":"authenticated"}',
+  true
+);
+
+do $vehicle_workspace_tenant$
+begin
+  if not exists (
+    select 1 from public.vehicles
+    where id = '68300000-0000-4000-8000-000000000001'
+  ) or not exists (
+    select 1 from public.work_orders
+    where id = '68400000-0000-4000-8000-000000000001'
+  ) or not exists (
+    select 1 from public.invoices
+    where id = '68500000-0000-4000-8000-000000000001'
+  ) then
+    raise exception 'Vehicle workspace owner could not read same-Shop sources.';
+  end if;
+
+  if exists (
+    select 1 from public.vehicles
+    where id = '68300000-0000-4000-8000-000000000002'
+  ) or exists (
+    select 1 from public.work_orders
+    where id = '68400000-0000-4000-8000-000000000002'
+  ) or exists (
+    select 1 from public.invoices
+    where id = '68500000-0000-4000-8000-000000000002'
+  ) then
+    raise exception 'Vehicle workspace tenant boundary exposed Shop B records.';
+  end if;
+end
+$vehicle_workspace_tenant$;
+
+reset role;
+select set_config('request.jwt.claims', '', true);
+select set_config('request.jwt.claim.role', '', true);
+
+-- A mechanic can see the same-Shop vehicle identity under existing vehicle RLS,
+-- but an unassigned WO is not visible. The TypeScript read model requires that
+-- RLS-visible WO anchor before returning any vehicle history.
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"68100000-0000-4000-8000-000000000003","role":"authenticated"}',
+  true
+);
+
+do $vehicle_workspace_mechanic$
+begin
+  if not exists (
+    select 1 from public.vehicles
+    where id = '68300000-0000-4000-8000-000000000001'
+  ) then
+    raise exception 'Vehicle workspace mechanic fixture could not read vehicle identity.';
+  end if;
+
+  if exists (
+    select 1 from public.work_orders
+    where id = '68400000-0000-4000-8000-000000000001'
+  ) then
+    raise exception 'Unassigned mechanic read a work order anchor.';
+  end if;
+end
+$vehicle_workspace_mechanic$;
+
+reset role;
+select set_config('request.jwt.claims', '', true);
+select set_config('request.jwt.claim.role', '', true);
+
+-- Anonymous direct access cannot discover either tenant.
+set local role anon;
+
+do $vehicle_workspace_anon$
+begin
+  begin
+    if exists (
+      select 1 from public.vehicles
+      where id in (
+        '68300000-0000-4000-8000-000000000001',
+        '68300000-0000-4000-8000-000000000002'
+      )
+    ) then
+      raise exception 'Anonymous actor discovered Vehicle Workspace vehicles.';
+    end if;
+  exception
+    when insufficient_privilege then null;
+  end;
+
+  begin
+    if exists (
+      select 1 from public.work_orders
+      where id in (
+        '68400000-0000-4000-8000-000000000001',
+        '68400000-0000-4000-8000-000000000002'
+      )
+    ) then
+      raise exception 'Anonymous actor discovered Vehicle Workspace work orders.';
+    end if;
+  exception
+    when insufficient_privilege then null;
+  end;
+end
+$vehicle_workspace_anon$;
+
+reset role;
+rollback;

--- a/tests/vehicle-workspace-contract.test.ts
+++ b/tests/vehicle-workspace-contract.test.ts
@@ -1,0 +1,2173 @@
+import { describe, expect, it } from "vitest";
+
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+import {
+  createWorkOrderHandoffHref,
+  VEHICLE_WORKSPACE_READER_ROLES,
+} from "@/features/vehicles/lib/vehicleWorkspace";
+import {
+  vehicleWorkspacePermissionsForRole,
+} from "@/features/vehicles/server/vehicleWorkspacePermissions";
+import {
+  extractInspectionFindings,
+  loadVehicleWorkspaceSnapshot,
+  vehicleWorkspaceCreateWorkOrderHref,
+} from "@/features/vehicles/server/loadVehicleWorkspaceSnapshot";
+import { searchShopVehicleRecords } from "@/features/vehicles/server/searchShopVehicleRecords";
+
+const SHOP_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "service",
+  "parts",
+  "mechanic",
+  "lead_hand",
+  "foreman",
+] as const satisfies readonly CanonicalRole[];
+
+const NON_SHOP_ROLES = [
+  "fleet_manager",
+  "dispatcher",
+  "driver",
+  "customer",
+  "unknown",
+] as const satisfies readonly CanonicalRole[];
+
+type QueryResult = {
+  data: unknown;
+  error: { message: string } | null;
+};
+
+type QueryCall = {
+  table: string;
+  operation: string;
+  args: unknown[];
+};
+
+type QueryBuilder = {
+  select: (...args: unknown[]) => QueryBuilder;
+  eq: (...args: unknown[]) => QueryBuilder;
+  in: (...args: unknown[]) => QueryBuilder;
+  neq: (...args: unknown[]) => QueryBuilder;
+  or: (...args: unknown[]) => QueryBuilder;
+  gte: (...args: unknown[]) => QueryBuilder;
+  gt: (...args: unknown[]) => QueryBuilder;
+  order: (...args: unknown[]) => QueryBuilder;
+  limit: (...args: unknown[]) => QueryBuilder;
+  maybeSingle: (...args: unknown[]) => QueryBuilder;
+  then<TResult1 = QueryResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: QueryResult) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?:
+      | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+      | null,
+  ): Promise<TResult1 | TResult2>;
+};
+
+function createSupabaseFixture(
+  results: Record<string, QueryResult[]>,
+): { client: unknown; calls: QueryCall[] } {
+  const calls: QueryCall[] = [];
+  const tableCounts = new Map<string, number>();
+
+  const client = {
+    from(table: string) {
+      const index = tableCounts.get(table) ?? 0;
+      tableCounts.set(table, index + 1);
+      const result = results[table]?.[index];
+      if (!result) {
+        throw new Error(`Missing Supabase fixture result for ${table}[${index}]`);
+      }
+      const query: QueryBuilder = {
+        select(...args: unknown[]) {
+          calls.push({ table, operation: "select", args });
+          return query;
+        },
+        eq(...args: unknown[]) {
+          calls.push({ table, operation: "eq", args });
+          return query;
+        },
+        in(...args: unknown[]) {
+          calls.push({ table, operation: "in", args });
+          return query;
+        },
+        neq(...args: unknown[]) {
+          calls.push({ table, operation: "neq", args });
+          return query;
+        },
+        or(...args: unknown[]) {
+          calls.push({ table, operation: "or", args });
+          return query;
+        },
+        gte(...args: unknown[]) {
+          calls.push({ table, operation: "gte", args });
+          return query;
+        },
+        gt(...args: unknown[]) {
+          calls.push({ table, operation: "gt", args });
+          return query;
+        },
+        order(...args: unknown[]) {
+          calls.push({ table, operation: "order", args });
+          return query;
+        },
+        limit(...args: unknown[]) {
+          calls.push({ table, operation: "limit", args });
+          return query;
+        },
+        maybeSingle(...args: unknown[]) {
+          calls.push({ table, operation: "maybeSingle", args });
+          return query;
+        },
+        then<TResult1 = QueryResult, TResult2 = never>(
+          onfulfilled?: ((value: QueryResult) => TResult1 | PromiseLike<TResult1>) | null,
+          onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+        ): Promise<TResult1 | TResult2> {
+          return Promise.resolve(result).then(onfulfilled, onrejected);
+        },
+      };
+      return query;
+    },
+  };
+
+  return { client, calls };
+}
+
+function workspaceFixture(
+  overrides: {
+    additionalWorkOrders?: unknown[];
+    bookings?: unknown[];
+    history?: unknown[];
+    invoices?: unknown[];
+    inspections?: unknown[];
+    partRequests?: unknown[];
+    quoteLines?: unknown[];
+    workOrderLines?: unknown[];
+    workOrderParts?: unknown[];
+  } = {},
+) {
+  const vehicle = {
+    id: "vehicle-1",
+    shop_id: "shop-a",
+    customer_id: "customer-1",
+    year: 2022,
+    make: "Ford",
+    model: "Transit",
+    submodel: null,
+    vin: "1FTBW1X80NKA12345",
+    license_plate: "SHOP-22",
+    unit_number: "17",
+    mileage: "64000",
+    odometer_unit: "km",
+    engine_hours: null,
+    status: "active",
+  };
+  const workOrders = [
+    {
+      id: "wo-1",
+      customer_id: "customer-1",
+      vehicle_id: vehicle.id,
+      custom_id: "1048",
+      status: "in_progress",
+      record_type: "work_order",
+      approval_state: "approved",
+      estimate_number: null,
+      estimate_status: null,
+      scheduled_at: null,
+      odometer_km: 64000,
+      created_at: "2026-01-01T10:00:00.000Z",
+      updated_at: "2026-01-03T10:00:00.000Z",
+    },
+    {
+      id: "wo-2",
+      customer_id: "customer-1",
+      vehicle_id: vehicle.id,
+      custom_id: "1051",
+      status: "awaiting_approval",
+      record_type: "work_order",
+      approval_state: "pending",
+      estimate_number: null,
+      estimate_status: null,
+      scheduled_at: null,
+      odometer_km: 64100,
+      created_at: "2026-01-02T10:00:00.000Z",
+      updated_at: "2026-01-04T10:00:00.000Z",
+    },
+    ...(overrides.additionalWorkOrders ?? []),
+  ];
+
+  const inspections =
+    overrides.inspections ??
+    [
+      {
+        id: "inspection-1",
+        work_order_id: "wo-1",
+        work_order_line_id: null,
+        inspection_type: "Digital vehicle inspection",
+        status: "completed",
+        completed: true,
+        summary: {
+          items: [
+            {
+              item: "Front brakes",
+              status: "fail",
+              value: "3",
+              unit: "mm",
+              note: "Below service limit",
+            },
+          ],
+        },
+        created_at: "2026-01-02T10:00:00.000Z",
+        started_at: "2026-01-02T10:00:00.000Z",
+        finalized_at: "2026-01-02T11:00:00.000Z",
+        updated_at: "2026-01-02T11:00:00.000Z",
+        pdf_url: null,
+        pdf_storage_path: null,
+      },
+    ];
+
+  return createSupabaseFixture({
+    vehicles: [
+      { data: vehicle, error: null },
+      { data: [], error: null },
+    ],
+    work_orders: [{ data: workOrders, error: null }],
+    customers: [
+      {
+        data: {
+          id: "customer-1",
+          account_type: "business",
+          active: true,
+          business_name: "North Star Plumbing",
+          name: null,
+          first_name: null,
+          last_name: null,
+          email: "dispatch@example.test",
+          phone: "555-0100",
+          phone_number: null,
+          archived_at: null,
+          merged_into_customer_id: null,
+        },
+        error: null,
+      },
+    ],
+    bookings: [
+      {
+        data:
+          overrides.bookings ??
+          [
+            {
+              id: "booking-1",
+              work_order_id: "wo-1",
+              starts_at: "2026-02-03T10:00:00.000Z",
+              ends_at: "2026-02-03T11:00:00.000Z",
+              status: "confirmed",
+              notes: "Waiter",
+              created_at: "2026-01-01T10:00:00.000Z",
+            },
+          ],
+        error: null,
+      },
+    ],
+    inspections: [{ data: inspections, error: null }],
+    work_order_lines: [{ data: overrides.workOrderLines ?? [], error: null }],
+    work_order_parts: [{ data: overrides.workOrderParts ?? [], error: null }],
+    work_order_quote_lines: [{ data: overrides.quoteLines ?? [], error: null }],
+    maintenance_suggestions: [{ data: [], error: null }],
+    history: [{ data: overrides.history ?? [], error: null }],
+    vehicle_media: [{ data: [], error: null }],
+    work_order_media: [{ data: [], error: null }],
+    part_requests: [{ data: overrides.partRequests ?? [], error: null }],
+    invoices: [
+      {
+        data:
+          overrides.invoices ??
+          [
+            {
+              id: "invoice-1",
+              work_order_id: "wo-1",
+              invoice_number: "INV-1048",
+              status: "open",
+              currency: "CAD",
+              total: 850,
+              outstanding_total: 250,
+              paid_total: 600,
+              created_at: "2026-01-03T10:00:00.000Z",
+              issued_at: "2026-01-03T10:00:00.000Z",
+              paid_at: null,
+              updated_at: "2026-01-03T10:00:00.000Z",
+            },
+          ],
+        error: null,
+      },
+    ],
+    payments: [{ data: [], error: null }],
+  });
+}
+
+function searchVehicleRow(
+  overrides: {
+    customerId?: string | null;
+    id?: string;
+    licensePlate?: string | null;
+    make?: string;
+    status?: string | null;
+    vin?: string | null;
+  } = {},
+) {
+  return {
+    id: overrides.id ?? "vehicle-1",
+    customer_id: overrides.customerId ?? null,
+    year: 2022,
+    make: overrides.make ?? "Ford",
+    model: "Transit",
+    submodel: null,
+    vin:
+      overrides.vin === undefined
+        ? "1FTBW1X80NKA12345"
+        : overrides.vin,
+    license_plate:
+      overrides.licensePlate === undefined
+        ? "SHOP-22"
+        : overrides.licensePlate,
+    unit_number: "17",
+    mileage: "64000",
+    odometer_unit: "km",
+    engine_hours: null,
+    status: overrides.status === undefined ? "active" : overrides.status,
+    created_at: "2026-01-01T10:00:00.000Z",
+  };
+}
+
+function searchWorkOrderRow(
+  id: string,
+  vehicleId: string,
+  overrides: {
+    customId?: string | null;
+    estimateNumber?: string | null;
+    estimateStatus?: string | null;
+    odometerKm?: number | null;
+    recordType?: string;
+    status?: string;
+    createdAt?: string;
+    updatedAt?: string | null;
+    vehicleMileage?: string | null;
+  } = {},
+) {
+  return {
+    id,
+    custom_id: overrides.customId === undefined ? id : overrides.customId,
+    status: overrides.status ?? "in_progress",
+    record_type: overrides.recordType ?? "work_order",
+    estimate_number: overrides.estimateNumber ?? null,
+    estimate_status: overrides.estimateStatus ?? null,
+    customer_id: null,
+    customer_name: null,
+    vehicle_id: vehicleId,
+    vehicle_year: 2022,
+    vehicle_make: "Ford",
+    vehicle_model: "Transit",
+    vehicle_submodel: null,
+    vehicle_vin: "1FTBW1X80NKA12345",
+    vehicle_license_plate: "SHOP-22",
+    vehicle_unit_number: "17",
+    vehicle_mileage:
+      overrides.vehicleMileage === undefined
+        ? "64000"
+        : overrides.vehicleMileage,
+    odometer_km:
+      overrides.odometerKm === undefined ? 64000 : overrides.odometerKm,
+    created_at: overrides.createdAt ?? "2026-01-01T10:00:00.000Z",
+    updated_at:
+      overrides.updatedAt === undefined
+        ? "2026-01-02T10:00:00.000Z"
+        : overrides.updatedAt,
+  };
+}
+
+async function runDirectVehicleSearch(query: string, vehicle: unknown) {
+  const fixture = createSupabaseFixture({
+    vehicles: [
+      { data: [vehicle], error: null },
+      { data: [vehicle], error: null },
+    ],
+    work_orders: [
+      { data: [], error: null },
+      { data: [], error: null },
+    ],
+    customers: [{ data: [], error: null }],
+    bookings: [{ data: [], error: null }],
+    work_order_lines: [{ data: [], error: null }],
+    work_order_quote_lines: [{ data: [], error: null }],
+  });
+  const response = await searchShopVehicleRecords({
+    supabase: fixture.client as never,
+    shopId: "shop-a",
+    role: "owner",
+    query,
+    now: new Date("2026-01-10T00:00:00.000Z"),
+  });
+  return { fixture, response };
+}
+
+describe("Shop Vehicle Workspace contract", () => {
+  it("keeps an explicit Shop-reader allowlist and excludes portal and Fleet roles", () => {
+    expect(VEHICLE_WORKSPACE_READER_ROLES).toEqual(SHOP_ROLES);
+    expect(
+      NON_SHOP_ROLES.filter((role) =>
+        VEHICLE_WORKSPACE_READER_ROLES.includes(
+          role as (typeof VEHICLE_WORKSPACE_READER_ROLES)[number],
+        ),
+      ),
+    ).toEqual([]);
+  });
+
+  it("projects role capabilities without expanding financial access", () => {
+    const projected = Object.fromEntries(
+      [...SHOP_ROLES, ...NON_SHOP_ROLES].map((role) => [
+        role,
+        vehicleWorkspacePermissionsForRole(role),
+      ]),
+    );
+
+    expect(Object.fromEntries(SHOP_ROLES.map((role) => [role, projected[role]])))
+      .toEqual({
+        owner: {
+          canViewAccountContact: true,
+          canOpenAccount: true,
+          canViewFinancials: true,
+          canViewEstimates: true,
+          canOpenInspections: true,
+          canOpenWorkOrders: true,
+          canViewPartRequests: true,
+          canCreateWorkOrder: true,
+          canBookAppointment: true,
+          canCreateEstimate: true,
+          canMessageCustomer: true,
+          canViewRelatedVehicles: true,
+          isAssignedWorkOnly: false,
+        },
+        admin: {
+          canViewAccountContact: true,
+          canOpenAccount: true,
+          canViewFinancials: true,
+          canViewEstimates: true,
+          canOpenInspections: true,
+          canOpenWorkOrders: true,
+          canViewPartRequests: true,
+          canCreateWorkOrder: true,
+          canBookAppointment: true,
+          canCreateEstimate: true,
+          canMessageCustomer: true,
+          canViewRelatedVehicles: true,
+          isAssignedWorkOnly: false,
+        },
+        manager: {
+          canViewAccountContact: true,
+          canOpenAccount: true,
+          canViewFinancials: true,
+          canViewEstimates: true,
+          canOpenInspections: true,
+          canOpenWorkOrders: true,
+          canViewPartRequests: true,
+          canCreateWorkOrder: true,
+          canBookAppointment: true,
+          canCreateEstimate: true,
+          canMessageCustomer: true,
+          canViewRelatedVehicles: true,
+          isAssignedWorkOnly: false,
+        },
+        advisor: {
+          canViewAccountContact: true,
+          canOpenAccount: true,
+          canViewFinancials: false,
+          canViewEstimates: true,
+          canOpenInspections: true,
+          canOpenWorkOrders: true,
+          canViewPartRequests: false,
+          canCreateWorkOrder: true,
+          canBookAppointment: true,
+          canCreateEstimate: true,
+          canMessageCustomer: true,
+          canViewRelatedVehicles: true,
+          isAssignedWorkOnly: false,
+        },
+        service: {
+          canViewAccountContact: true,
+          canOpenAccount: false,
+          canViewFinancials: false,
+          canViewEstimates: true,
+          canOpenInspections: false,
+          canOpenWorkOrders: false,
+          canViewPartRequests: false,
+          canCreateWorkOrder: true,
+          canBookAppointment: false,
+          canCreateEstimate: true,
+          canMessageCustomer: true,
+          canViewRelatedVehicles: true,
+          isAssignedWorkOnly: false,
+        },
+        parts: {
+          canViewAccountContact: false,
+          canOpenAccount: false,
+          canViewFinancials: false,
+          canViewEstimates: true,
+          canOpenInspections: false,
+          canOpenWorkOrders: false,
+          canViewPartRequests: true,
+          canCreateWorkOrder: false,
+          canBookAppointment: false,
+          canCreateEstimate: false,
+          canMessageCustomer: false,
+          canViewRelatedVehicles: true,
+          isAssignedWorkOnly: false,
+        },
+        mechanic: {
+          canViewAccountContact: false,
+          canOpenAccount: false,
+          canViewFinancials: false,
+          canViewEstimates: false,
+          canOpenInspections: false,
+          canOpenWorkOrders: true,
+          canViewPartRequests: false,
+          canCreateWorkOrder: false,
+          canBookAppointment: false,
+          canCreateEstimate: false,
+          canMessageCustomer: false,
+          canViewRelatedVehicles: false,
+          isAssignedWorkOnly: true,
+        },
+        lead_hand: {
+          canViewAccountContact: true,
+          canOpenAccount: false,
+          canViewFinancials: false,
+          canViewEstimates: true,
+          canOpenInspections: true,
+          canOpenWorkOrders: true,
+          canViewPartRequests: false,
+          canCreateWorkOrder: true,
+          canBookAppointment: true,
+          canCreateEstimate: false,
+          canMessageCustomer: true,
+          canViewRelatedVehicles: true,
+          isAssignedWorkOnly: false,
+        },
+        foreman: {
+          canViewAccountContact: true,
+          canOpenAccount: false,
+          canViewFinancials: false,
+          canViewEstimates: true,
+          canOpenInspections: true,
+          canOpenWorkOrders: true,
+          canViewPartRequests: false,
+          canCreateWorkOrder: true,
+          canBookAppointment: true,
+          canCreateEstimate: true,
+          canMessageCustomer: true,
+          canViewRelatedVehicles: true,
+          isAssignedWorkOnly: false,
+        },
+      });
+    expect(
+      Object.entries(projected)
+        .filter(([, permissions]) => permissions.canViewFinancials)
+        .map(([role]) => role),
+    ).toEqual(["owner", "admin", "manager"]);
+    expect(
+      Object.entries(projected)
+        .filter(([, permissions]) => permissions.canViewEstimates)
+        .map(([role]) => role),
+    ).toEqual([
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "service",
+      "parts",
+      "lead_hand",
+      "foreman",
+    ]);
+    expect(
+      Object.entries(projected)
+        .filter(([, permissions]) => permissions.canOpenInspections)
+        .map(([role]) => role),
+    ).toEqual([
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "lead_hand",
+      "foreman",
+    ]);
+    expect(
+      Object.entries(projected)
+        .filter(([, permissions]) => permissions.canOpenWorkOrders)
+        .map(([role]) => role),
+    ).toEqual([
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "lead_hand",
+      "foreman",
+    ]);
+    expect(
+      Object.entries(projected)
+        .filter(([, permissions]) => permissions.canViewPartRequests)
+        .map(([role]) => role),
+    ).toEqual(["owner", "admin", "manager", "parts"]);
+    expect(NON_SHOP_ROLES.map((role) => projected[role])).toEqual(
+      NON_SHOP_ROLES.map(() => ({
+        canViewAccountContact: false,
+        canOpenAccount: false,
+        canViewFinancials: false,
+        canViewEstimates: false,
+        canOpenInspections: false,
+        canOpenWorkOrders: false,
+        canViewPartRequests: false,
+        canCreateWorkOrder: false,
+        canBookAppointment: false,
+        canCreateEstimate: false,
+        canMessageCustomer: false,
+        canViewRelatedVehicles: false,
+        isAssignedWorkOnly: false,
+      })),
+    );
+  });
+
+  it("hands the canonical customer and vehicle to the existing fast work-order flow", () => {
+    const href = createWorkOrderHandoffHref({
+      customerId: "customer/id",
+      vehicleId: "vehicle id",
+    });
+
+    expect(href).not.toBeNull();
+    const url = new URL(href!, "https://shop.example.test");
+    expect(url.pathname).toBe("/work-orders/create");
+    expect(Object.fromEntries(url.searchParams)).toEqual({
+      autostart: "1",
+      customerId: "customer/id",
+      vehicleId: "vehicle id",
+    });
+    expect(
+      createWorkOrderHandoffHref({ customerId: null, vehicleId: "vehicle-1" }),
+    ).toBeNull();
+  });
+
+  it("parses only failed and recommended inspection evidence", () => {
+    expect(
+      extractInspectionFindings({
+        items: [
+          { item: "Battery", status: "pass" },
+          { item: "Front brakes", status: "FAIL", value: "3", unit: "mm" },
+        ],
+        sections: [
+          {
+            title: "Tires",
+            items: [
+              {
+                name: "Right rear",
+                status: "recommend",
+                notes: "Uneven wear",
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        label: "Front brakes",
+        status: "fail",
+        measurement: "3 mm",
+      }),
+      expect.objectContaining({
+        label: "Right rear",
+        section: "Tires",
+        status: "recommend",
+        note: "Uneven wear",
+      }),
+    ]);
+  });
+
+  it("returns canonical source references and preserves every active work order", async () => {
+    const fixture = workspaceFixture();
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+      now: new Date("2026-01-10T00:00:00.000Z"),
+    });
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.identity).toMatchObject({
+      mileage: "64100",
+      odometerUnit: "km",
+    });
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        activeWork: expect.any(Array),
+        upcomingAppointments: expect.any(Array),
+        attentionItems: expect.any(Array),
+        recentTimeline: expect.any(Array),
+        relatedVehicles: expect.any(Array),
+        conflicts: expect.any(Array),
+      }),
+    );
+
+    const workOrderSources = snapshot!.activeWork
+      .filter((item) => item.reference.sourceType === "work_order")
+      .map((item) => item.reference.sourceId);
+    expect(workOrderSources).toEqual(["wo-2", "wo-1"]);
+    expect(snapshot!.conflicts).toContainEqual(
+      expect.objectContaining({
+        kind: "multiple_active_work_orders",
+        sourceIds: ["wo-1", "wo-2"],
+      }),
+    );
+
+    for (const collection of [
+      snapshot!.activeWork,
+      snapshot!.upcomingAppointments,
+      snapshot!.attentionItems,
+      snapshot!.recentTimeline,
+    ]) {
+      expect(collection.length).toBeGreaterThan(0);
+      expect(collection.every((item) => item.reference.sourceId.length > 0)).toBe(
+        true,
+      );
+    }
+    expect(snapshot!.attentionItems).toContainEqual(
+      expect.objectContaining({
+        kind: "failed_inspection",
+        title: "Front brakes",
+        explanation: expect.stringContaining("3 mm"),
+        reference: expect.objectContaining({
+          sourceType: "inspection",
+          sourceId: "inspection-1",
+        }),
+      }),
+    );
+    expect(snapshot!.recentTimeline).toContainEqual(
+      expect.objectContaining({
+        kind: "work_order",
+        detail: expect.stringContaining("Odometer: 64100 km"),
+        reference: expect.objectContaining({ sourceId: "wo-2" }),
+      }),
+    );
+  });
+
+  it("blocks Create WO for archived-account or vehicle-status conflicts only", async () => {
+    const fixture = workspaceFixture();
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+    const conflict = (
+      kind: "archived_account" | "historical_owner" | "vehicle_status",
+    ) => ({
+      kind,
+      title: kind,
+      detail: kind,
+      sourceIds: ["source-1"],
+    });
+
+    expect(vehicleWorkspaceCreateWorkOrderHref(snapshot!)).not.toBeNull();
+    expect(
+      vehicleWorkspaceCreateWorkOrderHref({
+        ...snapshot!,
+        conflicts: [conflict("historical_owner")],
+      }),
+    ).not.toBeNull();
+    expect(
+      vehicleWorkspaceCreateWorkOrderHref({
+        ...snapshot!,
+        conflicts: [conflict("archived_account")],
+      }),
+    ).toBeNull();
+    expect(
+      vehicleWorkspaceCreateWorkOrderHref({
+        ...snapshot!,
+        conflicts: [conflict("vehicle_status")],
+      }),
+    ).toBeNull();
+  });
+
+  it("retains imported odometer evidence and earlier-account ambiguity", async () => {
+    const historyRow = (id: string) => ({
+      id,
+      customer_id: "customer-old",
+      work_order_id: null,
+      work_order_number: "LEGACY-17",
+      historical_status: "completed",
+      description: "Imported service",
+      odometer: 59000,
+      service_date: "2025-12-01",
+      opened_at: "2025-12-01T10:00:00.000Z",
+      closed_at: "2025-12-01T12:00:00.000Z",
+      source_system: "legacy",
+    });
+    const fixture = workspaceFixture({
+      history: [historyRow("history-1"), historyRow("history-2")],
+    });
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(snapshot?.recentTimeline).toContainEqual(
+      expect.objectContaining({
+        kind: "history",
+        detail: expect.stringContaining("Odometer: 59000"),
+        reference: expect.objectContaining({
+          sourceType: "history",
+          sourceId: "history-1",
+        }),
+      }),
+    );
+    expect(snapshot?.conflicts).toContainEqual(
+      expect.objectContaining({
+        kind: "historical_owner",
+        sourceIds: ["customer-old"],
+      }),
+    );
+  });
+
+  it("keeps only genuinely open inspections in Active now", async () => {
+    const inspection = (id: string, status: string, completed = false) => ({
+      id,
+      work_order_id: "wo-1",
+      work_order_line_id: null,
+      inspection_type: id,
+      status,
+      completed,
+      summary: { items: [] },
+      created_at: "2026-01-02T10:00:00.000Z",
+      started_at: "2026-01-02T10:00:00.000Z",
+      finalized_at: status === "finalized" ? "2026-01-02T11:00:00.000Z" : null,
+      updated_at: "2026-01-02T11:00:00.000Z",
+      pdf_url: null,
+      pdf_storage_path: null,
+    });
+    const fixture = workspaceFixture({
+      inspections: [
+        inspection("inspection-open", "in-progress"),
+        inspection("inspection-finalized", "finalized"),
+        inspection("inspection-cancelled", "cancelled"),
+        inspection("inspection-completed", "completed", true),
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(
+      snapshot?.activeWork
+        .filter((item) => item.kind === "inspection")
+        .map((item) => item.reference.sourceId),
+    ).toEqual(["inspection-open"]);
+  });
+
+  it("keeps completed or canceled future bookings out of upcoming appointments", async () => {
+    const booking = (id: string, status: string) => ({
+      id,
+      work_order_id: "wo-1",
+      starts_at: "2026-02-03T10:00:00.000Z",
+      ends_at: "2026-02-03T11:00:00.000Z",
+      status,
+      notes: null,
+      created_at: "2026-01-01T10:00:00.000Z",
+    });
+    const fixture = workspaceFixture({
+      bookings: [
+        booking("booking-confirmed", "confirmed"),
+        booking("booking-completed", "completed"),
+        booking("booking-canceled", "canceled"),
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+      now: new Date("2026-01-10T00:00:00.000Z"),
+    });
+
+    expect(
+      snapshot?.upcomingAppointments.map(
+        (appointment) => appointment.reference.sourceId,
+      ),
+    ).toEqual(["booking-confirmed"]);
+  });
+
+  it("deduplicates deferred quote evidence without suppressing unrelated line attention", async () => {
+    const line = (
+      id: string,
+      overrides: Partial<{
+        approval_state: string | null;
+        hold_reason: string | null;
+        line_status: string | null;
+        status: string;
+        voided_at: string | null;
+      }> = {},
+    ) => ({
+      id,
+      work_order_id: "wo-1",
+      description: `Repair ${id}`,
+      complaint: "Customer concern",
+      correction: null,
+      hold_reason: null,
+      status: "pending",
+      line_status: "pending",
+      approval_state: "pending",
+      urgency: "normal",
+      voided_at: null,
+      created_at: "2026-01-02T10:00:00.000Z",
+      updated_at: "2026-01-03T10:00:00.000Z",
+      ...overrides,
+    });
+    const quoteLine = (
+      id: string,
+      workOrderLineId: string,
+      decision: string,
+    ) => ({
+      id,
+      work_order_id: "wo-1",
+      work_order_line_id: workOrderLineId,
+      source_work_order_line_id: null,
+      description: `Estimate ${id}`,
+      title: `Estimate ${id}`,
+      status: "open",
+      decision,
+      defer_reason: decision.includes("defer") ? "Customer deferred" : null,
+      decline_reason: null,
+      approved_at: decision.includes("approved")
+        ? "2026-01-04T10:00:00.000Z"
+        : null,
+      deferred_at: decision.includes("defer")
+        ? "2026-01-04T10:00:00.000Z"
+        : null,
+      declined_at: null,
+      created_at: "2026-01-02T10:00:00.000Z",
+      updated_at: "2026-01-04T10:00:00.000Z",
+    });
+    const fixture = workspaceFixture({
+      workOrderLines: [
+        line("line-waiting", { line_status: "Waiting Parts" }),
+        line("line-linked-deferred", { line_status: "deferred" }),
+        line("line-awaiting", { line_status: "awaiting-parts" }),
+        line("line-declined", {
+          line_status: "pending",
+          approval_state: "customer declined",
+        }),
+        line("line-held", { hold_reason: "Backordered" }),
+        line("line-voided", {
+          line_status: "deferred",
+          voided_at: "2026-01-05T10:00:00.000Z",
+        }),
+        line("line-canceled", {
+          status: "canceled",
+        }),
+      ],
+      quoteLines: [
+        quoteLine("quote-approved", "line-waiting", "approved"),
+        quoteLine(
+          "quote-deferred",
+          "line-linked-deferred",
+          "customer deferred",
+        ),
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+    const attentionSources = snapshot?.attentionItems.map(
+      (item) => `${item.reference.sourceType}:${item.reference.sourceId}`,
+    );
+
+    expect(attentionSources).toEqual(
+      expect.arrayContaining([
+        "work_order_quote_line:quote-deferred",
+        "work_order_line:line-waiting",
+        "work_order_line:line-awaiting",
+        "work_order_line:line-declined",
+        "work_order_line:line-held",
+      ]),
+    );
+    expect(attentionSources).not.toContain(
+      "work_order_line:line-linked-deferred",
+    );
+    expect(attentionSources).not.toContain("work_order_quote_line:quote-approved");
+    expect(attentionSources).not.toContain("work_order_line:line-voided");
+    expect(attentionSources).not.toContain("work_order_line:line-canceled");
+    expect(snapshot?.recentTimeline).toContainEqual(
+      expect.objectContaining({
+        kind: "approval",
+        title: "Estimate quote-approved",
+        detail: "Decision: approved",
+        reference: expect.objectContaining({
+          sourceType: "work_order_quote_line",
+          sourceId: "quote-approved",
+          href: "/estimates/wo-1",
+        }),
+      }),
+    );
+  });
+
+  it("projects only net-installed canonical parts into the timeline", async () => {
+    const part = (
+      id: string,
+      overrides: Partial<{
+        description_snapshot: string | null;
+        is_active: boolean;
+        manufacturer_snapshot: string | null;
+        part_number_snapshot: string | null;
+        quantity_consumed: number;
+        quantity_returned: number;
+        updated_at: string;
+        work_order_id: string;
+        work_order_line_id: string | null;
+      }> = {},
+    ) => ({
+      id,
+      work_order_id: "wo-1",
+      work_order_line_id: "line-1",
+      description_snapshot: `Part ${id}`,
+      manufacturer_snapshot: null,
+      part_number_snapshot: null,
+      sku_snapshot: null,
+      quantity_consumed: 1,
+      quantity_returned: 0,
+      is_active: true,
+      created_at: "2026-01-07T10:00:00.000Z",
+      updated_at: "2026-01-08T10:00:00.000Z",
+      ...overrides,
+    });
+    const fixture = workspaceFixture({
+      workOrderParts: [
+        part("part-focused", {
+          description_snapshot: "Front brake pad set",
+          quantity_consumed: 3,
+          quantity_returned: 1,
+          updated_at: "2026-01-09T10:00:00.000Z",
+        }),
+        part("part-work-order", {
+          description_snapshot: null,
+          manufacturer_snapshot: "ACDelco",
+          part_number_snapshot: "PF63",
+          work_order_id: "wo-2",
+          work_order_line_id: null,
+        }),
+        part("part-inactive", { is_active: false, quantity_consumed: 4 }),
+        part("part-returned", {
+          quantity_consumed: 2,
+          quantity_returned: 2,
+        }),
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+    const partEvents = snapshot?.recentTimeline.filter(
+      (event) => event.kind === "part",
+    );
+    const partSelect = fixture.calls.find(
+      (call) =>
+        call.table === "work_order_parts" && call.operation === "select",
+    );
+
+    expect(partEvents).toEqual([
+      expect.objectContaining({
+        title: "Front brake pad set",
+        detail: "Installed quantity: 2",
+        reference: expect.objectContaining({
+          sourceType: "work_order_part",
+          sourceId: "part-focused",
+          href: "/work-orders/wo-1/focused-job/line-1",
+        }),
+      }),
+      expect.objectContaining({
+        title: "ACDelco PF63",
+        detail: "Installed quantity: 1",
+        reference: expect.objectContaining({
+          sourceType: "work_order_part",
+          sourceId: "part-work-order",
+          href: "/work-orders/wo-2",
+        }),
+      }),
+    ]);
+    expect(partSelect?.args[0]).toContain("quantity_consumed");
+    expect(partSelect?.args[0]).toContain("quantity_returned");
+    expect(String(partSelect?.args[0])).not.toContain("price");
+    expect(String(partSelect?.args[0])).not.toContain("cost");
+    expect(
+      fixture.calls.some(
+        (call) =>
+          call.table === "work_order_parts" &&
+          call.operation === "eq" &&
+          call.args[0] === "shop_id" &&
+          call.args[1] === "shop-a",
+      ),
+    ).toBe(true);
+  });
+
+  it("shows active parts requests only to roles accepted by the canonical parts route", async () => {
+    const requested = {
+      id: "request-open",
+      work_order_id: "wo-1",
+      status: "requested",
+      notes: "Brake pads needed",
+      created_at: "2026-01-08T10:00:00.000Z",
+    };
+    const fulfilled = {
+      ...requested,
+      id: "request-fulfilled",
+      status: "fulfilled",
+    };
+    const partsFixture = workspaceFixture({
+      partRequests: [requested, fulfilled],
+    });
+    const partsSnapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: partsFixture.client as never,
+      shopId: "shop-a",
+      role: "parts",
+      vehicleId: "vehicle-1",
+    });
+    const advisorFixture = workspaceFixture({ partRequests: [requested] });
+    const advisorSnapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: advisorFixture.client as never,
+      shopId: "shop-a",
+      role: "advisor",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(
+      partsSnapshot?.activeWork.filter((item) => item.kind === "part_request"),
+    ).toEqual([
+      expect.objectContaining({
+        status: "requested",
+        detail: "Brake pads needed",
+        reference: expect.objectContaining({
+          sourceType: "part_request",
+          sourceId: "request-open",
+          href: "/parts/requests/request-open",
+        }),
+      }),
+    ]);
+    expect(
+      partsFixture.calls.filter((call) => call.table === "part_requests"),
+    ).not.toHaveLength(0);
+    expect(
+      advisorFixture.calls.filter((call) => call.table === "part_requests"),
+    ).toEqual([]);
+    expect(
+      advisorSnapshot?.activeWork.some((item) => item.kind === "part_request"),
+    ).toBe(false);
+  });
+
+  it("opens estimate records through their canonical estimate route", async () => {
+    const fixture = workspaceFixture({
+      additionalWorkOrders: [
+        {
+          id: "estimate-1",
+          customer_id: "customer-1",
+          vehicle_id: "vehicle-1",
+          custom_id: null,
+          status: "awaiting_approval",
+          record_type: "estimate",
+          approval_state: "pending",
+          estimate_number: "EST-72",
+          estimate_status: "sent",
+          scheduled_at: null,
+          odometer_km: 64200,
+          created_at: "2026-01-05T10:00:00.000Z",
+          updated_at: "2026-01-06T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+    const estimate = snapshot?.activeWork.find(
+      (item) => item.reference.sourceId === "estimate-1",
+    );
+
+    expect(estimate).toMatchObject({
+      kind: "estimate",
+      reference: {
+        sourceId: "estimate-1",
+        sourceLabel: "Estimate EST-72",
+        href: "/estimates/estimate-1",
+      },
+    });
+  });
+
+  it("retains estimate, quote, and inspection evidence for a mechanic without granting detail access", async () => {
+    const fixture = workspaceFixture({
+      additionalWorkOrders: [
+        {
+          id: "estimate-mechanic",
+          customer_id: "customer-1",
+          vehicle_id: "vehicle-1",
+          custom_id: null,
+          status: "awaiting_approval",
+          record_type: "estimate",
+          approval_state: "pending",
+          estimate_number: "EST-MECH",
+          estimate_status: "sent",
+          scheduled_at: null,
+          odometer_km: null,
+          created_at: "2026-01-05T10:00:00.000Z",
+          updated_at: "2026-01-06T10:00:00.000Z",
+        },
+      ],
+      quoteLines: [
+        {
+          id: "quote-mechanic",
+          work_order_id: "estimate-mechanic",
+          work_order_line_id: null,
+          source_work_order_line_id: null,
+          description: "Front brakes",
+          title: "Front brakes",
+          status: "open",
+          decision: "customer deferred",
+          defer_reason: "Return next visit",
+          decline_reason: null,
+          approved_at: null,
+          deferred_at: "2026-01-07T10:00:00.000Z",
+          declined_at: null,
+          created_at: "2026-01-05T10:00:00.000Z",
+          updated_at: "2026-01-07T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "mechanic",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(snapshot?.permissions).toMatchObject({
+      canViewEstimates: false,
+      canOpenInspections: false,
+      canOpenWorkOrders: true,
+    });
+    expect(snapshot?.activeWork).toContainEqual(
+      expect.objectContaining({
+        kind: "estimate",
+        reference: expect.objectContaining({
+          sourceId: "estimate-mechanic",
+          href: "/estimates/estimate-mechanic",
+        }),
+      }),
+    );
+    expect(snapshot?.attentionItems).toContainEqual(
+      expect.objectContaining({
+        kind: "deferred_work",
+        reference: expect.objectContaining({
+          sourceType: "work_order_quote_line",
+          sourceId: "quote-mechanic",
+          href: "/estimates/estimate-mechanic",
+        }),
+      }),
+    );
+    expect(snapshot?.recentTimeline).toContainEqual(
+      expect.objectContaining({
+        kind: "approval",
+        reference: expect.objectContaining({
+          sourceType: "work_order_quote_line",
+          sourceId: "quote-mechanic",
+        }),
+      }),
+    );
+    expect(snapshot?.attentionItems).toContainEqual(
+      expect.objectContaining({
+        kind: "failed_inspection",
+        reference: expect.objectContaining({
+          sourceType: "inspection",
+          sourceId: "inspection-1",
+        }),
+      }),
+    );
+  });
+
+  it("shows only actionable estimates and operationally active work orders", async () => {
+    const actionableEstimateStatuses = [
+      "draft",
+      "waiting_for_parts",
+      "ready_for_advisor",
+      "sent",
+      "partially_approved",
+    ];
+    const inactiveEstimateStatuses = [
+      "approved",
+      "declined",
+      "deferred",
+      "expired",
+    ];
+    const terminalWorkOrderStatuses = [
+      "archived",
+      "canceled",
+      "cancelled",
+      "closed",
+      "completed",
+      "done",
+      "invoiced",
+      "paid",
+      "void",
+      "voided",
+    ];
+    const row = (
+      id: string,
+      status: string,
+      recordType: "estimate" | "work_order",
+    ) => ({
+      id,
+      customer_id: "customer-1",
+      vehicle_id: "vehicle-1",
+      custom_id: recordType === "work_order" ? id : null,
+      status: recordType === "estimate" ? "awaiting_approval" : status,
+      record_type: recordType,
+      approval_state: "pending",
+      estimate_number: recordType === "estimate" ? `EST-${id}` : null,
+      estimate_status: recordType === "estimate" ? status : null,
+      scheduled_at: null,
+      odometer_km: null,
+      created_at: "2026-01-07T10:00:00.000Z",
+      updated_at: "2026-01-08T10:00:00.000Z",
+    });
+    const fixture = workspaceFixture({
+      additionalWorkOrders: [
+        ...actionableEstimateStatuses.map((status) =>
+          row(`estimate-${status}`, status, "estimate"),
+        ),
+        ...inactiveEstimateStatuses.map((status) =>
+          row(`estimate-${status}`, status, "estimate"),
+        ),
+        {
+          ...row("estimate-terminal-sent", "sent", "estimate"),
+          status: "completed",
+        },
+        ...terminalWorkOrderStatuses.map((status) =>
+          row(`wo-${status}`, status, "work_order"),
+        ),
+        row("wo-ready", "ready_to_invoice", "work_order"),
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(
+      snapshot?.activeWork
+        .filter((item) => item.kind === "estimate")
+        .map((item) => item.status)
+        .sort(),
+    ).toEqual([...actionableEstimateStatuses].sort());
+    expect(
+      snapshot?.activeWork
+        .filter((item) => item.kind === "work_order")
+        .map((item) => item.reference.sourceId)
+        .sort(),
+    ).toEqual(["wo-1", "wo-2", "wo-ready"]);
+    expect(
+      snapshot?.conflicts.find(
+        (conflict) => conflict.kind === "multiple_active_work_orders",
+      )?.sourceIds,
+    ).toEqual(["wo-1", "wo-2", "wo-ready"]);
+  });
+
+  it("does not serialize mixed or unknown currency sums and distinguishes no invoices", async () => {
+    const invoice = (id: string, currency: string | null) => ({
+      id,
+      work_order_id: "wo-1",
+      invoice_number: id,
+      status: "open",
+      currency,
+      total: 100,
+      outstanding_total: 60,
+      paid_total: 40,
+      created_at: "2026-01-03T10:00:00.000Z",
+      issued_at: "2026-01-03T10:00:00.000Z",
+      paid_at: null,
+      updated_at: "2026-01-03T10:00:00.000Z",
+    });
+    const loadFinancialSummary = async (invoices: unknown[]) => {
+      const fixture = workspaceFixture({ invoices });
+      const snapshot = await loadVehicleWorkspaceSnapshot({
+        supabase: fixture.client as never,
+        shopId: "shop-a",
+        role: "owner",
+        vehicleId: "vehicle-1",
+      });
+      return snapshot?.financialSummary;
+    };
+
+    const [mixed, unknown, empty] = await Promise.all([
+      loadFinancialSummary([
+        invoice("invoice-cad", "CAD"),
+        invoice("invoice-usd", "USD"),
+      ]),
+      loadFinancialSummary([
+        invoice("invoice-known", "CAD"),
+        invoice("invoice-unknown", null),
+      ]),
+      loadFinancialSummary([]),
+    ]);
+
+    expect(mixed).toEqual({
+      visible: true,
+      currency: null,
+      invoiceCount: 2,
+      outstandingAmount: null,
+      paidAmount: null,
+    });
+    expect(unknown).toEqual({
+      visible: true,
+      currency: null,
+      invoiceCount: 2,
+      outstandingAmount: null,
+      paidAmount: null,
+    });
+    expect(empty).toEqual({
+      visible: true,
+      currency: null,
+      invoiceCount: 0,
+      outstandingAmount: null,
+      paidAmount: null,
+    });
+  });
+
+  it("projects a mechanic-visible account without selecting contact fields", async () => {
+    const fixture = workspaceFixture();
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "mechanic",
+      vehicleId: "vehicle-1",
+    });
+    const customerSelect = fixture.calls.find(
+      (call) => call.table === "customers" && call.operation === "select",
+    );
+
+    expect(snapshot?.currentAccount).toMatchObject({
+      id: "customer-1",
+      displayName: "North Star Plumbing",
+    });
+    expect(snapshot?.currentAccount).not.toHaveProperty("email");
+    expect(snapshot?.currentAccount).not.toHaveProperty("phone");
+    expect(customerSelect?.args[0]).not.toContain("email");
+    expect(customerSelect?.args[0]).not.toContain("phone");
+    expect(snapshot?.financialSummary).toEqual({ visible: false });
+  });
+
+  it("does not execute invoice or payment queries for a non-financial role", async () => {
+    const fixture = workspaceFixture();
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "advisor",
+      vehicleId: "vehicle-1",
+      now: new Date("2026-01-10T00:00:00.000Z"),
+    });
+
+    expect(snapshot?.financialSummary).toEqual({ visible: false });
+    expect(
+      fixture.calls.filter((call) =>
+        ["invoices", "payments"].includes(call.table),
+      ),
+    ).toEqual([]);
+  });
+
+  it("requires a mechanic-visible work-order anchor before returning history", async () => {
+    const fixture = createSupabaseFixture({
+      vehicles: [
+        {
+          data: {
+            id: "vehicle-1",
+            shop_id: "shop-a",
+            customer_id: "customer-1",
+            year: 2022,
+            make: "Ford",
+            model: "Transit",
+            submodel: null,
+            vin: "1FTBW1X80NKA12345",
+            license_plate: "SHOP-22",
+            unit_number: "17",
+            mileage: "64000",
+            odometer_unit: "km",
+            engine_hours: null,
+            status: "active",
+          },
+          error: null,
+        },
+      ],
+      work_orders: [{ data: [], error: null }],
+    });
+
+    await expect(
+      loadVehicleWorkspaceSnapshot({
+        supabase: fixture.client as never,
+        shopId: "shop-a",
+        role: "mechanic",
+        vehicleId: "vehicle-1",
+      }),
+    ).resolves.toBeNull();
+    expect(fixture.calls.map((call) => call.table)).not.toContain("history");
+    expect(fixture.calls.map((call) => call.table)).not.toContain("customers");
+  });
+
+  it("retains mechanic search evidence with explicit record kinds for link gating", async () => {
+    const vehicle = searchVehicleRow();
+    const workOrder = searchWorkOrderRow("wo-mechanic", vehicle.id);
+    const estimate = searchWorkOrderRow("estimate-mechanic", vehicle.id, {
+      estimateNumber: "EST-MECH",
+      estimateStatus: "sent",
+      recordType: "estimate",
+      status: "awaiting_approval",
+    });
+    const fixture = createSupabaseFixture({
+      work_orders: [
+        { data: [workOrder, estimate], error: null },
+        { data: [workOrder, estimate], error: null },
+      ],
+      vehicles: [
+        { data: [vehicle], error: null },
+        { data: [vehicle], error: null },
+      ],
+      bookings: [{ data: [], error: null }],
+      work_order_lines: [{ data: [], error: null }],
+      work_order_quote_lines: [{ data: [], error: null }],
+    });
+
+    const response = await searchShopVehicleRecords({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "mechanic",
+      query: "Ford",
+      now: new Date("2026-01-10T00:00:00.000Z"),
+    });
+
+    expect(response.permissions).toMatchObject({
+      canViewEstimates: false,
+      canOpenWorkOrders: true,
+    });
+    expect(response.groups[0]?.vehicles[0]?.activeWork).toEqual([
+      expect.objectContaining({
+        kind: "work_order",
+        reference: expect.objectContaining({ sourceId: "wo-mechanic" }),
+      }),
+      expect.objectContaining({
+        kind: "estimate",
+        reference: expect.objectContaining({
+          sourceId: "estimate-mechanic",
+          href: "/estimates/estimate-mechanic",
+        }),
+      }),
+    ]);
+  });
+
+  it("deduplicates candidates by ID, reloads canonical vehicles, and keeps all active work", async () => {
+    const vehicle = searchVehicleRow();
+    const visibleWorkOrders = [
+      searchWorkOrderRow("wo-1", vehicle.id),
+      searchWorkOrderRow("wo-2", vehicle.id),
+    ];
+    const fixture = createSupabaseFixture({
+      vehicles: [
+        { data: [vehicle, vehicle], error: null },
+        { data: [vehicle], error: null },
+      ],
+      work_orders: [
+        {
+          data: [
+            ...visibleWorkOrders,
+            searchWorkOrderRow(
+              "wo-cross-reference",
+              "vehicle-not-canonical",
+            ),
+          ],
+          error: null,
+        },
+        { data: visibleWorkOrders, error: null },
+      ],
+      customers: [{ data: [], error: null }],
+      bookings: [{ data: [], error: null }],
+      work_order_lines: [{ data: [], error: null }],
+      work_order_quote_lines: [{ data: [], error: null }],
+      invoices: [{ data: [], error: null }],
+    });
+
+    const response = await searchShopVehicleRecords({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      query: "Ford",
+      now: new Date("2026-01-10T00:00:00.000Z"),
+    });
+
+    expect(response.groups.flatMap((group) => group.vehicles)).toHaveLength(1);
+    expect(response.groups[0]?.vehicles[0]?.vehicle.id).toBe("vehicle-1");
+    expect(
+      response.groups[0]?.vehicles[0]?.activeWork.map(
+        (item) => item.reference.sourceId,
+      ),
+    ).toEqual(["wo-1", "wo-2"]);
+
+    const canonicalVehicleIdQuery = fixture.calls.find(
+      (call) =>
+        call.table === "vehicles" &&
+        call.operation === "in" &&
+        call.args[0] === "id",
+    );
+    expect(canonicalVehicleIdQuery?.args[1]).toEqual([
+      "vehicle-1",
+      "vehicle-not-canonical",
+    ]);
+  });
+
+  it("only offers Create WO for an active canonical vehicle and account", async () => {
+    const baseAccount = {
+      id: "customer-1",
+      account_type: "business",
+      active: true,
+      business_name: "North Star Plumbing",
+      name: null,
+      first_name: null,
+      last_name: null,
+      archived_at: null,
+      merged_into_customer_id: null,
+    };
+    const cardFor = async (
+      vehicleStatus: string | null,
+      accountOverrides: {
+        active?: boolean;
+        archived_at?: string | null;
+        merged_into_customer_id?: string | null;
+      } | null = {},
+    ) => {
+      const vehicle = searchVehicleRow({
+        customerId: baseAccount.id,
+        status: vehicleStatus,
+      });
+      const account = accountOverrides
+        ? { ...baseAccount, ...accountOverrides }
+        : null;
+      const activeWorkOrders = [
+        searchWorkOrderRow("wo-1", vehicle.id),
+        searchWorkOrderRow("wo-2", vehicle.id),
+      ];
+      const fixture = createSupabaseFixture({
+        vehicles: [
+          { data: [vehicle], error: null },
+          { data: [vehicle], error: null },
+        ],
+        work_orders: [
+          { data: [], error: null },
+          { data: activeWorkOrders, error: null },
+        ],
+        customers: [
+          { data: [], error: null },
+          { data: account ? [account] : [], error: null },
+        ],
+        bookings: [{ data: [], error: null }],
+        work_order_lines: [{ data: [], error: null }],
+        work_order_quote_lines: [{ data: [], error: null }],
+      });
+      const response = await searchShopVehicleRecords({
+        supabase: fixture.client as never,
+        shopId: "shop-a",
+        role: "advisor",
+        query: "Ford",
+      });
+      return response.groups[0]?.vehicles[0];
+    };
+
+    const eligible = await cardFor("active");
+    expect(eligible?.activeWork).toHaveLength(2);
+    expect(eligible?.createWorkOrderHref).toBe(
+      "/work-orders/create?autostart=1&customerId=customer-1&vehicleId=vehicle-1",
+    );
+
+    for (const status of ["archived", "merged", "duplicate", "inactive"]) {
+      expect((await cardFor(status))?.createWorkOrderHref).toBeNull();
+    }
+    expect(
+      (await cardFor("active", { active: false }))?.createWorkOrderHref,
+    ).toBeNull();
+    expect(
+      (
+        await cardFor("active", {
+          archived_at: "2026-01-05T10:00:00.000Z",
+        })
+      )?.createWorkOrderHref,
+    ).toBeNull();
+    expect(
+      (
+        await cardFor("active", {
+          merged_into_customer_id: "customer-2",
+        })
+      )?.createWorkOrderHref,
+    ).toBeNull();
+    expect((await cardFor("active", null))?.createWorkOrderHref).toBeNull();
+  });
+
+  it("does not project account-only IDs to Parts in the raw search response", async () => {
+    const customerOnly = {
+      id: "customer-without-vehicle",
+      account_type: "business",
+      active: true,
+      business_name: "No Vehicle Holdings",
+      name: null,
+      first_name: null,
+      last_name: null,
+      email: "private@example.test",
+      phone: "555-0199",
+      phone_number: null,
+      identity_name: "no vehicle holdings",
+      identity_email: "private@example.test",
+      identity_phone: "5550199",
+      archived_at: null,
+      merged_into_customer_id: null,
+    };
+    const searchAs = async (role: "owner" | "parts") => {
+      const fixture = createSupabaseFixture({
+        vehicles: [
+          { data: [], error: null },
+          { data: [], error: null },
+        ],
+        work_orders: [{ data: [], error: null }],
+        customers: [{ data: [customerOnly], error: null }],
+      });
+      const response = await searchShopVehicleRecords({
+        supabase: fixture.client as never,
+        shopId: "shop-a",
+        role,
+        query: "No Vehicle Holdings",
+      });
+      return { fixture, response };
+    };
+
+    const owner = await searchAs("owner");
+    const parts = await searchAs("parts");
+
+    expect(owner.response.accountsWithoutVehicles).toEqual([
+      expect.objectContaining({ id: customerOnly.id }),
+    ]);
+    expect(parts.response.accountsWithoutVehicles).toEqual([]);
+    expect(parts.response.groups).toEqual([]);
+    expect(JSON.stringify(parts.response)).not.toContain(customerOnly.id);
+    const partsCustomerSelect = parts.fixture.calls.find(
+      (call) => call.table === "customers" && call.operation === "select",
+    );
+    expect(partsCustomerSelect?.args[0]).not.toContain("email");
+    expect(partsCustomerSelect?.args[0]).not.toContain("phone");
+  });
+
+  it("returns bounded recent canonical cards for an empty search", async () => {
+    const vehicle = searchVehicleRow();
+    const fixture = createSupabaseFixture({
+      vehicles: [
+        { data: [vehicle], error: null },
+        { data: [vehicle], error: null },
+      ],
+      work_orders: [{ data: [], error: null }],
+      bookings: [{ data: [], error: null }],
+      work_order_lines: [{ data: [], error: null }],
+      work_order_quote_lines: [{ data: [], error: null }],
+    });
+
+    const response = await searchShopVehicleRecords({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      query: "   ",
+      limit: 5,
+      now: new Date("2026-01-10T00:00:00.000Z"),
+    });
+
+    expect(response.query).toBe("");
+    expect(response.groups[0]?.vehicles[0]?.vehicle.id).toBe("vehicle-1");
+    expect(
+      fixture.calls.filter(
+        (call) => call.table === "vehicles" && call.operation === "or",
+      ),
+    ).toEqual([]);
+    expect(
+      fixture.calls.some(
+        (call) =>
+          call.table === "vehicles" &&
+          call.operation === "limit" &&
+          call.args[0] === 120,
+      ),
+    ).toBe(true);
+  });
+
+  it("finds VINs, plates, and phone numbers across stored separators", async () => {
+    const compactVin = await runDirectVehicleSearch(
+      "1FTBW1X80NKA12345",
+      searchVehicleRow({ vin: "1FT-BW1X80-NKA12345" }),
+    );
+    const compactPlate = await runDirectVehicleSearch(
+      "SHOP22",
+      searchVehicleRow({ licensePlate: "SHOP-22" }),
+    );
+
+    expect(compactVin.response.groups[0]?.vehicles[0]?.vehicle.id).toBe(
+      "vehicle-1",
+    );
+    expect(compactPlate.response.groups[0]?.vehicles[0]?.vehicle.id).toBe(
+      "vehicle-1",
+    );
+    expect(
+      compactVin.fixture.calls
+        .filter(
+          (call) => call.table === "vehicles" && call.operation === "or",
+        )
+        .flatMap((call) => call.args.map(String))
+        .join(" "),
+    ).toContain("vin.ilike.%1%f%t%b%w%1%x%8%0%n%k%a%1%2%3%4%5%");
+    expect(
+      compactPlate.fixture.calls
+        .filter(
+          (call) => call.table === "vehicles" && call.operation === "or",
+        )
+        .flatMap((call) => call.args.map(String))
+        .join(" "),
+    ).toContain("license_plate.ilike.%s%h%o%p%2%2%");
+
+    const customer = {
+      id: "customer-1",
+      account_type: "business",
+      active: true,
+      business_name: "North Star Plumbing",
+      name: null,
+      first_name: null,
+      last_name: null,
+      email: "dispatch@example.test",
+      phone: "555-0100",
+      phone_number: null,
+      identity_name: "north star plumbing",
+      identity_email: "dispatch@example.test",
+      identity_phone: "5550100",
+    };
+    const vehicle = searchVehicleRow({ customerId: customer.id });
+    const phoneFixture = createSupabaseFixture({
+      vehicles: [
+        { data: [], error: null },
+        { data: [vehicle], error: null },
+        { data: [vehicle], error: null },
+      ],
+      work_orders: [
+        { data: [], error: null },
+        { data: [], error: null },
+      ],
+      customers: [
+        { data: [customer], error: null },
+        { data: [customer], error: null },
+      ],
+      bookings: [{ data: [], error: null }],
+      work_order_lines: [{ data: [], error: null }],
+      work_order_quote_lines: [{ data: [], error: null }],
+    });
+    const phoneResponse = await searchShopVehicleRecords({
+      supabase: phoneFixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      query: "5550100",
+    });
+
+    expect(phoneResponse.groups[0]?.vehicles[0]?.currentAccount?.id).toBe(
+      "customer-1",
+    );
+    expect(
+      phoneFixture.calls
+        .filter(
+          (call) => call.table === "customers" && call.operation === "or",
+        )
+        .flatMap((call) => call.args.map(String))
+        .join(" "),
+    ).toContain("phone.ilike.%5%5%5%0%1%0%0%");
+  });
+
+  it("normalizes a WO-prefixed query and opens estimate matches canonically", async () => {
+    const vehicle = searchVehicleRow();
+    const estimate = searchWorkOrderRow("estimate-1048", vehicle.id, {
+      customId: "1048",
+      estimateNumber: "EST-1048",
+      estimateStatus: "sent",
+      recordType: "estimate",
+      status: "awaiting_approval",
+    });
+    const declinedEstimate = searchWorkOrderRow(
+      "estimate-1048-declined",
+      vehicle.id,
+      {
+        customId: "1048",
+        estimateNumber: "EST-1048-B",
+        estimateStatus: "declined",
+        recordType: "estimate",
+        status: "awaiting_approval",
+      },
+    );
+    const fixture = createSupabaseFixture({
+      vehicles: [
+        { data: [], error: null },
+        { data: [vehicle], error: null },
+      ],
+      work_orders: [
+        { data: [estimate, declinedEstimate], error: null },
+        { data: [estimate, declinedEstimate], error: null },
+      ],
+      customers: [{ data: [], error: null }],
+      bookings: [{ data: [], error: null }],
+      work_order_lines: [{ data: [], error: null }],
+      work_order_quote_lines: [{ data: [], error: null }],
+      invoices: [{ data: [], error: null }],
+    });
+
+    const response = await searchShopVehicleRecords({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      query: "WO-1048",
+      now: new Date("2026-01-10T00:00:00.000Z"),
+    });
+    const card = response.groups[0]?.vehicles[0];
+    const workOrderFilters = fixture.calls
+      .filter(
+        (call) => call.table === "work_orders" && call.operation === "or",
+      )
+      .flatMap((call) => call.args.map(String))
+      .join(" ");
+
+    expect(card?.vehicle.id).toBe("vehicle-1");
+    expect(card?.activeWork).toContainEqual(
+      expect.objectContaining({
+        kind: "estimate",
+        title: "Estimate EST-1048",
+        status: "sent",
+        reference: expect.objectContaining({
+          sourceId: "estimate-1048",
+          href: "/estimates/estimate-1048",
+        }),
+      }),
+    );
+    expect(card?.activeWork).not.toContainEqual(
+      expect.objectContaining({
+        reference: expect.objectContaining({
+          sourceId: "estimate-1048-declined",
+        }),
+      }),
+    );
+    expect(workOrderFilters).toContain("custom_id.ilike.%1048%");
+    expect(workOrderFilters).not.toContain("custom_id.ilike.%wo%");
+  });
+
+  it("normalizes a compact single-token WO prefix to the canonical custom id", async () => {
+    const vehicle = searchVehicleRow();
+    const workOrder = searchWorkOrderRow("work-order-1048", vehicle.id, {
+      customId: "1048",
+    });
+    const fixture = createSupabaseFixture({
+      vehicles: [
+        { data: [], error: null },
+        { data: [vehicle], error: null },
+      ],
+      work_orders: [
+        { data: [workOrder], error: null },
+        { data: [workOrder], error: null },
+      ],
+      customers: [{ data: [], error: null }],
+      bookings: [{ data: [], error: null }],
+      work_order_lines: [{ data: [], error: null }],
+      work_order_quote_lines: [{ data: [], error: null }],
+      invoices: [{ data: [], error: null }],
+    });
+
+    const response = await searchShopVehicleRecords({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      query: "WO1048",
+    });
+    const workOrderFilters = fixture.calls
+      .filter(
+        (call) => call.table === "work_orders" && call.operation === "or",
+      )
+      .flatMap((call) => call.args.map(String))
+      .join(" ");
+
+    expect(response.groups[0]?.vehicles[0]?.vehicle.id).toBe(vehicle.id);
+    expect(workOrderFilters).toContain("custom_id.ilike.%1048%");
+    expect(workOrderFilters).not.toContain("custom_id.ilike.%wo1048%");
+  });
+
+  it("excludes terminal work and stale terminal-line attention while preserving current summaries", async () => {
+    const vehicle = searchVehicleRow();
+    const newest = searchWorkOrderRow("wo-newest", vehicle.id, {
+      odometerKm: 67000,
+      createdAt: "2026-01-05T10:00:00.000Z",
+      updatedAt: null,
+      vehicleMileage: "64000",
+    });
+    const canceled = searchWorkOrderRow("wo-canceled", vehicle.id, {
+      status: "canceled",
+      updatedAt: "2026-01-03T10:00:00.000Z",
+    });
+    const done = searchWorkOrderRow("wo-done", vehicle.id, {
+      odometerKm: null,
+      status: "done",
+      updatedAt: "2026-01-02T18:00:00.000Z",
+    });
+    const ready = searchWorkOrderRow("wo-ready", vehicle.id, {
+      odometerKm: null,
+      status: "ready_to_invoice",
+      updatedAt: "2026-01-02T12:00:00.000Z",
+    });
+    const older = searchWorkOrderRow("wo-older", vehicle.id, {
+      odometerKm: 65000,
+      updatedAt: "2026-01-04T10:00:00.000Z",
+      vehicleMileage: null,
+    });
+    // Mirrors `updated_at desc nulls last`: the newest created WO appears after
+    // older rows whose updated_at is populated.
+    const workOrders = [older, canceled, done, ready, newest];
+    const fixture = createSupabaseFixture({
+      vehicles: [
+        { data: [vehicle], error: null },
+        { data: [vehicle], error: null },
+      ],
+      work_orders: [
+        { data: workOrders, error: null },
+        { data: workOrders, error: null },
+      ],
+      customers: [{ data: [], error: null }],
+      bookings: [
+        {
+          data: [
+            {
+              id: "booking-completed",
+              vehicle_id: vehicle.id,
+              work_order_id: older.id,
+              status: "Completed",
+              starts_at: "2026-01-11T10:00:00.000Z",
+              ends_at: "2026-01-11T11:00:00.000Z",
+              notes: null,
+            },
+            {
+              id: "booking-next",
+              vehicle_id: vehicle.id,
+              work_order_id: newest.id,
+              status: "confirmed",
+              starts_at: "2026-01-12T10:00:00.000Z",
+              ends_at: "2026-01-12T11:00:00.000Z",
+              notes: null,
+            },
+          ],
+          error: null,
+        },
+      ],
+      work_order_lines: [
+        {
+          data: [
+            {
+              id: "line-active-deferred",
+              vehicle_id: vehicle.id,
+              work_order_id: newest.id,
+              status: "open",
+              line_status: "deferred",
+              approval_state: null,
+              hold_reason: null,
+              voided_at: null,
+            },
+            ...["canceled", "completed", "invoiced", "ready_to_invoice"].map(
+              (status) => ({
+                id: `line-terminal-${status}`,
+                vehicle_id: vehicle.id,
+                work_order_id: newest.id,
+                status,
+                line_status: "deferred",
+                approval_state: "declined",
+                hold_reason: "Stale hold reason",
+                voided_at: null,
+              }),
+            ),
+          ],
+          error: null,
+        },
+      ],
+      work_order_quote_lines: [{ data: [], error: null }],
+      invoices: [
+        {
+          data: [
+            {
+              id: "invoice-cad",
+              work_order_id: newest.id,
+              outstanding_total: 100,
+              currency: "CAD",
+            },
+            {
+              id: "invoice-usd",
+              work_order_id: older.id,
+              outstanding_total: 80,
+              currency: "USD",
+            },
+          ],
+          error: null,
+        },
+      ],
+    });
+
+    const response = await searchShopVehicleRecords({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      query: "Ford",
+      now: new Date("2026-01-10T00:00:00.000Z"),
+    });
+    const card = response.groups[0]?.vehicles[0];
+
+    expect(card?.activeWork.map((item) => item.reference.sourceId)).toEqual([
+      "wo-older",
+      "wo-ready",
+      "wo-newest",
+    ]);
+    expect(card?.latestOdometer).toBe("67000");
+    expect(card?.attentionCount).toBe(1);
+    expect(card?.nextAppointment?.reference.sourceId).toBe("booking-next");
+    expect(card).not.toHaveProperty("outstandingAmount");
+    expect(card?.currency).toBeNull();
+  });
+});

--- a/tests/vehicle-workspace-route.test.ts
+++ b/tests/vehicle-workspace-route.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SHOP_ID = "a4100000-0000-4000-8000-000000000001";
+const VEHICLE_ID = "a4300000-0000-4000-8000-000000000001";
+
+const mocks = vi.hoisted(() => ({
+  requireApiAccess: vi.fn(),
+  requirePageAccess: vi.fn(),
+  search: vi.fn(),
+  loadSnapshot: vi.fn(),
+  createWorkOrderHref: vi.fn(),
+  createServerClient: vi.fn(),
+  noStore: vi.fn(),
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireApiAccess,
+  requireShopPageAccess: mocks.requirePageAccess,
+}));
+
+vi.mock("@/features/vehicles/server/searchShopVehicleRecords", () => ({
+  searchShopVehicleRecords: mocks.search,
+}));
+
+vi.mock("@/features/vehicles/server/loadVehicleWorkspaceSnapshot", () => ({
+  loadVehicleWorkspaceSnapshot: mocks.loadSnapshot,
+  vehicleWorkspaceCreateWorkOrderHref: mocks.createWorkOrderHref,
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createServerSupabaseRSC: mocks.createServerClient,
+}));
+
+vi.mock("next/cache", () => ({
+  unstable_noStore: mocks.noStore,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: mocks.notFound,
+}));
+
+vi.mock("@/features/vehicles/components/VehicleWorkspace", () => ({
+  default: () => null,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("GET /api/vehicles/search authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireApiAccess.mockResolvedValue({
+      ok: true,
+      profile: { id: "profile-1", shop_id: SHOP_ID, role: "owner" },
+      canonicalRole: "owner",
+      authUserId: "user-1",
+      supabase: { from: vi.fn() },
+    });
+    mocks.search.mockResolvedValue({
+      query: "Ford",
+      groups: [],
+      accountsWithoutVehicles: [],
+      permissions: {},
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  it("returns the access response before running a search for an anonymous caller", async () => {
+    mocks.requireApiAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Not authenticated" }, { status: 401 }),
+    });
+    const { GET } = await import("../app/api/vehicles/search/route");
+
+    const response = await GET(
+      new Request("https://profixiq.test/api/vehicles/search?q=Ford"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.search).not.toHaveBeenCalled();
+  });
+
+  it("returns the access response before running a search for a disallowed role", async () => {
+    mocks.requireApiAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
+    const { GET } = await import("../app/api/vehicles/search/route");
+
+    const response = await GET(
+      new Request("https://profixiq.test/api/vehicles/search?q=Ford"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mocks.search).not.toHaveBeenCalled();
+  });
+
+  it("derives shop and role from the authenticated actor", async () => {
+    const { GET } = await import("../app/api/vehicles/search/route");
+    const response = await GET(
+      new Request(
+        "https://profixiq.test/api/vehicles/search?q=Ford&shopId=forged&role=owner",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.search).toHaveBeenCalledWith({
+      supabase: expect.any(Object),
+      shopId: SHOP_ID,
+      role: "owner",
+      query: "Ford",
+    });
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+  });
+});
+
+describe("Vehicle Workspace page authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requirePageAccess.mockResolvedValue({
+      profile: { id: "profile-1", shop_id: SHOP_ID, role: "owner" },
+      canonicalRole: "owner",
+    });
+    mocks.createServerClient.mockReturnValue({ from: vi.fn() });
+    mocks.createWorkOrderHref.mockReturnValue(
+      `/work-orders/create?customerId=customer-1&vehicleId=${VEHICLE_ID}`,
+    );
+  });
+
+  it("authorizes before rejecting a malformed vehicle ID", async () => {
+    const { default: VehicleWorkspacePage } = await import(
+      "../app/vehicles/[id]/page"
+    );
+
+    await expect(
+      VehicleWorkspacePage({ params: Promise.resolve({ id: "not-a-uuid" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(mocks.requirePageAccess).toHaveBeenCalledTimes(1);
+    expect(mocks.loadSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("returns the same not-found posture for an invisible cross-shop vehicle", async () => {
+    mocks.loadSnapshot.mockResolvedValue(null);
+    const serverClient = { from: vi.fn() };
+    mocks.createServerClient.mockReturnValue(serverClient);
+    const { default: VehicleWorkspacePage } = await import(
+      "../app/vehicles/[id]/page"
+    );
+
+    await expect(
+      VehicleWorkspacePage({ params: Promise.resolve({ id: VEHICLE_ID }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(mocks.loadSnapshot).toHaveBeenCalledWith({
+      supabase: serverClient,
+      shopId: SHOP_ID,
+      role: "owner",
+      vehicleId: VEHICLE_ID,
+    });
+    expect(mocks.createWorkOrderHref).not.toHaveBeenCalled();
+  });
+});

--- a/tests/vehicle-workspace-security.test.ts
+++ b/tests/vehicle-workspace-security.test.ts
@@ -1,0 +1,208 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const loader = read(
+  "features/vehicles/server/loadVehicleWorkspaceSnapshot.ts",
+);
+const search = read("features/vehicles/server/searchShopVehicleRecords.ts");
+const searchRoute = read("app/api/vehicles/search/route.ts");
+const workspacePage = read("app/vehicles/[id]/page.tsx");
+const workspaceComponent = read(
+  "features/vehicles/components/VehicleWorkspace.tsx",
+);
+const vehicleSearchPage = read("features/vehicles/app/vehicles/page.tsx");
+
+describe("Shop Vehicle Workspace security contract", () => {
+  it("anchors the canonical vehicle and work-order reads to the requested shop", () => {
+    const vehicleQuery = loader.slice(
+      loader.indexOf("const vehicleResult"),
+      loader.indexOf(
+        'throwQueryError(vehicleResult.error, "Unable to load vehicle")',
+      ),
+    );
+    const workOrderQuery = loader.slice(
+      loader.indexOf("const workOrdersResult"),
+      loader.indexOf(
+        'throwQueryError(workOrdersResult.error, "Unable to load work orders")',
+      ),
+    );
+
+    expect(vehicleQuery).toContain('.from("vehicles")');
+    expect(vehicleQuery).toContain('.eq("shop_id", input.shopId)');
+    expect(vehicleQuery).toContain('.eq("id", input.vehicleId)');
+    expect(vehicleQuery).toContain(".maybeSingle()");
+    expect(workOrderQuery).toContain('.from("work_orders")');
+    expect(workOrderQuery).toContain('.eq("shop_id", input.shopId)');
+    expect(workOrderQuery).toContain('.eq("vehicle_id", input.vehicleId)');
+  });
+
+  it("scopes installed-part evidence without projecting commercial fields", () => {
+    const partQuery = loader.slice(
+      loader.indexOf('.from("work_order_parts")'),
+      loader.indexOf('.from("work_order_quote_lines")'),
+    );
+
+    expect(partQuery).toContain('.eq("shop_id", input.shopId)');
+    expect(partQuery).toContain('.eq("is_active", true)');
+    expect(partQuery).toContain('.in("work_order_id", workOrderIds)');
+    expect(partQuery).toContain("quantity_consumed,quantity_returned");
+    expect(partQuery).not.toContain("price");
+    expect(partQuery).not.toContain("cost");
+  });
+
+  it("uses the caller's RLS client and guards protected financial reads", () => {
+    expect(loader).not.toContain("createAdminSupabase");
+    expect(loader).not.toContain("service_role");
+    expect(loader.match(/permissions\.canViewFinancials && workOrderIds\.length/g))
+      .toHaveLength(2);
+    expect(loader).toContain(
+      "permissions.canViewPartRequests && workOrderIds.length",
+    );
+    expect(loader).toContain(
+      "if (permissions.isAssignedWorkOnly && workOrders.length === 0) return null",
+    );
+    expect(loader.indexOf("if (permissions.isAssignedWorkOnly")).toBeLessThan(
+      loader.indexOf("const accountQuery"),
+    );
+  });
+
+  it("keeps search candidates canonical, shop-scoped, and assignment-scoped", () => {
+    const canonicalVehicleLoad = search.slice(
+      search.indexOf("if (boundedVehicleIds.length)"),
+      search.indexOf("const currentCustomerIds"),
+    );
+
+    expect(search).not.toContain("createAdminSupabase");
+    expect(search).not.toContain("service_role");
+    expect(search).toContain("const candidateVehicleIds = new Map<string, true>()");
+    expect(search).toContain("candidateVehicleIds.set(row.id, true)");
+    expect(search).toContain("candidateVehicleIds.set(row.vehicle_id, true)");
+    expect(canonicalVehicleLoad).toContain('.from("vehicles")');
+    expect(canonicalVehicleLoad).toContain('.eq("shop_id", input.shopId)');
+    expect(canonicalVehicleLoad).toContain('.in("id", boundedVehicleIds)');
+    expect(search).toContain("const activeWorkOrdersByVehicle = new Map");
+    expect(search).toContain("rows.push(row)");
+    expect(search).toContain(
+      "activeWork: (activeWorkOrdersByVehicle.get(vehicle.id) ?? []).map",
+    );
+
+    const mechanicScope = search.slice(
+      search.indexOf("if (isMechanic)"),
+      search.indexOf("let directVehicleMatches"),
+    );
+    expect(mechanicScope).toContain('.from("work_orders")');
+    expect(mechanicScope).toContain('.eq("shop_id", input.shopId)');
+    expect(mechanicScope).toContain("visibleMechanicWorkOrders");
+    expect(mechanicScope).toContain("const allowedVehicleIds = Array.from");
+    expect(mechanicScope).toContain('.in("id", allowedVehicleIds)');
+    expect(search).toContain(
+      "if (permissions.canViewFinancials && workOrderIds.length)",
+    );
+    expect(search).toContain(
+      "const canSearchAccountContact = permissions.canViewAccountContact",
+    );
+    expect(search).toContain(".select(CUSTOMER_COLUMNS)");
+    expect(search.match(/\.select\(CUSTOMER_SAFE_COLUMNS\)/g)).toHaveLength(2);
+    expect(search).toContain(
+      '"id,account_type,active,business_name,name,first_name,last_name,identity_name,archived_at,merged_into_customer_id"',
+    );
+    expect(search).toContain("customerFilterForTerm(term, true)");
+    expect(search).toContain("customerFilterForTerm(term, false)");
+  });
+
+  it("retains restricted evidence while gating canonical detail links by role", () => {
+    expect(loader).toContain('href: `/estimates/${row.work_order_id}`');
+    expect(search).toContain(
+      'kind: workOrderIsEstimate(row) ? "estimate" : "work_order"',
+    );
+
+    expect(workspaceComponent).toContain(
+      'if (item.kind === "estimate") return permissions.canViewEstimates',
+    );
+    expect(workspaceComponent).toContain(
+      'if (event.kind === "estimate") return permissions.canViewEstimates',
+    );
+    expect(workspaceComponent).toContain(
+      'reference.sourceType === "work_order_quote_line"',
+    );
+    expect(workspaceComponent).toContain(
+      'reference.sourceType === "inspection"',
+    );
+    expect(workspaceComponent).toContain(
+      'reference.sourceType === "history"',
+    );
+    expect(workspaceComponent).toContain(
+      "WORK_ORDER_SOURCE_TYPES.has(reference.sourceType)",
+    );
+    expect(workspaceComponent).toContain(
+      "canOpenReference(\n              snapshot.documentSummary.latestReference",
+    );
+    expect(workspaceComponent).toContain("Source retained");
+
+    expect(vehicleSearchPage).toContain('work.kind === "estimate"');
+    expect(vehicleSearchPage).toContain("permissions.canViewEstimates");
+    expect(vehicleSearchPage).toContain("permissions.canOpenWorkOrders");
+    expect(vehicleSearchPage).toContain(
+      "data-source-id={work.reference.sourceId}",
+    );
+  });
+
+  it("guards the search API with the exact workspace role allowlist", () => {
+    const guard = searchRoute.indexOf("await requireShopScopedApiAccess");
+    const searchCall = searchRoute.indexOf("await searchShopVehicleRecords");
+
+    expect(searchRoute).toContain(
+      "allowRoles: VEHICLE_WORKSPACE_READER_ROLES",
+    );
+    expect(guard).toBeGreaterThan(-1);
+    expect(searchCall).toBeGreaterThan(guard);
+    expect(searchRoute).toContain("supabase: access.supabase");
+    expect(searchRoute).toContain("shopId: access.profile.shop_id");
+    expect(searchRoute).toContain("role: access.canonicalRole");
+    expect(searchRoute).not.toContain("createAdminSupabase");
+    expect(searchRoute).toContain('"Cache-Control": "private, no-store"');
+  });
+
+  it("authorizes the page before loading and gives invalid or invisible IDs the same posture", () => {
+    const guard = workspacePage.indexOf("await requireShopPageAccess");
+    const paramsRead = workspacePage.indexOf("await params");
+    const loaderCall = workspacePage.indexOf(
+      "await loadVehicleWorkspaceSnapshot",
+    );
+
+    expect(workspacePage).toContain(
+      "allowRoles: VEHICLE_WORKSPACE_READER_ROLES",
+    );
+    expect(workspacePage).toContain("supabase: createServerSupabaseRSC()");
+    expect(workspacePage).not.toContain("createAdminSupabase");
+    expect(guard).toBeGreaterThan(-1);
+    expect(paramsRead).toBeGreaterThan(guard);
+    expect(loaderCall).toBeGreaterThan(guard);
+    expect(workspacePage).toContain("shopId: profile.shop_id");
+    expect(workspacePage).toContain("role: canonicalRole");
+    expect(workspacePage).toContain("vehicleId: id");
+    expect(workspacePage).toContain("if (!UUID_PATTERN.test(id)) notFound()");
+    expect(workspacePage).toContain("if (!snapshot) notFound()");
+    expect(workspacePage.match(/notFound\(\)/g)).toHaveLength(2);
+  });
+
+  it("does not format ambiguous or absent financial totals as a currency amount", () => {
+    expect(
+      workspaceComponent.match(
+        /snapshot\.financialSummary\.invoiceCount === 0/g,
+      ),
+    ).toHaveLength(2);
+    expect(workspaceComponent.match(/"No invoices"/g)).toHaveLength(2);
+    expect(workspaceComponent.match(/"Multiple currencies"/g)).toHaveLength(
+      2,
+    );
+    expect(workspaceComponent).toContain(
+      "snapshot.financialSummary.outstandingAmount === null",
+    );
+    expect(workspaceComponent).toContain(
+      "snapshot.financialSummary.paidAmount === null",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- Added the focused repository/schema audit and canonical relationship contract for a vehicle-owned Shop workspace.
- Replaced the browser-local Vehicle Files lookup with a bounded, authenticated server search across customer/company identity, contact values, VIN, plate, unit, year/make/model, and work-order number.
- Added the guarded `/vehicles/[vehicleId]` read model with Vehicle header, Active now, Needs attention, Recent timeline, financial/document summaries, related vehicles, and explicit conflict cards.
- Preserved every canonical source ID and only exposes links when the destination page authorizes the current role.
- Reused the existing Create Work Order flow with canonical `customerId` and `vehicleId` prefilled; no mutation flow was rebuilt.
- Added exact appointment deep links for scheduling-authorized roles, including canonical linked-profile resolution.
- Added Vehicle Open Work support and tenant-boundary runtime SQL to clean replay.

## Why

This proves one narrow Shop vertical slice—search → authoritative vehicle workspace → existing prepopulated action—without removing standalone pages, copying source records, changing lifecycle states, or introducing a workspace table.

## Authorization and data contract

- `vehicles.id` is the only workspace anchor.
- Page/API access derives shop and role from the authenticated actor and keeps the RLS client in every operational query.
- Mechanics require at least one RLS-visible assigned work order before any workspace is returned.
- Account contact, financial, parts-request, estimate, inspection, appointment, and legacy detail links are projected independently by existing capabilities.
- Malformed, missing, unassigned, and cross-shop vehicle IDs share the same not-found posture.

Two audited compatibility gates are deliberately documented rather than papered over:

1. Legacy same-shop invoice/payment policies are broader than the TypeScript financial capability. The workspace does not query or return those fields to restricted roles, but base-table RLS tightening needs a separate role-shaped billing migration and consumer cutover.
2. Imported `history` rows with `work_order_id is null` are currently blocked by the WO-based history policy. The read model does not bypass RLS; a forward policy decision is required before imported history can be called complete.

## Validation

- Focused TypeScript 5.4.5 compile: zero diagnostics on the exact rebased tree.
- Behavioral workspace/search harness: 28/28 passing.
- Security source-contract harness: 8/8 passing.
- Node strip-type syntax checks: 13 changed TypeScript files passing.
- Workflow YAML parse and `git diff --check`: passing.
- Rollback-only tenant/RLS fixture executed successfully against canonical ProFixIQ Supabase; clean-replay execution is wired into CI.
- Full dependency-backed Vitest, lint, type-check, build, API audit, and regression inventory remain authoritative in GitHub CI because this checkout has no project `node_modules`.
