### PR TITLE
Workspace Platform: extract shared foundation

### DIFF
--- a/docs/workspace-platform-foundation-audit.md
+++ b/docs/workspace-platform-foundation-audit.md
@@ -1,0 +1,214 @@
+# Workspace Platform — Shared Foundation and Authorization Audit
+
+Date: 2026-08-19
+
+## Product decision
+
+ProFixIQ will use the following operating model:
+
+> Queues find the work. Workspaces do the work.
+
+Dispatch, Appointments, Parts, Receiving, Accounting, search, reporting, and
+other cross-record queues remain first-class. Selecting one long-lived or
+operational resource opens its canonical workspace.
+
+The initial consumers are:
+
+1. Customer / Vehicle Workspace — lifetime record and reference
+   implementation.
+2. Work Order Workspace — command center for one repair event.
+3. Fleet Unit Workspace — future consumer.
+4. Field Service Workspace — future consumer/adaptation.
+
+This is a shared presentation, context, and authorization platform. It is not a
+single universal data loader and it does not create copied workspace records.
+
+## Protected Work Order ID-page contract
+
+The existing `/work-orders/[id]` experience is the screen technicians live in.
+Its one-view layout, interaction speed, and existing operational logic are a
+product contract.
+
+For the Workspace Platform foundation:
+
+- `app/work-orders/[id]/page.tsx` is unchanged.
+- `app/work-orders/[id]/Client.tsx` is unchanged.
+- Existing repair, inspection, parts, punch, estimate, and work-order mutation
+  logic is unchanged.
+- The existing `WorkOrderOperationalTimelineDock` remains attached.
+- A future Work Order Workspace must evolve this page in place at the same
+  canonical URL. It must not replace it with a separate, less efficient detail
+  page or duplicate its domain services.
+
+Shared Workspace components may later be adopted incrementally where they
+preserve the current layout exactly. A visual rewrite is not a prerequisite for
+the Work Order Workspace.
+
+## Phase 2A inventory
+
+| Area | Current source | Classification | Foundation decision |
+| --- | --- | --- | --- |
+| Vehicle read model | `features/vehicles/server/loadVehicleWorkspaceSnapshot.ts` | Vehicle-specific, security-sensitive | Keep resource-specific and server-side. Do not generalize into one workspace loader. |
+| Vehicle source-link policy | `features/vehicles/components/VehicleWorkspace.tsx` | Vehicle-specific, security-sensitive | Keep permission decisions beside the vehicle contract. Shared cards receive an already-authorized href or no href. |
+| Vehicle role projection | `features/vehicles/server/vehicleWorkspacePermissions.ts` | Transitional authorization | Preserve for current behavior; replace only after an effective capability resolver exists. |
+| Shell and responsive spacing | Vehicle Workspace component | Workspace-generic | Extracted as `WorkspaceShell`. |
+| Sticky identity header | Vehicle Workspace component | Workspace-generic presentation | Extracted as `WorkspaceHeader`; resource identity remains the caller's responsibility. |
+| Action row | Vehicle Workspace component | Workspace-generic presentation | Extracted as `WorkspaceCommandBar`; callers remain responsible for action authorization. |
+| Section heading and panel | Vehicle Workspace component | Workspace-generic | Extracted as `WorkspaceSection`. |
+| Linked/read-only card surface | Vehicle Workspace component | Workspace-generic presentation | Extracted as `WorkspaceCard`. It is explicitly not an authorization boundary. |
+| Status, empty state, source footer | Vehicle Workspace component | Workspace-generic | Extracted as `WorkspaceStatus`, `WorkspaceEmptyState`, and `WorkspaceSourceReference`. |
+| Timeline rail | Vehicle Workspace component | Workspace-generic presentation | Extracted as `WorkspaceTimeline` and `WorkspaceTimelineItem`. Event semantics remain resource-specific. |
+| Vehicle identity, attention, financial and document cards | Vehicle Workspace component | Vehicle-specific | Keep in Vehicle Workspace until a second consumer proves a shared contract. |
+| Copilot route context | `features/assistant/lib/deriveAssistantContext.ts` and Shop Assistant trusted context | Reusable but incomplete | Keep existing behavior. Introduce a serializable `WorkspaceResourceContext`; do not add capabilities until the effective resolver is authoritative. |
+
+The extraction deliberately avoids theoretical abstractions. Vehicle Workspace
+remains the reference implementation, and the Work Order ID page is not changed
+to prove reuse.
+
+## Shared component security rule
+
+`WorkspaceCard`, `WorkspaceSection`, and future `WorkspaceAccessBoundary`
+components are presentation helpers only.
+
+The required request path remains:
+
+1. Authenticate the actor.
+2. Resolve tenant and resource scope from trusted server context.
+3. Resolve effective capabilities.
+4. Query only authorized rows and columns.
+5. Shape a role-appropriate snapshot.
+6. Render shared components.
+
+Hiding a card in React is never authorization. A restricted payload must not
+contain the sensitive data in the first place. Direct Data API access must also
+remain protected by grants and RLS where the table is exposed.
+
+## Current authorization audit
+
+### What exists
+
+- `features/shared/lib/rbac.ts` canonicalizes roles and returns a static
+  `ActorCapabilities` preset.
+- `ROLE_GROUPS` provides shared fixed role allowlists for common routes and
+  actions.
+- Server page/API guards resolve an authenticated profile and shop before
+  running protected work.
+- Vehicle Workspace uses a role-shaped server read model and keeps the caller's
+  cookie-backed Supabase client so RLS remains part of the boundary.
+- Work-order RLS in
+  `supabase/migrations/20260716100000_role_gated_work_order_rls.sql` separates
+  shop-wide readers from mechanics assigned to a work order or repair line.
+- `operational_events` provides a useful canonical event foundation, but its
+  current raw read policy is limited to owner/admin/manager.
+- Shop Assistant resolves trusted resource context server-side and its tool
+  registry checks the existing coarse capability map.
+
+### What does not exist yet
+
+- Shop-customized role policies.
+- Individual employee `INHERIT` / `ALLOW` / `DENY` overrides.
+- A general protected-capability catalog and grant ceiling.
+- A general staff-to-location membership/scope model suitable for Workspace
+  authorization.
+- One effective resolver shared by UI, API, database policy, and Copilot.
+- Immutable audit events for role-policy and individual-override changes.
+- A safe delegated permission-administration flow that prevents privilege
+  escalation.
+
+`profiles.role` and `profiles.shop_id` are not sufficient for those features.
+Product-package entitlements, service-vehicle capabilities, integration
+capabilities, and `ai_automation_capability_settings` solve different problems
+and must not be repurposed as employee authorization.
+
+## Effective-access target
+
+The next authorization slice should resolve access in this order:
+
+1. Authenticated tenant membership.
+2. ProFixIQ role preset.
+3. Shop role-policy override.
+4. Individual override, with `DENY` taking precedence over `ALLOW`, then
+   `INHERIT` falling through.
+5. Protected-capability grant ceiling.
+6. Resource scope: shop, future location, assignment, and relationship to the
+   resource.
+7. Effective capability envelope used by UI, API/domain services, RLS/RPC, and
+   Copilot tools.
+
+`NONE`, `VIEW`, and `MANAGE` are module presentation states derived from
+granular capabilities. They should not replace granular authorization keys.
+For example, Work Order Assignment can derive its module state from separate
+view and manage capabilities.
+
+The first proving capability should be `work_order.assignment.manage`. It
+supports the Lead Hand case without granting a technician the Manager role.
+
+## Database implications for the next authorization slice
+
+No database change is required for this shared presentation foundation.
+
+The effective authorization foundation will likely require new forward-only
+schema for:
+
+- capability catalog and protected/grantable metadata;
+- shop role-policy overrides;
+- individual tri-state overrides;
+- resource scope assignments;
+- immutable permission audit events;
+- stable database helpers used by RLS/RPC.
+
+Before that migration is designed, every current capability consumer and RLS
+policy must be mapped. New exposed tables require explicit grants as well as
+RLS; authorization data must not be stored in user-editable metadata. Location
+scope must not be simulated until a canonical staff/location relationship is
+defined.
+
+## Work Order Workspace adoption path
+
+The Work Order Workspace is the second consumer, but it starts from the current
+screen rather than replacing it:
+
+1. Keep `/work-orders/[id]`, its one-view layout, and all existing operations.
+2. Add a server-loaded, role-shaped Work Order snapshot alongside the current
+   client implementation in small compatible steps.
+3. Adopt shared shell/header/card/timeline primitives only where visual and
+   interaction parity is proven.
+4. Turn repair lines into expandable operational containers powered by the
+   existing canonical services.
+5. Compose Inspection, Parts, Estimate/Approval, Communication, and Timeline
+   modules using effective capabilities and resource scope.
+6. Add Financials and Invoice only after their column/data-access boundaries are
+   enforced for every role.
+7. Retire old client-side reads only after the equivalent server projection and
+   mutation path are verified.
+
+This preserves technician efficiency while improving authorization and shared
+architecture underneath the screen.
+
+## Follow-on delivery sequence
+
+1. **Shared Workspace Foundation** — this slice: extract proven presentation
+   primitives and record the authorization audit; no migration.
+2. **Effective Authorization Foundation** — capability catalog, shop policies,
+   individual overrides, protected grants, initial shop/assignment scope, audit
+   events, and direct-access tests.
+3. **Customer / Vehicle Phase 2 completion** — continue on the shared
+   primitives without changing its canonical read model.
+4. **Work Order Workspace MVP** — evolve the existing ID page in place,
+   preserving its layout and logic.
+5. **Permissions Administration** — business-language role and employee access
+   controls with delegated grant ceilings.
+6. **Copilot Workspace Integration** — use the same trusted resource context and
+   effective authorization resolver as the UI and domain services.
+
+## Exit criteria for this foundation slice
+
+- Vehicle Workspace renders through shared primitives without changing its
+  server read model, actions, source-link policy, responsive layout, or content.
+- Shared primitives contain no role checks, database calls, or sensitive-data
+  decisions.
+- The Work Order ID page and client are absent from the task diff.
+- No migration or production data change exists.
+- Vercel remains production-only (`main: true`, wildcard preview disabled).
+- Focused tests, type-check, lint, application checks, build, and final diff
+  review pass before publication.

--- a/features/vehicles/components/VehicleWorkspace.tsx
+++ b/features/vehicles/components/VehicleWorkspace.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import type { ReactNode } from "react";
 
 import type {
   ActiveWorkSummary,
@@ -10,6 +9,22 @@ import type {
   VehicleWorkspaceReference,
   VehicleWorkspaceSnapshot,
 } from "@/features/vehicles/lib/vehicleWorkspace";
+import {
+  WorkspaceCard,
+  WorkspaceCommandBar,
+  WorkspaceEmptyState as EmptyState,
+  WorkspaceHeader,
+  WorkspaceSection,
+  WorkspaceShell,
+  WorkspaceSourceReference as SourceFooter,
+  WorkspaceStatus,
+  WorkspaceTimeline,
+  WorkspaceTimelineItem,
+  WORKSPACE_EYEBROW as EYEBROW,
+  WORKSPACE_ITEM as ITEM,
+  WORKSPACE_LINK_FOCUS as LINK_FOCUS,
+  WORKSPACE_PANEL as PANEL,
+} from "@/features/workspace/components";
 
 type VehicleWorkspaceProps = {
   snapshot: VehicleWorkspaceSnapshot;
@@ -18,15 +33,6 @@ type VehicleWorkspaceProps = {
   createEstimateHref: string | null;
   messageCustomerHref: string | null;
 };
-
-const PANEL =
-  "rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-panel-bg-soft,var(--theme-surface-page))] shadow-[var(--theme-shadow-medium)] backdrop-blur-xl";
-const ITEM =
-  "rounded-xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-item-bg,var(--theme-surface-inset))]";
-const EYEBROW =
-  "text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]";
-const LINK_FOCUS =
-  "focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-copper-soft,#fdba74)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--theme-surface-page)]";
 
 function textOrDash(value: string | number | null | undefined): string {
   if (value == null) return "—";
@@ -72,36 +78,7 @@ function vehicleTitle(snapshot: VehicleWorkspaceSnapshot): string {
 }
 
 function StatusPill({ value }: { value: string }) {
-  return (
-    <span className="inline-flex max-w-full rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.15em] text-[color:var(--theme-text-secondary)]">
-      {humanize(value)}
-    </span>
-  );
-}
-
-function SourceFooter({
-  label,
-  canOpen = true,
-}: {
-  label: string;
-  canOpen?: boolean;
-}) {
-  return (
-    <span className="mt-3 flex items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] pt-3 text-xs text-[color:var(--theme-text-muted)]">
-      <span className="min-w-0 truncate">Source: {label}</span>
-      <span aria-hidden="true" className="shrink-0 text-[color:var(--accent-copper-light,#fdba74)]">
-        {canOpen ? "Open →" : "Source retained"}
-      </span>
-    </span>
-  );
-}
-
-function EmptyState({ children }: { children: ReactNode }) {
-  return (
-    <p className={`${ITEM} px-4 py-5 text-sm text-[color:var(--theme-text-muted)]`}>
-      {children}
-    </p>
-  );
+  return <WorkspaceStatus>{humanize(value)}</WorkspaceStatus>;
 }
 
 const WORK_ORDER_SOURCE_TYPES = new Set<
@@ -194,24 +171,15 @@ function ActiveWorkCard({
 
   return (
     <li>
-      {canOpen ? (
-        <Link
-          href={item.reference.href}
-          data-source-id={item.reference.sourceId}
-          data-source-type={item.reference.sourceType}
-          className={`${ITEM} ${LINK_FOCUS} block h-full p-4 transition hover:border-[color:var(--accent-copper-soft,#fdba74)] hover:bg-[color:var(--theme-surface-subtle)]`}
-        >
-          {content}
-        </Link>
-      ) : (
-        <div
-          data-source-id={item.reference.sourceId}
-          data-source-type={item.reference.sourceType}
-          className={`${ITEM} block h-full p-4`}
-        >
-          {content}
-        </div>
-      )}
+      <WorkspaceCard
+        href={canOpen ? item.reference.href : null}
+        sourceId={item.reference.sourceId}
+        sourceType={item.reference.sourceType}
+        className="block h-full p-4"
+        interactiveClassName="transition hover:border-[color:var(--accent-copper-soft,#fdba74)] hover:bg-[color:var(--theme-surface-subtle)]"
+      >
+        {content}
+      </WorkspaceCard>
     </li>
   );
 }
@@ -254,24 +222,15 @@ function AppointmentCard({
 
   return (
     <li>
-      {canOpen ? (
-        <Link
-          href={appointment.reference.href}
-          data-source-id={appointment.reference.sourceId}
-          data-source-type={appointment.reference.sourceType}
-          className={`${ITEM} ${LINK_FOCUS} block h-full p-4 transition hover:border-[color:var(--accent-copper-soft,#fdba74)] hover:bg-[color:var(--theme-surface-subtle)]`}
-        >
-          {content}
-        </Link>
-      ) : (
-        <div
-          data-source-id={appointment.reference.sourceId}
-          data-source-type={appointment.reference.sourceType}
-          className={`${ITEM} block h-full p-4`}
-        >
-          {content}
-        </div>
-      )}
+      <WorkspaceCard
+        href={canOpen ? appointment.reference.href : null}
+        sourceId={appointment.reference.sourceId}
+        sourceType={appointment.reference.sourceType}
+        className="block h-full p-4"
+        interactiveClassName="transition hover:border-[color:var(--accent-copper-soft,#fdba74)] hover:bg-[color:var(--theme-surface-subtle)]"
+      >
+        {content}
+      </WorkspaceCard>
     </li>
   );
 }
@@ -367,30 +326,17 @@ function TimelineEvent({
   );
 
   return (
-    <li className="relative pl-7 before:absolute before:left-[7px] before:top-3 before:h-full before:w-px before:bg-[color:var(--theme-border-soft)] last:before:hidden">
-      <span
-        aria-hidden="true"
-        className="absolute left-0 top-2 h-[15px] w-[15px] rounded-full border-2 border-[color:var(--accent-copper-soft,#fdba74)] bg-[color:var(--theme-surface-page)]"
-      />
-      {canOpen ? (
-        <Link
-          href={event.reference.href}
-          data-source-id={event.reference.sourceId}
-          data-source-type={event.reference.sourceType}
-          className={`${ITEM} ${LINK_FOCUS} block p-4 transition hover:border-[color:var(--accent-copper-soft,#fdba74)]`}
-        >
-          {content}
-        </Link>
-      ) : (
-        <div
-          data-source-id={event.reference.sourceId}
-          data-source-type={event.reference.sourceType}
-          className={`${ITEM} block p-4`}
-        >
-          {content}
-        </div>
-      )}
-    </li>
+    <WorkspaceTimelineItem>
+      <WorkspaceCard
+        href={canOpen ? event.reference.href : null}
+        sourceId={event.reference.sourceId}
+        sourceType={event.reference.sourceType}
+        className="block p-4"
+        interactiveClassName="transition hover:border-[color:var(--accent-copper-soft,#fdba74)]"
+      >
+        {content}
+      </WorkspaceCard>
+    </WorkspaceTimelineItem>
   );
 }
 
@@ -411,8 +357,8 @@ export function VehicleWorkspace({
   ].filter((row): row is [string, string] => Boolean(row));
 
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-4 text-[color:var(--theme-text-primary)] sm:px-6 sm:py-6 lg:px-8">
-      <header className={`${PANEL} sticky top-2 z-20 overflow-hidden p-4 sm:p-5`}>
+    <WorkspaceShell>
+      <WorkspaceHeader>
         <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2">
@@ -493,9 +439,9 @@ export function VehicleWorkspace({
                 No current account
               </p>
             )}
-            <nav
-              aria-label="Vehicle actions"
-              className="flex flex-wrap gap-2 xl:justify-end"
+            <WorkspaceCommandBar
+              ariaLabel="Vehicle actions"
+              className="xl:justify-end"
             >
               {currentAccount &&
               snapshot.permissions.canOpenAccount ? (
@@ -538,7 +484,7 @@ export function VehicleWorkspace({
                   Message
                 </Link>
               ) : null}
-            </nav>
+            </WorkspaceCommandBar>
           </div>
         </div>
 
@@ -563,28 +509,22 @@ export function VehicleWorkspace({
             </ul>
           </div>
         ) : null}
-      </header>
+      </WorkspaceHeader>
 
-      <section
-        aria-labelledby="active-now-heading"
-        className={`${PANEL} p-4 sm:p-5`}
-      >
-        <div className="flex flex-wrap items-end justify-between gap-2">
-          <div>
-            <p className={EYEBROW}>Current condition</p>
-            <h2 id="active-now-heading" className="mt-1 text-xl font-bold">
-              Active now
-            </h2>
-          </div>
-          <p className="text-xs text-[color:var(--theme-text-muted)]">
+      <WorkspaceSection
+        headingId="active-now-heading"
+        eyebrow="Current condition"
+        title="Active now"
+        summary={
+          <>
             {snapshot.activeWork.length} active record
             {snapshot.activeWork.length === 1 ? "" : "s"}
             {snapshot.upcomingAppointments.length
               ? ` · ${snapshot.upcomingAppointments.length} upcoming`
               : ""}
-          </p>
-        </div>
-
+          </>
+        }
+      >
         {snapshot.activeWork.length || snapshot.upcomingAppointments.length ? (
           <ul className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             {snapshot.activeWork.map((item) => (
@@ -610,24 +550,19 @@ export function VehicleWorkspace({
             </EmptyState>
           </div>
         )}
-      </section>
+      </WorkspaceSection>
 
-      <section
-        aria-labelledby="attention-heading"
-        className={`${PANEL} p-4 sm:p-5`}
-      >
-        <div className="flex flex-wrap items-end justify-between gap-2">
-          <div>
-            <p className={EYEBROW}>Evidence-backed items</p>
-            <h2 id="attention-heading" className="mt-1 text-xl font-bold">
-              Needs attention
-            </h2>
-          </div>
-          <p className="text-xs text-[color:var(--theme-text-muted)]">
+      <WorkspaceSection
+        headingId="attention-heading"
+        eyebrow="Evidence-backed items"
+        title="Needs attention"
+        summary={
+          <>
             {snapshot.attentionItems.length} evidence item
             {snapshot.attentionItems.length === 1 ? "" : "s"}
-          </p>
-        </div>
+          </>
+        }
+      >
         {snapshot.attentionItems.length ? (
           <ul className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             {snapshot.attentionItems.map((item) => (
@@ -645,26 +580,17 @@ export function VehicleWorkspace({
             </EmptyState>
           </div>
         )}
-      </section>
+      </WorkspaceSection>
 
-      <section
-        aria-labelledby="timeline-heading"
-        className={`${PANEL} p-4 sm:p-5`}
+      <WorkspaceSection
+        headingId="timeline-heading"
+        eyebrow="Canonical record stream"
+        title="Recent timeline"
+        summary="Most recent first"
       >
-        <div className="flex flex-wrap items-end justify-between gap-2">
-          <div>
-            <p className={EYEBROW}>Canonical record stream</p>
-            <h2 id="timeline-heading" className="mt-1 text-xl font-bold">
-              Recent timeline
-            </h2>
-          </div>
-          <p className="text-xs text-[color:var(--theme-text-muted)]">
-            Most recent first
-          </p>
-        </div>
         {visibleTimeline.length ? (
           <>
-            <ol className="mt-5 space-y-3">
+            <WorkspaceTimeline className="mt-5">
               {visibleTimeline.map((event) => (
                 <TimelineEvent
                   key={`${event.reference.sourceType}:${event.reference.sourceId}:${event.kind}`}
@@ -672,7 +598,7 @@ export function VehicleWorkspace({
                   canOpen={canOpenTimelineEvent(event, snapshot.permissions)}
                 />
               ))}
-            </ol>
+            </WorkspaceTimeline>
             {olderTimeline.length ? (
               <details className={`${ITEM} mt-4 p-4`}>
                 <summary
@@ -681,7 +607,7 @@ export function VehicleWorkspace({
                   Show {olderTimeline.length} older event
                   {olderTimeline.length === 1 ? "" : "s"}
                 </summary>
-                <ol className="mt-5 space-y-3">
+                <WorkspaceTimeline className="mt-5">
                   {olderTimeline.map((event) => (
                     <TimelineEvent
                       key={`${event.reference.sourceType}:${event.reference.sourceId}:${event.kind}`}
@@ -689,7 +615,7 @@ export function VehicleWorkspace({
                       canOpen={canOpenTimelineEvent(event, snapshot.permissions)}
                     />
                   ))}
-                </ol>
+                </WorkspaceTimeline>
               </details>
             ) : null}
           </>
@@ -698,7 +624,7 @@ export function VehicleWorkspace({
             <EmptyState>No timeline events are visible for this vehicle.</EmptyState>
           </div>
         )}
-      </section>
+      </WorkspaceSection>
 
       <aside
         aria-label="Vehicle workspace summaries"
@@ -843,7 +769,7 @@ export function VehicleWorkspace({
           </section>
         ) : null}
       </aside>
-    </main>
+    </WorkspaceShell>
   );
 }
 

--- a/features/vehicles/lib/vehicleWorkspace.ts
+++ b/features/vehicles/lib/vehicleWorkspace.ts
@@ -1,4 +1,5 @@
 import type { CanonicalRole } from "@/features/shared/lib/rbac";
+import type { WorkspaceSourceReference } from "@/features/workspace/lib/workspace";
 
 export const VEHICLE_WORKSPACE_READER_ROLES = [
   "owner",
@@ -27,12 +28,8 @@ export type VehicleWorkspaceSourceType =
   | "work_order_part"
   | "work_order_quote_line";
 
-export type VehicleWorkspaceReference = {
-  sourceType: VehicleWorkspaceSourceType;
-  sourceId: string;
-  sourceLabel: string;
-  href: string;
-};
+export type VehicleWorkspaceReference =
+  WorkspaceSourceReference<VehicleWorkspaceSourceType>;
 
 export type VehicleWorkspacePermissions = {
   canViewAccountContact: boolean;

--- a/features/workspace/components/WorkspaceCard.tsx
+++ b/features/workspace/components/WorkspaceCard.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { cn } from "@/features/shared/lib/utils";
+import {
+  WORKSPACE_ITEM,
+  WORKSPACE_LINK_FOCUS,
+} from "@/features/workspace/components/workspaceStyles";
+
+export type WorkspaceCardProps = {
+  children: ReactNode;
+  href?: string | null;
+  sourceId?: string;
+  sourceType?: string;
+  className?: string;
+  interactiveClassName?: string;
+};
+
+/**
+ * Presentation-only card surface. Callers must authorize and shape data before
+ * passing an href or children; this component is not a security boundary.
+ */
+export function WorkspaceCard({
+  children,
+  href,
+  sourceId,
+  sourceType,
+  className,
+  interactiveClassName,
+}: WorkspaceCardProps) {
+  const dataAttributes = {
+    "data-source-id": sourceId,
+    "data-source-type": sourceType,
+  };
+  const baseClassName = cn(WORKSPACE_ITEM, className);
+
+  if (!href) {
+    return (
+      <div {...dataAttributes} className={baseClassName}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      {...dataAttributes}
+      className={cn(
+        baseClassName,
+        WORKSPACE_LINK_FOCUS,
+        interactiveClassName,
+      )}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/features/workspace/components/WorkspaceCommandBar.tsx
+++ b/features/workspace/components/WorkspaceCommandBar.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/features/shared/lib/utils";
+
+export type WorkspaceCommandBarProps = {
+  ariaLabel: string;
+  children: ReactNode;
+  className?: string;
+};
+
+export function WorkspaceCommandBar({
+  ariaLabel,
+  children,
+  className,
+}: WorkspaceCommandBarProps) {
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className={cn("flex flex-wrap gap-2", className)}
+    >
+      {children}
+    </nav>
+  );
+}

--- a/features/workspace/components/WorkspaceEmptyState.tsx
+++ b/features/workspace/components/WorkspaceEmptyState.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/features/shared/lib/utils";
+import { WORKSPACE_ITEM } from "@/features/workspace/components/workspaceStyles";
+
+export type WorkspaceEmptyStateProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function WorkspaceEmptyState({
+  children,
+  className,
+}: WorkspaceEmptyStateProps) {
+  return (
+    <p
+      className={cn(
+        WORKSPACE_ITEM,
+        "px-4 py-5 text-sm text-[color:var(--theme-text-muted)]",
+        className,
+      )}
+    >
+      {children}
+    </p>
+  );
+}

--- a/features/workspace/components/WorkspaceHeader.tsx
+++ b/features/workspace/components/WorkspaceHeader.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/features/shared/lib/utils";
+import { WORKSPACE_PANEL } from "@/features/workspace/components/workspaceStyles";
+
+export type WorkspaceHeaderProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function WorkspaceHeader({
+  children,
+  className,
+}: WorkspaceHeaderProps) {
+  return (
+    <header
+      className={cn(
+        WORKSPACE_PANEL,
+        "sticky top-2 z-20 overflow-hidden p-4 sm:p-5",
+        className,
+      )}
+    >
+      {children}
+    </header>
+  );
+}

--- a/features/workspace/components/WorkspaceSection.tsx
+++ b/features/workspace/components/WorkspaceSection.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/features/shared/lib/utils";
+import {
+  WORKSPACE_EYEBROW,
+  WORKSPACE_PANEL,
+} from "@/features/workspace/components/workspaceStyles";
+
+export type WorkspaceSectionProps = {
+  headingId: string;
+  eyebrow: string;
+  title: string;
+  summary?: ReactNode;
+  children: ReactNode;
+  className?: string;
+};
+
+export function WorkspaceSection({
+  headingId,
+  eyebrow,
+  title,
+  summary,
+  children,
+  className,
+}: WorkspaceSectionProps) {
+  return (
+    <section
+      aria-labelledby={headingId}
+      className={cn(WORKSPACE_PANEL, "p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <p className={WORKSPACE_EYEBROW}>{eyebrow}</p>
+          <h2 id={headingId} className="mt-1 text-xl font-bold">
+            {title}
+          </h2>
+        </div>
+        {summary != null ? (
+          <p className="text-xs text-[color:var(--theme-text-muted)]">
+            {summary}
+          </p>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/features/workspace/components/WorkspaceShell.tsx
+++ b/features/workspace/components/WorkspaceShell.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/features/shared/lib/utils";
+
+export type WorkspaceShellProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function WorkspaceShell({
+  children,
+  className,
+}: WorkspaceShellProps) {
+  return (
+    <main
+      className={cn(
+        "mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-4 text-[color:var(--theme-text-primary)] sm:px-6 sm:py-6 lg:px-8",
+        className,
+      )}
+    >
+      {children}
+    </main>
+  );
+}

--- a/features/workspace/components/WorkspaceSourceReference.tsx
+++ b/features/workspace/components/WorkspaceSourceReference.tsx
@@ -1,0 +1,21 @@
+export type WorkspaceSourceReferenceProps = {
+  label: string;
+  canOpen?: boolean;
+};
+
+export function WorkspaceSourceReference({
+  label,
+  canOpen = true,
+}: WorkspaceSourceReferenceProps) {
+  return (
+    <span className="mt-3 flex items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] pt-3 text-xs text-[color:var(--theme-text-muted)]">
+      <span className="min-w-0 truncate">Source: {label}</span>
+      <span
+        aria-hidden="true"
+        className="shrink-0 text-[color:var(--accent-copper-light,#fdba74)]"
+      >
+        {canOpen ? "Open →" : "Source retained"}
+      </span>
+    </span>
+  );
+}

--- a/features/workspace/components/WorkspaceStatus.tsx
+++ b/features/workspace/components/WorkspaceStatus.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+export type WorkspaceStatusProps = {
+  children: ReactNode;
+};
+
+export function WorkspaceStatus({ children }: WorkspaceStatusProps) {
+  return (
+    <span className="inline-flex max-w-full rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.15em] text-[color:var(--theme-text-secondary)]">
+      {children}
+    </span>
+  );
+}

--- a/features/workspace/components/WorkspaceTimeline.tsx
+++ b/features/workspace/components/WorkspaceTimeline.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/features/shared/lib/utils";
+
+export type WorkspaceTimelineProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function WorkspaceTimeline({
+  children,
+  className,
+}: WorkspaceTimelineProps) {
+  return <ol className={cn("space-y-3", className)}>{children}</ol>;
+}
+
+export type WorkspaceTimelineItemProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function WorkspaceTimelineItem({
+  children,
+  className,
+}: WorkspaceTimelineItemProps) {
+  return (
+    <li
+      className={cn(
+        "relative pl-7 before:absolute before:left-[7px] before:top-3 before:h-full before:w-px before:bg-[color:var(--theme-border-soft)] last:before:hidden",
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="absolute left-0 top-2 h-[15px] w-[15px] rounded-full border-2 border-[color:var(--accent-copper-soft,#fdba74)] bg-[color:var(--theme-surface-page)]"
+      />
+      {children}
+    </li>
+  );
+}

--- a/features/workspace/components/index.ts
+++ b/features/workspace/components/index.ts
@@ -1,0 +1,15 @@
+export { WorkspaceCard } from "./WorkspaceCard";
+export { WorkspaceCommandBar } from "./WorkspaceCommandBar";
+export { WorkspaceEmptyState } from "./WorkspaceEmptyState";
+export { WorkspaceHeader } from "./WorkspaceHeader";
+export { WorkspaceSection } from "./WorkspaceSection";
+export { WorkspaceShell } from "./WorkspaceShell";
+export { WorkspaceSourceReference } from "./WorkspaceSourceReference";
+export { WorkspaceStatus } from "./WorkspaceStatus";
+export { WorkspaceTimeline, WorkspaceTimelineItem } from "./WorkspaceTimeline";
+export {
+  WORKSPACE_EYEBROW,
+  WORKSPACE_ITEM,
+  WORKSPACE_LINK_FOCUS,
+  WORKSPACE_PANEL,
+} from "./workspaceStyles";

--- a/features/workspace/components/workspaceStyles.ts
+++ b/features/workspace/components/workspaceStyles.ts
@@ -1,0 +1,11 @@
+export const WORKSPACE_PANEL =
+  "rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-panel-bg-soft,var(--theme-surface-page))] shadow-[var(--theme-shadow-medium)] backdrop-blur-xl";
+
+export const WORKSPACE_ITEM =
+  "rounded-xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--desktop-item-bg,var(--theme-surface-inset))]";
+
+export const WORKSPACE_EYEBROW =
+  "text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]";
+
+export const WORKSPACE_LINK_FOCUS =
+  "focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-copper-soft,#fdba74)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--theme-surface-page)]";

--- a/features/workspace/lib/workspace.ts
+++ b/features/workspace/lib/workspace.ts
@@ -1,0 +1,29 @@
+export type WorkspaceKind =
+  | "customer_vehicle"
+  | "work_order"
+  | "fleet_unit"
+  | "field_service";
+
+export type WorkspaceModuleAccess = "none" | "view" | "manage";
+
+export type WorkspaceSourceReference<SourceType extends string = string> = {
+  sourceType: SourceType;
+  sourceId: string;
+  sourceLabel: string;
+  href: string;
+};
+
+/**
+ * Serializable resource identity that UI and Copilot adapters can share.
+ * Authorization capabilities are intentionally excluded until the effective
+ * capability resolver is backed by server/database policy.
+ */
+export type WorkspaceResourceContext = {
+  kind: WorkspaceKind;
+  shopId: string;
+  resourceId: string;
+  customerId?: string | null;
+  vehicleId?: string | null;
+  workOrderId?: string | null;
+  locationId?: string | null;
+};

--- a/tests/vehicle-workspace-security.test.ts
+++ b/tests/vehicle-workspace-security.test.ts
@@ -12,6 +12,9 @@ const workspacePage = read("app/vehicles/[id]/page.tsx");
 const workspaceComponent = read(
   "features/vehicles/components/VehicleWorkspace.tsx",
 );
+const workspaceSourceReference = read(
+  "features/workspace/components/WorkspaceSourceReference.tsx",
+);
 const vehicleSearchPage = read("features/vehicles/app/vehicles/page.tsx");
 
 describe("Shop Vehicle Workspace security contract", () => {
@@ -144,7 +147,7 @@ describe("Shop Vehicle Workspace security contract", () => {
     expect(workspaceComponent).toContain(
       "canOpenReference(\n              snapshot.documentSummary.latestReference",
     );
-    expect(workspaceComponent).toContain("Source retained");
+    expect(workspaceSourceReference).toContain("Source retained");
 
     expect(vehicleSearchPage).toContain('work.kind === "estimate"');
     expect(vehicleSearchPage).toContain("permissions.canViewEstimates");

--- a/tests/workspace-platform-foundation.test.tsx
+++ b/tests/workspace-platform-foundation.test.tsx
@@ -1,0 +1,143 @@
+import { readFileSync } from "node:fs";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  WorkspaceCard,
+  WorkspaceCommandBar,
+  WorkspaceEmptyState,
+  WorkspaceHeader,
+  WorkspaceSection,
+  WorkspaceShell,
+  WorkspaceSourceReference,
+  WorkspaceStatus,
+  WorkspaceTimeline,
+  WorkspaceTimelineItem,
+} from "@/features/workspace/components";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("Workspace Platform shared foundation", () => {
+  it("renders the common shell, sticky header, command bar, and section semantics", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceShell>
+        <WorkspaceHeader>
+          <WorkspaceCommandBar ariaLabel="Workspace actions">
+            <button type="button">Act</button>
+          </WorkspaceCommandBar>
+        </WorkspaceHeader>
+        <WorkspaceSection
+          headingId="active-work-heading"
+          eyebrow="Current condition"
+          title="Active work"
+          summary="2 records"
+        >
+          <WorkspaceEmptyState>No additional records.</WorkspaceEmptyState>
+        </WorkspaceSection>
+      </WorkspaceShell>,
+    );
+
+    expect(markup).toContain("<main");
+    expect(markup).toContain("sticky top-2");
+    expect(markup).toContain('aria-label="Workspace actions"');
+    expect(markup).toContain('aria-labelledby="active-work-heading"');
+    expect(markup).toContain('id="active-work-heading"');
+    expect(markup).toContain("Current condition");
+    expect(markup).toContain("No additional records.");
+  });
+
+  it("keeps canonical source identity when a card is openable or read-only", () => {
+    const openMarkup = renderToStaticMarkup(
+      <WorkspaceCard
+        href="/work-orders/wo-1"
+        sourceId="wo-1"
+        sourceType="work_order"
+        className="block p-4"
+      >
+        Work order
+      </WorkspaceCard>,
+    );
+    const restrictedMarkup = renderToStaticMarkup(
+      <WorkspaceCard
+        sourceId="invoice-1"
+        sourceType="invoice"
+        className="block p-4"
+      >
+        Restricted invoice source
+      </WorkspaceCard>,
+    );
+    const sourceMarkup = renderToStaticMarkup(
+      <WorkspaceSourceReference label="Invoice INV-1" canOpen={false} />,
+    );
+
+    expect(openMarkup).toContain('href="/work-orders/wo-1"');
+    expect(openMarkup).toContain('data-source-id="wo-1"');
+    expect(openMarkup).toContain('data-source-type="work_order"');
+    expect(restrictedMarkup).not.toContain("href=");
+    expect(restrictedMarkup).toContain('data-source-id="invoice-1"');
+    expect(sourceMarkup).toContain("Source retained");
+  });
+
+  it("renders reusable status and timeline presentation without resource semantics", () => {
+    const markup = renderToStaticMarkup(
+      <WorkspaceTimeline>
+        <WorkspaceTimelineItem>
+          <WorkspaceCard className="block p-4">
+            <WorkspaceStatus>in progress</WorkspaceStatus>
+          </WorkspaceCard>
+        </WorkspaceTimelineItem>
+      </WorkspaceTimeline>,
+    );
+
+    expect(markup).toContain("<ol");
+    expect(markup).toContain("<li");
+    expect(markup).toContain("in progress");
+  });
+
+  it("keeps shared presentation primitives free of role and data-access logic", () => {
+    const source = [
+      "WorkspaceCard.tsx",
+      "WorkspaceCommandBar.tsx",
+      "WorkspaceEmptyState.tsx",
+      "WorkspaceHeader.tsx",
+      "WorkspaceSection.tsx",
+      "WorkspaceShell.tsx",
+      "WorkspaceSourceReference.tsx",
+      "WorkspaceStatus.tsx",
+      "WorkspaceTimeline.tsx",
+      "workspaceStyles.ts",
+    ]
+      .map((file) => read(`features/workspace/components/${file}`))
+      .join("\n");
+
+    expect(source).not.toContain("createBrowserSupabase");
+    expect(source).not.toContain("createServerSupabase");
+    expect(source).not.toContain("getActorCapabilities");
+    expect(source).not.toContain("ROLE_GROUPS");
+    expect(source).not.toContain('"use client"');
+    expect(source).toContain("this component is not a security boundary");
+  });
+
+  it("adopts shared primitives in Vehicle Workspace without touching the Work Order ID screen", () => {
+    const vehicleWorkspace = read(
+      "features/vehicles/components/VehicleWorkspace.tsx",
+    );
+    const workOrderPage = read("app/work-orders/[id]/page.tsx");
+    const workOrderClient = read("app/work-orders/[id]/Client.tsx");
+
+    expect(vehicleWorkspace).toContain(
+      'from "@/features/workspace/components"',
+    );
+    expect(vehicleWorkspace).toContain("<WorkspaceShell>");
+    expect(vehicleWorkspace).toContain("<WorkspaceHeader>");
+    expect(vehicleWorkspace).toContain("<WorkspaceCommandBar");
+    expect(vehicleWorkspace).toContain("<WorkspaceSection");
+    expect(workOrderPage).toContain("<WorkOrderIdClient />");
+    expect(workOrderPage).toContain("<WorkOrderOperationalTimelineDock />");
+    expect(workOrderPage).not.toContain("features/workspace");
+    expect(workOrderClient).not.toContain("features/workspace");
+  });
+});


### PR DESCRIPTION
## What changed

- introduces server-compatible shared Workspace presentation primitives for shell, sticky header, command bar, sections, cards, status, empty/read-only states, canonical source references, and timeline layout
- refactors Vehicle Workspace onto those primitives without changing its snapshot loader, role shaping, actions, or source-link policy
- adds generic serializable workspace resource/reference contracts
- records the current authorization audit and phased effective-capability plan
- adds focused render and boundary tests

## Protected Work Order contract

`/work-orders/[id]` is intentionally unchanged. Its current one-view technician layout, URL, and operational logic are preserved. The future Work Order Workspace will evolve that screen in place rather than replace it or duplicate its domain services.

## Authorization boundary

Shared components are presentation only. Server loaders, APIs, and RLS remain responsible for tenant/resource authorization and for omitting sensitive data. No new permission engine or role checks were added.

## Database / migrations

None.

## Validation

Local:

- `git diff --check`
- Node TypeScript syntax checks for changed `.ts` contracts
- static shared-boundary audit
- exact hash parity for both Work Order ID files against `main`
- no migration diff
- Vercel production-only branch policy verified

Dependency-backed type-check, lint, focused tests, full tests, and production build run through existing Agent PR Checks on the exact PR head because this checkout's package links are incomplete.

## Deployment safety

`vercel.json` is unchanged with `main: true` and `"*": false`; this branch must not create a Vercel preview deployment.