### PR TITLE
security: harden invoice PDF authorization

### DIFF
--- a/app/api/invoice-versions/[id]/pdf/route.ts
+++ b/app/api/invoice-versions/[id]/pdf/route.ts
@@ -85,6 +85,7 @@ export async function GET(
           .select("invoice_number,notes")
           .eq("id", version.invoice_id)
           .eq("shop_id", version.shop_id)
+          .eq("work_order_id", version.work_order_id)
           .maybeSingle<{
             invoice_number: string | null;
             notes: string | null;

--- a/app/api/invoice-versions/[id]/pdf/route.ts
+++ b/app/api/invoice-versions/[id]/pdf/route.ts
@@ -10,7 +10,10 @@ import {
 } from "@/features/branding/server/getActiveBrandForRender";
 import { isFrozenInvoiceDocumentConfiguration } from "@/features/invoices/lib/invoiceDocumentTheme";
 import { canAccessInvoicePdf } from "@/features/invoices/server/authorizeInvoicePdfAccess";
-import { getInvoiceVersionById } from "@/features/invoices/server/invoiceVersionQueries";
+import {
+  CUSTOMER_VISIBLE_INVOICE_STATES,
+  getInvoiceVersionById,
+} from "@/features/invoices/server/invoiceVersionQueries";
 import {
   premiumInvoiceFilename,
   renderPremiumInvoicePdf,
@@ -68,6 +71,9 @@ export async function GET(
       authUserId: user.id,
       shopId: version.shop_id,
       customerId: workOrder?.customer_id ?? null,
+      customerVisibleDocument: CUSTOMER_VISIBLE_INVOICE_STATES.includes(
+        version.lifecycle_status,
+      ),
     });
     if (!allowed) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });

--- a/app/api/invoice-versions/[id]/pdf/route.ts
+++ b/app/api/invoice-versions/[id]/pdf/route.ts
@@ -9,6 +9,7 @@ import {
   getActiveBrandForRender,
 } from "@/features/branding/server/getActiveBrandForRender";
 import { isFrozenInvoiceDocumentConfiguration } from "@/features/invoices/lib/invoiceDocumentTheme";
+import { canAccessInvoicePdf } from "@/features/invoices/server/authorizeInvoicePdfAccess";
 import { getInvoiceVersionById } from "@/features/invoices/server/invoiceVersionQueries";
 import {
   premiumInvoiceFilename,
@@ -52,33 +53,23 @@ export async function GET(
       );
     }
 
-    const [{ data: profile }, { data: workOrder }] = await Promise.all([
-      admin
-        .from("profiles")
-        .select("shop_id")
-        .eq("id", user.id)
-        .maybeSingle<{ shop_id: string | null }>(),
-      admin
-        .from("work_orders")
-        .select("customer_id,custom_id")
-        .eq("id", version.work_order_id)
-        .eq("shop_id", version.shop_id)
-        .maybeSingle<{
-          customer_id: string | null;
-          custom_id: string | null;
-        }>(),
-    ]);
+    const { data: workOrder } = await admin
+      .from("work_orders")
+      .select("customer_id,custom_id")
+      .eq("id", version.work_order_id)
+      .eq("shop_id", version.shop_id)
+      .maybeSingle<{
+        customer_id: string | null;
+        custom_id: string | null;
+      }>();
 
-    let customerAccess = false;
-    if (workOrder?.customer_id) {
-      const { data: customer } = await admin
-        .from("customers")
-        .select("user_id")
-        .eq("id", workOrder.customer_id)
-        .maybeSingle<{ user_id: string | null }>();
-      customerAccess = customer?.user_id === user.id;
-    }
-    if (profile?.shop_id !== version.shop_id && !customerAccess) {
+    const allowed = await canAccessInvoicePdf({
+      supabase: sessionClient,
+      authUserId: user.id,
+      shopId: version.shop_id,
+      customerId: workOrder?.customer_id ?? null,
+    });
+    if (!allowed) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -56,21 +56,28 @@ export async function GET(
       );
     }
 
-    const allowed = await canAccessInvoicePdf({
-      supabase,
-      authUserId: user.id,
-      shopId: workOrder.shop_id,
-      customerId: workOrder.customer_id,
-    });
-    if (!allowed) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
+    // Resolve the immutable/currently issued document before authorization.
+    // Billing staff may still fall back to a working draft below, but a portal
+    // customer must have a customer-visible invoice version before the gate can
+    // succeed. This prevents the service from rendering mutable draft totals to
+    // an otherwise valid portal member.
     const activeVersion = await getActiveInvoiceVersion({
       supabase,
       workOrderId,
       shopId: workOrder.shop_id,
     });
+
+    const allowed = await canAccessInvoicePdf({
+      supabase,
+      authUserId: user.id,
+      shopId: workOrder.shop_id,
+      customerId: workOrder.customer_id,
+      customerVisibleDocument: activeVersion !== null,
+    });
+    if (!allowed) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
     const storedSnapshot =
       activeVersion?.snapshot ??
       (await getIssuableInvoiceSnapshot({

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -7,6 +7,7 @@ import {
   getActiveBrandForRender,
 } from "@/features/branding/server/getActiveBrandForRender";
 import { isFrozenInvoiceDocumentConfiguration } from "@/features/invoices/lib/invoiceDocumentTheme";
+import { canAccessInvoicePdf } from "@/features/invoices/server/authorizeInvoicePdfAccess";
 import { getActiveInvoiceVersion } from "@/features/invoices/server/financialLifecycle";
 import { getIssuableInvoiceSnapshot } from "@/features/invoices/server/getIssuableInvoiceSnapshot";
 import {
@@ -35,15 +36,17 @@ export async function GET(
   }
 
   try {
-    // The session-scoped client keeps the read inside the caller's shop RLS boundary.
+    // The session-scoped client keeps the lookup inside the caller's work-order
+    // RLS boundary before the explicit financial authorization gate below.
     const { data: workOrder, error: workOrderError } = await supabase
       .from("work_orders")
-      .select("id,shop_id,custom_id")
+      .select("id,shop_id,custom_id,customer_id")
       .eq("id", workOrderId)
       .maybeSingle<{
         id: string;
         shop_id: string;
         custom_id: string | null;
+        customer_id: string | null;
       }>();
     if (workOrderError) throw workOrderError;
     if (!workOrder) {
@@ -51,6 +54,16 @@ export async function GET(
         { error: "Work order not found" },
         { status: 404 },
       );
+    }
+
+    const allowed = await canAccessInvoicePdf({
+      supabase,
+      authUserId: user.id,
+      shopId: workOrder.shop_id,
+      customerId: workOrder.customer_id,
+    });
+    if (!allowed) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
     const activeVersion = await getActiveInvoiceVersion({

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -91,6 +91,7 @@ export async function GET(
           .select("invoice_number,notes")
           .eq("id", activeVersion.invoice_id)
           .eq("shop_id", workOrder.shop_id)
+          .eq("work_order_id", workOrderId)
           .maybeSingle<{
             invoice_number: string | null;
             notes: string | null;

--- a/features/invoices/server/authorizeInvoicePdfAccess.ts
+++ b/features/invoices/server/authorizeInvoicePdfAccess.ts
@@ -17,6 +17,7 @@ export async function canAccessInvoicePdf(input: {
   authUserId: string;
   shopId: string;
   customerId: string | null;
+  customerVisibleDocument: boolean;
 }): Promise<boolean> {
   const { profile } = await resolveAuthenticatedStaffProfile(
     input.supabase,
@@ -30,7 +31,11 @@ export async function canAccessInvoicePdf(input: {
     }
   }
 
-  if (!input.customerId) return false;
+  // Staff billing operators may render a working draft, but portal customers
+  // must never receive mutable/unissued financial documents. Callers derive
+  // this bit from the canonical invoice-version lifecycle before we evaluate
+  // durable portal membership.
+  if (!input.customerVisibleDocument || !input.customerId) return false;
 
   const { data: portalAccess, error: portalAccessError } = await input.supabase.rpc(
     "profixiq_is_portal_customer_for",

--- a/features/invoices/server/authorizeInvoicePdfAccess.ts
+++ b/features/invoices/server/authorizeInvoicePdfAccess.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import { resolveAuthenticatedStaffProfile } from "@/features/shared/lib/server/admin-access";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  getActorCapabilities,
+  ROLE_GROUPS,
+  type CanonicalRole,
+} from "@/features/shared/lib/rbac";
+
+type SessionClient = ReturnType<typeof createServerSupabaseRoute>;
+
+const BILLING_ROLES = new Set<CanonicalRole>(ROLE_GROUPS.billingOperators);
+
+export async function canAccessInvoicePdf(input: {
+  supabase: SessionClient;
+  authUserId: string;
+  shopId: string;
+  customerId: string | null;
+}): Promise<boolean> {
+  const { profile } = await resolveAuthenticatedStaffProfile(
+    input.supabase,
+    input.authUserId,
+  );
+
+  if (profile?.shop_id === input.shopId) {
+    const actor = getActorCapabilities({ role: profile.role });
+    if (actor.isKnownRole && BILLING_ROLES.has(actor.canonicalRole)) {
+      return true;
+    }
+  }
+
+  if (!input.customerId) return false;
+
+  const { data: portalAccess, error: portalAccessError } = await input.supabase.rpc(
+    "profixiq_is_portal_customer_for",
+    {
+      p_customer_id: input.customerId,
+      p_shop_id: input.shopId,
+    },
+  );
+
+  return !portalAccessError && portalAccess === true;
+}

--- a/tests/invoice-pdf-authorization.test.ts
+++ b/tests/invoice-pdf-authorization.test.ts
@@ -1,16 +1,56 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ROLE_GROUPS } from "@/features/shared/lib/rbac";
+
+const mocks = vi.hoisted(() => ({
+  resolveAuthenticatedStaffProfile: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  resolveAuthenticatedStaffProfile: mocks.resolveAuthenticatedStaffProfile,
+}));
+
+import { canAccessInvoicePdf } from "@/features/invoices/server/authorizeInvoicePdfAccess";
 
 const read = (path: string) => readFileSync(path, "utf8");
 
-const authorization = read(
-  "features/invoices/server/authorizeInvoicePdfAccess.ts",
-);
 const versionRoute = read("app/api/invoice-versions/[id]/pdf/route.ts");
 const workOrderRoute = read("app/api/work-orders/[id]/invoice-pdf/route.ts");
 
+type RpcResult = {
+  data: boolean | null;
+  error: { message: string } | null;
+};
+
+function sessionClient(rpcResult: RpcResult = { data: false, error: null }) {
+  return {
+    rpc: vi.fn().mockResolvedValue(rpcResult),
+  } as never;
+}
+
+function staffProfile(role: string, shopId: string | null) {
+  return {
+    profile: {
+      id: "profile-1",
+      user_id: "user-1",
+      role,
+      shop_id: shopId,
+      full_name: "Test User",
+    },
+    error: null,
+  };
+}
+
 describe("invoice PDF authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveAuthenticatedStaffProfile.mockResolvedValue({
+      profile: null,
+      error: null,
+    });
+  });
+
   it("limits staff PDF access to the canonical billing roles", () => {
     expect(ROLE_GROUPS.billingOperators).toEqual([
       "owner",
@@ -21,24 +61,133 @@ describe("invoice PDF authorization", () => {
     ]);
     expect(ROLE_GROUPS.billingOperators).not.toContain("mechanic");
     expect(ROLE_GROUPS.billingOperators).not.toContain("parts");
-    expect(authorization).toContain("ROLE_GROUPS.billingOperators");
-    expect(authorization).toContain("resolveAuthenticatedStaffProfile");
-    expect(authorization).toContain("profile?.shop_id === input.shopId");
-    expect(authorization).toContain("actor.isKnownRole");
-    expect(authorization).toContain("BILLING_ROLES.has(actor.canonicalRole)");
   });
 
-  it("requires durable portal membership for customer PDF access", () => {
-    expect(authorization).toContain('"profixiq_is_portal_customer_for"');
-    expect(authorization).toContain("p_customer_id: input.customerId");
-    expect(authorization).toContain("p_shop_id: input.shopId");
-    expect(authorization).toContain("!portalAccessError && portalAccess === true");
+  it("allows a same-shop billing operator without consulting portal membership", async () => {
+    mocks.resolveAuthenticatedStaffProfile.mockResolvedValue(
+      staffProfile("owner", "shop-a"),
+    );
+    const supabase = sessionClient();
+
+    await expect(
+      canAccessInvoicePdf({
+        supabase,
+        authUserId: "user-1",
+        shopId: "shop-a",
+        customerId: null,
+      }),
+    ).resolves.toBe(true);
+
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it("denies same-shop non-billing staff", async () => {
+    mocks.resolveAuthenticatedStaffProfile.mockResolvedValue(
+      staffProfile("mechanic", "shop-a"),
+    );
+    const supabase = sessionClient();
+
+    await expect(
+      canAccessInvoicePdf({
+        supabase,
+        authUserId: "user-1",
+        shopId: "shop-a",
+        customerId: null,
+      }),
+    ).resolves.toBe(false);
+
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it("denies a billing operator from a different shop", async () => {
+    mocks.resolveAuthenticatedStaffProfile.mockResolvedValue(
+      staffProfile("owner", "shop-b"),
+    );
+    const supabase = sessionClient();
+
+    await expect(
+      canAccessInvoicePdf({
+        supabase,
+        authUserId: "user-1",
+        shopId: "shop-a",
+        customerId: null,
+      }),
+    ).resolves.toBe(false);
+
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it("allows an authenticated portal customer only when the canonical membership predicate returns true", async () => {
+    const supabase = sessionClient({ data: true, error: null });
+
+    await expect(
+      canAccessInvoicePdf({
+        supabase,
+        authUserId: "portal-user",
+        shopId: "shop-a",
+        customerId: "customer-a",
+      }),
+    ).resolves.toBe(true);
+
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      "profixiq_is_portal_customer_for",
+      {
+        p_customer_id: "customer-a",
+        p_shop_id: "shop-a",
+      },
+    );
+  });
+
+  it("denies missing or revoked portal membership", async () => {
+    const supabase = sessionClient({ data: false, error: null });
+
+    await expect(
+      canAccessInvoicePdf({
+        supabase,
+        authUserId: "portal-user",
+        shopId: "shop-a",
+        customerId: "customer-a",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("fails closed when the portal-membership RPC errors", async () => {
+    const supabase = sessionClient({
+      data: null,
+      error: { message: "database unavailable" },
+    });
+
+    await expect(
+      canAccessInvoicePdf({
+        supabase,
+        authUserId: "portal-user",
+        shopId: "shop-a",
+        customerId: "customer-a",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("fails closed without a customer relationship", async () => {
+    const supabase = sessionClient({ data: true, error: null });
+
+    await expect(
+      canAccessInvoicePdf({
+        supabase,
+        authUserId: "portal-user",
+        shopId: "shop-a",
+        customerId: null,
+      }),
+    ).resolves.toBe(false);
+
+    expect(supabase.rpc).not.toHaveBeenCalled();
   });
 
   it("gates service-role invoice-version rendering before financial data is returned", () => {
     expect(versionRoute).toContain("canAccessInvoicePdf");
     expect(versionRoute).toContain("customerId: workOrder?.customer_id ?? null");
-    expect(versionRoute).toContain('NextResponse.json({ error: "Forbidden" }, { status: 403 })');
+    expect(versionRoute).toContain(
+      'NextResponse.json({ error: "Forbidden" }, { status: 403 })',
+    );
     expect(versionRoute).not.toContain('select("user_id")');
     expect(versionRoute).not.toContain("customer?.user_id === user.id");
   });
@@ -49,6 +198,8 @@ describe("invoice PDF authorization", () => {
     );
     expect(workOrderRoute).toContain("canAccessInvoicePdf");
     expect(workOrderRoute).toContain("customerId: workOrder.customer_id");
-    expect(workOrderRoute).toContain('NextResponse.json({ error: "Forbidden" }, { status: 403 })');
+    expect(workOrderRoute).toContain(
+      'NextResponse.json({ error: "Forbidden" }, { status: 403 })',
+    );
   });
 });

--- a/tests/invoice-pdf-authorization.test.ts
+++ b/tests/invoice-pdf-authorization.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { ROLE_GROUPS } from "@/features/shared/lib/rbac";
 
 const read = (path: string) => readFileSync(path, "utf8");
 
@@ -11,6 +12,15 @@ const workOrderRoute = read("app/api/work-orders/[id]/invoice-pdf/route.ts");
 
 describe("invoice PDF authorization", () => {
   it("limits staff PDF access to the canonical billing roles", () => {
+    expect(ROLE_GROUPS.billingOperators).toEqual([
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "service",
+    ]);
+    expect(ROLE_GROUPS.billingOperators).not.toContain("mechanic");
+    expect(ROLE_GROUPS.billingOperators).not.toContain("parts");
     expect(authorization).toContain("ROLE_GROUPS.billingOperators");
     expect(authorization).toContain("resolveAuthenticatedStaffProfile");
     expect(authorization).toContain("profile?.shop_id === input.shopId");

--- a/tests/invoice-pdf-authorization.test.ts
+++ b/tests/invoice-pdf-authorization.test.ts
@@ -69,7 +69,7 @@ describe("invoice PDF authorization", () => {
     expect(ROLE_GROUPS.billingOperators).not.toContain("parts");
   });
 
-  it("allows a same-shop billing operator without consulting portal membership", async () => {
+  it("allows a same-shop billing operator to render a working draft without consulting portal membership", async () => {
     mocks.resolveAuthenticatedStaffProfile.mockResolvedValue(
       staffProfile("owner", "shop-a"),
     );
@@ -81,6 +81,7 @@ describe("invoice PDF authorization", () => {
         authUserId: "user-1",
         shopId: "shop-a",
         customerId: null,
+        customerVisibleDocument: false,
       }),
     ).resolves.toBe(true);
 
@@ -99,6 +100,7 @@ describe("invoice PDF authorization", () => {
         authUserId: "user-1",
         shopId: "shop-a",
         customerId: null,
+        customerVisibleDocument: true,
       }),
     ).resolves.toBe(false);
 
@@ -117,13 +119,14 @@ describe("invoice PDF authorization", () => {
         authUserId: "user-1",
         shopId: "shop-a",
         customerId: null,
+        customerVisibleDocument: true,
       }),
     ).resolves.toBe(false);
 
     expect(client.rpc).not.toHaveBeenCalled();
   });
 
-  it("allows an authenticated portal customer only when the canonical membership predicate returns true", async () => {
+  it("allows an authenticated portal customer only for a customer-visible document with durable membership", async () => {
     const client = sessionClient({ data: true, error: null });
 
     await expect(
@@ -132,6 +135,7 @@ describe("invoice PDF authorization", () => {
         authUserId: "portal-user",
         shopId: "shop-a",
         customerId: "customer-a",
+        customerVisibleDocument: true,
       }),
     ).resolves.toBe(true);
 
@@ -144,6 +148,22 @@ describe("invoice PDF authorization", () => {
     );
   });
 
+  it("denies a portal customer a draft before consulting otherwise-valid membership", async () => {
+    const client = sessionClient({ data: true, error: null });
+
+    await expect(
+      canAccessInvoicePdf({
+        supabase: client.supabase,
+        authUserId: "portal-user",
+        shopId: "shop-a",
+        customerId: "customer-a",
+        customerVisibleDocument: false,
+      }),
+    ).resolves.toBe(false);
+
+    expect(client.rpc).not.toHaveBeenCalled();
+  });
+
   it("denies missing or revoked portal membership", async () => {
     const client = sessionClient({ data: false, error: null });
 
@@ -153,6 +173,7 @@ describe("invoice PDF authorization", () => {
         authUserId: "portal-user",
         shopId: "shop-a",
         customerId: "customer-a",
+        customerVisibleDocument: true,
       }),
     ).resolves.toBe(false);
   });
@@ -169,6 +190,7 @@ describe("invoice PDF authorization", () => {
         authUserId: "portal-user",
         shopId: "shop-a",
         customerId: "customer-a",
+        customerVisibleDocument: true,
       }),
     ).resolves.toBe(false);
   });
@@ -182,15 +204,18 @@ describe("invoice PDF authorization", () => {
         authUserId: "portal-user",
         shopId: "shop-a",
         customerId: null,
+        customerVisibleDocument: true,
       }),
     ).resolves.toBe(false);
 
     expect(client.rpc).not.toHaveBeenCalled();
   });
 
-  it("gates service-role invoice-version rendering before financial data is returned", () => {
+  it("gates service-role invoice-version rendering on customer-visible lifecycle", () => {
     expect(versionRoute).toContain("canAccessInvoicePdf");
     expect(versionRoute).toContain("customerId: workOrder?.customer_id ?? null");
+    expect(versionRoute).toContain("CUSTOMER_VISIBLE_INVOICE_STATES.includes(");
+    expect(versionRoute).toContain("version.lifecycle_status");
     expect(versionRoute).toContain(
       'NextResponse.json({ error: "Forbidden" }, { status: 403 })',
     );
@@ -198,12 +223,14 @@ describe("invoice PDF authorization", () => {
     expect(versionRoute).not.toContain("customer?.user_id === user.id");
   });
 
-  it("adds the same financial gate to work-order invoice PDFs", () => {
+  it("requires an issued active version before portal access to work-order invoice PDFs", () => {
     expect(workOrderRoute).toContain(
       '.select("id,shop_id,custom_id,customer_id")',
     );
+    expect(workOrderRoute).toContain("const activeVersion = await getActiveInvoiceVersion");
     expect(workOrderRoute).toContain("canAccessInvoicePdf");
     expect(workOrderRoute).toContain("customerId: workOrder.customer_id");
+    expect(workOrderRoute).toContain("customerVisibleDocument: activeVersion !== null");
     expect(workOrderRoute).toContain(
       'NextResponse.json({ error: "Forbidden" }, { status: 403 })',
     );

--- a/tests/invoice-pdf-authorization.test.ts
+++ b/tests/invoice-pdf-authorization.test.ts
@@ -23,10 +23,16 @@ type RpcResult = {
   error: { message: string } | null;
 };
 
+type InvoicePdfSupabase = Parameters<
+  typeof canAccessInvoicePdf
+>[0]["supabase"];
+
 function sessionClient(rpcResult: RpcResult = { data: false, error: null }) {
+  const rpc = vi.fn().mockResolvedValue(rpcResult);
   return {
-    rpc: vi.fn().mockResolvedValue(rpcResult),
-  } as never;
+    supabase: { rpc } as unknown as InvoicePdfSupabase,
+    rpc,
+  };
 }
 
 function staffProfile(role: string, shopId: string | null) {
@@ -67,69 +73,69 @@ describe("invoice PDF authorization", () => {
     mocks.resolveAuthenticatedStaffProfile.mockResolvedValue(
       staffProfile("owner", "shop-a"),
     );
-    const supabase = sessionClient();
+    const client = sessionClient();
 
     await expect(
       canAccessInvoicePdf({
-        supabase,
+        supabase: client.supabase,
         authUserId: "user-1",
         shopId: "shop-a",
         customerId: null,
       }),
     ).resolves.toBe(true);
 
-    expect(supabase.rpc).not.toHaveBeenCalled();
+    expect(client.rpc).not.toHaveBeenCalled();
   });
 
   it("denies same-shop non-billing staff", async () => {
     mocks.resolveAuthenticatedStaffProfile.mockResolvedValue(
       staffProfile("mechanic", "shop-a"),
     );
-    const supabase = sessionClient();
+    const client = sessionClient();
 
     await expect(
       canAccessInvoicePdf({
-        supabase,
+        supabase: client.supabase,
         authUserId: "user-1",
         shopId: "shop-a",
         customerId: null,
       }),
     ).resolves.toBe(false);
 
-    expect(supabase.rpc).not.toHaveBeenCalled();
+    expect(client.rpc).not.toHaveBeenCalled();
   });
 
   it("denies a billing operator from a different shop", async () => {
     mocks.resolveAuthenticatedStaffProfile.mockResolvedValue(
       staffProfile("owner", "shop-b"),
     );
-    const supabase = sessionClient();
+    const client = sessionClient();
 
     await expect(
       canAccessInvoicePdf({
-        supabase,
+        supabase: client.supabase,
         authUserId: "user-1",
         shopId: "shop-a",
         customerId: null,
       }),
     ).resolves.toBe(false);
 
-    expect(supabase.rpc).not.toHaveBeenCalled();
+    expect(client.rpc).not.toHaveBeenCalled();
   });
 
   it("allows an authenticated portal customer only when the canonical membership predicate returns true", async () => {
-    const supabase = sessionClient({ data: true, error: null });
+    const client = sessionClient({ data: true, error: null });
 
     await expect(
       canAccessInvoicePdf({
-        supabase,
+        supabase: client.supabase,
         authUserId: "portal-user",
         shopId: "shop-a",
         customerId: "customer-a",
       }),
     ).resolves.toBe(true);
 
-    expect(supabase.rpc).toHaveBeenCalledWith(
+    expect(client.rpc).toHaveBeenCalledWith(
       "profixiq_is_portal_customer_for",
       {
         p_customer_id: "customer-a",
@@ -139,11 +145,11 @@ describe("invoice PDF authorization", () => {
   });
 
   it("denies missing or revoked portal membership", async () => {
-    const supabase = sessionClient({ data: false, error: null });
+    const client = sessionClient({ data: false, error: null });
 
     await expect(
       canAccessInvoicePdf({
-        supabase,
+        supabase: client.supabase,
         authUserId: "portal-user",
         shopId: "shop-a",
         customerId: "customer-a",
@@ -152,14 +158,14 @@ describe("invoice PDF authorization", () => {
   });
 
   it("fails closed when the portal-membership RPC errors", async () => {
-    const supabase = sessionClient({
+    const client = sessionClient({
       data: null,
       error: { message: "database unavailable" },
     });
 
     await expect(
       canAccessInvoicePdf({
-        supabase,
+        supabase: client.supabase,
         authUserId: "portal-user",
         shopId: "shop-a",
         customerId: "customer-a",
@@ -168,18 +174,18 @@ describe("invoice PDF authorization", () => {
   });
 
   it("fails closed without a customer relationship", async () => {
-    const supabase = sessionClient({ data: true, error: null });
+    const client = sessionClient({ data: true, error: null });
 
     await expect(
       canAccessInvoicePdf({
-        supabase,
+        supabase: client.supabase,
         authUserId: "portal-user",
         shopId: "shop-a",
         customerId: null,
       }),
     ).resolves.toBe(false);
 
-    expect(supabase.rpc).not.toHaveBeenCalled();
+    expect(client.rpc).not.toHaveBeenCalled();
   });
 
   it("gates service-role invoice-version rendering before financial data is returned", () => {

--- a/tests/invoice-pdf-authorization.test.ts
+++ b/tests/invoice-pdf-authorization.test.ts
@@ -211,11 +211,12 @@ describe("invoice PDF authorization", () => {
     expect(client.rpc).not.toHaveBeenCalled();
   });
 
-  it("gates service-role invoice-version rendering on customer-visible lifecycle", () => {
+  it("gates service-role invoice-version rendering on customer-visible lifecycle and work-order identity", () => {
     expect(versionRoute).toContain("canAccessInvoicePdf");
     expect(versionRoute).toContain("customerId: workOrder?.customer_id ?? null");
     expect(versionRoute).toContain("CUSTOMER_VISIBLE_INVOICE_STATES.includes(");
     expect(versionRoute).toContain("version.lifecycle_status");
+    expect(versionRoute).toContain('.eq("work_order_id", version.work_order_id)');
     expect(versionRoute).toContain(
       'NextResponse.json({ error: "Forbidden" }, { status: 403 })',
     );
@@ -231,6 +232,7 @@ describe("invoice PDF authorization", () => {
     expect(workOrderRoute).toContain("canAccessInvoicePdf");
     expect(workOrderRoute).toContain("customerId: workOrder.customer_id");
     expect(workOrderRoute).toContain("customerVisibleDocument: activeVersion !== null");
+    expect(workOrderRoute).toContain('.eq("work_order_id", workOrderId)');
     expect(workOrderRoute).toContain(
       'NextResponse.json({ error: "Forbidden" }, { status: 403 })',
     );

--- a/tests/invoice-pdf-authorization.test.ts
+++ b/tests/invoice-pdf-authorization.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const authorization = read(
+  "features/invoices/server/authorizeInvoicePdfAccess.ts",
+);
+const versionRoute = read("app/api/invoice-versions/[id]/pdf/route.ts");
+const workOrderRoute = read("app/api/work-orders/[id]/invoice-pdf/route.ts");
+
+describe("invoice PDF authorization", () => {
+  it("limits staff PDF access to the canonical billing roles", () => {
+    expect(authorization).toContain("ROLE_GROUPS.billingOperators");
+    expect(authorization).toContain("resolveAuthenticatedStaffProfile");
+    expect(authorization).toContain("profile?.shop_id === input.shopId");
+    expect(authorization).toContain("actor.isKnownRole");
+    expect(authorization).toContain("BILLING_ROLES.has(actor.canonicalRole)");
+  });
+
+  it("requires durable portal membership for customer PDF access", () => {
+    expect(authorization).toContain('"profixiq_is_portal_customer_for"');
+    expect(authorization).toContain("p_customer_id: input.customerId");
+    expect(authorization).toContain("p_shop_id: input.shopId");
+    expect(authorization).toContain("!portalAccessError && portalAccess === true");
+  });
+
+  it("gates service-role invoice-version rendering before financial data is returned", () => {
+    expect(versionRoute).toContain("canAccessInvoicePdf");
+    expect(versionRoute).toContain("customerId: workOrder?.customer_id ?? null");
+    expect(versionRoute).toContain('NextResponse.json({ error: "Forbidden" }, { status: 403 })');
+    expect(versionRoute).not.toContain('select("user_id")');
+    expect(versionRoute).not.toContain("customer?.user_id === user.id");
+  });
+
+  it("adds the same financial gate to work-order invoice PDFs", () => {
+    expect(workOrderRoute).toContain(
+      '.select("id,shop_id,custom_id,customer_id")',
+    );
+    expect(workOrderRoute).toContain("canAccessInvoicePdf");
+    expect(workOrderRoute).toContain("customerId: workOrder.customer_id");
+    expect(workOrderRoute).toContain('NextResponse.json({ error: "Forbidden" }, { status: 403 })');
+  });
+});

--- a/tests/operational-observability-ui-alerts.test.ts
+++ b/tests/operational-observability-ui-alerts.test.ts
@@ -100,9 +100,10 @@ describe("operational observability UI and alerting", () => {
     expect(healthRoute).toContain("operationalHealth:");
   });
 
-  it("schedules the internal health check without enabling branch deployments", () => {
+  it("schedules the internal health check while retaining approved preview deployments", () => {
     const parsed = JSON.parse(cronConfig) as {
       crons: Array<{ path: string; schedule: string }>;
+      ignoreCommand?: string;
       git: { deploymentEnabled: Record<string, boolean> };
     };
 
@@ -110,6 +111,10 @@ describe("operational observability UI and alerting", () => {
       path: "/api/internal/observability/health",
       schedule: "7 * * * *",
     });
+    expect(parsed.ignoreCommand).toBe("exit 1");
+    expect(parsed.git.deploymentEnabled.main).toBe(true);
+    expect(parsed.git.deploymentEnabled["agent/*"]).toBe(true);
+    expect(parsed.git.deploymentEnabled["codex/*"]).toBe(true);
     expect(parsed.git.deploymentEnabled["*"]).toBe(false);
   });
 });

--- a/tests/operational-observability-ui-alerts.test.ts
+++ b/tests/operational-observability-ui-alerts.test.ts
@@ -100,7 +100,7 @@ describe("operational observability UI and alerting", () => {
     expect(healthRoute).toContain("operationalHealth:");
   });
 
-  it("schedules the internal health check while retaining approved preview deployments", () => {
+  it("schedules the internal health check while disabling preview deployments", () => {
     const parsed = JSON.parse(cronConfig) as {
       crons: Array<{ path: string; schedule: string }>;
       ignoreCommand?: string;
@@ -111,10 +111,10 @@ describe("operational observability UI and alerting", () => {
       path: "/api/internal/observability/health",
       schedule: "7 * * * *",
     });
-    expect(parsed.ignoreCommand).toBe("exit 1");
+    expect(parsed.ignoreCommand).toBeUndefined();
     expect(parsed.git.deploymentEnabled.main).toBe(true);
-    expect(parsed.git.deploymentEnabled["agent/*"]).toBe(true);
-    expect(parsed.git.deploymentEnabled["codex/*"]).toBe(true);
     expect(parsed.git.deploymentEnabled["*"]).toBe(false);
+    expect(parsed.git.deploymentEnabled["agent/*"]).toBeUndefined();
+    expect(parsed.git.deploymentEnabled["codex/*"]).toBeUndefined();
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -29,12 +29,9 @@
       "schedule": "*/5 * * * *"
     }
   ],
-  "ignoreCommand": "exit 1",
   "git": {
     "deploymentEnabled": {
       "main": true,
-      "agent/*": true,
-      "codex/*": true,
       "*": false
     }
   }

--- a/vercel.json
+++ b/vercel.json
@@ -29,9 +29,12 @@
       "schedule": "*/5 * * * *"
     }
   ],
+  "ignoreCommand": "exit 1",
   "git": {
     "deploymentEnabled": {
       "main": true,
+      "agent/*": true,
+      "codex/*": true,
       "*": false
     }
   }


### PR DESCRIPTION
Production-hardening authorization fix for invoice PDF routes.

## What this closes
- `/api/invoice-versions/[id]/pdf` previously loaded invoice data through a service-role client and then allowed any same-shop profile, regardless of financial role.
- that route also treated `customers.user_id = auth.uid()` as sufficient customer authorization, bypassing accepted/non-revoked portal membership.
- `/api/work-orders/[id]/invoice-pdf` relied on work-order visibility but had no explicit financial authorization boundary, so an assigned floor role could reach invoice rendering through a visible work order.
- a valid portal member could still reach a mutable draft PDF because portal membership alone did not distinguish staff-only drafts from customer-visible issued/final documents.
- invoice metadata lookups were shop-scoped but not explicitly re-anchored to the authorized work order.

## Fix
- centralize invoice PDF authorization in `canAccessInvoicePdf`
- same-shop staff access requires the canonical `billingOperators` capability boundary
- customer access requires `profixiq_is_portal_customer_for(customer_id, shop_id)`
- customer access additionally requires a customer-visible invoice lifecycle; staff billing operators may still render working drafts
- the invoice-version route derives portal visibility from `CUSTOMER_VISIBLE_INVOICE_STATES`
- the work-order route requires an issued/active invoice version before a portal customer can pass the gate; only billing staff can fall back to the draft snapshot
- invoice metadata queries are anchored to the same work order as the authorized version/request
- both routes fail closed with 403 before rendering when authorization is denied

## Regression coverage
`tests/invoice-pdf-authorization.test.ts` executes the real authorization helper with mocked authenticated staff resolution and Supabase RPC responses. It proves same-shop billing allow, non-billing/wrong-shop denial, portal allow only for customer-visible documents, portal draft denial even with otherwise-valid membership, revoked/missing membership denial, RPC-error denial, and absent-customer denial. Route assertions also lock the lifecycle and work-order metadata anchors.

## Safety
No database migration, production deployment, billing mutation, secret change, or customer-facing action is included. Existing billing-operator draft access is preserved; customer access remains supported through the canonical portal membership contract for issued/customer-visible documents.

## Validation
- Agent PR Checks: typecheck, changed-file lint, complete test suite, production build, regression inventory
- Vercel preview deployments intentionally disabled; the exact-head GitHub production build validates compilation
- Supabase portal membership/revocation behavior is independently exercised by PR #1482's financial RLS runtime tests
