### PR TITLE
Align AI observability cron authentication runbook

### DIFF
--- a/docs/ops/ai-observability.md
+++ b/docs/ops/ai-observability.md
@@ -36,15 +36,18 @@ AI observability provides owner/admin/manager visibility into AI review-layer he
 ## Environment prerequisites
 
 - Internal stale-expiration route enabled
-- `INTERNAL_CRON_SECRET` configured for cron authentication
+- `CRON_SECRET` configured for scheduled Vercel bearer authentication
+- `INTERNAL_CRON_SECRET` configured when controlled manual header invocations are required
 - Vercel cron configured to call stale expiration route on schedule
 
 ## If stale backlog grows
 
-1. Confirm `/api/internal/ai/expire-stale` invocation frequency and auth headers.
-2. Check observability widget for last expiration timestamp and error-like events.
-3. Review AI event stream for blocked/failed patterns before taking action.
-4. Verify app role/capability access for operators reviewing AI inbox/recommendations.
+1. Confirm `/api/internal/ai/expire-stale` invocation frequency.
+2. Verify scheduled requests use `Authorization: Bearer <CRON_SECRET>`; controlled manual requests use `x-internal-cron-secret: <INTERNAL_CRON_SECRET>`.
+3. Check runtime logs for authorization or expiration failures.
+4. Check observability widget for last expiration timestamp and error-like events.
+5. Review AI event stream for blocked/failed patterns before taking action.
+6. Verify app role/capability access for operators reviewing AI inbox/recommendations.
 
 ## Operational guardrails
 


### PR DESCRIPTION
## What changed

- document `CRON_SECRET` as the prerequisite for scheduled Vercel bearer authentication
- document `INTERNAL_CRON_SECRET` as the independent secret for controlled manual header invocations
- expand stale-backlog troubleshooting to verify each authentication path and inspect runtime logs

## Why

This addresses the post-merge Codex review on #1490. The companion observability runbook still described `INTERNAL_CRON_SECRET` as the cron prerequisite even though scheduled Vercel requests now authenticate with `Authorization: Bearer <CRON_SECRET>`.

## Validation

- confirmed the stale prerequisite wording is removed
- confirmed both scheduled and manual environment variables and headers are documented
- exact diff is one documentation file, one commit, based on merge commit `a350bca59e26111a998c87cc5008549eb51b7068`

No runtime code or database migration is included.