### PR TITLE
chore: restore hardening preview controls

### DIFF
--- a/tests/operational-observability-ui-alerts.test.ts
+++ b/tests/operational-observability-ui-alerts.test.ts
@@ -100,9 +100,10 @@ describe("operational observability UI and alerting", () => {
     expect(healthRoute).toContain("operationalHealth:");
   });
 
-  it("schedules the internal health check without enabling branch deployments", () => {
+  it("schedules the internal health check while retaining approved preview deployments", () => {
     const parsed = JSON.parse(cronConfig) as {
       crons: Array<{ path: string; schedule: string }>;
+      ignoreCommand?: string;
       git: { deploymentEnabled: Record<string, boolean> };
     };
 
@@ -110,6 +111,10 @@ describe("operational observability UI and alerting", () => {
       path: "/api/internal/observability/health",
       schedule: "7 * * * *",
     });
+    expect(parsed.ignoreCommand).toBe("exit 1");
+    expect(parsed.git.deploymentEnabled.main).toBe(true);
+    expect(parsed.git.deploymentEnabled["agent/*"]).toBe(true);
+    expect(parsed.git.deploymentEnabled["codex/*"]).toBe(true);
     expect(parsed.git.deploymentEnabled["*"]).toBe(false);
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -29,9 +29,12 @@
       "schedule": "*/5 * * * *"
     }
   ],
+  "ignoreCommand": "exit 1",
   "git": {
     "deploymentEnabled": {
       "main": true,
+      "agent/*": true,
+      "codex/*": true,
       "*": false
     }
   }


### PR DESCRIPTION
Production-hardening release-control regression fix.

A later merge reverted the preview controls previously introduced by #1462 and #1469. Current `main` once again allows only `main` deployments, so every non-main PR preview is canceled before live UI validation can run.

This PR restores the known-good default-deny policy:
- `main`, `agent/*`, and `codex/*` are explicitly deployable
- all other branches remain denied by `*`: false
- `ignoreCommand: "exit 1"` prevents the project Ignored Build Step from silently skipping allowed deployments

It also strengthens the existing operational-observability regression test so future changes must preserve the approved preview allowlist and ignore command instead of checking only the catch-all deny.

No application logic, cron schedules, database state, production deployment, secrets, billing, or customer-facing behavior is changed. This PR should remain draft until CI and its own Vercel preview prove the release-control path.