### PR TITLE
Fix Vehicle Workspace authority and presentation

### DIFF
--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -21,6 +21,10 @@ import {
   CustomerDuplicateReviewError,
   type CustomerDuplicateCandidate,
 } from "@/features/customers/lib/customerAccountCommands";
+import {
+  customerServiceHistoryPresentation,
+  formatOdometer,
+} from "@/features/customers/lib/customerServiceHistory";
 import { ImportedHistoryRecordCard } from "@/features/work-orders/components/ImportedHistoryRecordCard";
 import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
@@ -55,7 +59,13 @@ type ImportedHistory = Pick<
 > & {
   vehicles: Pick<
     Vehicle,
-    "year" | "make" | "model" | "vin" | "license_plate" | "unit_number"
+    | "year"
+    | "make"
+    | "model"
+    | "vin"
+    | "license_plate"
+    | "unit_number"
+    | "odometer_unit"
   > | null;
 };
 type VehicleMedia = DB["public"]["Tables"]["vehicle_media"]["Row"];
@@ -133,6 +143,14 @@ const STATUS_CHIP: Record<string, string> = {
   queued: "bg-indigo-900/35 border-indigo-400/40 text-indigo-100",
   in_progress: "bg-amber-900/30 border-amber-400/40 text-amber-100",
   on_hold: "bg-amber-900/35 border-amber-400/45 text-amber-100",
+  waiting_parts: "bg-amber-900/35 border-amber-400/45 text-amber-100",
+  waiting_for_parts: "bg-amber-900/35 border-amber-400/45 text-amber-100",
+  awaiting_approval: "bg-sky-900/35 border-sky-400/40 text-sky-100",
+  approved: "bg-emerald-900/30 border-emerald-400/40 text-emerald-100",
+  sent: "bg-sky-900/35 border-sky-400/40 text-sky-100",
+  partially_approved: "bg-amber-900/35 border-amber-400/45 text-amber-100",
+  cancelled: "bg-rose-900/30 border-rose-400/40 text-rose-100",
+  canceled: "bg-rose-900/30 border-rose-400/40 text-rose-100",
   completed: "bg-emerald-900/30 border-emerald-400/40 text-emerald-100",
   ready_to_invoice: "bg-emerald-900/30 border-emerald-400/40 text-emerald-100",
   invoiced: "bg-teal-900/30 border-teal-400/40 text-teal-100",
@@ -254,19 +272,6 @@ function compactDate(iso: string | null | undefined): string | null {
   return format(d, "MMM yyyy");
 }
 
-function formatNumberLike(
-  value: string | number | null | undefined,
-): string | null {
-  if (value == null) return null;
-  const raw = String(value).trim();
-  if (!raw) return null;
-  const numeric = Number(raw.replace(/,/g, ""));
-  if (!Number.isFinite(numeric)) return raw;
-  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(
-    numeric,
-  );
-}
-
 function formatEngineFuel(vehicle: Vehicle): string | null {
   return (
     [strOrNull(vehicle.engine), strOrNull(vehicle.fuel_type)]
@@ -289,16 +294,6 @@ function formatVehicleStatus(value: string | null | undefined): string | null {
   return clean
     .replace(/_/g, " ")
     .replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-function formatOdometer(
-  value: string | number | null | undefined,
-  unit: string | null | undefined,
-): string | null {
-  const formatted = formatNumberLike(value);
-  if (!formatted) return null;
-  const cleanUnit = strOrNull(unit);
-  return cleanUnit ? `${formatted} ${cleanUnit}` : formatted;
 }
 
 function formatPlateWithRegion(
@@ -808,7 +803,7 @@ export default function CustomerProfilePage(): JSX.Element {
         const { data: historyRows, error: historyErr } = await supabase
           .from("history")
           .select(
-            "id,customer_id,vehicle_id,work_order_id,service_date,description,notes,created_at,work_order_number,invoice_number,odometer,symptom,cause,correction,labor_hours,labor_sale,total,imported_from_session_id,source_system,vehicles:vehicles(year,make,model,vin,license_plate,unit_number)",
+            "id,customer_id,vehicle_id,work_order_id,service_date,description,notes,created_at,work_order_number,invoice_number,odometer,symptom,cause,correction,labor_hours,labor_sale,total,imported_from_session_id,source_system,vehicles:vehicles(year,make,model,vin,license_plate,unit_number,odometer_unit)",
           )
           .eq("customer_id", customerId)
           .order("service_date", { ascending: false });
@@ -2522,7 +2517,10 @@ export default function CustomerProfilePage(): JSX.Element {
                                               ? `Invoice ${row.invoice_number}`
                                               : null,
                                             row.odometer != null
-                                              ? `${formatNumberLike(row.odometer)} mi`
+                                              ? formatOdometer(
+                                                  row.odometer,
+                                                  row.vehicles?.odometer_unit,
+                                                )
                                               : null,
                                           ]
                                             .filter(Boolean)
@@ -2596,22 +2594,8 @@ export default function CustomerProfilePage(): JSX.Element {
                   {serviceHistorySlice.map((entry) => {
                     if (entry.kind === "work_order") {
                       const wo = entry.workOrder;
-                      const status = String(
-                        ((wo as unknown as Record<string, unknown>)[
-                          "status"
-                        ] as string | null) ?? "awaiting",
-                      );
-                      const normalizedStatus = status.toLowerCase();
-                      const lifecycleLabel =
-                        normalizedStatus.includes("complete") ||
-                        normalizedStatus.includes("invoice")
-                          ? "Completed"
-                          : normalizedStatus.includes("progress")
-                            ? "In progress"
-                            : "Active";
-                      const customId = (
-                        wo as unknown as Record<string, unknown>
-                      )["custom_id"] as string | undefined;
+                      const presentation =
+                        customerServiceHistoryPresentation(wo);
                       const vehicle = entry.vehicle;
                       const vehicleLabel = vehicle
                         ? fmtVehicleLabel(vehicle)
@@ -2621,16 +2605,18 @@ export default function CustomerProfilePage(): JSX.Element {
                         <button
                           key={`wo-${wo.id}`}
                           type="button"
-                          onClick={() => router.push(`/work-orders/${wo.id}`)}
+                          onClick={() => router.push(presentation.href)}
                           className={`${CARD_INNER} w-full p-3 text-left hover:border-[var(--accent-copper-soft)]/65`}
-                          title="Open work order"
+                          title={
+                            presentation.lifecycleLabel === "Estimate"
+                              ? "Open estimate"
+                              : "Open work order"
+                          }
                         >
                           <div className="flex flex-wrap items-start justify-between gap-3">
                             <div className="min-w-0">
                               <div className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                                {customId
-                                  ? `WO ${customId}`
-                                  : `WO #${wo.id.slice(0, 8)}`}
+                                {presentation.title}
                               </div>
                               <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-secondary)]">
                                 {safeDate(wo.created_at)}
@@ -2639,11 +2625,11 @@ export default function CustomerProfilePage(): JSX.Element {
                             </div>
 
                             <div className="flex flex-wrap items-center gap-2">
-                              <span className={chipClass(status)}>
-                                {lifecycleLabel}
+                              <span className={chipClass(presentation.statusKey)}>
+                                {presentation.lifecycleLabel}
                               </span>
                               <span className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
-                                {status.replaceAll("_", " ")}
+                                {presentation.statusLabel}
                               </span>
                             </div>
                           </div>

--- a/features/customers/lib/customerServiceHistory.ts
+++ b/features/customers/lib/customerServiceHistory.ts
@@ -1,0 +1,88 @@
+import {
+  formatOperationalLabel,
+  isEstimateRecord,
+  normalizeWorkOrderStatus,
+} from "@/features/work-orders/lib/work-order-status";
+
+type CustomerServiceHistoryRecord = {
+  id: string;
+  custom_id?: string | null;
+  status?: string | null;
+  record_type?: string | null;
+  estimate_number?: string | null;
+  estimate_status?: string | null;
+};
+
+const ODOMETER_NUMBER_FORMATTER = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+});
+
+export type CustomerServiceHistoryPresentation = {
+  href: string;
+  lifecycleLabel: "Active" | "Closed" | "Completed" | "Estimate" | "In progress";
+  statusKey: string;
+  statusLabel: string;
+  title: string;
+};
+
+export function formatOdometer(
+  value: string | number | null | undefined,
+  unit: string | null | undefined,
+): string | null {
+  if (value == null) return null;
+  const raw = String(value).trim();
+  if (!raw) return null;
+  const numeric = Number(raw.replace(/,/g, ""));
+  const formatted = Number.isFinite(numeric)
+    ? ODOMETER_NUMBER_FORMATTER.format(numeric)
+    : raw;
+  const cleanUnit = String(unit ?? "").trim();
+  return cleanUnit ? `${formatted} ${cleanUnit}` : formatted;
+}
+
+function normalizedStatusKey(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_") || "new";
+}
+
+function workOrderTitle(record: CustomerServiceHistoryRecord): string {
+  const customId = record.custom_id?.trim();
+  return customId
+    ? `WO-${customId.replace(/^wo-?/i, "")}`
+    : `WO ${record.id.slice(0, 8)}`;
+}
+
+export function customerServiceHistoryPresentation(
+  record: CustomerServiceHistoryRecord,
+): CustomerServiceHistoryPresentation {
+  const isEstimate = isEstimateRecord(record);
+  const statusValue = isEstimate
+    ? record.estimate_status ?? record.status
+    : record.status;
+  const statusKey = normalizedStatusKey(statusValue);
+  const canonicalStatus = normalizeWorkOrderStatus(record.status);
+
+  const lifecycleLabel = isEstimate
+    ? "Estimate"
+    : canonicalStatus === "cancelled"
+      ? "Closed"
+      : canonicalStatus === "completed" || canonicalStatus === "invoiced"
+        ? "Completed"
+        : canonicalStatus === "in_progress"
+          ? "In progress"
+          : "Active";
+
+  return {
+    href: isEstimate ? `/estimates/${record.id}` : `/work-orders/${record.id}`,
+    lifecycleLabel,
+    statusKey,
+    statusLabel: formatOperationalLabel(statusValue),
+    title: isEstimate
+      ? record.estimate_number?.trim()
+        ? `Estimate ${record.estimate_number.trim()}`
+        : `Estimate ${record.id.slice(0, 8)}`
+      : workOrderTitle(record),
+  };
+}

--- a/features/vehicles/components/VehicleWorkspace.tsx
+++ b/features/vehicles/components/VehicleWorkspace.tsx
@@ -602,7 +602,7 @@ export function VehicleWorkspace({
           <ul className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             {snapshot.attentionItems.map((item) => (
               <AttentionCard
-                key={`${item.reference.sourceType}:${item.reference.sourceId}:${item.kind}`}
+                key={`${item.reference.sourceType}:${item.reference.sourceId}:${item.kind}:${item.title}:${item.explanation}:${item.occurredAt ?? ""}`}
                 item={item}
                 canOpen={canOpenReference(item.reference, snapshot.permissions)}
               />

--- a/features/vehicles/server/loadVehicleWorkspaceSnapshot.ts
+++ b/features/vehicles/server/loadVehicleWorkspaceSnapshot.ts
@@ -4,7 +4,11 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 import type { Database, Json } from "@shared/types/types/supabase";
 import type { CanonicalRole } from "@/features/shared/lib/rbac";
-import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
+import {
+  formatOperationalLabel,
+  isEstimateRecord,
+  normalizeWorkOrderStatus,
+} from "@/features/work-orders/lib/work-order-status";
 import type { MaintenanceSuggestionItem } from "@/features/maintenance/server/types";
 import {
   createWorkOrderHandoffHref,
@@ -301,6 +305,61 @@ const TERMINAL_LINE_STATES = new Set([
   "ready_to_invoice",
   "voided",
 ]);
+const QUERY_PAGE_SIZE = 500;
+const WORK_ORDER_ID_CHUNK_SIZE = 100;
+const MAX_QUERY_PAGES = 100;
+const UPCOMING_APPOINTMENT_LIMIT = 40;
+
+type QueryPage<T> = {
+  data: T[] | null;
+  error: { message: string } | null;
+};
+
+async function collectAllPages<T>(
+  context: string,
+  loadPage: (from: number, to: number) => Promise<QueryPage<T>>,
+): Promise<T[]> {
+  const rows: T[] = [];
+
+  for (let page = 0; page < MAX_QUERY_PAGES; page += 1) {
+    const from = page * QUERY_PAGE_SIZE;
+    const result = await loadPage(from, from + QUERY_PAGE_SIZE - 1);
+    throwQueryError(result.error, context);
+    const pageRows = result.data ?? [];
+    rows.push(...pageRows);
+    if (pageRows.length < QUERY_PAGE_SIZE) return rows;
+  }
+
+  throw new Error(`${context}: query exceeded the safe pagination limit`);
+}
+
+function chunkWorkOrderIds(ids: readonly string[]): string[][] {
+  const chunks: string[][] = [];
+  for (let index = 0; index < ids.length; index += WORK_ORDER_ID_CHUNK_SIZE) {
+    chunks.push(ids.slice(index, index + WORK_ORDER_ID_CHUNK_SIZE));
+  }
+  return chunks;
+}
+
+async function collectWorkOrderScopedRows<T>(
+  context: string,
+  workOrderIds: readonly string[],
+  loadPage: (
+    ids: string[],
+    from: number,
+    to: number,
+  ) => Promise<QueryPage<T>>,
+): Promise<T[]> {
+  const rows: T[] = [];
+  for (const ids of chunkWorkOrderIds(workOrderIds)) {
+    rows.push(
+      ...(await collectAllPages(context, (from, to) =>
+        loadPage(ids, from, to),
+      )),
+    );
+  }
+  return rows;
+}
 
 function text(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
@@ -320,7 +379,7 @@ function quoteLineIsDeferred(row: WorkspaceQuoteLineRow): boolean {
 }
 
 function workOrderIsEstimate(row: WorkspaceWorkOrderRow): boolean {
-  return row.record_type === "estimate" || Boolean(row.estimate_number);
+  return isEstimateRecord(row);
 }
 
 function estimateIsActionable(row: WorkspaceWorkOrderRow): boolean {
@@ -354,10 +413,14 @@ function latestWorkOrderOdometer(
     )
     .sort(
       (a, b) =>
-        new Date(dateValue(b.updated_at, b.created_at)).getTime() -
-        new Date(dateValue(a.updated_at, a.created_at)).getTime(),
+        workOrderServiceTime(b) - workOrderServiceTime(a),
     )[0];
   return newestReading?.odometer_km ?? null;
+}
+
+function workOrderServiceTime(row: WorkspaceWorkOrderRow): number {
+  const value = Date.parse(row.scheduled_at ?? row.created_at ?? "");
+  return Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
 }
 
 function workspaceVehicleIdentity(
@@ -553,6 +616,7 @@ function buildAttentionItems(input: {
   maintenance: MaintenanceSuggestionRow[];
 }): VehicleAttentionItem[] {
   const items: VehicleAttentionItem[] = [];
+  const representedMaintenanceServices = new Set<string>();
   const representedLineIds = new Set(
     input.quoteLines
       .filter(quoteLineIsDeferred)
@@ -653,13 +717,17 @@ function buildAttentionItems(input: {
   for (const suggestionRow of input.maintenance) {
     const workOrder = input.workOrdersById.get(suggestionRow.work_order_id);
     for (const suggestion of maintenanceItems(suggestionRow)) {
+      const maintenanceKey = normalizedOperationalState(
+        suggestion.serviceCode || suggestion.label,
+      );
+      if (representedMaintenanceServices.has(maintenanceKey)) continue;
+      representedMaintenanceServices.add(maintenanceKey);
       items.push({
         kind: "maintenance_due",
         title: suggestion.label,
         explanation: [
           suggestion.whyDue,
           workOrder ? `evaluated for ${workOrderLabel(workOrder)}` : null,
-          suggestion.serviceCode ? `service ${suggestion.serviceCode}` : null,
         ]
           .filter(Boolean)
           .join(" · "),
@@ -708,7 +776,16 @@ function buildTimeline(input: {
             : `Estimate ${row.id.slice(0, 8)}`
           : workOrderLabel(row),
       detail:
-        [isEstimate ? row.estimate_status : row.status, odometer]
+        [
+          isEstimate
+            ? row.estimate_status
+              ? formatOperationalLabel(row.estimate_status)
+              : null
+            : row.status
+              ? formatOperationalLabel(row.status)
+              : null,
+          odometer,
+        ]
           .filter(Boolean)
           .join(" · ") || null,
       occurredAt: dateValue(row.updated_at, row.created_at),
@@ -720,7 +797,10 @@ function buildTimeline(input: {
     events.push({
       kind: "appointment",
       title: "Appointment",
-      detail: [row.status, text(row.notes)].filter(Boolean).join(" · ") || null,
+      detail:
+        [row.status ? formatOperationalLabel(row.status) : null, text(row.notes)]
+          .filter(Boolean)
+          .join(" · ") || null,
       occurredAt: row.starts_at,
       reference: {
         sourceType: "appointment",
@@ -735,7 +815,7 @@ function buildTimeline(input: {
     events.push({
       kind: "inspection",
       title: inspectionReference(row).sourceLabel,
-      detail: row.status,
+      detail: row.status ? formatOperationalLabel(row.status) : null,
       occurredAt: dateValue(row.finalized_at, row.updated_at, row.started_at, row.created_at),
       reference: inspectionReference(row),
     });
@@ -747,7 +827,7 @@ function buildTimeline(input: {
     events.push({
       kind: "repair",
       title: text(row.description) ?? text(row.correction) ?? "Repair completed",
-      detail: status.replaceAll("_", " "),
+      detail: formatOperationalLabel(status),
       occurredAt: dateValue(row.updated_at, row.created_at),
       reference: lineReference(row),
     });
@@ -784,7 +864,7 @@ function buildTimeline(input: {
       kind: "approval",
       title:
         text(row.title) ?? text(row.description) ?? "Estimate item decision",
-      detail: `Decision: ${decision.replaceAll("_", " ")}`,
+      detail: `Decision: ${formatOperationalLabel(decision)}`,
       occurredAt: dateValue(decisionAt, row.updated_at, row.created_at),
       reference: quoteLineReference(row),
     });
@@ -818,7 +898,7 @@ function buildTimeline(input: {
     events.push({
       kind: "invoice",
       title: row.invoice_number ? `Invoice ${row.invoice_number}` : `Invoice ${row.id.slice(0, 8)}`,
-      detail: row.status,
+      detail: row.status ? formatOperationalLabel(row.status) : null,
       occurredAt: dateValue(row.paid_at, row.issued_at, row.updated_at, row.created_at),
       reference: {
         sourceType: "invoice",
@@ -834,7 +914,7 @@ function buildTimeline(input: {
     events.push({
       kind: "payment",
       title: "Payment recorded",
-      detail: row.status,
+      detail: row.status ? formatOperationalLabel(row.status) : null,
       occurredAt: dateValue(row.paid_at, row.created_at),
       reference: {
         sourceType: "payment",
@@ -889,6 +969,7 @@ function buildDocumentSummary(input: {
   vehicleMedia: WorkspaceVehicleMediaRow[];
   workOrderMedia: WorkspaceWorkOrderMediaRow[];
   inspections: WorkspaceInspectionRow[];
+  workOrdersById: Map<string, WorkspaceWorkOrderRow>;
 }): VehicleDocumentSummary {
   const reports = input.inspections.filter(
     (row) => Boolean(row.pdf_url || row.pdf_storage_path),
@@ -905,10 +986,11 @@ function buildDocumentSummary(input: {
       ? {
           sourceType: "work_order_media",
           sourceId: newestWorkOrderMedia.id,
-          sourceLabel:
-            text(newestWorkOrderMedia.file_name) ??
-            text(newestWorkOrderMedia.kind) ??
-            `Work-order file ${newestWorkOrderMedia.id.slice(0, 8)}`,
+          sourceLabel: `${formatOperationalLabel(newestWorkOrderMedia.kind || "attachment")} from ${
+            input.workOrdersById.has(newestWorkOrderMedia.work_order_id)
+              ? workOrderLabel(input.workOrdersById.get(newestWorkOrderMedia.work_order_id)!)
+              : "work order"
+          }`,
           href: `/work-orders/${newestWorkOrderMedia.work_order_id}`,
         }
       : reports[0]
@@ -995,6 +1077,107 @@ function buildConflicts(input: {
   return conflicts;
 }
 
+function latestCanonicalServiceWorkOrder(
+  workOrders: WorkspaceWorkOrderRow[],
+): WorkspaceWorkOrderRow | null {
+  return (
+    [...workOrders]
+      .filter((row) => {
+        if (workOrderIsEstimate(row)) return false;
+        const state = normalizedOperationalState(row.status);
+        return !["archived", "canceled", "cancelled", "void", "voided"].includes(
+          state,
+        );
+      })
+      .sort((a, b) => {
+        const timeDifference = workOrderServiceTime(b) - workOrderServiceTime(a);
+        return timeDifference === 0 ? b.id.localeCompare(a.id) : timeDifference;
+      })[0] ?? null
+  );
+}
+
+function maintenanceCacheIsFresh(input: {
+  cache: MaintenanceSuggestionRow;
+  workOrder: WorkspaceWorkOrderRow;
+  lines: WorkspaceWorkOrderLineRow[];
+}): boolean {
+  const cacheTime = Date.parse(input.cache.updated_at);
+  if (!Number.isFinite(cacheTime)) return false;
+
+  const sourceTimes = [
+    input.workOrder.updated_at,
+    input.workOrder.created_at,
+    ...input.lines
+      .filter((line) => line.work_order_id === input.workOrder.id)
+      .flatMap((line) => [line.updated_at, line.created_at]),
+  ]
+    .map((value) => Date.parse(value ?? ""))
+    .filter(Number.isFinite);
+
+  return sourceTimes.every((sourceTime) => cacheTime >= sourceTime);
+}
+
+async function loadVehicleBookings(input: {
+  supabase: SupabaseClient<Database>;
+  shopId: string;
+  vehicleId: string;
+  now: Date;
+}): Promise<WorkspaceBookingRow[]> {
+  const upcoming: WorkspaceBookingRow[] = [];
+  const appointmentPageSize = 100;
+  const nowIso = input.now.toISOString();
+
+  for (let page = 0; page < MAX_QUERY_PAGES; page += 1) {
+    const from = page * appointmentPageSize;
+    const result = await input.supabase
+      .from("bookings")
+      .select("id,work_order_id,starts_at,ends_at,status,notes,created_at")
+      .eq("shop_id", input.shopId)
+      .eq("vehicle_id", input.vehicleId)
+      .gte("ends_at", nowIso)
+      .order("starts_at", { ascending: true })
+      .order("id", { ascending: true })
+      .range(from, from + appointmentPageSize - 1);
+    throwQueryError(result.error, "Unable to load upcoming appointments");
+    const pageRows = (result.data ?? []) as WorkspaceBookingRow[];
+    for (const row of pageRows) {
+      if (
+        !TERMINAL_APPOINTMENT_STATUSES.has(
+          normalizedOperationalState(row.status),
+        )
+      ) {
+        upcoming.push(row);
+      }
+      if (upcoming.length >= UPCOMING_APPOINTMENT_LIMIT) break;
+    }
+    if (
+      upcoming.length >= UPCOMING_APPOINTMENT_LIMIT ||
+      pageRows.length < appointmentPageSize
+    ) {
+      break;
+    }
+  }
+
+  const recentResult = await input.supabase
+    .from("bookings")
+    .select("id,work_order_id,starts_at,ends_at,status,notes,created_at")
+    .eq("shop_id", input.shopId)
+    .eq("vehicle_id", input.vehicleId)
+    .lt("ends_at", nowIso)
+    .order("starts_at", { ascending: false })
+    .limit(40);
+  throwQueryError(recentResult.error, "Unable to load recent appointments");
+
+  const byId = new Map<string, WorkspaceBookingRow>();
+  for (const row of [
+    ...upcoming.slice(0, UPCOMING_APPOINTMENT_LIMIT),
+    ...((recentResult.data ?? []) as WorkspaceBookingRow[]),
+  ]) {
+    byId.set(row.id, row);
+  }
+  return [...byId.values()];
+}
+
 function throwQueryError(error: { message: string } | null, context: string): void {
   if (error) throw new Error(`${context}: ${error.message}`);
 }
@@ -1020,25 +1203,35 @@ export async function loadVehicleWorkspaceSnapshot(input: {
   if (!vehicleResult.data) return null;
   const vehicle = vehicleResult.data as WorkspaceVehicleRow;
 
-  const workOrdersResult = await input.supabase
-    .from("work_orders")
-    .select(
-      "id,customer_id,vehicle_id,custom_id,status,record_type,approval_state,estimate_number,estimate_status,scheduled_at,odometer_km,created_at,updated_at",
-    )
-    .eq("shop_id", input.shopId)
-    .eq("vehicle_id", input.vehicleId)
-    .order("updated_at", { ascending: false, nullsFirst: false })
-    .limit(100);
-  throwQueryError(workOrdersResult.error, "Unable to load work orders");
-  const workOrders = (workOrdersResult.data ?? []) as WorkspaceWorkOrderRow[];
+  const workOrders = await collectAllPages<WorkspaceWorkOrderRow>(
+    "Unable to load work orders",
+    async (from, to) => {
+      const result = await input.supabase
+        .from("work_orders")
+        .select(
+          "id,customer_id,vehicle_id,custom_id,status,record_type,approval_state,estimate_number,estimate_status,scheduled_at,odometer_km,created_at,updated_at",
+        )
+        .eq("shop_id", input.shopId)
+        .eq("vehicle_id", input.vehicleId)
+        .order("created_at", { ascending: false, nullsFirst: false })
+        .order("id", { ascending: false })
+        .range(from, to);
+      return {
+        data: (result.data ?? null) as WorkspaceWorkOrderRow[] | null,
+        error: result.error,
+      };
+    },
+  );
 
   // Work-order RLS is the canonical assignment boundary for mechanics. A same-shop
   // vehicle row alone must never grant a mechanic access to unrelated history.
   if (permissions.isAssignedWorkOnly && workOrders.length === 0) return null;
 
   const workOrderIds = workOrders.map((row) => row.id);
+  const maintenanceWorkOrder = latestCanonicalServiceWorkOrder(workOrders);
   const customerId = vehicle.customer_id;
   const emptyRows = Promise.resolve({ data: [], error: null });
+  const emptySingle = Promise.resolve({ data: null, error: null });
 
   const accountQuery = customerId
     ? permissions.canViewAccountContact
@@ -1077,61 +1270,104 @@ export async function loadVehicleWorkspaceSnapshot(input: {
     paymentsResult,
   ] = await Promise.all([
     accountQuery,
-    input.supabase
-      .from("bookings")
-      .select("id,work_order_id,starts_at,ends_at,status,notes,created_at")
-      .eq("shop_id", input.shopId)
-      .eq("vehicle_id", input.vehicleId)
-      .order("starts_at", { ascending: false })
-      .limit(40),
-    input.supabase
-      .from("inspections")
-      .select(
-        "id,work_order_id,work_order_line_id,inspection_type,status,completed,summary,created_at,started_at,finalized_at,updated_at,pdf_url,pdf_storage_path",
-      )
-      .eq("shop_id", input.shopId)
-      .eq("vehicle_id", input.vehicleId)
-      .order("updated_at", { ascending: false, nullsFirst: false })
-      .limit(40),
-    workOrderIds.length
-      ? input.supabase
-          .from("work_order_lines")
+    loadVehicleBookings({
+      supabase: input.supabase,
+      shopId: input.shopId,
+      vehicleId: input.vehicleId,
+      now,
+    }).then((data) => ({ data, error: null })),
+    collectAllPages<WorkspaceInspectionRow>(
+      "Unable to load inspections",
+      async (from, to) => {
+        const result = await input.supabase
+          .from("inspections")
           .select(
-            "id,work_order_id,description,complaint,correction,hold_reason,status,line_status,approval_state,urgency,voided_at,created_at,updated_at",
+            "id,work_order_id,work_order_line_id,inspection_type,status,completed,summary,created_at,started_at,finalized_at,updated_at,pdf_url,pdf_storage_path",
           )
           .eq("shop_id", input.shopId)
-          .in("work_order_id", workOrderIds)
-          .limit(300)
+          .eq("vehicle_id", input.vehicleId)
+          .order("created_at", { ascending: false, nullsFirst: false })
+          .order("id", { ascending: false })
+          .range(from, to);
+        return {
+          data: (result.data ?? null) as WorkspaceInspectionRow[] | null,
+          error: result.error,
+        };
+      },
+    ).then((data) => ({ data, error: null })),
+    workOrderIds.length
+      ? collectWorkOrderScopedRows<WorkspaceWorkOrderLineRow>(
+          "Unable to load repair lines",
+          workOrderIds,
+          async (ids, from, to) => {
+            const result = await input.supabase
+              .from("work_order_lines")
+              .select(
+                "id,work_order_id,description,complaint,correction,hold_reason,status,line_status,approval_state,urgency,voided_at,created_at,updated_at",
+              )
+              .eq("shop_id", input.shopId)
+              .in("work_order_id", ids)
+              .order("id", { ascending: true })
+              .range(from, to);
+            return {
+              data: (result.data ?? null) as WorkspaceWorkOrderLineRow[] | null,
+              error: result.error,
+            };
+          },
+        ).then((data) => ({ data, error: null }))
       : emptyRows,
     workOrderIds.length
-      ? input.supabase
-          .from("work_order_parts")
-          .select(
-            "id,work_order_id,work_order_line_id,description_snapshot,manufacturer_snapshot,part_number_snapshot,sku_snapshot,quantity_consumed,quantity_returned,is_active,created_at,updated_at",
-          )
-          .eq("shop_id", input.shopId)
-          .eq("is_active", true)
-          .in("work_order_id", workOrderIds)
-          .limit(300)
+      ? collectWorkOrderScopedRows<WorkspaceWorkOrderPartRow>(
+          "Unable to load installed parts",
+          workOrderIds,
+          async (ids, from, to) => {
+            const result = await input.supabase
+              .from("work_order_parts")
+              .select(
+                "id,work_order_id,work_order_line_id,description_snapshot,manufacturer_snapshot,part_number_snapshot,sku_snapshot,quantity_consumed,quantity_returned,is_active,created_at,updated_at",
+              )
+              .eq("shop_id", input.shopId)
+              .eq("is_active", true)
+              .in("work_order_id", ids)
+              .order("id", { ascending: true })
+              .range(from, to);
+            return {
+              data: (result.data ?? null) as WorkspaceWorkOrderPartRow[] | null,
+              error: result.error,
+            };
+          },
+        ).then((data) => ({ data, error: null }))
       : emptyRows,
     workOrderIds.length
-      ? input.supabase
-          .from("work_order_quote_lines")
-          .select(
-            "id,work_order_id,work_order_line_id,source_work_order_line_id,description,title,status,decision,defer_reason,decline_reason,approved_at,deferred_at,declined_at,created_at,updated_at",
-          )
-          .eq("shop_id", input.shopId)
-          .in("work_order_id", workOrderIds)
-          .limit(300)
+      ? collectWorkOrderScopedRows<WorkspaceQuoteLineRow>(
+          "Unable to load estimate items",
+          workOrderIds,
+          async (ids, from, to) => {
+            const result = await input.supabase
+              .from("work_order_quote_lines")
+              .select(
+                "id,work_order_id,work_order_line_id,source_work_order_line_id,description,title,status,decision,defer_reason,decline_reason,approved_at,deferred_at,declined_at,created_at,updated_at",
+              )
+              .eq("shop_id", input.shopId)
+              .in("work_order_id", ids)
+              .order("id", { ascending: true })
+              .range(from, to);
+            return {
+              data: (result.data ?? null) as WorkspaceQuoteLineRow[] | null,
+              error: result.error,
+            };
+          },
+        ).then((data) => ({ data, error: null }))
       : emptyRows,
-    workOrderIds.length
+    maintenanceWorkOrder
       ? input.supabase
           .from("maintenance_suggestions")
           .select("work_order_id,vehicle_id,status,suggestions,created_at,updated_at,error_message,mileage_km")
           .eq("vehicle_id", input.vehicleId)
-          .in("work_order_id", workOrderIds)
+          .eq("work_order_id", maintenanceWorkOrder.id)
           .eq("status", "ready")
-      : emptyRows,
+          .maybeSingle()
+      : emptySingle,
     input.supabase
       .from("history")
       .select(
@@ -1149,47 +1385,99 @@ export async function loadVehicleWorkspaceSnapshot(input: {
           .neq("id", input.vehicleId)
           .limit(20)
       : emptyRows,
-    input.supabase
-      .from("vehicle_media")
-      .select("id,type,filename,created_at")
-      .eq("shop_id", input.shopId)
-      .eq("vehicle_id", input.vehicleId)
-      .limit(100),
-    workOrderIds.length
-      ? input.supabase
-          .from("work_order_media")
-          .select("id,work_order_id,kind,file_name,created_at")
+    collectAllPages<WorkspaceVehicleMediaRow>(
+      "Unable to load vehicle media",
+      async (from, to) => {
+        const result = await input.supabase
+          .from("vehicle_media")
+          .select("id,type,filename,created_at")
           .eq("shop_id", input.shopId)
-          .in("work_order_id", workOrderIds)
-          .limit(100)
+          .eq("vehicle_id", input.vehicleId)
+          .order("id", { ascending: true })
+          .range(from, to);
+        return {
+          data: (result.data ?? null) as WorkspaceVehicleMediaRow[] | null,
+          error: result.error,
+        };
+      },
+    ).then((data) => ({ data, error: null })),
+    workOrderIds.length
+      ? collectWorkOrderScopedRows<WorkspaceWorkOrderMediaRow>(
+          "Unable to load work-order media",
+          workOrderIds,
+          async (ids, from, to) => {
+            const result = await input.supabase
+              .from("work_order_media")
+              .select("id,work_order_id,kind,file_name,created_at")
+              .eq("shop_id", input.shopId)
+              .in("work_order_id", ids)
+              .order("id", { ascending: true })
+              .range(from, to);
+            return {
+              data: (result.data ?? null) as WorkspaceWorkOrderMediaRow[] | null,
+              error: result.error,
+            };
+          },
+        ).then((data) => ({ data, error: null }))
       : emptyRows,
     permissions.canViewPartRequests && workOrderIds.length
-      ? input.supabase
-          .from("part_requests")
-          .select("id,work_order_id,status,notes,created_at")
-          .eq("shop_id", input.shopId)
-          .in("work_order_id", workOrderIds)
-          .order("created_at", { ascending: false })
-          .limit(100)
+      ? collectWorkOrderScopedRows<WorkspacePartRequestRow>(
+          "Unable to load parts requests",
+          workOrderIds,
+          async (ids, from, to) => {
+            const result = await input.supabase
+              .from("part_requests")
+              .select("id,work_order_id,status,notes,created_at")
+              .eq("shop_id", input.shopId)
+              .in("work_order_id", ids)
+              .order("id", { ascending: true })
+              .range(from, to);
+            return {
+              data: (result.data ?? null) as WorkspacePartRequestRow[] | null,
+              error: result.error,
+            };
+          },
+        ).then((data) => ({ data, error: null }))
       : emptyRows,
     permissions.canViewFinancials && workOrderIds.length
-      ? input.supabase
-          .from("invoices")
-          .select(
-            "id,work_order_id,invoice_number,status,currency,total,outstanding_total,paid_total,created_at,issued_at,paid_at,updated_at",
-          )
-          .eq("shop_id", input.shopId)
-          .in("work_order_id", workOrderIds)
-          .order("updated_at", { ascending: false })
+      ? collectWorkOrderScopedRows<WorkspaceInvoiceRow>(
+          "Unable to load invoices",
+          workOrderIds,
+          async (ids, from, to) => {
+            const result = await input.supabase
+              .from("invoices")
+              .select(
+                "id,work_order_id,invoice_number,status,currency,total,outstanding_total,paid_total,created_at,issued_at,paid_at,updated_at",
+              )
+              .eq("shop_id", input.shopId)
+              .in("work_order_id", ids)
+              .order("id", { ascending: true })
+              .range(from, to);
+            return {
+              data: (result.data ?? null) as WorkspaceInvoiceRow[] | null,
+              error: result.error,
+            };
+          },
+        ).then((data) => ({ data, error: null }))
       : emptyRows,
     permissions.canViewFinancials && workOrderIds.length
-      ? input.supabase
-          .from("payments")
-          .select("id,work_order_id,status,amount,currency,paid_at,created_at")
-          .eq("shop_id", input.shopId)
-          .in("work_order_id", workOrderIds)
-          .order("created_at", { ascending: false })
-          .limit(100)
+      ? collectWorkOrderScopedRows<WorkspacePaymentRow>(
+          "Unable to load payments",
+          workOrderIds,
+          async (ids, from, to) => {
+            const result = await input.supabase
+              .from("payments")
+              .select("id,work_order_id,status,amount,currency,paid_at,created_at")
+              .eq("shop_id", input.shopId)
+              .in("work_order_id", ids)
+              .order("id", { ascending: true })
+              .range(from, to);
+            return {
+              data: (result.data ?? null) as WorkspacePaymentRow[] | null,
+              error: result.error,
+            };
+          },
+        ).then((data) => ({ data, error: null }))
       : emptyRows,
   ]);
 
@@ -1218,7 +1506,19 @@ export async function loadVehicleWorkspaceSnapshot(input: {
   const lines = (linesResult.data ?? []) as WorkspaceWorkOrderLineRow[];
   const parts = (partsResult.data ?? []) as WorkspaceWorkOrderPartRow[];
   const quoteLines = (quoteLinesResult.data ?? []) as WorkspaceQuoteLineRow[];
-  const maintenance = (maintenanceResult.data ?? []) as MaintenanceSuggestionRow[];
+  const maintenanceCandidate = (maintenanceResult.data ?? null) as
+    | MaintenanceSuggestionRow
+    | null;
+  const maintenance =
+    maintenanceCandidate &&
+    maintenanceWorkOrder &&
+    maintenanceCacheIsFresh({
+      cache: maintenanceCandidate,
+      workOrder: maintenanceWorkOrder,
+      lines,
+    })
+      ? [maintenanceCandidate]
+      : [];
   const history = (historyResult.data ?? []) as WorkspaceHistoryRow[];
   const vehicleMedia = (vehicleMediaResult.data ?? []) as WorkspaceVehicleMediaRow[];
   const workOrderMedia = (workOrderMediaResult.data ?? []) as WorkspaceWorkOrderMediaRow[];
@@ -1323,11 +1623,14 @@ export async function loadVehicleWorkspaceSnapshot(input: {
     const workOrder = row.work_order_id
       ? workOrdersById.get(row.work_order_id)
       : null;
+    const requestSummary = text(row.notes)?.split(/\r?\n/, 1)[0]?.trim() || null;
     activeWork.push({
       kind: "part_request",
-      title: "Parts request",
+      title:
+        requestSummary ??
+        (workOrder ? `Parts for ${workOrderLabel(workOrder)}` : "Parts request"),
       status: row.status,
-      detail: text(row.notes) ?? (workOrder ? workOrderLabel(workOrder) : null),
+      detail: workOrder ? `Requested for ${workOrderLabel(workOrder)}` : null,
       occurredAt: row.created_at,
       reference: {
         sourceType: "part_request",
@@ -1389,6 +1692,7 @@ export async function loadVehicleWorkspaceSnapshot(input: {
       vehicleMedia,
       workOrderMedia,
       inspections,
+      workOrdersById,
     }),
     relatedVehicles,
     conflicts: buildConflicts({

--- a/features/vehicles/server/loadVehicleWorkspaceSnapshot.ts
+++ b/features/vehicles/server/loadVehicleWorkspaceSnapshot.ts
@@ -413,13 +413,16 @@ function latestWorkOrderOdometer(
     )
     .sort(
       (a, b) =>
-        workOrderServiceTime(b) - workOrderServiceTime(a),
+        workOrderEvidenceTime(b) - workOrderEvidenceTime(a),
     )[0];
   return newestReading?.odometer_km ?? null;
 }
 
-function workOrderServiceTime(row: WorkspaceWorkOrderRow): number {
-  const value = Date.parse(row.scheduled_at ?? row.created_at ?? "");
+function workOrderEvidenceTime(row: WorkspaceWorkOrderRow): number {
+  // The canonical work-order schema has no odometer-captured timestamp.
+  // created_at is the immutable intake boundary; scheduled_at is planning data
+  // synchronized from bookings and must never reorder recorded evidence.
+  const value = Date.parse(row.created_at ?? "");
   return Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
 }
 
@@ -971,9 +974,13 @@ function buildDocumentSummary(input: {
   inspections: WorkspaceInspectionRow[];
   workOrdersById: Map<string, WorkspaceWorkOrderRow>;
 }): VehicleDocumentSummary {
-  const reports = input.inspections.filter(
-    (row) => Boolean(row.pdf_url || row.pdf_storage_path),
-  );
+  const reports = input.inspections
+    .filter((row) => Boolean(row.pdf_url || row.pdf_storage_path))
+    .sort((a, b) => {
+      const evidenceOrder =
+        inspectionReportEvidenceTime(b) - inspectionReportEvidenceTime(a);
+      return evidenceOrder || b.id.localeCompare(a.id);
+    });
   const newestWorkOrderMedia = [...input.workOrderMedia].sort(
     (a, b) => new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
   )[0];
@@ -997,6 +1004,15 @@ function buildDocumentSummary(input: {
         ? inspectionReference(reports[0])
         : null,
   };
+}
+
+function inspectionReportEvidenceTime(row: WorkspaceInspectionRow): number {
+  const timestamps = [row.finalized_at, row.updated_at, row.created_at]
+    .map((value) => Date.parse(value ?? ""))
+    .filter(Number.isFinite);
+  return timestamps.length > 0
+    ? Math.max(...timestamps)
+    : Number.NEGATIVE_INFINITY;
 }
 
 function buildConflicts(input: {
@@ -1090,7 +1106,7 @@ function latestCanonicalServiceWorkOrder(
         );
       })
       .sort((a, b) => {
-        const timeDifference = workOrderServiceTime(b) - workOrderServiceTime(a);
+        const timeDifference = workOrderEvidenceTime(b) - workOrderEvidenceTime(a);
         return timeDifference === 0 ? b.id.localeCompare(a.id) : timeDifference;
       })[0] ?? null
   );
@@ -1286,6 +1302,7 @@ export async function loadVehicleWorkspaceSnapshot(input: {
           )
           .eq("shop_id", input.shopId)
           .eq("vehicle_id", input.vehicleId)
+          .order("updated_at", { ascending: false, nullsFirst: false })
           .order("created_at", { ascending: false, nullsFirst: false })
           .order("id", { ascending: false })
           .range(from, to);

--- a/features/vehicles/server/searchShopVehicleRecords.ts
+++ b/features/vehicles/server/searchShopVehicleRecords.ts
@@ -399,7 +399,9 @@ function workOrderIsEstimate(row: SearchWorkOrderRow): boolean {
 }
 
 function workOrderEvidenceTime(row: SearchWorkOrderRow): number {
-  const value = Date.parse(row.scheduled_at ?? row.created_at ?? "");
+  // The work-order record has no odometer-captured timestamp. created_at is
+  // the immutable intake boundary; scheduled_at is mutable scheduler data.
+  const value = Date.parse(row.created_at ?? "");
   return Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
 }
 

--- a/features/vehicles/server/searchShopVehicleRecords.ts
+++ b/features/vehicles/server/searchShopVehicleRecords.ts
@@ -4,7 +4,10 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 
 import type { CanonicalRole } from "@/features/shared/lib/rbac";
-import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
+import {
+  isEstimateRecord,
+  normalizeWorkOrderStatus,
+} from "@/features/work-orders/lib/work-order-status";
 import {
   createWorkOrderHandoffHref,
   customerAccountDisplayName,
@@ -86,6 +89,7 @@ type SearchWorkOrderRow = Pick<
   | "vehicle_unit_number"
   | "vehicle_mileage"
   | "odometer_km"
+  | "scheduled_at"
   | "created_at"
   | "updated_at"
 >;
@@ -187,7 +191,7 @@ const CUSTOMER_COLUMNS =
 const CUSTOMER_SAFE_COLUMNS =
   "id,account_type,active,business_name,name,first_name,last_name,identity_name,archived_at,merged_into_customer_id";
 const WORK_ORDER_COLUMNS =
-  "id,custom_id,status,record_type,estimate_number,estimate_status,customer_id,customer_name,vehicle_id,vehicle_year,vehicle_make,vehicle_model,vehicle_submodel,vehicle_vin,vehicle_license_plate,vehicle_unit_number,vehicle_mileage,odometer_km,created_at,updated_at";
+  "id,custom_id,status,record_type,estimate_number,estimate_status,customer_id,customer_name,vehicle_id,vehicle_year,vehicle_make,vehicle_model,vehicle_submodel,vehicle_vin,vehicle_license_plate,vehicle_unit_number,vehicle_mileage,odometer_km,scheduled_at,created_at,updated_at";
 
 function normalizedState(value: string | null | undefined): string {
   return String(value ?? "")
@@ -391,11 +395,11 @@ function workOrderDisplayStatus(row: SearchWorkOrderRow): string {
 }
 
 function workOrderIsEstimate(row: SearchWorkOrderRow): boolean {
-  return row.record_type === "estimate" || Boolean(row.estimate_number);
+  return isEstimateRecord(row);
 }
 
 function workOrderEvidenceTime(row: SearchWorkOrderRow): number {
-  const value = Date.parse(row.updated_at ?? row.created_at ?? "");
+  const value = Date.parse(row.scheduled_at ?? row.created_at ?? "");
   return Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
 }
 

--- a/features/work-orders/lib/work-order-status.ts
+++ b/features/work-orders/lib/work-order-status.ts
@@ -13,6 +13,11 @@ export const CANONICAL_WORK_ORDER_STATUSES = [
 
 export type WorkOrderStatus = (typeof CANONICAL_WORK_ORDER_STATUSES)[number];
 
+type EstimateIdentity = {
+  record_type?: unknown;
+  estimate_number?: unknown;
+};
+
 const LEGACY_TO_CANONICAL: Record<string, WorkOrderStatus> = {
   new: "new",
   queued: "new",
@@ -38,4 +43,28 @@ const LEGACY_TO_CANONICAL: Record<string, WorkOrderStatus> = {
 export function normalizeWorkOrderStatus(value: unknown): WorkOrderStatus {
   const key = String(value ?? "").trim().toLowerCase().replaceAll(" ", "_");
   return LEGACY_TO_CANONICAL[key] ?? "new";
+}
+
+/**
+ * `record_type` is the canonical lifecycle discriminator. Converted estimates
+ * retain their estimate number for traceability, so that number alone must not
+ * turn a canonical work order back into an estimate.
+ */
+export function isEstimateRecord(value: EstimateIdentity): boolean {
+  const recordType = String(value.record_type ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  if (recordType === "estimate") return true;
+  if (recordType === "work_order") return false;
+  return recordType.length === 0 && Boolean(value.estimate_number);
+}
+
+export function formatOperationalLabel(value: unknown): string {
+  const words = String(value ?? "")
+    .trim()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ");
+  if (!words) return "Not recorded";
+  return words.replace(/\b\w/g, (character) => character.toUpperCase());
 }

--- a/tests/customer-service-history-presentation.test.ts
+++ b/tests/customer-service-history-presentation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  customerServiceHistoryPresentation,
+  formatOdometer,
+} from "@/features/customers/lib/customerServiceHistory";
+
+describe("customer service-history presentation", () => {
+  it("does not invent miles when the canonical odometer unit is unknown", () => {
+    expect(formatOdometer("216751", null)).toBe("216,751");
+    expect(formatOdometer("216751", "km")).toBe("216,751 km");
+  });
+
+  it("presents canonical estimates as estimates with the estimate route", () => {
+    expect(
+      customerServiceHistoryPresentation({
+        id: "estimate-1",
+        custom_id: "000013",
+        status: "new",
+        record_type: "estimate",
+        estimate_number: "EST-06A7D9326B",
+        estimate_status: "waiting_for_parts",
+      }),
+    ).toEqual({
+      href: "/estimates/estimate-1",
+      lifecycleLabel: "Estimate",
+      statusKey: "waiting_for_parts",
+      statusLabel: "Waiting For Parts",
+      title: "Estimate EST-06A7D9326B",
+    });
+  });
+
+  it("does not label cancelled work orders as active", () => {
+    const presentation = customerServiceHistoryPresentation({
+      id: "work-order-1",
+      custom_id: "000010",
+      status: "cancelled",
+      record_type: "work_order",
+      estimate_number: null,
+      estimate_status: null,
+    });
+
+    expect(presentation).toMatchObject({
+      href: "/work-orders/work-order-1",
+      lifecycleLabel: "Closed",
+      statusKey: "cancelled",
+      statusLabel: "Cancelled",
+      title: "WO-000010",
+    });
+    expect(presentation.lifecycleLabel).not.toBe("Active");
+  });
+
+  it("keeps converted estimates classified as canonical work orders", () => {
+    expect(
+      customerServiceHistoryPresentation({
+        id: "converted-1",
+        custom_id: "001234",
+        status: "in_progress",
+        record_type: "work_order",
+        estimate_number: "EST-LEGACY",
+        estimate_status: "approved",
+      }),
+    ).toEqual({
+      href: "/work-orders/converted-1",
+      lifecycleLabel: "In progress",
+      statusKey: "in_progress",
+      statusLabel: "In Progress",
+      title: "WO-001234",
+    });
+  });
+});

--- a/tests/vehicle-workspace-contract.test.ts
+++ b/tests/vehicle-workspace-contract.test.ts
@@ -780,6 +780,40 @@ describe("Shop Vehicle Workspace contract", () => {
     );
   });
 
+  it("does not let rescheduling an older work order replace newer odometer evidence", async () => {
+    const fixture = workspaceFixture({
+      additionalWorkOrders: [
+        {
+          id: "wo-rescheduled-old",
+          customer_id: "customer-1",
+          vehicle_id: "vehicle-1",
+          custom_id: "1001",
+          status: "completed",
+          record_type: "work_order",
+          approval_state: "approved",
+          estimate_number: null,
+          estimate_status: null,
+          scheduled_at: "2027-01-01T10:00:00.000Z",
+          odometer_km: 60000,
+          created_at: "2025-12-01T10:00:00.000Z",
+          updated_at: "2026-08-19T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(snapshot?.identity).toMatchObject({
+      mileage: "64100",
+      odometerUnit: "km",
+    });
+  });
+
   it("blocks Create WO for archived-account or vehicle-status conflicts only", async () => {
     const fixture = workspaceFixture();
     const snapshot = await loadVehicleWorkspaceSnapshot({
@@ -1398,6 +1432,57 @@ describe("Shop Vehicle Workspace contract", () => {
     expect(snapshot?.documentSummary.latestReference?.sourceLabel).not.toContain(
       "ea15b3b8",
     );
+  });
+
+  it("opens the most recently finalized or regenerated inspection report", async () => {
+    const fixture = workspaceFixture({
+      inspections: [
+        {
+          id: "inspection-newer-created",
+          work_order_id: "wo-2",
+          work_order_line_id: null,
+          inspection_type: "Newer-created inspection",
+          status: "finalized",
+          completed: true,
+          summary: null,
+          created_at: "2026-01-04T10:00:00.000Z",
+          started_at: "2026-01-04T10:00:00.000Z",
+          finalized_at: "2026-01-04T11:00:00.000Z",
+          updated_at: "2026-01-04T11:00:00.000Z",
+          pdf_url: "/reports/newer-created.pdf",
+          pdf_storage_path: null,
+        },
+        {
+          id: "inspection-latest-report",
+          work_order_id: "wo-1",
+          work_order_line_id: null,
+          inspection_type: "Latest finalized inspection",
+          status: "finalized",
+          completed: true,
+          summary: null,
+          created_at: "2026-01-02T10:00:00.000Z",
+          started_at: "2026-01-02T10:00:00.000Z",
+          finalized_at: "2026-01-05T11:00:00.000Z",
+          updated_at: "2026-01-06T11:00:00.000Z",
+          pdf_url: "/reports/latest.pdf",
+          pdf_storage_path: null,
+        },
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(snapshot?.documentSummary.latestReference).toEqual({
+      sourceType: "inspection",
+      sourceId: "inspection-latest-report",
+      sourceLabel: "Latest finalized inspection",
+      href: "/inspections/inspection-latest-report",
+    });
   });
 
   it("opens estimate records through their canonical estimate route", async () => {
@@ -2322,6 +2407,7 @@ describe("Shop Vehicle Workspace contract", () => {
     });
     const older = searchWorkOrderRow("wo-older", vehicle.id, {
       odometerKm: 65000,
+      scheduledAt: "2027-01-01T10:00:00.000Z",
       createdAt: "2026-01-01T09:00:00.000Z",
       updatedAt: "2026-08-04T10:00:00.000Z",
       vehicleMileage: null,

--- a/tests/vehicle-workspace-contract.test.ts
+++ b/tests/vehicle-workspace-contract.test.ts
@@ -54,8 +54,10 @@ type QueryBuilder = {
   or: (...args: unknown[]) => QueryBuilder;
   gte: (...args: unknown[]) => QueryBuilder;
   gt: (...args: unknown[]) => QueryBuilder;
+  lt: (...args: unknown[]) => QueryBuilder;
   order: (...args: unknown[]) => QueryBuilder;
   limit: (...args: unknown[]) => QueryBuilder;
+  range: (...args: unknown[]) => QueryBuilder;
   maybeSingle: (...args: unknown[]) => QueryBuilder;
   then<TResult1 = QueryResult, TResult2 = never>(
     onfulfilled?:
@@ -110,12 +112,20 @@ function createSupabaseFixture(
           calls.push({ table, operation: "gt", args });
           return query;
         },
+        lt(...args: unknown[]) {
+          calls.push({ table, operation: "lt", args });
+          return query;
+        },
         order(...args: unknown[]) {
           calls.push({ table, operation: "order", args });
           return query;
         },
         limit(...args: unknown[]) {
           calls.push({ table, operation: "limit", args });
+          return query;
+        },
+        range(...args: unknown[]) {
+          calls.push({ table, operation: "range", args });
           return query;
         },
         maybeSingle(...args: unknown[]) {
@@ -143,9 +153,11 @@ function workspaceFixture(
     history?: unknown[];
     invoices?: unknown[];
     inspections?: unknown[];
+    maintenanceSuggestion?: unknown | null;
     partRequests?: unknown[];
     quoteLines?: unknown[];
     workOrderLines?: unknown[];
+    workOrderMedia?: unknown[];
     workOrderParts?: unknown[];
   } = {},
 ) {
@@ -198,6 +210,12 @@ function workspaceFixture(
     },
     ...(overrides.additionalWorkOrders ?? []),
   ];
+  const workOrderChunkCount = Math.max(1, Math.ceil(workOrders.length / 100));
+  const chunkedResults = (data: unknown[]) =>
+    Array.from({ length: workOrderChunkCount }, (_, index) => ({
+      data: index === 0 ? data : [],
+      error: null,
+    }));
 
   const inspections =
     overrides.inspections ??
@@ -271,40 +289,39 @@ function workspaceFixture(
           ],
         error: null,
       },
+      { data: [], error: null },
     ],
     inspections: [{ data: inspections, error: null }],
-    work_order_lines: [{ data: overrides.workOrderLines ?? [], error: null }],
-    work_order_parts: [{ data: overrides.workOrderParts ?? [], error: null }],
-    work_order_quote_lines: [{ data: overrides.quoteLines ?? [], error: null }],
-    maintenance_suggestions: [{ data: [], error: null }],
+    work_order_lines: chunkedResults(overrides.workOrderLines ?? []),
+    work_order_parts: chunkedResults(overrides.workOrderParts ?? []),
+    work_order_quote_lines: chunkedResults(overrides.quoteLines ?? []),
+    maintenance_suggestions: [
+      { data: overrides.maintenanceSuggestion ?? null, error: null },
+    ],
     history: [{ data: overrides.history ?? [], error: null }],
     vehicle_media: [{ data: [], error: null }],
-    work_order_media: [{ data: [], error: null }],
-    part_requests: [{ data: overrides.partRequests ?? [], error: null }],
-    invoices: [
-      {
-        data:
-          overrides.invoices ??
-          [
-            {
-              id: "invoice-1",
-              work_order_id: "wo-1",
-              invoice_number: "INV-1048",
-              status: "open",
-              currency: "CAD",
-              total: 850,
-              outstanding_total: 250,
-              paid_total: 600,
-              created_at: "2026-01-03T10:00:00.000Z",
-              issued_at: "2026-01-03T10:00:00.000Z",
-              paid_at: null,
-              updated_at: "2026-01-03T10:00:00.000Z",
-            },
-          ],
-        error: null,
-      },
-    ],
-    payments: [{ data: [], error: null }],
+    work_order_media: chunkedResults(overrides.workOrderMedia ?? []),
+    part_requests: chunkedResults(overrides.partRequests ?? []),
+    invoices: chunkedResults(
+      overrides.invoices ??
+        [
+          {
+            id: "invoice-1",
+            work_order_id: "wo-1",
+            invoice_number: "INV-1048",
+            status: "open",
+            currency: "CAD",
+            total: 850,
+            outstanding_total: 250,
+            paid_total: 600,
+            created_at: "2026-01-03T10:00:00.000Z",
+            issued_at: "2026-01-03T10:00:00.000Z",
+            paid_at: null,
+            updated_at: "2026-01-03T10:00:00.000Z",
+          },
+        ],
+    ),
+    payments: chunkedResults([]),
   });
 }
 
@@ -351,6 +368,7 @@ function searchWorkOrderRow(
     estimateStatus?: string | null;
     odometerKm?: number | null;
     recordType?: string;
+    scheduledAt?: string | null;
     status?: string;
     createdAt?: string;
     updatedAt?: string | null;
@@ -380,6 +398,7 @@ function searchWorkOrderRow(
         : overrides.vehicleMileage,
     odometer_km:
       overrides.odometerKm === undefined ? 64000 : overrides.odometerKm,
+    scheduled_at: overrides.scheduledAt ?? null,
     created_at: overrides.createdAt ?? "2026-01-01T10:00:00.000Z",
     updated_at:
       overrides.updatedAt === undefined
@@ -911,6 +930,169 @@ describe("Shop Vehicle Workspace contract", () => {
         (appointment) => appointment.reference.sourceId,
       ),
     ).toEqual(["booking-confirmed"]);
+    const upcomingCalls = fixture.calls.filter(
+      (call) => call.table === "bookings" &&
+        ["gte", "order", "range"].includes(call.operation),
+    );
+    expect(upcomingCalls).toContainEqual({
+      table: "bookings",
+      operation: "gte",
+      args: ["ends_at", "2026-01-10T00:00:00.000Z"],
+    });
+    expect(upcomingCalls).toContainEqual({
+      table: "bookings",
+      operation: "order",
+      args: ["starts_at", { ascending: true }],
+    });
+    expect(upcomingCalls).toContainEqual({
+      table: "bookings",
+      operation: "range",
+      args: [0, 99],
+    });
+  });
+
+  it("pages complete work-order evidence and retains an older open record", async () => {
+    const newerClosedRows = Array.from({ length: 101 }, (_, index) => ({
+      id: `wo-closed-${index}`,
+      customer_id: "customer-1",
+      vehicle_id: "vehicle-1",
+      custom_id: `CLOSED-${index}`,
+      status: "completed",
+      record_type: "work_order",
+      approval_state: "approved",
+      estimate_number: null,
+      estimate_status: null,
+      scheduled_at: null,
+      odometer_km: null,
+      created_at: `2026-01-${String((index % 28) + 1).padStart(2, "0")}T10:00:00.000Z`,
+      updated_at: "2026-02-01T10:00:00.000Z",
+    }));
+    const olderOpen = {
+      id: "wo-older-open",
+      customer_id: "customer-1",
+      vehicle_id: "vehicle-1",
+      custom_id: "0042",
+      status: "in_progress",
+      record_type: "work_order",
+      approval_state: "approved",
+      estimate_number: null,
+      estimate_status: null,
+      scheduled_at: "2020-01-05T10:00:00.000Z",
+      odometer_km: 12000,
+      created_at: "2020-01-01T10:00:00.000Z",
+      updated_at: "2026-08-01T10:00:00.000Z",
+    };
+    const fixture = workspaceFixture({
+      additionalWorkOrders: [...newerClosedRows, olderOpen],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(snapshot?.identity.mileage).toBe("64100");
+    expect(snapshot?.activeWork).toContainEqual(
+      expect.objectContaining({
+        kind: "work_order",
+        reference: expect.objectContaining({ sourceId: "wo-older-open" }),
+      }),
+    );
+    expect(
+      snapshot?.conflicts.find(
+        (conflict) => conflict.kind === "multiple_active_work_orders",
+      )?.sourceIds,
+    ).toContain("wo-older-open");
+
+    const partScopes = fixture.calls.filter(
+      (call) => call.table === "work_order_parts" && call.operation === "in",
+    );
+    expect(partScopes).toHaveLength(2);
+    expect(partScopes[1]?.args[1]).toContain("wo-older-open");
+    const workOrderCalls = fixture.calls.filter(
+      (call) => call.table === "work_orders",
+    );
+    expect(workOrderCalls).toContainEqual({
+      table: "work_orders",
+      operation: "range",
+      args: [0, 499],
+    });
+    expect(workOrderCalls.some((call) => call.operation === "limit")).toBe(
+      false,
+    );
+  });
+
+  it("uses only a fresh cache for the latest canonical service work order", async () => {
+    const suggestion = {
+      work_order_id: "wo-2",
+      vehicle_id: "vehicle-1",
+      status: "ready",
+      suggestions: [
+        {
+          label: "Engine oil service",
+          serviceCode: "OIL",
+          dueNow: true,
+          suppressed: false,
+          whyDue: "Mileage interval reached",
+        },
+      ],
+      created_at: "2026-01-02T12:00:00.000Z",
+      updated_at: "2026-01-05T12:00:00.000Z",
+      error_message: null,
+      mileage_km: 64100,
+    };
+    const freshFixture = workspaceFixture({ maintenanceSuggestion: suggestion });
+    const staleFixture = workspaceFixture({
+      maintenanceSuggestion: {
+        ...suggestion,
+        updated_at: "2026-01-03T12:00:00.000Z",
+      },
+    });
+
+    const [fresh, stale] = await Promise.all([
+      loadVehicleWorkspaceSnapshot({
+        supabase: freshFixture.client as never,
+        shopId: "shop-a",
+        role: "owner",
+        vehicleId: "vehicle-1",
+      }),
+      loadVehicleWorkspaceSnapshot({
+        supabase: staleFixture.client as never,
+        shopId: "shop-a",
+        role: "owner",
+        vehicleId: "vehicle-1",
+      }),
+    ]);
+
+    expect(fresh?.attentionItems).toContainEqual(
+      expect.objectContaining({
+        kind: "maintenance_due",
+        title: "Engine oil service",
+        explanation: "Mileage interval reached · evaluated for WO-1051",
+        reference: expect.objectContaining({ sourceId: "wo-2" }),
+      }),
+    );
+    expect(
+      fresh?.attentionItems.filter((item) => item.kind === "maintenance_due"),
+    ).toHaveLength(1);
+    expect(
+      fresh?.attentionItems.find((item) => item.kind === "maintenance_due")
+        ?.explanation,
+    ).not.toContain("OIL");
+    expect(stale?.attentionItems.some((item) => item.kind === "maintenance_due"))
+      .toBe(false);
+    expect(
+      freshFixture.calls.filter(
+        (call) => call.table === "maintenance_suggestions" &&
+          call.operation === "eq",
+      ),
+    ).toContainEqual({
+      table: "maintenance_suggestions",
+      operation: "eq",
+      args: ["work_order_id", "wo-2"],
+    });
   });
 
   it("deduplicates deferred quote evidence without suppressing unrelated line attention", async () => {
@@ -1021,7 +1203,7 @@ describe("Shop Vehicle Workspace contract", () => {
       expect.objectContaining({
         kind: "approval",
         title: "Estimate quote-approved",
-        detail: "Decision: approved",
+        detail: "Decision: Approved",
         reference: expect.objectContaining({
           sourceType: "work_order_quote_line",
           sourceId: "quote-approved",
@@ -1166,8 +1348,9 @@ describe("Shop Vehicle Workspace contract", () => {
       partsSnapshot?.activeWork.filter((item) => item.kind === "part_request"),
     ).toEqual([
       expect.objectContaining({
+        title: "Brake pads needed",
         status: "requested",
-        detail: "Brake pads needed",
+        detail: "Requested for WO-1048",
         reference: expect.objectContaining({
           sourceType: "part_request",
           sourceId: "request-open",
@@ -1184,6 +1367,37 @@ describe("Shop Vehicle Workspace contract", () => {
     expect(
       advisorSnapshot?.activeWork.some((item) => item.kind === "part_request"),
     ).toBe(false);
+  });
+
+  it("labels opaque work-order media with its canonical source record", async () => {
+    const fixture = workspaceFixture({
+      workOrderMedia: [
+        {
+          id: "media-1",
+          work_order_id: "wo-1",
+          kind: "photo",
+          file_name: "ea15b3b8-7ed4-421a-bf68-92475461c6cd.jpg",
+          created_at: "2026-01-08T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(snapshot?.documentSummary.latestReference).toEqual({
+      sourceType: "work_order_media",
+      sourceId: "media-1",
+      sourceLabel: "Photo from WO-1048",
+      href: "/work-orders/wo-1",
+    });
+    expect(snapshot?.documentSummary.latestReference?.sourceLabel).not.toContain(
+      "ea15b3b8",
+    );
   });
 
   it("opens estimate records through their canonical estimate route", async () => {
@@ -1225,6 +1439,56 @@ describe("Shop Vehicle Workspace contract", () => {
         href: "/estimates/estimate-1",
       },
     });
+  });
+
+  it("treats an approved converted estimate as its canonical work order", async () => {
+    const fixture = workspaceFixture({
+      additionalWorkOrders: [
+        {
+          id: "wo-converted-estimate",
+          customer_id: "customer-1",
+          vehicle_id: "vehicle-1",
+          custom_id: "1072",
+          status: "in_progress",
+          record_type: "work_order",
+          approval_state: "approved",
+          estimate_number: "EST-72",
+          estimate_status: "approved",
+          scheduled_at: "2026-01-06T10:00:00.000Z",
+          odometer_km: null,
+          created_at: "2026-01-05T10:00:00.000Z",
+          updated_at: "2026-01-06T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(snapshot?.activeWork).toContainEqual(
+      expect.objectContaining({
+        kind: "work_order",
+        reference: {
+          sourceType: "work_order",
+          sourceId: "wo-converted-estimate",
+          sourceLabel: "WO-1072",
+          href: "/work-orders/wo-converted-estimate",
+        },
+      }),
+    );
+    expect(snapshot?.recentTimeline).toContainEqual(
+      expect.objectContaining({
+        kind: "work_order",
+        reference: expect.objectContaining({
+          sourceId: "wo-converted-estimate",
+          href: "/work-orders/wo-converted-estimate",
+        }),
+      }),
+    );
   });
 
   it("retains estimate, quote, and inspection evidence for a mechanic without granting detail access", async () => {
@@ -2058,12 +2322,27 @@ describe("Shop Vehicle Workspace contract", () => {
     });
     const older = searchWorkOrderRow("wo-older", vehicle.id, {
       odometerKm: 65000,
-      updatedAt: "2026-01-04T10:00:00.000Z",
+      createdAt: "2026-01-01T09:00:00.000Z",
+      updatedAt: "2026-08-04T10:00:00.000Z",
       vehicleMileage: null,
     });
+    const convertedEstimate = searchWorkOrderRow(
+      "wo-converted-estimate",
+      vehicle.id,
+      {
+        customId: "1072",
+        estimateNumber: "EST-72",
+        estimateStatus: "approved",
+        odometerKm: null,
+        recordType: "work_order",
+        status: "in_progress",
+        scheduledAt: "2026-01-06T10:00:00.000Z",
+        createdAt: "2026-01-06T09:00:00.000Z",
+      },
+    );
     // Mirrors `updated_at desc nulls last`: the newest created WO appears after
     // older rows whose updated_at is populated.
-    const workOrders = [older, canceled, done, ready, newest];
+    const workOrders = [older, canceled, done, ready, newest, convertedEstimate];
     const fixture = createSupabaseFixture({
       vehicles: [
         { data: [vehicle], error: null },
@@ -2163,7 +2442,16 @@ describe("Shop Vehicle Workspace contract", () => {
       "wo-older",
       "wo-ready",
       "wo-newest",
+      "wo-converted-estimate",
     ]);
+    expect(card?.activeWork.at(-1)).toMatchObject({
+      kind: "work_order",
+      title: "WO-1072",
+      reference: {
+        sourceId: "wo-converted-estimate",
+        href: "/work-orders/wo-converted-estimate",
+      },
+    });
     expect(card?.latestOdometer).toBe("67000");
     expect(card?.attentionCount).toBe(1);
     expect(card?.nextAppointment?.reference.sourceId).toBe("booking-next");

--- a/tests/vehicle-workspace-security.test.ts
+++ b/tests/vehicle-workspace-security.test.ts
@@ -23,10 +23,10 @@ describe("Shop Vehicle Workspace security contract", () => {
       ),
     );
     const workOrderQuery = loader.slice(
-      loader.indexOf("const workOrdersResult"),
       loader.indexOf(
-        'throwQueryError(workOrdersResult.error, "Unable to load work orders")',
+        "const workOrders = await collectAllPages<WorkspaceWorkOrderRow>",
       ),
+      loader.indexOf("// Work-order RLS is the canonical assignment boundary"),
     );
 
     expect(vehicleQuery).toContain('.from("vehicles")');
@@ -36,6 +36,8 @@ describe("Shop Vehicle Workspace security contract", () => {
     expect(workOrderQuery).toContain('.from("work_orders")');
     expect(workOrderQuery).toContain('.eq("shop_id", input.shopId)');
     expect(workOrderQuery).toContain('.eq("vehicle_id", input.vehicleId)');
+    expect(workOrderQuery).toContain(".range(from, to)");
+    expect(workOrderQuery).not.toContain(".limit(100)");
   });
 
   it("scopes installed-part evidence without projecting commercial fields", () => {
@@ -46,7 +48,10 @@ describe("Shop Vehicle Workspace security contract", () => {
 
     expect(partQuery).toContain('.eq("shop_id", input.shopId)');
     expect(partQuery).toContain('.eq("is_active", true)');
-    expect(partQuery).toContain('.in("work_order_id", workOrderIds)');
+    expect(partQuery).toContain('.in("work_order_id", ids)');
+    expect(loader).toContain(
+      "collectWorkOrderScopedRows<WorkspaceWorkOrderPartRow>",
+    );
     expect(partQuery).toContain("quantity_consumed,quantity_returned");
     expect(partQuery).not.toContain("price");
     expect(partQuery).not.toContain("cost");


### PR DESCRIPTION
## What changed

- Page the complete vehicle work-order source set and chunk dependent evidence queries so older open records, invoices, media, parts, and conflicts are not lost.
- Fetch nearest upcoming appointments before applying display limits.
- Treat `record_type` as the canonical estimate/work-order discriminator, including converted estimates.
- Rank odometer and latest-service evidence by immutable work-order intake time rather than mutable scheduler or update timestamps.
- Rank inspection-report shortcuts by the newest finalization or regeneration evidence.
- Project only a fresh maintenance cache for the latest canonical service work order and deduplicate service evidence.
- Improve parts, document, timeline, and customer service-history labels and routes.
- Stop inventing miles when imported history has no canonical odometer unit.

## Root cause

The foundation read model truncated work orders before deriving summaries, selected appointments in the wrong direction, treated retained estimate numbers as lifecycle truth, and projected every ready per-work-order maintenance cache. Mutable scheduling and record-update timestamps were also being used to rank service evidence, while inspection documents relied on creation order rather than report finalization/regeneration evidence. The legacy customer timeline independently labeled every work-order-table row as an active work order.

## User impact

The workspace now retains all canonical source IDs while showing authoritative current state: older open work remains visible, the nearest appointment is correct, converted estimates stay work orders, rescheduling cannot replace newer odometer evidence, the latest inspection shortcut opens the most recently finalized or regenerated report, stale maintenance claims are omitted, and source cards use useful human-readable labels. The legacy customer history now routes estimates correctly and labels cancelled work as closed.

## Validation

- Focused Vehicle Workspace, security, and presentation tests: 46 passed
- TypeScript: passed
- Changed-file ESLint: passed
- `git diff --check`: passed
- Vercel deployment policy remains production-only (`main: true`, `*: false`)

No schema migration or production mutation is included.