### PR TITLE
Shop Vehicle Workspace: add operational action handoffs

### DIFF
--- a/app/api/chat/users/route.ts
+++ b/app/api/chat/users/route.ts
@@ -4,10 +4,39 @@ import {
   createServerSupabaseRoute,
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
+import { isCustomerMessagingRole } from "@/features/ai/lib/chat/authorization";
 
 export const dynamic = "force-dynamic";
 
 const MAX_ROWS = 200;
+
+type CustomerDirectoryRow = {
+  id: string;
+  user_id: string | null;
+  name: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  phone: string | null;
+};
+
+function customerOption(customer: CustomerDirectoryRow) {
+  return {
+    id: customer.id,
+    user_id: customer.user_id,
+    full_name:
+      customer.name?.trim() ||
+      [customer.first_name, customer.last_name]
+        .filter(Boolean)
+        .join(" ")
+        .trim() ||
+      customer.email ||
+      "Customer",
+    email: customer.email,
+    phone: customer.phone,
+    can_message: Boolean(customer.user_id),
+  };
+}
 
 export async function GET(req: Request) {
   const userClient = createServerSupabaseRoute();
@@ -15,6 +44,7 @@ export async function GET(req: Request) {
 
   const { searchParams } = new URL(req.url);
   const q = searchParams.get("q")?.trim() ?? "";
+  const customerId = searchParams.get("customerId")?.trim() ?? "";
 
   // who is calling
   const {
@@ -43,6 +73,35 @@ export async function GET(req: Request) {
     return NextResponse.json(
       { error: "Current user is not associated with a shop" },
       { status: 403 },
+    );
+  }
+
+  const canMessageCustomers = isCustomerMessagingRole(me.role);
+  if (customerId) {
+    if (!canMessageCustomers) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { data: customer, error: customerError } = await admin
+      .from("customers")
+      .select("id, user_id, name, first_name, last_name, email, phone")
+      .eq("shop_id", shopId)
+      .eq("id", customerId)
+      .maybeSingle<CustomerDirectoryRow>();
+
+    if (customerError) {
+      return NextResponse.json(
+        { error: customerError.message ?? "Failed to load customer" },
+        { status: 500 },
+      );
+    }
+    if (!customer) {
+      return NextResponse.json({ error: "Customer not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      { customer: customerOption(customer) },
+      { headers: { "Cache-Control": "private, no-store" } },
     );
   }
 
@@ -81,10 +140,6 @@ export async function GET(req: Request) {
       avatar_url: (u as { avatar_url?: string | null }).avatar_url ?? null,
     })) ?? [];
 
-  const canMessageCustomers = ["owner", "admin", "manager", "advisor"].includes(
-    (me.role ?? "").toLowerCase(),
-  );
-
   if (!canMessageCustomers) {
     return NextResponse.json({ users: normalized, customers: [] });
   }
@@ -110,18 +165,7 @@ export async function GET(req: Request) {
     );
   }
 
-  const customers = (customerRows ?? []).map((customer) => ({
-    id: customer.id,
-    user_id: customer.user_id,
-    full_name:
-      customer.name?.trim() ||
-      [customer.first_name, customer.last_name].filter(Boolean).join(" ").trim() ||
-      customer.email ||
-      "Customer",
-    email: customer.email,
-    phone: customer.phone,
-    can_message: Boolean(customer.user_id),
-  }));
+  const customers = (customerRows ?? []).map(customerOption);
 
   return NextResponse.json({ users: normalized, customers });
 }

--- a/app/api/portal/book/route.ts
+++ b/app/api/portal/book/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { ROLE_GROUPS } from "@/features/shared/lib/rbac";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import {
   createPortalBooking,
   type CreatePortalBookingInput,
@@ -28,26 +28,12 @@ function legacyStaffOperationKey(userId: string, body: CreatePortalBookingInput)
 
 export async function POST(req: Request) {
   try {
-    const supabase = createServerSupabaseRoute();
-    const {
-      data: { user },
-      error: authErr,
-    } = await supabase.auth.getUser();
+    const access = await requireShopScopedApiAccess({
+      allowRoles: ROLE_GROUPS.schedulerBookingWriters,
+    });
+    if (!access.ok) return access.response;
 
-    if (authErr || !user) return bad("Not authenticated", 401);
-
-    const { data: profile, error: profileErr } = await supabase
-      .from("profiles")
-      .select("role")
-      .eq("id", user.id)
-      .maybeSingle<{ role: string | null }>();
-
-    if (profileErr) return bad(profileErr.message, 403);
-
-    const actor = getActorCapabilities({ role: profile?.role ?? null });
-    if (!actor.isKnownRole || (!actor.canManageScheduling && !actor.canViewShopWideData)) {
-      return bad("This legacy endpoint is staff-only", 403);
-    }
+    const { authUserId: userId, supabase } = access;
 
     const body = (await req.json().catch(() => null)) as CreatePortalBookingInput | null;
     if (!body) return bad("Invalid JSON body", 400);
@@ -56,11 +42,11 @@ export async function POST(req: Request) {
       req.headers.get("Idempotency-Key")?.trim() ||
       body.operationKey?.trim() ||
       body.idempotencyKey?.trim() ||
-      legacyStaffOperationKey(user.id, body);
+      legacyStaffOperationKey(userId, body);
 
     const result = await createPortalBooking({
       supabase,
-      userId: user.id,
+      userId,
       input: { ...body, operationKey },
       actorMode: "allow-staff",
     });

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,29 +1,34 @@
-"use client";
+import ChatListClient from "@/features/chat/components/ChatListClient";
 
-import { useEffect, useState } from "react";
-import PageShell from "@/features/shared/components/PageShell";
-import InboxModal from "@/features/chat/components/InboxModal";
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-export default function ChatListPage(): JSX.Element {
-  const [open, setOpen] = useState(true);
+type ChatListPageProps = {
+  searchParams: Promise<{
+    compose?: string;
+    contextType?: string;
+    contextId?: string;
+    customerId?: string;
+  }>;
+};
 
-  useEffect(() => {
-    setOpen(true);
-  }, []);
+export default async function ChatListPage({
+  searchParams,
+}: ChatListPageProps) {
+  const requested = await searchParams;
+  const contextId = requested.contextId?.trim() ?? "";
+  const customerId = requested.customerId?.trim() ?? "";
+  const startCustomerCompose =
+    requested.compose === "customer" &&
+    requested.contextType === "vehicle" &&
+    UUID_PATTERN.test(contextId) &&
+    UUID_PATTERN.test(customerId);
 
   return (
-    <PageShell title="Inbox">
-      <div className="rounded-xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
-        <p className="mb-3">Inbox is now layered as an operational modal so messaging stays in context.</p>
-        <button
-          type="button"
-          onClick={() => setOpen(true)}
-          className="rounded border border-[var(--accent-copper-soft)] px-3 py-1.5 text-xs font-semibold text-[var(--accent-copper-soft)] hover:bg-orange-500/10"
-        >
-          Open Inbox
-        </button>
-      </div>
-      <InboxModal open={open} onClose={() => setOpen(false)} />
-    </PageShell>
+    <ChatListClient
+      startCustomerCompose={startCustomerCompose}
+      contextId={startCustomerCompose ? contextId : null}
+      customerId={startCustomerCompose ? customerId : null}
+    />
   );
 }

--- a/app/dashboard/appointments/page.tsx
+++ b/app/dashboard/appointments/page.tsx
@@ -43,6 +43,11 @@ type ShopRow = Pick<
   "id" | "name" | "slug" | "accepts_online_booking"
 >;
 type CustomerRow = Database["public"]["Tables"]["customers"]["Row"];
+type AppointmentCreatePrefill = {
+  customer: CustomerRow;
+  vehicleId: string;
+  vehicleLabel: string;
+};
 
 type ShopContextResponse = {
   shop?: ShopRow | null;
@@ -207,6 +212,9 @@ export default function PortalAppointmentsPage(): JSX.Element {
   const search = useSearchParams();
   const router = useRouter();
   const requestedBookingId = search.get("bookingId")?.trim() ?? "";
+  const requestedCreate = search.get("openCreate") === "1";
+  const requestedCustomerId = search.get("customerId")?.trim() ?? "";
+  const requestedVehicleId = search.get("vehicleId")?.trim() ?? "";
 
   const [shops, setShops] = useState<ShopRow[]>([]);
   const [shopSlug, setShopSlug] = useState<string>(search.get("shop") || "");
@@ -226,6 +234,8 @@ export default function PortalAppointmentsPage(): JSX.Element {
   const [panelMode, setPanelMode] = useState<PanelMode>(null);
   const [editing, setEditing] = useState<Booking | null>(null);
   const [creatingDate, setCreatingDate] = useState<string | null>(null);
+  const [createPrefill, setCreatePrefill] =
+    useState<AppointmentCreatePrefill | null>(null);
 
   const [query, setQuery] = useState<string>("");
   const [listTab, setListTab] = useState<ListTab>("all");
@@ -233,6 +243,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
 
   const bookingsAbortRef = useRef<AbortController | null>(null);
   const requestsAbortRef = useRef<AbortController | null>(null);
+  const consumedCreateHandoffRef = useRef<string | null>(null);
 
   // "..." menu state
   const [menuOpenFor, setMenuOpenFor] = useState<string | null>(null);
@@ -404,6 +415,66 @@ export default function PortalAppointmentsPage(): JSX.Element {
     };
   }, [supabase, selectedShop]);
 
+  // Workspace handoffs are hydrated from same-shop canonical rows before the
+  // create drawer opens. Query parameters are hints only; the create endpoint
+  // performs the authoritative relationship and tenant checks again.
+  useEffect(() => {
+    if (
+      !requestedCreate ||
+      !requestedCustomerId ||
+      !requestedVehicleId ||
+      !selectedShop ||
+      loadingCustomers
+    ) {
+      return;
+    }
+
+    const handoffKey = `${selectedShop.id}:${requestedCustomerId}:${requestedVehicleId}`;
+    if (consumedCreateHandoffRef.current === handoffKey) return;
+    const customer = customers.find((row) => row.id === requestedCustomerId);
+    if (!customer) return;
+
+    const controller = new AbortController();
+    void (async () => {
+      const { data: vehicle, error } = await supabase
+        .from("vehicles")
+        .select("id,year,make,model,unit_number,license_plate,vin")
+        .eq("shop_id", selectedShop.id)
+        .eq("id", requestedVehicleId)
+        .eq("customer_id", requestedCustomerId)
+        .abortSignal(controller.signal)
+        .maybeSingle();
+      if (controller.signal.aborted) return;
+      if (error || !vehicle) {
+        toast.error("The selected customer and vehicle could not be opened.");
+        return;
+      }
+
+      const label =
+        [vehicle.year, vehicle.make, vehicle.model].filter(Boolean).join(" ") ||
+        (vehicle.unit_number ? `Unit ${vehicle.unit_number}` : null) ||
+        vehicle.license_plate ||
+        vehicle.vin ||
+        "Selected vehicle";
+      consumedCreateHandoffRef.current = handoffKey;
+      setCreatePrefill({ customer, vehicleId: vehicle.id, vehicleLabel: label });
+      setCreatingDate(isoDate(weekStart));
+      setEditing(null);
+      setPanelMode("create");
+    })();
+
+    return () => controller.abort();
+  }, [
+    customers,
+    loadingCustomers,
+    requestedCreate,
+    requestedCustomerId,
+    requestedVehicleId,
+    selectedShop,
+    supabase,
+    weekStart,
+  ]);
+
   const refreshBookings = useCallback(
     async (slug: string, ws: Date, we: Date) => {
       if (!slug) return;
@@ -532,6 +603,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
   }, [filteredBookings, listTab]);
 
   function openCreate(dayIso: string) {
+    setCreatePrefill(null);
     setCreatingDate(dayIso);
     setEditing(null);
     setPanelMode("create");
@@ -547,6 +619,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
     setPanelMode(null);
     setEditing(null);
     setCreatingDate(null);
+    setCreatePrefill(null);
   }
 
   async function handleCreate(form: {
@@ -554,6 +627,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
     startsAt: string;
     endsAt: string;
     customerId?: string;
+    vehicleId?: string;
     customerName: string;
     customerEmail: string;
     customerPhone: string;
@@ -581,6 +655,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
           endsAt: endIso,
           notes: form.notes,
           customerId: form.customerId ?? null,
+          vehicleId: form.vehicleId ?? null,
           customerName: form.customerName,
           customerEmail: form.customerEmail,
           customerPhone: form.customerPhone,
@@ -1120,6 +1195,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
                 defaultDate={creatingDate ?? isoDate(weekStart)}
                 customers={customers}
                 loadingCustomers={loadingCustomers}
+                prefill={createPrefill}
                 onCancel={closePanel}
                 onSubmit={handleCreate}
               />
@@ -1344,6 +1420,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
                 defaultDate={creatingDate ?? isoDate(weekStart)}
                 customers={customers}
                 loadingCustomers={loadingCustomers}
+                prefill={createPrefill}
                 onCancel={closePanel}
                 onSubmit={handleCreate}
               />
@@ -1391,18 +1468,21 @@ function CreateForm({
   defaultDate,
   customers,
   loadingCustomers,
+  prefill,
   onCancel,
   onSubmit,
 }: {
   defaultDate: string;
   customers: CustomerRow[];
   loadingCustomers: boolean;
+  prefill: AppointmentCreatePrefill | null;
   onCancel: () => void;
   onSubmit: (form: {
     date: string;
     startsAt: string;
     endsAt: string;
     customerId?: string;
+    vehicleId?: string;
     customerName: string;
     customerEmail: string;
     customerPhone: string;
@@ -1412,10 +1492,41 @@ function CreateForm({
   const [date, setDate] = useState(defaultDate);
   const [startsAt, setStartsAt] = useState("09:00");
   const [endsAt, setEndsAt] = useState("10:00");
-  const [customerId, setCustomerId] = useState<string>("");
-  const [customerName, setCustomerName] = useState("");
-  const [customerEmail, setCustomerEmail] = useState("");
-  const [customerPhone, setCustomerPhone] = useState("");
+  const initialCustomer = prefill?.customer ?? null;
+  const initialRecord = initialCustomer as unknown as Record<
+    string,
+    unknown
+  > | null;
+  const initialFull = initialRecord
+    ? safeString(initialRecord["full_name"]) || safeString(initialRecord["name"])
+    : "";
+  const initialFirst = initialRecord
+    ? safeString(initialRecord["first_name"])
+    : "";
+  const initialLast = initialRecord
+    ? safeString(initialRecord["last_name"])
+    : "";
+  const [customerId, setCustomerId] = useState<string>(
+    initialCustomer?.id ?? "",
+  );
+  const [vehicleId, setVehicleId] = useState<string>(
+    prefill?.vehicleId ?? "",
+  );
+  const [customerName, setCustomerName] = useState(
+    initialFull || `${initialFirst} ${initialLast}`.trim(),
+  );
+  const [customerEmail, setCustomerEmail] = useState(
+    initialRecord
+      ? safeString(initialRecord["email"]) ||
+        safeString(initialRecord["contact_email"])
+      : "",
+  );
+  const [customerPhone, setCustomerPhone] = useState(
+    initialRecord
+      ? safeString(initialRecord["phone"]) ||
+        safeString(initialRecord["mobile"])
+      : "",
+  );
   const [notes, setNotes] = useState("");
 
   useEffect(() => {
@@ -1424,6 +1535,7 @@ function CreateForm({
 
   const handleSelectCustomer = (id: string) => {
     setCustomerId(id);
+    if (id !== prefill?.customer.id) setVehicleId("");
     const c = customers.find((x) => x.id === id);
     if (!c) return;
 
@@ -1450,6 +1562,7 @@ function CreateForm({
           startsAt,
           endsAt,
           customerId: customerId || undefined,
+          vehicleId: vehicleId || undefined,
           customerName,
           customerEmail,
           customerPhone,
@@ -1460,6 +1573,13 @@ function CreateForm({
       <h3 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
         Create appointment
       </h3>
+
+      {vehicleId && prefill ? (
+        <div className="rounded-xl border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-sm">
+          <span className="text-[color:var(--theme-text-muted)]">Vehicle</span>{" "}
+          <strong>{prefill.vehicleLabel}</strong>
+        </div>
+      ) : null}
 
       <div className="grid gap-2 sm:grid-cols-2">
         <label className="text-xs text-[color:var(--theme-text-secondary)]">

--- a/app/estimates/new/page.tsx
+++ b/app/estimates/new/page.tsx
@@ -3,26 +3,119 @@ export const revalidate = 0;
 
 import EstimateBuilder from "@/features/estimates/components/EstimateBuilder";
 import { ESTIMATE_ADVISOR_ROLES } from "@/features/estimates/lib/access";
+import type {
+  EstimateCustomerForm,
+  EstimateVehicleForm,
+} from "@/features/estimates/types";
 import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
-export default async function NewEstimatePage() {
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type NewEstimatePageProps = {
+  searchParams: Promise<{ customerId?: string; vehicleId?: string }>;
+};
+
+export default async function NewEstimatePage({
+  searchParams,
+}: NewEstimatePageProps) {
   const { profile } = await requireShopPageAccess({
     allowRoles: ESTIMATE_ADVISOR_ROLES,
     requiredCapability: "canAuthorizeQuotes",
   });
   const supabase = createServerSupabaseRSC();
-  const { data: shop } = await supabase
+  const requested = await searchParams;
+  const requestedCustomerId = requested.customerId?.trim() ?? "";
+  const requestedVehicleId = requested.vehicleId?.trim() ?? "";
+  const customerId = UUID_PATTERN.test(requestedCustomerId)
+    ? requestedCustomerId
+    : null;
+  const vehicleId = UUID_PATTERN.test(requestedVehicleId)
+    ? requestedVehicleId
+    : null;
+  const shopPromise = supabase
     .from("shops")
     .select("labor_rate,timezone")
     .eq("id", profile.shop_id)
     .maybeSingle();
+
+  let initialCustomer: EstimateCustomerForm | null = null;
+  let initialVehicle: EstimateVehicleForm | null = null;
+  if (customerId && vehicleId) {
+    const [customerResult, vehicleResult] = await Promise.all([
+      supabase
+        .from("customers")
+        .select(
+          "id,business_name,name,first_name,last_name,phone,email,address,city,province,postal_code",
+        )
+        .eq("shop_id", profile.shop_id)
+        .eq("id", customerId)
+        .maybeSingle(),
+      supabase
+        .from("vehicles")
+        .select(
+          "id,customer_id,year,make,model,vin,license_plate,mileage,color,unit_number,engine_hours,engine,submodel,engine_family,engine_type,transmission,transmission_type,fuel_type,drivetrain",
+        )
+        .eq("shop_id", profile.shop_id)
+        .eq("id", vehicleId)
+        .eq("customer_id", customerId)
+        .maybeSingle(),
+    ]);
+
+    if (
+      !customerResult.error &&
+      !vehicleResult.error &&
+      customerResult.data &&
+      vehicleResult.data
+    ) {
+      const customer = customerResult.data;
+      const vehicle = vehicleResult.data;
+      initialCustomer = {
+        id: customer.id,
+        business_name: customer.business_name,
+        name: customer.name,
+        first_name: customer.first_name,
+        last_name: customer.last_name,
+        phone: customer.phone,
+        email: customer.email,
+        address: customer.address,
+        city: customer.city,
+        province: customer.province,
+        postal_code: customer.postal_code,
+      };
+      initialVehicle = {
+        id: vehicle.id,
+        year: vehicle.year == null ? null : String(vehicle.year),
+        make: vehicle.make,
+        model: vehicle.model,
+        vin: vehicle.vin,
+        license_plate: vehicle.license_plate,
+        mileage: vehicle.mileage,
+        color: vehicle.color,
+        unit_number: vehicle.unit_number,
+        engine_hours:
+          vehicle.engine_hours == null ? null : String(vehicle.engine_hours),
+        engine: vehicle.engine,
+        submodel: vehicle.submodel,
+        engine_family: vehicle.engine_family,
+        engine_type: vehicle.engine_type,
+        transmission: vehicle.transmission,
+        transmission_type: vehicle.transmission_type,
+        fuel_type: vehicle.fuel_type,
+        drivetrain: vehicle.drivetrain,
+      };
+    }
+  }
+  const { data: shop } = await shopPromise;
 
   return (
     <EstimateBuilder
       shopId={profile.shop_id}
       defaultLaborRate={Number(shop?.labor_rate ?? 0)}
       shopTimezone={shop?.timezone ?? "UTC"}
+      initialCustomer={initialCustomer}
+      initialVehicle={initialVehicle}
     />
   );
 }

--- a/app/vehicles/[id]/page.tsx
+++ b/app/vehicles/[id]/page.tsx
@@ -2,7 +2,10 @@ import { unstable_noStore as noStore } from "next/cache";
 import { notFound } from "next/navigation";
 
 import VehicleWorkspace from "@/features/vehicles/components/VehicleWorkspace";
-import { VEHICLE_WORKSPACE_READER_ROLES } from "@/features/vehicles/lib/vehicleWorkspace";
+import {
+  VEHICLE_WORKSPACE_READER_ROLES,
+  vehicleWorkspaceActionHrefs,
+} from "@/features/vehicles/lib/vehicleWorkspace";
 import {
   loadVehicleWorkspaceSnapshot,
   vehicleWorkspaceCreateWorkOrderHref,
@@ -44,10 +47,15 @@ export default async function VehicleWorkspacePage({
   // public result so callers cannot use this route to enumerate vehicle IDs.
   if (!snapshot) notFound();
 
+  const actionHrefs = vehicleWorkspaceActionHrefs(snapshot);
+
   return (
     <VehicleWorkspace
       snapshot={snapshot}
       createWorkOrderHref={vehicleWorkspaceCreateWorkOrderHref(snapshot)}
+      bookAppointmentHref={actionHrefs.bookAppointment}
+      createEstimateHref={actionHrefs.createEstimate}
+      messageCustomerHref={actionHrefs.messageCustomer}
     />
   );
 }

--- a/features/chat/components/ChatListClient.tsx
+++ b/features/chat/components/ChatListClient.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import InboxModal from "@/features/chat/components/InboxModal";
+import PageShell from "@/features/shared/components/PageShell";
+
+type ChatListClientProps = {
+  startCustomerCompose: boolean;
+  contextId: string | null;
+  customerId: string | null;
+};
+
+export default function ChatListClient({
+  startCustomerCompose,
+  contextId,
+  customerId,
+}: ChatListClientProps): JSX.Element {
+  const [open, setOpen] = useState(true);
+  const contextOverride = useMemo(
+    () =>
+      startCustomerCompose && contextId
+        ? {
+            context_type: "vehicle",
+            context_id: contextId,
+            deep_link: `/vehicles/${contextId}`,
+            context_label: "Vehicle workspace",
+          }
+        : null,
+    [contextId, startCustomerCompose],
+  );
+
+  return (
+    <PageShell title="Inbox">
+      <div className="rounded-xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+        <p className="mb-3">
+          Inbox is now layered as an operational modal so messaging stays in
+          context.
+        </p>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded border border-[var(--accent-copper-soft)] px-3 py-1.5 text-xs font-semibold text-[var(--accent-copper-soft)] hover:bg-orange-500/10"
+        >
+          Open Inbox
+        </button>
+      </div>
+      <InboxModal
+        open={open}
+        onClose={() => setOpen(false)}
+        startNew={startCustomerCompose}
+        initialCustomerId={customerId}
+        contextOverride={contextOverride}
+      />
+    </PageShell>
+  );
+}

--- a/features/chat/components/InboxModal.tsx
+++ b/features/chat/components/InboxModal.tsx
@@ -58,6 +58,9 @@ type Props = {
   open: boolean;
   onClose: () => void;
   seedConversationId?: string | null;
+  startNew?: boolean;
+  initialCustomerId?: string | null;
+  contextOverride?: ComposeContext | null;
 };
 
 type ComposeContext = {
@@ -132,6 +135,9 @@ export default function InboxModal({
   open,
   onClose,
   seedConversationId = null,
+  startNew = false,
+  initialCustomerId = null,
+  contextOverride = null,
 }: Props): JSX.Element | null {
   const pathname = usePathname() ?? "/dashboard";
   const supabase = useMemo(() => createBrowserSupabase(), []);
@@ -149,11 +155,11 @@ export default function InboxModal({
   const [sending, setSending] = useState(false);
   const [selectedRecipients, setSelectedRecipients] = useState<string[]>([]);
   const [selectedCustomerId, setSelectedCustomerId] = useState<string | null>(
-    null,
+    initialCustomerId,
   );
   const [composeAudience, setComposeAudience] = useState<
     "internal" | "customer"
-  >("internal");
+  >(initialCustomerId ? "customer" : "internal");
   const [roleFilter, setRoleFilter] = useState("all");
   const [useContext, setUseContext] = useState(true);
   const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(
@@ -168,7 +174,10 @@ export default function InboxModal({
   const [draftSaved, setDraftSaved] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
 
-  const context = useMemo(() => inferContext(pathname), [pathname]);
+  const context = useMemo(
+    () => contextOverride ?? inferContext(pathname),
+    [contextOverride, pathname],
+  );
   const draftTargetId = activeConversationId
     ? `conversation:${activeConversationId}`
     : `staff:new:${composeAudience}:${context.context_type ?? "general"}:${context.context_id ?? "none"}`;
@@ -207,9 +216,13 @@ export default function InboxModal({
     const data = (await res.json()) as ConversationPayload[];
     setRows(data);
     setActiveConversationId(
-      (curr) => curr ?? seedConversationId ?? data[0]?.conversation.id ?? null,
+      (curr) =>
+        curr ??
+        (startNew
+          ? null
+          : seedConversationId ?? data[0]?.conversation.id ?? null),
     );
-  }, [seedConversationId]);
+  }, [seedConversationId, startNew]);
 
   const loadMessages = useCallback(async (conversationId: string) => {
     const res = await fetch("/api/chat/get-messages", {
@@ -247,6 +260,21 @@ export default function InboxModal({
       })
       .catch(() => undefined);
   }, [open, supabase, loadConversations]);
+
+  useEffect(() => {
+    if (!open || !startNew || !initialCustomerId || customers.length === 0) {
+      return;
+    }
+    const customer = customers.find((row) => row.id === initialCustomerId);
+    setComposeAudience("customer");
+    setActiveConversationId(null);
+    setSelectedCustomerId(customer?.can_message ? customer.id : null);
+    if (!customer?.can_message) {
+      setSendError(
+        "This customer must activate messaging before a message can be sent.",
+      );
+    }
+  }, [customers, initialCustomerId, open, startNew]);
 
   useEffect(() => {
     if (!open || !me) {
@@ -292,7 +320,11 @@ export default function InboxModal({
       setCompose(next.content);
       if (!activeConversationId) {
         setSelectedRecipients(next.recipientIds ?? []);
-        setSelectedCustomerId(next.customerId ?? null);
+        setSelectedCustomerId(
+          startNew && initialCustomerId
+            ? initialCustomerId
+            : next.customerId ?? null,
+        );
         setUseContext(next.useContext ?? true);
       }
       setDraftSaved(Boolean(stored?.content));
@@ -301,7 +333,14 @@ export default function InboxModal({
     return () => {
       cancelled = true;
     };
-  }, [activeConversationId, draftScope, draftTargetId, open]);
+  }, [
+    activeConversationId,
+    draftScope,
+    draftTargetId,
+    initialCustomerId,
+    open,
+    startNew,
+  ]);
 
   useEffect(() => {
     if (

--- a/features/chat/components/InboxModal.tsx
+++ b/features/chat/components/InboxModal.tsx
@@ -13,6 +13,7 @@ import {
   removeOfflineMessageDraft,
   resolveMessagingDraftScope,
   saveOfflineMessageDraft,
+  staffNewMessageDraftTarget,
   warmMessagingRouteShells,
   type OfflineMessageDraft,
 } from "@/features/chat/offline/messageDrafts";
@@ -155,8 +156,14 @@ export default function InboxModal({
   const [sending, setSending] = useState(false);
   const [selectedRecipients, setSelectedRecipients] = useState<string[]>([]);
   const [selectedCustomerId, setSelectedCustomerId] = useState<string | null>(
-    initialCustomerId,
+    startNew && initialCustomerId ? null : initialCustomerId,
   );
+  const [handoffCustomer, setHandoffCustomer] =
+    useState<CustomerOption | null>(null);
+  const [handoffCustomerResolved, setHandoffCustomerResolved] = useState(
+    !startNew || !initialCustomerId,
+  );
+  const [handoffError, setHandoffError] = useState<string | null>(null);
   const [composeAudience, setComposeAudience] = useState<
     "internal" | "customer"
   >(initialCustomerId ? "customer" : "internal");
@@ -180,13 +187,27 @@ export default function InboxModal({
   );
   const draftTargetId = activeConversationId
     ? `conversation:${activeConversationId}`
-    : `staff:new:${composeAudience}:${context.context_type ?? "general"}:${context.context_id ?? "none"}`;
+    : staffNewMessageDraftTarget({
+        audience: composeAudience,
+        customerId: selectedCustomerId,
+        contextType: context.context_type,
+        contextId: context.context_id,
+      });
+  const handoffPending = Boolean(
+    open && startNew && initialCustomerId && !handoffCustomerResolved,
+  );
   const draftReady = Boolean(
+    !handoffPending &&
     draftScope &&
     messageDraft &&
     loadedDraftTarget === draftTargetId &&
     messageDraft.targetId === draftTargetId,
   );
+  const customerOptions = useMemo(() => {
+    const options = new Map(customers.map((customer) => [customer.id, customer]));
+    if (handoffCustomer) options.set(handoffCustomer.id, handoffCustomer);
+    return [...options.values()];
+  }, [customers, handoffCustomer]);
   const newConversationFingerprint = useMemo(
     () =>
       JSON.stringify({
@@ -262,19 +283,68 @@ export default function InboxModal({
   }, [open, supabase, loadConversations]);
 
   useEffect(() => {
-    if (!open || !startNew || !initialCustomerId || customers.length === 0) {
+    if (!startNew || !initialCustomerId) {
+      setHandoffCustomer(null);
+      setHandoffCustomerResolved(true);
+      setHandoffError(null);
       return;
     }
-    const customer = customers.find((row) => row.id === initialCustomerId);
+    if (!open) {
+      setHandoffCustomer(null);
+      setHandoffCustomerResolved(false);
+      setHandoffError(null);
+      return;
+    }
+
+    let cancelled = false;
     setComposeAudience("customer");
     setActiveConversationId(null);
-    setSelectedCustomerId(customer?.can_message ? customer.id : null);
-    if (!customer?.can_message) {
-      setSendError(
-        "This customer must activate messaging before a message can be sent.",
-      );
-    }
-  }, [customers, initialCustomerId, open, startNew]);
+    setSelectedCustomerId(null);
+    setHandoffCustomer(null);
+    setHandoffCustomerResolved(false);
+    setHandoffError(null);
+    setMessageDraft(null);
+    setLoadedDraftTarget(null);
+    setCompose("");
+
+    void fetch(
+      `/api/chat/users?customerId=${encodeURIComponent(initialCustomerId)}`,
+      { credentials: "include", cache: "no-store" },
+    )
+      .then(async (response) => {
+        const body = (await response.json().catch(() => null)) as {
+          customer?: CustomerOption | null;
+          error?: string;
+        } | null;
+        if (cancelled) return;
+        const customer =
+          response.ok && body?.customer?.id === initialCustomerId
+            ? body.customer
+            : null;
+        setHandoffCustomer(customer);
+        setSelectedCustomerId(customer?.can_message ? customer.id : null);
+
+        if (!customer?.can_message) {
+          setHandoffError(
+            customer
+              ? "This customer must activate messaging before a message can be sent."
+              : "This customer is not available for messaging in this shop.",
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setHandoffError("The customer could not be verified for messaging.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setHandoffCustomerResolved(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [initialCustomerId, open, startNew]);
 
   useEffect(() => {
     if (!open || !me) {
@@ -305,7 +375,7 @@ export default function InboxModal({
   }, [me, open]);
 
   useEffect(() => {
-    if (!open || !draftScope) return;
+    if (!open || !draftScope || handoffPending) return;
     let cancelled = false;
     setLoadedDraftTarget(null);
     void getOfflineMessageDraft({
@@ -313,21 +383,23 @@ export default function InboxModal({
       targetId: draftTargetId,
     }).then((stored) => {
       if (cancelled) return;
+      const storedMatchesRecipient = Boolean(
+        !stored ||
+          activeConversationId ||
+          composeAudience !== "customer" ||
+          stored.customerId === selectedCustomerId,
+      );
+      const safeStored = storedMatchesRecipient ? stored : null;
       const next =
-        stored ??
+        safeStored ??
         createMessageDraft({ scope: draftScope, targetId: draftTargetId });
       setMessageDraft(next);
       setCompose(next.content);
       if (!activeConversationId) {
         setSelectedRecipients(next.recipientIds ?? []);
-        setSelectedCustomerId(
-          startNew && initialCustomerId
-            ? initialCustomerId
-            : next.customerId ?? null,
-        );
         setUseContext(next.useContext ?? true);
       }
-      setDraftSaved(Boolean(stored?.content));
+      setDraftSaved(Boolean(safeStored?.content));
       setLoadedDraftTarget(draftTargetId);
     });
     return () => {
@@ -335,11 +407,12 @@ export default function InboxModal({
     };
   }, [
     activeConversationId,
+    composeAudience,
     draftScope,
     draftTargetId,
-    initialCustomerId,
+    handoffPending,
     open,
-    startNew,
+    selectedCustomerId,
   ]);
 
   useEffect(() => {
@@ -880,12 +953,15 @@ export default function InboxModal({
                 </>
               ) : (
                 <div className="max-h-32 overflow-auto rounded border border-[color:var(--theme-border-soft)] p-1.5">
-                  {customers.map((customer) => (
+                  {customerOptions.map((customer) => (
                     <button
                       key={customer.id}
                       type="button"
                       disabled={!draftReady || sending || !customer.can_message}
-                      onClick={() => setSelectedCustomerId(customer.id)}
+                      onClick={() => {
+                        setSelectedCustomerId(customer.id);
+                        setHandoffError(null);
+                      }}
                       className={`mb-1 flex w-full items-center justify-between rounded px-2 py-1.5 text-left ${
                         selectedCustomerId === customer.id
                           ? "bg-[color:var(--theme-surface-subtle)] ring-1 ring-[var(--accent-copper-soft)]"
@@ -958,8 +1034,10 @@ export default function InboxModal({
               Saved on this device · delivery requires a connection
             </p>
           ) : null}
-          {sendError ? (
-            <p className="px-3 pb-2 text-[10px] text-red-300">{sendError}</p>
+          {sendError || handoffError ? (
+            <p className="px-3 pb-2 text-[10px] text-red-300">
+              {sendError ?? handoffError}
+            </p>
           ) : null}
         </section>
 

--- a/features/chat/offline/messageDrafts.ts
+++ b/features/chat/offline/messageDrafts.ts
@@ -32,6 +32,27 @@ export type OfflineMessageDraft = {
   updatedAt: string;
 };
 
+export function staffNewMessageDraftTarget(args: {
+  audience: "internal" | "customer";
+  customerId: string | null;
+  contextType: string | null;
+  contextId: string | null;
+}): string {
+  const recipient =
+    args.audience === "customer"
+      ? `customer:${args.customerId ?? "none"}`
+      : "team";
+
+  return [
+    "staff",
+    "new",
+    args.audience,
+    recipient,
+    args.contextType ?? "general",
+    args.contextId ?? "none",
+  ].join(":");
+}
+
 export function createMessageDraft(args: {
   scope: OfflineMutationScope;
   targetId: string;

--- a/features/estimates/components/EstimateBuilder.tsx
+++ b/features/estimates/components/EstimateBuilder.tsx
@@ -44,6 +44,8 @@ type Props = {
   shopId?: string;
   defaultLaborRate?: number;
   shopTimezone?: string;
+  initialCustomer?: EstimateCustomerForm | null;
+  initialVehicle?: EstimateVehicleForm | null;
 };
 
 type MutationResult = {
@@ -247,6 +249,8 @@ export default function EstimateBuilder({
   shopId: initialShopId,
   defaultLaborRate = 0,
   shopTimezone = "UTC",
+  initialCustomer = null,
+  initialVehicle = null,
 }: Props) {
   const router = useRouter();
   const isNew = !estimateId;
@@ -259,16 +263,16 @@ export default function EstimateBuilder({
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [customer, setCustomer] = useState<EstimateCustomerForm>({
-    ...EMPTY_ESTIMATE_CUSTOMER,
+    ...(initialCustomer ?? EMPTY_ESTIMATE_CUSTOMER),
   });
   const [vehicle, setVehicle] = useState<EstimateVehicleForm>({
-    ...EMPTY_ESTIMATE_VEHICLE,
+    ...(initialVehicle ?? EMPTY_ESTIMATE_VEHICLE),
   });
   const [selectedCustomerId, setSelectedCustomerId] = useState<string | null>(
-    null,
+    initialCustomer?.id ?? null,
   );
   const [selectedVehicleId, setSelectedVehicleId] = useState<string | null>(
-    null,
+    initialVehicle?.id ?? null,
   );
   const [lines, setLines] = useState<EstimateLineDraft[]>(() => [
     newLine(defaultLaborRate),

--- a/features/shared/lib/rbac.ts
+++ b/features/shared/lib/rbac.ts
@@ -47,6 +47,7 @@ export const ROLE_GROUPS = {
     "lead_hand",
     "foreman",
   ],
+  schedulerBookingWriters: ["owner", "admin", "manager", "advisor"],
   workAssigners: [
     "owner",
     "admin",

--- a/features/vehicles/components/VehicleWorkspace.tsx
+++ b/features/vehicles/components/VehicleWorkspace.tsx
@@ -151,7 +151,7 @@ function canOpenTimelineEvent(
   event: VehicleTimelineEvent,
   permissions: VehicleWorkspacePermissions,
 ): boolean {
-  if (event.kind === "appointment" && !permissions.canBookAppointment) {
+  if (event.kind === "appointment" && !permissions.canOpenAppointments) {
     return false;
   }
   if (event.kind === "estimate") return permissions.canViewEstimates;
@@ -598,7 +598,7 @@ export function VehicleWorkspace({
               <AppointmentCard
                 key={`${appointment.reference.sourceType}:${appointment.reference.sourceId}`}
                 appointment={appointment}
-                canOpen={snapshot.permissions.canBookAppointment}
+                canOpen={snapshot.permissions.canOpenAppointments}
               />
             ))}
           </ul>

--- a/features/vehicles/components/VehicleWorkspace.tsx
+++ b/features/vehicles/components/VehicleWorkspace.tsx
@@ -14,6 +14,9 @@ import type {
 type VehicleWorkspaceProps = {
   snapshot: VehicleWorkspaceSnapshot;
   createWorkOrderHref: string | null;
+  bookAppointmentHref: string | null;
+  createEstimateHref: string | null;
+  messageCustomerHref: string | null;
 };
 
 const PANEL =
@@ -394,6 +397,9 @@ function TimelineEvent({
 export function VehicleWorkspace({
   snapshot,
   createWorkOrderHref,
+  bookAppointmentHref,
+  createEstimateHref,
+  messageCustomerHref,
 }: VehicleWorkspaceProps) {
   const { identity, currentAccount } = snapshot;
   const visibleTimeline = snapshot.recentTimeline.slice(0, 8);
@@ -506,6 +512,30 @@ export function VehicleWorkspace({
                   className={`${LINK_FOCUS} rounded-lg border border-[color:var(--accent-copper-soft,#fdba74)] bg-[color:var(--accent-copper,#c47a3a)] px-3.5 py-2 text-sm font-semibold text-white transition hover:brightness-110`}
                 >
                   Create Work Order
+                </Link>
+              ) : null}
+              {snapshot.permissions.canBookAppointment && bookAppointmentHref ? (
+                <Link
+                  href={bookAppointmentHref}
+                  className={`${LINK_FOCUS} rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3.5 py-2 text-sm font-semibold transition hover:bg-[color:var(--theme-surface-subtle)]`}
+                >
+                  Book
+                </Link>
+              ) : null}
+              {snapshot.permissions.canCreateEstimate && createEstimateHref ? (
+                <Link
+                  href={createEstimateHref}
+                  className={`${LINK_FOCUS} rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3.5 py-2 text-sm font-semibold transition hover:bg-[color:var(--theme-surface-subtle)]`}
+                >
+                  Estimate
+                </Link>
+              ) : null}
+              {snapshot.permissions.canMessageCustomer && messageCustomerHref ? (
+                <Link
+                  href={messageCustomerHref}
+                  className={`${LINK_FOCUS} rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3.5 py-2 text-sm font-semibold transition hover:bg-[color:var(--theme-surface-subtle)]`}
+                >
+                  Message
                 </Link>
               ) : null}
             </nav>

--- a/features/vehicles/lib/vehicleWorkspace.ts
+++ b/features/vehicles/lib/vehicleWorkspace.ts
@@ -44,6 +44,7 @@ export type VehicleWorkspacePermissions = {
   canViewPartRequests: boolean;
   canCreateWorkOrder: boolean;
   canBookAppointment: boolean;
+  canOpenAppointments: boolean;
   canCreateEstimate: boolean;
   canMessageCustomer: boolean;
   canViewRelatedVehicles: boolean;

--- a/features/vehicles/lib/vehicleWorkspace.ts
+++ b/features/vehicles/lib/vehicleWorkspace.ts
@@ -183,6 +183,49 @@ export type VehicleWorkspaceSnapshot = {
   conflicts: VehicleWorkspaceConflict[];
 };
 
+export type VehicleWorkspaceActionHrefs = {
+  bookAppointment: string | null;
+  createEstimate: string | null;
+  messageCustomer: string | null;
+};
+
+export function vehicleWorkspaceActionHrefs(
+  snapshot: VehicleWorkspaceSnapshot,
+): VehicleWorkspaceActionHrefs {
+  const account = snapshot.currentAccount;
+  const blocked = snapshot.conflicts.some((conflict) =>
+    ["archived_account", "vehicle_status"].includes(conflict.kind),
+  );
+  if (
+    blocked ||
+    !account?.active ||
+    account.archivedAt ||
+    account.mergedIntoCustomerId
+  ) {
+    return {
+      bookAppointment: null,
+      createEstimate: null,
+      messageCustomer: null,
+    };
+  }
+
+  const handoff = new URLSearchParams({
+    customerId: account.id,
+    vehicleId: snapshot.identity.id,
+  });
+  return {
+    bookAppointment: snapshot.permissions.canBookAppointment
+      ? `/dashboard/appointments?openCreate=1&${handoff.toString()}`
+      : null,
+    createEstimate: snapshot.permissions.canCreateEstimate
+      ? `/estimates/new?${handoff.toString()}`
+      : null,
+    messageCustomer: snapshot.permissions.canMessageCustomer
+      ? `/chat?compose=customer&contextType=vehicle&contextId=${encodeURIComponent(snapshot.identity.id)}&customerId=${encodeURIComponent(account.id)}`
+      : null,
+  };
+}
+
 export type VehicleWorkspaceSearchCard = {
   vehicle: VehicleIdentity;
   currentAccount: Pick<CustomerAccountSummary, "id" | "displayName"> | null;

--- a/features/vehicles/server/vehicleWorkspacePermissions.ts
+++ b/features/vehicles/server/vehicleWorkspacePermissions.ts
@@ -52,6 +52,9 @@ export function vehicleWorkspacePermissionsForRole(
   const isWorkOrderCreator = (
     ROLE_GROUPS.workOrderCreators as readonly CanonicalRole[]
   ).includes(role);
+  const isSchedulerBookingWriter = (
+    ROLE_GROUPS.schedulerBookingWriters as readonly CanonicalRole[]
+  ).includes(role);
 
   return {
     canViewAccountContact:
@@ -73,7 +76,8 @@ export function vehicleWorkspacePermissionsForRole(
       role,
     ),
     canCreateWorkOrder: isWorkOrderCreator,
-    canBookAppointment: capabilities.canManageScheduling,
+    canBookAppointment: isSchedulerBookingWriter,
+    canOpenAppointments: capabilities.canManageScheduling,
     canCreateEstimate: estimateActorForRole(role).canCreate,
     canMessageCustomer: isCustomerMessagingRole(role),
     canViewRelatedVehicles:

--- a/tests/chat-users-route.test.ts
+++ b/tests/chat-users-route.test.ts
@@ -35,6 +35,7 @@ const mockState = {
   customers: [] as CustomerRow[],
   lastProfilesEq: null as { column: string; value: string } | null,
   lastCustomersEq: null as { column: string; value: string } | null,
+  customerEqFilters: [] as Array<{ column: string; value: string }>,
 };
 
 function asAwaitable<T extends object>(
@@ -77,38 +78,55 @@ function createAdminClient() {
   return {
     from: vi.fn((table: string) => {
       if (table === "customers") {
-        let eqFilter: { column: string; value: string } | null = null;
+        const eqFilters: Array<{ column: string; value: string }> = [];
         let searchQuery = "";
+        let limitValue: number | null = null;
         const baseQuery: Record<string, unknown> = {};
-        const query = asAwaitable(baseQuery, async () => {
-          const scoped =
-            eqFilter?.column === "shop_id"
-              ? mockState.customers.filter((row) => row.shop_id === eqFilter?.value)
-              : mockState.customers;
+        const resolveRows = async (): Promise<QueryResult<unknown>> => {
+          const scoped = mockState.customers.filter((row) =>
+            eqFilters.every(
+              (filter) =>
+                row[filter.column as keyof CustomerRow] === filter.value,
+            ),
+          );
           const searchMatch = /name\.ilike\.%(.*?)%,first_name\.ilike/.exec(searchQuery);
           const text = (searchMatch?.[1] ?? "").trim().toLowerCase();
+          const matching = text
+            ? scoped.filter((row) =>
+                [row.name, row.first_name, row.last_name, row.email, row.phone]
+                  .filter(Boolean)
+                  .some((value) => value?.toLowerCase().includes(text)),
+              )
+            : scoped;
           return {
-            data: text
-              ? scoped.filter((row) =>
-                  [row.name, row.first_name, row.last_name, row.email, row.phone]
-                    .filter(Boolean)
-                    .some((value) => value?.toLowerCase().includes(text)),
-                )
-              : scoped,
+            data: limitValue === null ? matching : matching.slice(0, limitValue),
             error: null,
           };
-        });
+        };
+        const query = asAwaitable(baseQuery, resolveRows);
         query.select = vi.fn(() => query);
         query.eq = vi.fn((column: string, value: string) => {
-          eqFilter = { column, value };
-          mockState.lastCustomersEq = eqFilter;
+          const filter = { column, value };
+          eqFilters.push(filter);
+          mockState.lastCustomersEq = filter;
+          mockState.customerEqFilters = [...eqFilters];
           return query;
         });
         query.order = vi.fn(() => query);
-        query.limit = vi.fn(() => query);
+        query.limit = vi.fn((value: number) => {
+          limitValue = value;
+          return query;
+        });
         query.or = vi.fn((pattern: string) => {
           searchQuery = pattern;
           return query;
+        });
+        query.maybeSingle = vi.fn(async () => {
+          const result = await resolveRows();
+          return {
+            data: (result.data as CustomerRow[])[0] ?? null,
+            error: result.error,
+          };
         });
         return query;
       }
@@ -181,6 +199,7 @@ describe("GET /api/chat/users", () => {
     };
     mockState.lastProfilesEq = null;
     mockState.lastCustomersEq = null;
+    mockState.customerEqFilters = [];
     mockState.profiles = [
       {
         id: "profile-actor",
@@ -292,6 +311,91 @@ describe("GET /api/chat/users", () => {
     expect(body.customers).toEqual([
       expect.objectContaining({ id: "customer-a", can_message: true }),
     ]);
+  });
+
+  it("resolves an exact handoff customer outside the capped directory", async () => {
+    const target: CustomerRow = {
+      id: "customer-target",
+      user_id: "customer-target-user",
+      name: "Target Customer",
+      first_name: "Target",
+      last_name: "Customer",
+      email: "target@example.com",
+      phone: "555-9999",
+      shop_id: "shop-a",
+    };
+    mockState.customers = [
+      ...Array.from({ length: 200 }, (_, index): CustomerRow => ({
+        id: `customer-${index}`,
+        user_id: `customer-user-${index}`,
+        name: `Customer ${index}`,
+        first_name: "Customer",
+        last_name: String(index),
+        email: `customer-${index}@example.com`,
+        phone: null,
+        shop_id: "shop-a",
+      })),
+      target,
+    ];
+
+    const { GET } = await import("../app/api/chat/users/route");
+    const directoryResponse = await GET(
+      new Request("http://localhost/api/chat/users"),
+    );
+    const directory = (await directoryResponse.json()) as {
+      customers: Array<{ id: string }>;
+    };
+    expect(directory.customers).toHaveLength(200);
+    expect(directory.customers.some((customer) => customer.id === target.id)).toBe(
+      false,
+    );
+
+    const exactResponse = await GET(
+      new Request(
+        `http://localhost/api/chat/users?customerId=${target.id}`,
+      ),
+    );
+    const exact = (await exactResponse.json()) as {
+      customer: { id: string; can_message: boolean };
+    };
+
+    expect(exactResponse.status).toBe(200);
+    expect(exact.customer).toEqual(
+      expect.objectContaining({ id: target.id, can_message: true }),
+    );
+    expect(mockState.customerEqFilters).toEqual([
+      { column: "shop_id", value: "shop-a" },
+      { column: "id", value: target.id },
+    ]);
+  });
+
+  it("does not resolve an exact handoff customer from another shop", async () => {
+    const { GET } = await import("../app/api/chat/users/route");
+    const response = await GET(
+      new Request("http://localhost/api/chat/users?customerId=customer-b"),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Customer not found",
+    });
+  });
+
+  it("uses the canonical customer-messaging role gate for exact lookups", async () => {
+    mockState.me.role = "service";
+    const { GET } = await import("../app/api/chat/users/route");
+    const allowed = await GET(
+      new Request("http://localhost/api/chat/users?customerId=customer-a"),
+    );
+    expect(allowed.status).toBe(200);
+
+    mockState.me.role = "tech";
+    mockState.customerEqFilters = [];
+    const denied = await GET(
+      new Request("http://localhost/api/chat/users?customerId=customer-a"),
+    );
+    expect(denied.status).toBe(403);
+    expect(mockState.customerEqFilters).toEqual([]);
   });
 
   it("does not expose the customer directory to non-customer-facing roles", async () => {

--- a/tests/offline-message-drafts.test.ts
+++ b/tests/offline-message-drafts.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { staffNewMessageDraftTarget } from "@/features/chat/offline/messageDrafts";
 
 const read = (path: string) => readFileSync(path, "utf8");
 const repository = read("features/chat/offline/messageDrafts.ts");
@@ -11,6 +12,29 @@ const appShell = read("features/shared/components/AppShell.tsx");
 const serviceWorker = read("app/sw.ts");
 
 describe("offline messaging drafts", () => {
+  it("binds each new customer draft to its intended recipient", () => {
+    const context = {
+      audience: "customer" as const,
+      contextType: "vehicle",
+      contextId: "vehicle-a",
+    };
+
+    const firstOwner = staffNewMessageDraftTarget({
+      ...context,
+      customerId: "customer-a",
+    });
+    const nextOwner = staffNewMessageDraftTarget({
+      ...context,
+      customerId: "customer-b",
+    });
+
+    expect(firstOwner).not.toBe(nextOwner);
+    expect(firstOwner).toContain("customer:customer-a");
+    expect(nextOwner).toContain("customer:customer-b");
+    expect(staffInbox).toContain("staffNewMessageDraftTarget");
+    expect(staffInbox).toContain("stored.customerId === selectedCustomerId");
+  });
+
   it("stores drafts in tenant-scoped IndexedDB and never localStorage", () => {
     expect(repository).toContain('const KIND = "message-draft"');
     expect(repository).toContain("saveOfflineSnapshot");

--- a/tests/role-gating-contract.test.ts
+++ b/tests/role-gating-contract.test.ts
@@ -32,6 +32,15 @@ describe("canonical role gating contract", () => {
     }
   });
 
+  it("matches scheduler booking writes to the canonical database roles", () => {
+    expect(ROLE_GROUPS.schedulerBookingWriters).toEqual([
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+    ]);
+  });
+
   it("limits managers to operational and workforce authority", () => {
     const manager = getActorCapabilities({ role: "manager" });
     expect(manager.canManageWorkforce).toBe(true);

--- a/tests/universal-scheduler-contract.test.ts
+++ b/tests/universal-scheduler-contract.test.ts
@@ -95,6 +95,10 @@ describe("Universal Scheduler cutover", () => {
       'rpc(\n    "apply_portal_booking_command_atomic"',
     );
     expect(agentReschedule).not.toContain('.from("bookings")\n    .update');
+    expect(legacyStaffCreate).toContain(
+      "allowRoles: ROLE_GROUPS.schedulerBookingWriters",
+    );
+    expect(legacyStaffCreate).not.toContain("canManageScheduling");
   });
 
   it("uses one availability engine for portal validation and slot discovery", () => {

--- a/tests/vehicle-workspace-contract.test.ts
+++ b/tests/vehicle-workspace-contract.test.ts
@@ -464,6 +464,7 @@ describe("Shop Vehicle Workspace contract", () => {
           canViewPartRequests: true,
           canCreateWorkOrder: true,
           canBookAppointment: true,
+          canOpenAppointments: true,
           canCreateEstimate: true,
           canMessageCustomer: true,
           canViewRelatedVehicles: true,
@@ -479,6 +480,7 @@ describe("Shop Vehicle Workspace contract", () => {
           canViewPartRequests: true,
           canCreateWorkOrder: true,
           canBookAppointment: true,
+          canOpenAppointments: true,
           canCreateEstimate: true,
           canMessageCustomer: true,
           canViewRelatedVehicles: true,
@@ -494,6 +496,7 @@ describe("Shop Vehicle Workspace contract", () => {
           canViewPartRequests: true,
           canCreateWorkOrder: true,
           canBookAppointment: true,
+          canOpenAppointments: true,
           canCreateEstimate: true,
           canMessageCustomer: true,
           canViewRelatedVehicles: true,
@@ -509,6 +512,7 @@ describe("Shop Vehicle Workspace contract", () => {
           canViewPartRequests: false,
           canCreateWorkOrder: true,
           canBookAppointment: true,
+          canOpenAppointments: true,
           canCreateEstimate: true,
           canMessageCustomer: true,
           canViewRelatedVehicles: true,
@@ -524,6 +528,7 @@ describe("Shop Vehicle Workspace contract", () => {
           canViewPartRequests: false,
           canCreateWorkOrder: true,
           canBookAppointment: false,
+          canOpenAppointments: false,
           canCreateEstimate: true,
           canMessageCustomer: true,
           canViewRelatedVehicles: true,
@@ -539,6 +544,7 @@ describe("Shop Vehicle Workspace contract", () => {
           canViewPartRequests: true,
           canCreateWorkOrder: false,
           canBookAppointment: false,
+          canOpenAppointments: false,
           canCreateEstimate: false,
           canMessageCustomer: false,
           canViewRelatedVehicles: true,
@@ -554,6 +560,7 @@ describe("Shop Vehicle Workspace contract", () => {
           canViewPartRequests: false,
           canCreateWorkOrder: false,
           canBookAppointment: false,
+          canOpenAppointments: false,
           canCreateEstimate: false,
           canMessageCustomer: false,
           canViewRelatedVehicles: false,
@@ -568,7 +575,8 @@ describe("Shop Vehicle Workspace contract", () => {
           canOpenWorkOrders: true,
           canViewPartRequests: false,
           canCreateWorkOrder: true,
-          canBookAppointment: true,
+          canBookAppointment: false,
+          canOpenAppointments: true,
           canCreateEstimate: false,
           canMessageCustomer: true,
           canViewRelatedVehicles: true,
@@ -583,7 +591,8 @@ describe("Shop Vehicle Workspace contract", () => {
           canOpenWorkOrders: true,
           canViewPartRequests: false,
           canCreateWorkOrder: true,
-          canBookAppointment: true,
+          canBookAppointment: false,
+          canOpenAppointments: true,
           canCreateEstimate: true,
           canMessageCustomer: true,
           canViewRelatedVehicles: true,
@@ -639,6 +648,23 @@ describe("Shop Vehicle Workspace contract", () => {
         .filter(([, permissions]) => permissions.canViewPartRequests)
         .map(([role]) => role),
     ).toEqual(["owner", "admin", "manager", "parts"]);
+    expect(
+      Object.entries(projected)
+        .filter(([, permissions]) => permissions.canBookAppointment)
+        .map(([role]) => role),
+    ).toEqual(["owner", "admin", "manager", "advisor"]);
+    expect(
+      Object.entries(projected)
+        .filter(([, permissions]) => permissions.canOpenAppointments)
+        .map(([role]) => role),
+    ).toEqual([
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "lead_hand",
+      "foreman",
+    ]);
     expect(NON_SHOP_ROLES.map((role) => projected[role])).toEqual(
       NON_SHOP_ROLES.map(() => ({
         canViewAccountContact: false,
@@ -650,6 +676,7 @@ describe("Shop Vehicle Workspace contract", () => {
         canViewPartRequests: false,
         canCreateWorkOrder: false,
         canBookAppointment: false,
+        canOpenAppointments: false,
         canCreateEstimate: false,
         canMessageCustomer: false,
         canViewRelatedVehicles: false,

--- a/tests/vehicle-workspace-operational-actions.test.ts
+++ b/tests/vehicle-workspace-operational-actions.test.ts
@@ -42,6 +42,7 @@ function snapshot(
       canViewPartRequests: true,
       canCreateWorkOrder: true,
       canBookAppointment: true,
+      canOpenAppointments: true,
       canCreateEstimate: true,
       canMessageCustomer: true,
       canViewRelatedVehicles: true,
@@ -146,5 +147,18 @@ describe("Vehicle Workspace operational action handoffs", () => {
     expect(estimate).toContain('.eq("customer_id", customerId)');
     expect(estimate).toContain("initialCustomer={initialCustomer}");
     expect(estimate).toContain("initialVehicle={initialVehicle}");
+  });
+
+  it("resolves message handoff customers by exact tenant-scoped id", () => {
+    const inbox = readFileSync(
+      "features/chat/components/InboxModal.tsx",
+      "utf8",
+    );
+
+    expect(inbox).toContain("/api/chat/users?customerId=");
+    expect(inbox).toContain('cache: "no-store"');
+    expect(inbox).not.toContain(
+      "customers.find((row) => row.id === initialCustomerId)",
+    );
   });
 });

--- a/tests/vehicle-workspace-operational-actions.test.ts
+++ b/tests/vehicle-workspace-operational-actions.test.ts
@@ -1,0 +1,150 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  vehicleWorkspaceActionHrefs,
+  type VehicleWorkspaceSnapshot,
+} from "@/features/vehicles/lib/vehicleWorkspace";
+
+function snapshot(
+  patch: Partial<VehicleWorkspaceSnapshot> = {},
+): VehicleWorkspaceSnapshot {
+  return {
+    identity: {
+      id: "11111111-1111-4111-8111-111111111111",
+      year: 2020,
+      make: "Ford",
+      model: "Transit",
+      submodel: null,
+      vin: "1FTBR1C80LKA00001",
+      licensePlate: "SHOP123",
+      unitNumber: null,
+      mileage: "100000",
+      odometerUnit: "km",
+      engineHours: null,
+      status: "active",
+    },
+    currentAccount: {
+      id: "22222222-2222-4222-8222-222222222222",
+      displayName: "Canonical Customer",
+      accountType: "customer",
+      active: true,
+      archivedAt: null,
+      mergedIntoCustomerId: null,
+    },
+    permissions: {
+      canViewAccountContact: true,
+      canOpenAccount: true,
+      canViewFinancials: true,
+      canViewEstimates: true,
+      canOpenInspections: true,
+      canOpenWorkOrders: true,
+      canViewPartRequests: true,
+      canCreateWorkOrder: true,
+      canBookAppointment: true,
+      canCreateEstimate: true,
+      canMessageCustomer: true,
+      canViewRelatedVehicles: true,
+      isAssignedWorkOnly: false,
+    },
+    activeWork: [],
+    upcomingAppointments: [],
+    attentionItems: [],
+    recentTimeline: [],
+    financialSummary: { visible: false },
+    documentSummary: {
+      vehicleMediaCount: 0,
+      workOrderMediaCount: 0,
+      inspectionReportCount: 0,
+      latestReference: null,
+    },
+    relatedVehicles: [],
+    conflicts: [],
+    ...patch,
+  };
+}
+
+describe("Vehicle Workspace operational action handoffs", () => {
+  it("retains the canonical customer and vehicle in each existing flow", () => {
+    expect(vehicleWorkspaceActionHrefs(snapshot())).toEqual({
+      bookAppointment:
+        "/dashboard/appointments?openCreate=1&customerId=22222222-2222-4222-8222-222222222222&vehicleId=11111111-1111-4111-8111-111111111111",
+      createEstimate:
+        "/estimates/new?customerId=22222222-2222-4222-8222-222222222222&vehicleId=11111111-1111-4111-8111-111111111111",
+      messageCustomer:
+        "/chat?compose=customer&contextType=vehicle&contextId=11111111-1111-4111-8111-111111111111&customerId=22222222-2222-4222-8222-222222222222",
+    });
+  });
+
+  it("does not emit actions that the current role cannot perform", () => {
+    const base = snapshot();
+    expect(
+      vehicleWorkspaceActionHrefs({
+        ...base,
+        permissions: {
+          ...base.permissions,
+          canBookAppointment: false,
+          canCreateEstimate: false,
+          canMessageCustomer: false,
+        },
+      }),
+    ).toEqual({
+      bookAppointment: null,
+      createEstimate: null,
+      messageCustomer: null,
+    });
+  });
+
+  const blockedCases = [
+    ["missing account", { currentAccount: null }],
+    [
+      "archived account",
+      {
+        currentAccount: {
+          ...snapshot().currentAccount!,
+          archivedAt: "2026-08-19T00:00:00.000Z",
+        },
+      },
+    ],
+    [
+      "vehicle conflict",
+      {
+        conflicts: [
+          {
+            kind: "vehicle_status" as const,
+            title: "Archived vehicle",
+            detail: "Actions are unavailable.",
+            sourceIds: ["11111111-1111-4111-8111-111111111111"],
+          },
+        ],
+      },
+    ],
+  ] satisfies Array<[string, Partial<VehicleWorkspaceSnapshot>]>;
+
+  it.each(blockedCases)(
+    "blocks all mutation handoffs for a %s",
+    (_label, patch) => {
+      expect(vehicleWorkspaceActionHrefs(snapshot(patch))).toEqual({
+        bookAppointment: null,
+        createEstimate: null,
+        messageCustomer: null,
+      });
+    },
+  );
+
+  it("revalidates booking and estimate prefill against shop and ownership", () => {
+    const booking = readFileSync(
+      "app/dashboard/appointments/page.tsx",
+      "utf8",
+    );
+    const estimate = readFileSync("app/estimates/new/page.tsx", "utf8");
+
+    expect(booking).toContain('.eq("shop_id", selectedShop.id)');
+    expect(booking).toContain('.eq("customer_id", requestedCustomerId)');
+    expect(booking).toContain("vehicleId: form.vehicleId ?? null");
+    expect(estimate).toContain('.eq("shop_id", profile.shop_id)');
+    expect(estimate).toContain('.eq("customer_id", customerId)');
+    expect(estimate).toContain("initialCustomer={initialCustomer}");
+    expect(estimate).toContain("initialVehicle={initialVehicle}");
+  });
+});


### PR DESCRIPTION
## What changed

- adds role-gated **Book**, **Estimate**, and **Message** actions to the authoritative Vehicle Workspace
- hands canonical customer and vehicle IDs into the existing appointment, estimate, and messaging flows
- validates appointment and estimate prefill rows against the signed-in shop and customer/vehicle ownership before hydrating the UI
- resolves message handoff customers with an exact, tenant-scoped, role-gated lookup instead of relying on the capped inbox directory
- binds unsent customer drafts to both the customer and vehicle context so ownership changes cannot redirect prior draft content
- aligns Book visibility and the legacy booking API with the scheduler RPC's owner/admin/manager/advisor write-role contract
- preserves appointment read links separately for lead-hand and foreman roles
- blocks operational handoffs for missing, archived, merged, or conflicted account/vehicle records
- adds focused behavioral and contract coverage for handoffs, tenant boundaries, recipient-safe drafts, and scheduler roles

## Why

This starts PR 2 of the Vehicle Workspace rollout without rebuilding mutation workflows. Staff can act from vehicle context without searching for the same customer and vehicle again, while canonical APIs retain authorization and relationship checks.

## User impact

Authorized staff get Book, Estimate, and Message alongside Create Work Order. Existing standalone pages and canonical mutation APIs remain in place.

The presentation-label cleanup noted during UI review remains deliberately deferred polish.

## Database / migrations

No schema or migration changes are included or required.

## Validation

- `git diff --check`
- Node TypeScript syntax checks for every changed `.ts` file
- focused behavioral smoke checks for exact recipient lookup, cross-shop denial, customer-bound draft keys, and scheduler permissions
- API route boundary audit
- no migration diff
- full dependency-backed type-check, lint, tests, inventory, and production build are delegated to standard PR checks because this clean checkout has no installed project toolchain

## Deployment safety

`vercel.json` remains unchanged with deployments enabled for `main` and disabled for `*`, so this branch must not create a Vercel preview deployment.
