### PR TITLE
chore: restore Vercel preview deployment gate

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -29,9 +29,12 @@
       "schedule": "*/5 * * * *"
     }
   ],
+  "ignoreCommand": "exit 1",
   "git": {
     "deploymentEnabled": {
       "main": true,
+      "agent/*": true,
+      "codex/*": true,
       "*": false
     }
   }


### PR DESCRIPTION
## Summary

- Restore the previously proven Vercel preview deployment controls that were lost from `main`.
- Keep production deployment enabled for `main`.
- Re-enable previews for `agent/*` and `codex/*` branches while preserving default-deny for all other branches.
- Restore `ignoreCommand: "exit 1"` so eligible branches are not skipped by ignored-build evaluation.

## Why

Production hardening requires a deployed preview before authenticated live UI verification and merge decisions. Current `main` only permits `main`, so the active `agent/*` hardening branches are canceled before build.

## Scope

`vercel.json` only. No application code, database changes, production deployment, secrets, billing, or customer-facing behavior.

## Validation

This exact configuration previously existed on merge commit `209e45a6a0a6f3c2d13f6deee2103c8557af8974` and produced working branch previews. Current active PR branches use the `agent/*` namespace.
