### PR TITLE
Fix stale AI cron authorization and error logging

### DIFF
--- a/app/api/internal/ai/expire-stale/route.ts
+++ b/app/api/internal/ai/expire-stale/route.ts
@@ -31,43 +31,24 @@ function parseBody(raw: ExpireStaleBody | null): { dryRun: boolean; shopId?: str
   return { dryRun, shopId, limit };
 }
 
-function parseBearerSecret(req: Request): string | null {
-  const authorization = req.headers.get("authorization")?.trim();
-  if (!authorization) {
-    return null;
-  }
-
-  const [scheme, token] = authorization.split(/\s+/, 2);
-  if (!scheme || !token || scheme.toLowerCase() !== "bearer") {
-    return null;
-  }
-
-  return token;
-}
-
-function isVercelCronAuthorized(req: Request): boolean {
-  const configuredSecret = process.env.INTERNAL_CRON_SECRET;
-  if (!configuredSecret) {
-    return false;
-  }
-
-  const bearerSecret = parseBearerSecret(req);
-  return !!bearerSecret && bearerSecret === configuredSecret;
-}
-
-function authorizeInternalRequest(req: Request): { ok: true } | { ok: false; response: NextResponse } {
-  const internalGate = requireInternalApiSecret({
+function authorizeInternalRequest(
+  req: Request,
+): { ok: true } | { ok: false; response: NextResponse } {
+  return requireInternalApiSecret({
     request: req,
     envSecretName: "INTERNAL_CRON_SECRET",
     headerName: "x-internal-cron-secret",
     routeLabel: "internal/ai/expire-stale",
+    bearerEnvSecretName: "CRON_SECRET",
   });
+}
 
-  if (internalGate.ok || isVercelCronAuthorized(req)) {
-    return { ok: true };
-  }
-
-  return { ok: false, response: internalGate.response };
+function expirationFailureResponse(error: unknown): NextResponse {
+  console.error("[internal/ai/expire-stale] expiration failed", error);
+  return NextResponse.json(
+    { error: "Failed to expire stale AI records" },
+    { status: 500 },
+  );
 }
 
 async function runExpiration(input: { dryRun: boolean; shopId?: string; limit: number }) {
@@ -116,8 +97,8 @@ export async function GET(req: Request) {
 
   try {
     return await runExpiration({ dryRun: false, limit: SCHEDULED_GET_LIMIT });
-  } catch {
-    return NextResponse.json({ error: "Failed to expire stale AI records" }, { status: 500 });
+  } catch (error) {
+    return expirationFailureResponse(error);
   }
 }
 
@@ -137,7 +118,7 @@ export async function POST(req: Request) {
 
   try {
     return await runExpiration(input);
-  } catch {
-    return NextResponse.json({ error: "Failed to expire stale AI records" }, { status: 500 });
+  } catch (error) {
+    return expirationFailureResponse(error);
   }
 }

--- a/docs/ops/ai-stale-expiration.md
+++ b/docs/ops/ai-stale-expiration.md
@@ -13,10 +13,12 @@ This scheduled job calls the internal stale-expiration route to expire stale can
 - The route remains internal-only.
 - Allowed auth patterns:
   - `x-internal-cron-secret: <INTERNAL_CRON_SECRET>`
-  - `Authorization: Bearer <INTERNAL_CRON_SECRET>`
+  - `Authorization: Bearer <CRON_SECRET>` (Vercel Cron)
 - Required env var names:
-  - `INTERNAL_CRON_SECRET`
-  - `CRON_SECRET` (set to the same value as `INTERNAL_CRON_SECRET` so Vercel Cron's bearer token is accepted)
+  - `CRON_SECRET` for scheduled Vercel invocations
+  - `INTERNAL_CRON_SECRET` for controlled manual invocations
+
+The two secrets are independent and do not need to contain the same value.
 
 ## Behavior
 - Scheduled `GET` runs expiration with:

--- a/tests/internal-ai-expire-stale-route.test.ts
+++ b/tests/internal-ai-expire-stale-route.test.ts
@@ -27,6 +27,7 @@ describe("/api/internal/ai/expire-stale route", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    delete process.env.CRON_SECRET;
     process.env.INTERNAL_CRON_SECRET = "test-secret";
     expireStaleAiRecordsMock.mockResolvedValue(buildResult());
   });
@@ -39,14 +40,16 @@ describe("/api/internal/ai/expire-stale route", () => {
     expect(expireStaleAiRecordsMock).not.toHaveBeenCalled();
   });
 
-  it("allows scheduled GET using bearer token and executes with bounded limit", async () => {
+  it("allows scheduled GET using Vercel CRON_SECRET and executes with bounded limit", async () => {
+    delete process.env.INTERNAL_CRON_SECRET;
+    process.env.CRON_SECRET = "vercel-cron-secret";
     expireStaleAiRecordsMock.mockResolvedValue(buildResult({ dryRun: false }));
 
     const { GET } = await import("../app/api/internal/ai/expire-stale/route");
     const response = await GET(new Request("http://localhost/api/internal/ai/expire-stale", {
       method: "GET",
       headers: {
-        authorization: "Bearer test-secret",
+        authorization: "Bearer vercel-cron-secret",
       },
     }));
 
@@ -66,6 +69,37 @@ describe("/api/internal/ai/expire-stale route", () => {
       previews: expect.objectContaining({ candidates: 3, expired: 1 }),
       approvals: expect.objectContaining({ candidates: 1, expired: 0 }),
     }));
+  });
+
+  it("logs the underlying expiration error while keeping the response generic", async () => {
+    const underlyingError = new Error(
+      "Failed to load stale recommendations: database unavailable",
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    expireStaleAiRecordsMock.mockRejectedValue(underlyingError);
+
+    try {
+      const { GET } = await import("../app/api/internal/ai/expire-stale/route");
+      const response = await GET(new Request("http://localhost/api/internal/ai/expire-stale", {
+        method: "GET",
+        headers: {
+          "x-internal-cron-secret": "test-secret",
+        },
+      }));
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: "Failed to expire stale AI records",
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[internal/ai/expire-stale] expiration failed",
+        underlyingError,
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("keeps POST dryRun default true and bounds limit", async () => {


### PR DESCRIPTION
## What changed

- authorize the stale-AI expiry cron with Vercel's standard `CRON_SECRET` bearer token through the shared internal-route guard
- preserve the independent `INTERNAL_CRON_SECRET` header path for controlled manual calls
- log the underlying cleanup exception while keeping the external 500 response generic
- add regression coverage for a production-style Vercel cron request and for failure observability
- correct the runbook so the two secrets no longer need to be identical

## Root cause

`/api/internal/ai/expire-stale` was the only affected scheduled route comparing the Vercel bearer token to `INTERNAL_CRON_SECRET`. Vercel sends `Authorization: Bearer <CRON_SECRET>`. When only `CRON_SECRET` was configured, the request exited at the authorization gate with HTTP 500 before a Supabase admin client was created, so the two eligible recommendations were never processed.

The prior bearer-token test used `INTERNAL_CRON_SECRET` for both sides and therefore encoded the incorrect production assumption.

## Impact

The next production cron invocation will reach the existing bounded cleanup path. Manual internal-header invocations remain supported. If cleanup itself fails later, Vercel runtime logs will contain the original exception while the HTTP response remains safe.

## Validation

- `git diff --check`
- expire-stale static auth/logging contract
- `node scripts/audit-api-routes.mjs` (465 routes analyzed; generated inventory refresh intentionally excluded)
- rollback-only production SQL probe as `service_role`: candidate reads, recommendation update, and expiry event insert all succeeded without persisting changes
- exact-head Agent PR Checks pending

No database migration is required.