### PR TITLE
Add Field My Truck foundation

### DIFF
--- a/.github/workflows/mobile-v1-validation.yml
+++ b/.github/workflows/mobile-v1-validation.yml
@@ -114,6 +114,9 @@ jobs:
         run: |
           set -o pipefail
           {
+            echo "=== Field My Truck isolation runtime ==="
+            psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+              -f tests/mobile/field-my-truck.runtime.sql
             echo "=== Solo Mobile V1 fake day ==="
             psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
               -f tests/mobile/mobile-v1-fake-day.runtime.sql
@@ -132,9 +135,6 @@ jobs:
             echo "=== Field truck inventory runtime ==="
             psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
               -f tests/mobile/field-truck-inventory.runtime.sql
-            echo "=== Field My Truck isolation runtime ==="
-            psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
-              -f tests/mobile/field-my-truck.runtime.sql
           } 2>&1 | tee "$RUNNER_TEMP/mobile-v1-runtime.log"
 
       - name: Upload Mobile V1 runtime diagnostics

--- a/.github/workflows/mobile-v1-validation.yml
+++ b/.github/workflows/mobile-v1-validation.yml
@@ -33,6 +33,7 @@ on:
       - "tests/mobile-v1-productization.test.ts"
       - "tests/mobile-v1-post-merge-hardening.test.ts"
       - "tests/mobile/field-truck-inventory.runtime.sql"
+      - "tests/mobile/field-my-truck.runtime.sql"
       - "tests/mobile/mobile-v1-fake-day.runtime.sql"
       - "tests/mobile/mobile-v1-team-dispatch.runtime.sql"
       - "tests/mobile/mobile-v1-codex-hardening.runtime.sql"
@@ -131,6 +132,9 @@ jobs:
             echo "=== Field truck inventory runtime ==="
             psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
               -f tests/mobile/field-truck-inventory.runtime.sql
+            echo "=== Field My Truck isolation runtime ==="
+            psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+              -f tests/mobile/field-my-truck.runtime.sql
           } 2>&1 | tee "$RUNNER_TEMP/mobile-v1-runtime.log"
 
       - name: Upload Mobile V1 runtime diagnostics

--- a/app/api/mobile/service/my-truck/files/route.ts
+++ b/app/api/mobile/service/my-truck/files/route.ts
@@ -1,0 +1,214 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  isDateKey,
+  isUuid,
+  toNonNegativeNumber,
+  toNullableText,
+} from "@/features/mobile/service/myTruck";
+import {
+  FIELD_TRUCK_RECORD_SELECT,
+  resolveAssignedFieldTruck,
+} from "@/features/mobile/service/server/myTruck";
+import { requireMobileServiceOperatorApiAccess } from "@/features/mobile/service/server/access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+const BUCKET = "field-truck-files";
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const EXTENSIONS = new Map([
+  ["application/pdf", "pdf"],
+  ["image/jpeg", "jpg"],
+  ["image/png", "png"],
+  ["image/webp", "webp"],
+]);
+
+function errorResponse(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+async function getContext() {
+  const access = await requireMobileServiceOperatorApiAccess();
+  if (!access.ok) return access;
+  try {
+    const truck = await resolveAssignedFieldTruck({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id,
+      profileId: access.profile.id,
+    });
+    return { ...access, truck };
+  } catch (error) {
+    console.error("[field/my-truck] assignment lookup failed", error);
+    return {
+      ok: false as const,
+      response: errorResponse("Unable to verify the assigned Field truck.", 500),
+    };
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const access = await getContext();
+  if (!access.ok) return access.response;
+  if (!access.truck) return errorResponse("No Field truck is assigned to you.", 409);
+
+  const id = request.nextUrl.searchParams.get("id")?.trim() ?? "";
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id)) {
+    return errorResponse("Invalid truck file.");
+  }
+  const { data: record, error } = await access.supabase
+    .from("field_truck_records")
+    .select("id,file_bucket,file_path")
+    .eq("id", id)
+    .eq("shop_id", access.profile.shop_id)
+    .eq("service_vehicle_id", access.truck.id)
+    .not("file_path", "is", null)
+    .maybeSingle<{
+      id: string;
+      file_bucket: string | null;
+      file_path: string | null;
+    }>();
+  if (error) return errorResponse("Truck file could not be verified.", 500);
+  if (!record?.file_path || record.file_bucket !== BUCKET) {
+    return errorResponse("Truck file was not found.", 404);
+  }
+
+  const admin = createAdminSupabase();
+  const { data, error: signError } = await admin.storage
+    .from(BUCKET)
+    .createSignedUrl(record.file_path, 60);
+  if (signError || !data?.signedUrl) {
+    return errorResponse("Truck file could not be opened.", 500);
+  }
+  return NextResponse.json(
+    { ok: true, url: data.signedUrl },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}
+
+export async function POST(request: Request) {
+  const access = await getContext();
+  if (!access.ok) return access.response;
+  if (!access.truck) return errorResponse("No Field truck is assigned to you.", 409);
+
+  if (!request.headers.get("content-type")?.includes("multipart/form-data")) {
+    return errorResponse("A multipart file upload is required.");
+  }
+  const form = await request.formData().catch(() => null);
+  const file = form?.get("file");
+  const recordType = String(form?.get("recordType") ?? "").trim();
+  const title = toNullableText(form?.get("title"), 180);
+  const operationKey = String(form?.get("operationKey") ?? "").trim();
+  if (!(file instanceof File) || file.size <= 0) {
+    return errorResponse("Choose a non-empty file.");
+  }
+  if (file.size > MAX_FILE_BYTES) {
+    return errorResponse("Truck files must be 10 MB or smaller.", 413);
+  }
+  const extension = EXTENSIONS.get(file.type.toLowerCase());
+  if (!extension) return errorResponse("Upload a PDF, JPEG, PNG, or WebP file.");
+  if (!title) return errorResponse("A title is required.");
+  if (!isUuid(operationKey)) {
+    return errorResponse("A valid operation key is required.");
+  }
+  if (!["document", "expense"].includes(recordType)) {
+    return errorResponse("Choose a document or expense receipt upload.");
+  }
+
+  const occurredOnValue = String(form?.get("occurredOn") ?? "").trim();
+  const dueOnValue = String(form?.get("dueOn") ?? "").trim();
+  const amount = toNonNegativeNumber(form?.get("amount"));
+  if (occurredOnValue && !isDateKey(occurredOnValue)) {
+    return errorResponse("Enter a valid cost date.");
+  }
+  if (dueOnValue && !isDateKey(dueOnValue)) {
+    return errorResponse("Enter a valid document expiry date.");
+  }
+  if (recordType === "expense" && amount === null) {
+    return errorResponse("Enter a valid cost amount.");
+  }
+
+  const currency = (toNullableText(form?.get("currency"), 3) ?? "CAD").toUpperCase();
+  if (!/^[A-Z]{3}$/.test(currency)) return errorResponse("Currency is invalid.");
+
+  const { data: replay, error: replayError } = await access.supabase
+    .from("field_truck_records")
+    .select(FIELD_TRUCK_RECORD_SELECT)
+    .eq("shop_id", access.profile.shop_id)
+    .eq("service_vehicle_id", access.truck.id)
+    .eq("operation_key", operationKey)
+    .maybeSingle();
+  if (replayError) {
+    return errorResponse("Truck file replay could not be verified.", 500);
+  }
+  if (replay) {
+    return NextResponse.json({ ok: true, replayed: true, record: replay });
+  }
+
+  const recordId = randomUUID();
+  const folder = recordType === "document" ? "documents" : "receipts";
+  const storagePath = `${access.profile.shop_id}/${access.truck.id}/${folder}/${recordId}/${randomUUID()}.${extension}`;
+  const admin = createAdminSupabase();
+  const { error: uploadError } = await admin.storage
+    .from(BUCKET)
+    .upload(storagePath, file, {
+      contentType: file.type,
+      upsert: false,
+    });
+  if (uploadError) {
+    console.error("[field/my-truck] file upload failed", uploadError);
+    return errorResponse("Truck file could not be uploaded.", 500);
+  }
+
+  const { data, error: insertError } = await access.supabase
+    .from("field_truck_records")
+    .insert({
+      id: recordId,
+      shop_id: access.profile.shop_id,
+      service_vehicle_id: access.truck.id,
+      created_by_profile_id: access.profile.id,
+      operation_key: operationKey,
+      record_type: recordType,
+      title,
+      occurred_on:
+        recordType === "expense"
+          ? occurredOnValue || new Date().toISOString().slice(0, 10)
+          : null,
+      amount: recordType === "expense" ? amount : null,
+      currency: recordType === "expense" ? currency : null,
+      vendor: toNullableText(form?.get("vendor"), 180),
+      due_on: recordType === "document" ? dueOnValue || null : null,
+      status: "completed",
+      notes: toNullableText(form?.get("notes")),
+      file_bucket: BUCKET,
+      file_path: storagePath,
+      original_filename: file.name.slice(0, 255),
+      content_type: file.type,
+      file_size_bytes: file.size,
+    })
+    .select(FIELD_TRUCK_RECORD_SELECT)
+    .single();
+
+  if (insertError || !data) {
+    await admin.storage.from(BUCKET).remove([storagePath]);
+    if (insertError?.code === "23505") {
+      const { data: concurrentReplay } = await access.supabase
+        .from("field_truck_records")
+        .select(FIELD_TRUCK_RECORD_SELECT)
+        .eq("shop_id", access.profile.shop_id)
+        .eq("service_vehicle_id", access.truck.id)
+        .eq("operation_key", operationKey)
+        .maybeSingle();
+      if (concurrentReplay) {
+        return NextResponse.json({
+          ok: true,
+          replayed: true,
+          record: concurrentReplay,
+        });
+      }
+    }
+    console.error("[field/my-truck] file metadata failed", insertError);
+    return errorResponse("Truck file metadata could not be saved.", 500);
+  }
+
+  return NextResponse.json({ ok: true, record: data }, { status: 201 });
+}

--- a/app/api/mobile/service/my-truck/files/route.ts
+++ b/app/api/mobile/service/my-truck/files/route.ts
@@ -15,7 +15,7 @@ import { requireMobileServiceOperatorApiAccess } from "@/features/mobile/service
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 const BUCKET = "field-truck-files";
-const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_FILE_BYTES = 4 * 1024 * 1024;
 const EXTENSIONS = new Map([
   ["application/pdf", "pdf"],
   ["image/jpeg", "jpg"],
@@ -121,7 +121,7 @@ export async function POST(request: Request) {
     return errorResponse("Choose a non-empty file.");
   }
   if (file.size > MAX_FILE_BYTES) {
-    return errorResponse("Truck files must be 10 MB or smaller.", 413);
+    return errorResponse("Truck files must be 4 MB or smaller.", 413);
   }
   const extension = EXTENSIONS.get(file.type.toLowerCase());
   if (!extension) return errorResponse("Upload a PDF, JPEG, PNG, or WebP file.");

--- a/app/api/mobile/service/my-truck/files/route.ts
+++ b/app/api/mobile/service/my-truck/files/route.ts
@@ -57,19 +57,38 @@ export async function GET(request: NextRequest) {
   }
   const { data: record, error } = await access.supabase
     .from("field_truck_records")
-    .select("id,file_bucket,file_path")
+    .select("id,record_type,file_bucket,file_path")
     .eq("id", id)
     .eq("shop_id", access.profile.shop_id)
     .eq("service_vehicle_id", access.truck.id)
     .not("file_path", "is", null)
     .maybeSingle<{
       id: string;
+      record_type: string;
       file_bucket: string | null;
       file_path: string | null;
     }>();
   if (error) return errorResponse("Truck file could not be verified.", 500);
   if (!record?.file_path || record.file_bucket !== BUCKET) {
     return errorResponse("Truck file was not found.", 404);
+  }
+  const expectedPrefix = `${access.profile.shop_id}/${access.truck.id}/`;
+  const pathParts = record.file_path.split("/");
+  const expectedFolder =
+    record.record_type === "document"
+      ? "documents"
+      : record.record_type === "expense"
+        ? "receipts"
+        : null;
+  if (
+    !expectedFolder ||
+    !record.file_path.startsWith(expectedPrefix) ||
+    pathParts.length !== 5 ||
+    pathParts[2] !== expectedFolder ||
+    pathParts[3] !== record.id ||
+    !pathParts[4]
+  ) {
+    return errorResponse("Truck file path is outside the assigned truck.", 403);
   }
 
   const admin = createAdminSupabase();

--- a/app/api/mobile/service/my-truck/route.ts
+++ b/app/api/mobile/service/my-truck/route.ts
@@ -258,32 +258,29 @@ export async function PATCH(request: Request) {
   if (readError) return errorResponse("Truck record could not be verified.", 500);
   if (!existing) return errorResponse("Truck record was not found.", 404);
 
-  let updates: Database["public"]["Tables"]["field_truck_records"]["Update"];
+  let endedAt: string | null = null;
   if (action === "end_downtime") {
     if (existing.record_type !== "downtime" || !existing.starts_at) {
       return errorResponse("Only active downtime can be ended.", 409);
     }
-    const endedAt = isIsoTimestamp(body?.endedAt)
+    endedAt = isIsoTimestamp(body?.endedAt)
       ? new Date(body.endedAt).toISOString()
       : new Date().toISOString();
     if (Date.parse(endedAt) <= Date.parse(existing.starts_at)) {
       return errorResponse("Downtime must end after it starts.");
     }
-    updates = { status: "completed", ends_at: endedAt };
   } else {
     if (existing.record_type !== "reminder") {
       return errorResponse("Only reminders can be completed or reopened.", 409);
     }
-    updates = { status: action === "complete" ? "completed" : "open" };
   }
 
   const { data, error } = await access.supabase
-    .from("field_truck_records")
-    .update(updates)
-    .eq("id", existing.id)
-    .eq("shop_id", access.profile.shop_id)
-    .eq("service_vehicle_id", access.truck.id)
-    .select(FIELD_TRUCK_RECORD_SELECT)
+    .rpc("field_transition_truck_record", {
+      p_record_id: existing.id,
+      p_action: String(action),
+      p_ended_at: endedAt,
+    })
     .single();
   if (error) return errorResponse("Truck record could not be updated.", 409);
   return NextResponse.json({ ok: true, record: data });

--- a/app/api/mobile/service/my-truck/route.ts
+++ b/app/api/mobile/service/my-truck/route.ts
@@ -1,0 +1,290 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+
+import {
+  isDateKey,
+  isFieldTruckRecordType,
+  isIsoTimestamp,
+  isUuid,
+  toNonNegativeNumber,
+  toNullableText,
+} from "@/features/mobile/service/myTruck";
+import {
+  FIELD_TRUCK_RECORD_SELECT,
+  loadFieldMyTruckSnapshot,
+  resolveAssignedFieldTruck,
+} from "@/features/mobile/service/server/myTruck";
+import { requireMobileServiceOperatorApiAccess } from "@/features/mobile/service/server/access";
+
+type RecordInsert =
+  Database["public"]["Tables"]["field_truck_records"]["Insert"];
+
+function errorResponse(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+async function getContext() {
+  const access = await requireMobileServiceOperatorApiAccess();
+  if (!access.ok) return access;
+  try {
+    const truck = await resolveAssignedFieldTruck({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id,
+      profileId: access.profile.id,
+    });
+    return { ...access, truck };
+  } catch (error) {
+    console.error("[field/my-truck] assignment lookup failed", error);
+    return {
+      ok: false as const,
+      response: errorResponse("Unable to verify the assigned Field truck.", 500),
+    };
+  }
+}
+
+export async function GET() {
+  const access = await requireMobileServiceOperatorApiAccess();
+  if (!access.ok) return access.response;
+
+  try {
+    const snapshot = await loadFieldMyTruckSnapshot({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id,
+      profileId: access.profile.id,
+    });
+    return NextResponse.json(
+      { ok: true, ...snapshot },
+      { headers: { "Cache-Control": "private, no-store" } },
+    );
+  } catch (error) {
+    console.error("[field/my-truck] snapshot failed", error);
+    return errorResponse("Unable to load My Truck.", 500);
+  }
+}
+
+export async function POST(request: Request) {
+  const access = await getContext();
+  if (!access.ok) return access.response;
+  if (!access.truck) return errorResponse("No Field truck is assigned to you.", 409);
+
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  if (!body || !isFieldTruckRecordType(body.recordType)) {
+    return errorResponse("Choose a valid truck record type.");
+  }
+  if (body.recordType === "document") {
+    return errorResponse("Documents must include a file upload.");
+  }
+  if (!isUuid(body.operationKey)) {
+    return errorResponse("A valid operation key is required.");
+  }
+
+  const title = toNullableText(body.title, 180);
+  if (!title) return errorResponse("A title is required.");
+
+  const occurredOn = body.occurredOn;
+  const dueOn = body.dueOn;
+  const startsAt = body.startsAt;
+  const endsAt = body.endsAt;
+  if (
+    occurredOn !== undefined &&
+    occurredOn !== null &&
+    !isDateKey(occurredOn)
+  ) {
+    return errorResponse("Enter a valid activity date.");
+  }
+  if (
+    dueOn !== undefined &&
+    dueOn !== null &&
+    dueOn !== "" &&
+    !isDateKey(dueOn)
+  ) {
+    return errorResponse("Enter a valid reminder date.");
+  }
+  if (
+    startsAt !== undefined &&
+    startsAt !== null &&
+    !isIsoTimestamp(startsAt)
+  ) {
+    return errorResponse("Enter a valid downtime start.");
+  }
+  if (
+    endsAt !== undefined &&
+    endsAt !== null &&
+    endsAt !== "" &&
+    !isIsoTimestamp(endsAt)
+  ) {
+    return errorResponse("Enter a valid downtime end.");
+  }
+
+  const odometer = toNonNegativeNumber(body.odometer);
+  const amount = toNonNegativeNumber(body.amount);
+  const dueOdometer = toNonNegativeNumber(body.dueOdometer);
+  if (body.recordType === "odometer" && odometer === null) {
+    return errorResponse("Enter a valid odometer reading.");
+  }
+  if (body.recordType === "expense" && amount === null) {
+    return errorResponse("Enter a valid cost amount.");
+  }
+  if (
+    body.recordType === "reminder" &&
+    !(typeof dueOn === "string" && dueOn) &&
+    dueOdometer === null
+  ) {
+    return errorResponse("A reminder needs a date or odometer target.");
+  }
+  if (body.recordType === "downtime" && !isIsoTimestamp(startsAt)) {
+    return errorResponse("Downtime needs a valid start time.");
+  }
+  if (
+    body.recordType === "downtime" &&
+    isIsoTimestamp(endsAt) &&
+    Date.parse(endsAt) <= Date.parse(startsAt as string)
+  ) {
+    return errorResponse("Downtime must end after it starts.");
+  }
+
+  const currency = (toNullableText(body.currency, 3) ?? "CAD").toUpperCase();
+  if (!/^[A-Z]{3}$/.test(currency)) return errorResponse("Currency is invalid.");
+
+  const row: RecordInsert = {
+    shop_id: access.profile.shop_id,
+    service_vehicle_id: access.truck.id,
+    created_by_profile_id: access.profile.id,
+    operation_key: body.operationKey,
+    record_type: body.recordType,
+    title,
+    occurred_on:
+      typeof occurredOn === "string"
+        ? occurredOn
+        : ["odometer", "maintenance", "expense"].includes(body.recordType)
+          ? new Date().toISOString().slice(0, 10)
+          : null,
+    odometer,
+    odometer_unit:
+      odometer === null
+        ? null
+        : toNullableText(body.odometerUnit, 12) ?? "km",
+    amount,
+    currency: amount === null ? null : currency,
+    vendor: toNullableText(body.vendor, 180),
+    due_on: typeof dueOn === "string" && dueOn ? dueOn : null,
+    due_odometer: dueOdometer,
+    starts_at: typeof startsAt === "string" ? new Date(startsAt).toISOString() : null,
+    ends_at:
+      typeof endsAt === "string" && endsAt
+        ? new Date(endsAt).toISOString()
+        : null,
+    status:
+      body.recordType === "downtime" && typeof endsAt === "string" && endsAt
+        ? "completed"
+        : body.recordType === "reminder" || body.recordType === "downtime"
+          ? "open"
+          : "completed",
+    notes: toNullableText(body.notes),
+  };
+
+  const { data: replay, error: replayError } = await access.supabase
+    .from("field_truck_records")
+    .select(FIELD_TRUCK_RECORD_SELECT)
+    .eq("shop_id", access.profile.shop_id)
+    .eq("service_vehicle_id", access.truck.id)
+    .eq("operation_key", body.operationKey)
+    .maybeSingle();
+  if (replayError) {
+    return errorResponse("Truck record replay could not be verified.", 500);
+  }
+  if (replay) {
+    return NextResponse.json({ ok: true, replayed: true, record: replay });
+  }
+
+  const { data, error } = await access.supabase
+    .from("field_truck_records")
+    .insert(row)
+    .select(FIELD_TRUCK_RECORD_SELECT)
+    .single();
+  if (error) {
+    if (error.code === "23505") {
+      const { data: concurrentReplay } = await access.supabase
+        .from("field_truck_records")
+        .select(FIELD_TRUCK_RECORD_SELECT)
+        .eq("shop_id", access.profile.shop_id)
+        .eq("service_vehicle_id", access.truck.id)
+        .eq("operation_key", body.operationKey)
+        .maybeSingle();
+      if (concurrentReplay) {
+        return NextResponse.json({
+          ok: true,
+          replayed: true,
+          record: concurrentReplay,
+        });
+      }
+    }
+    console.error("[field/my-truck] record create failed", error);
+    return errorResponse("Truck record could not be saved.", 409);
+  }
+
+  return NextResponse.json({ ok: true, record: data }, { status: 201 });
+}
+
+export async function PATCH(request: Request) {
+  const access = await getContext();
+  if (!access.ok) return access.response;
+  if (!access.truck) return errorResponse("No Field truck is assigned to you.", 409);
+
+  const body = (await request.json().catch(() => null)) as {
+    id?: unknown;
+    action?: unknown;
+    endedAt?: unknown;
+  } | null;
+  const id = toNullableText(body?.id, 80);
+  const action = body?.action;
+  if (!isUuid(id)) {
+    return errorResponse("Invalid truck record.");
+  }
+  if (!["complete", "reopen", "end_downtime"].includes(String(action))) {
+    return errorResponse("Invalid truck record action.");
+  }
+
+  const { data: existing, error: readError } = await access.supabase
+    .from("field_truck_records")
+    .select("id,record_type,starts_at")
+    .eq("id", id)
+    .eq("shop_id", access.profile.shop_id)
+    .eq("service_vehicle_id", access.truck.id)
+    .maybeSingle<{ id: string; record_type: string; starts_at: string | null }>();
+  if (readError) return errorResponse("Truck record could not be verified.", 500);
+  if (!existing) return errorResponse("Truck record was not found.", 404);
+
+  let updates: Database["public"]["Tables"]["field_truck_records"]["Update"];
+  if (action === "end_downtime") {
+    if (existing.record_type !== "downtime" || !existing.starts_at) {
+      return errorResponse("Only active downtime can be ended.", 409);
+    }
+    const endedAt = isIsoTimestamp(body?.endedAt)
+      ? new Date(body.endedAt).toISOString()
+      : new Date().toISOString();
+    if (Date.parse(endedAt) <= Date.parse(existing.starts_at)) {
+      return errorResponse("Downtime must end after it starts.");
+    }
+    updates = { status: "completed", ends_at: endedAt };
+  } else {
+    if (existing.record_type !== "reminder") {
+      return errorResponse("Only reminders can be completed or reopened.", 409);
+    }
+    updates = { status: action === "complete" ? "completed" : "open" };
+  }
+
+  const { data, error } = await access.supabase
+    .from("field_truck_records")
+    .update(updates)
+    .eq("id", existing.id)
+    .eq("shop_id", access.profile.shop_id)
+    .eq("service_vehicle_id", access.truck.id)
+    .select(FIELD_TRUCK_RECORD_SELECT)
+    .single();
+  if (error) return errorResponse("Truck record could not be updated.", 409);
+  return NextResponse.json({ ok: true, record: data });
+}

--- a/app/api/mobile/service/my-truck/route.ts
+++ b/app/api/mobile/service/my-truck/route.ts
@@ -42,15 +42,17 @@ async function getContext() {
   }
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   const access = await requireMobileServiceOperatorApiAccess();
   if (!access.ok) return access.response;
 
   try {
+    const monthKey = new URL(request.url).searchParams.get("month") ?? "";
     const snapshot = await loadFieldMyTruckSnapshot({
       supabase: access.supabase,
       shopId: access.profile.shop_id,
       profileId: access.profile.id,
+      monthKey: /^\d{4}-(0[1-9]|1[0-2])$/.test(monthKey) ? monthKey : undefined,
     });
     return NextResponse.json(
       { ok: true, ...snapshot },
@@ -164,7 +166,7 @@ export async function POST(request: Request) {
           : null,
     odometer,
     odometer_unit:
-      odometer === null
+      odometer === null && dueOdometer === null
         ? null
         : toNullableText(body.odometerUnit, 12) ?? "km",
     amount,

--- a/app/api/mobile/service/my-truck/route.ts
+++ b/app/api/mobile/service/my-truck/route.ts
@@ -275,13 +275,14 @@ export async function PATCH(request: Request) {
     }
   }
 
-  const { data, error } = await access.supabase
-    .rpc("field_transition_truck_record", {
+  const { data, error } = await access.supabase.rpc(
+    "field_transition_truck_record",
+    {
       p_record_id: existing.id,
       p_action: String(action),
-      p_ended_at: endedAt,
-    })
-    .single();
+      ...(endedAt ? { p_ended_at: endedAt } : {}),
+    },
+  );
   if (error) return errorResponse("Truck record could not be updated.", 409);
   return NextResponse.json({ ok: true, record: data });
 }

--- a/app/api/mobile/service/settings/route.ts
+++ b/app/api/mobile/service/settings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
 
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 type ConfigureRpcArgs =
   Database["public"]["Functions"]["mobile_configure_service_v1_atomic"]["Args"];
@@ -92,7 +93,7 @@ async function readSettings(
       (operator) => operator.profile_id,
     );
     const profilesResult = profileIds.length
-      ? await access.supabase
+      ? await createAdminSupabase()
           .from("profiles")
           .select("id,full_name,email")
           .eq("shop_id", access.profile.shop_id)

--- a/app/api/mobile/service/settings/route.ts
+++ b/app/api/mobile/service/settings/route.ts
@@ -70,7 +70,8 @@ async function readSettings(
   }> = [];
 
   if (canConfigure) {
-    const [operatorsResult, vehiclesResult] = await Promise.all([
+    const admin = createAdminSupabase();
+    const [operatorsResult, vehiclesResult, assignmentsResult] = await Promise.all([
       access.supabase
         .from("mobile_field_operators")
         .select("profile_id")
@@ -78,22 +79,28 @@ async function readSettings(
         .eq("enabled", true),
       access.supabase
         .from("service_vehicles")
-        .select("id,name,unit_number,primary_user_id")
+        .select("id,name,unit_number")
         .eq("shop_id", access.profile.shop_id)
         .eq("active", true)
         .contains("capabilities", { mobile_v1: true })
         .order("name", { ascending: true }),
+      admin
+        .from("field_service_vehicle_assignments")
+        .select("service_vehicle_id,profile_id")
+        .eq("shop_id", access.profile.shop_id),
     ]);
-    if (operatorsResult.error || vehiclesResult.error) {
+    if (operatorsResult.error || vehiclesResult.error || assignmentsResult.error) {
       throw new Error(
-        operatorsResult.error?.message ?? vehiclesResult.error?.message,
+        operatorsResult.error?.message ??
+          vehiclesResult.error?.message ??
+          assignmentsResult.error?.message,
       );
     }
     const profileIds = (operatorsResult.data ?? []).map(
       (operator) => operator.profile_id,
     );
     const profilesResult = profileIds.length
-      ? await createAdminSupabase()
+      ? await admin
           .from("profiles")
           .select("id,full_name,email")
           .eq("shop_id", access.profile.shop_id)
@@ -106,7 +113,10 @@ async function readSettings(
       id: vehicle.id,
       name: vehicle.name,
       unitNumber: vehicle.unit_number,
-      primaryUserId: vehicle.primary_user_id,
+      primaryUserId:
+        (assignmentsResult.data ?? []).find(
+          (assignment) => assignment.service_vehicle_id === vehicle.id,
+        )?.profile_id ?? null,
     }));
     fieldTeam = (profilesResult.data ?? []).map((profile) => ({
       profileId: profile.id,

--- a/app/api/mobile/service/settings/route.ts
+++ b/app/api/mobile/service/settings/route.ts
@@ -55,11 +55,75 @@ async function readSettings(
     settingsResult.error || operatorResult.error || vehicleResult.error;
   if (firstError) throw new Error(firstError.message);
 
+  const canConfigure = ["owner", "admin"].includes(access.canonicalRole);
+  let fieldTeam: Array<{
+    profileId: string;
+    name: string;
+    vehicleId: string | null;
+  }> = [];
+  let fieldVehicles: Array<{
+    id: string;
+    name: string;
+    unitNumber: string | null;
+    primaryUserId: string | null;
+  }> = [];
+
+  if (canConfigure) {
+    const [operatorsResult, vehiclesResult] = await Promise.all([
+      access.supabase
+        .from("mobile_field_operators")
+        .select("profile_id")
+        .eq("shop_id", access.profile.shop_id)
+        .eq("enabled", true),
+      access.supabase
+        .from("service_vehicles")
+        .select("id,name,unit_number,primary_user_id")
+        .eq("shop_id", access.profile.shop_id)
+        .eq("active", true)
+        .contains("capabilities", { mobile_v1: true })
+        .order("name", { ascending: true }),
+    ]);
+    if (operatorsResult.error || vehiclesResult.error) {
+      throw new Error(
+        operatorsResult.error?.message ?? vehiclesResult.error?.message,
+      );
+    }
+    const profileIds = (operatorsResult.data ?? []).map(
+      (operator) => operator.profile_id,
+    );
+    const profilesResult = profileIds.length
+      ? await access.supabase
+          .from("profiles")
+          .select("id,full_name,email")
+          .eq("shop_id", access.profile.shop_id)
+          .in("id", profileIds)
+          .order("full_name", { ascending: true })
+      : { data: [], error: null };
+    if (profilesResult.error) throw new Error(profilesResult.error.message);
+
+    fieldVehicles = (vehiclesResult.data ?? []).map((vehicle) => ({
+      id: vehicle.id,
+      name: vehicle.name,
+      unitNumber: vehicle.unit_number,
+      primaryUserId: vehicle.primary_user_id,
+    }));
+    fieldTeam = (profilesResult.data ?? []).map((profile) => ({
+      profileId: profile.id,
+      name: profile.full_name?.trim() || profile.email || "Field operator",
+      vehicleId:
+        fieldVehicles.find(
+          (vehicle) => vehicle.primaryUserId === profile.id,
+        )?.id ?? null,
+    }));
+  }
+
   return {
     settings: settingsResult.data ?? null,
     currentActorFieldOperator: operatorResult.data?.enabled === true,
     serviceVehicle: vehicleResult.data ?? null,
-    canConfigure: ["owner", "admin"].includes(access.canonicalRole),
+    canConfigure,
+    fieldTeam,
+    fieldVehicles,
   };
 }
 
@@ -152,4 +216,41 @@ export async function PUT(request: Request) {
   } catch {
     return NextResponse.json({ ok: true, result: data });
   }
+}
+
+export async function PATCH(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
+
+  const body = (await request.json().catch(() => null)) as {
+    profileId?: unknown;
+    serviceVehicleId?: unknown;
+  } | null;
+  const profileId = typeof body?.profileId === "string" ? body.profileId : "";
+  const serviceVehicleId =
+    typeof body?.serviceVehicleId === "string" ? body.serviceVehicleId : "";
+  const uuidPattern =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (!uuidPattern.test(profileId) || !uuidPattern.test(serviceVehicleId)) {
+    return NextResponse.json(
+      { error: "Choose a valid Field operator and truck." },
+      { status: 400 },
+    );
+  }
+
+  const { error } = await access.supabase.rpc("field_assign_service_vehicle", {
+    p_shop_id: access.profile.shop_id,
+    p_profile_id: profileId,
+    p_service_vehicle_id: serviceVehicleId,
+  });
+  if (error) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.code === "42501" ? 403 : 409 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, ...(await readSettings(access)) });
 }

--- a/app/mobile/service/my-truck/page.tsx
+++ b/app/mobile/service/my-truck/page.tsx
@@ -1,0 +1,7 @@
+import FieldMyTruck from "@/features/mobile/service/FieldMyTruck";
+
+export const dynamic = "force-dynamic";
+
+export default function FieldMyTruckPage() {
+  return <FieldMyTruck />;
+}

--- a/features/mobile/service/FieldHub.tsx
+++ b/features/mobile/service/FieldHub.tsx
@@ -18,6 +18,7 @@ import {
   RotateCcw,
   Settings2,
   SlidersHorizontal,
+  Truck,
   Wrench,
   Wifi,
   WifiOff,
@@ -111,6 +112,13 @@ const FIELD_DASHBOARD_CARDS: FieldDashboardCard[] = [
     description: "Return to active repairs and service calls.",
     href: "/mobile/service/jobs",
     icon: Wrench,
+  },
+  {
+    id: "my_truck",
+    title: "My Truck",
+    description: "Review maintenance, reminders, downtime, costs and documents.",
+    href: "/mobile/service/my-truck",
+    icon: Truck,
   },
   {
     id: "awaiting_approval",

--- a/features/mobile/service/FieldMyTruck.tsx
+++ b/features/mobile/service/FieldMyTruck.tsx
@@ -13,7 +13,7 @@ import {
   Truck,
   Wrench,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type {
   FieldMyTruckSnapshot,
@@ -26,17 +26,23 @@ type SnapshotResponse = FieldMyTruckSnapshot & { ok: true };
 const EMPTY_SNAPSHOT: FieldMyTruckSnapshot = {
   truck: null,
   records: [],
+  alerts: [],
   summary: {
     latestOdometer: null,
     odometerUnit: null,
     openReminders: 0,
     activeDowntime: 0,
-    monthCosts: 0,
-    currency: "CAD",
+    monthCostsByCurrency: [],
   },
 };
 
-const today = () => new Date().toISOString().slice(0, 10);
+const today = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
 const localDateTime = () => {
   const now = new Date();
   now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
@@ -77,10 +83,29 @@ function RecordForm({
 }: {
   type: FieldTruckRecordType;
   title: string;
-  onSubmit: (type: FieldTruckRecordType, form: FormData) => Promise<boolean>;
+  onSubmit: (
+    type: FieldTruckRecordType,
+    form: FormData,
+    operationKey: string,
+  ) => Promise<boolean>;
   busy: boolean;
 }) {
   const isUpload = type === "document" || type === "expense";
+  const pendingSubmission = useRef<{
+    fingerprint: string;
+    operationKey: string;
+  } | null>(null);
+
+  const submissionFingerprint = (form: FormData) =>
+    JSON.stringify(
+      [...form.entries()].map(([key, value]) => [
+        key,
+        value instanceof File
+          ? `${value.name}:${value.size}:${value.type}:${value.lastModified}`
+          : value,
+      ]),
+    );
+
   return (
     <details className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]">
       <summary className="flex min-h-14 cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 font-extrabold">
@@ -92,8 +117,18 @@ function RecordForm({
         onSubmit={(event) => {
           event.preventDefault();
           const form = event.currentTarget;
-          void onSubmit(type, new FormData(form)).then((saved) => {
-            if (saved) form.reset();
+          const formData = new FormData(form);
+          const fingerprint = submissionFingerprint(formData);
+          const operationKey =
+            pendingSubmission.current?.fingerprint === fingerprint
+              ? pendingSubmission.current.operationKey
+              : crypto.randomUUID();
+          pendingSubmission.current = { fingerprint, operationKey };
+          void onSubmit(type, formData, operationKey).then((saved) => {
+            if (saved) {
+              pendingSubmission.current = null;
+              form.reset();
+            }
           });
         }}
       >
@@ -213,7 +248,7 @@ function RecordRow({
   busy,
 }: {
   record: FieldTruckRecord;
-  onAction: (record: FieldTruckRecord) => Promise<void>;
+  onAction: (record: FieldTruckRecord, action?: "reopen") => Promise<void>;
   onOpenFile: (record: FieldTruckRecord) => Promise<void>;
   busy: boolean;
 }) {
@@ -240,7 +275,7 @@ function RecordRow({
         {record.ends_at ? <span>To {new Date(record.ends_at).toLocaleString()}</span> : null}
       </div>
       {record.notes ? <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">{record.notes}</p> : null}
-      {record.file_path || (record.status === "open" && ["reminder", "downtime"].includes(record.record_type)) ? (
+      {record.file_path || record.record_type === "reminder" || (record.status === "open" && record.record_type === "downtime") ? (
         <div className="mt-3 flex flex-wrap gap-2">
           {record.file_path ? (
             <button type="button" disabled={busy} onClick={() => void onOpenFile(record)} className="min-h-10 rounded-xl border border-[color:var(--theme-border-soft)] px-3 text-sm font-bold">Open file</button>
@@ -248,6 +283,11 @@ function RecordRow({
           {record.status === "open" && ["reminder", "downtime"].includes(record.record_type) ? (
             <button type="button" disabled={busy} onClick={() => void onAction(record)} className="inline-flex min-h-10 items-center gap-2 rounded-xl bg-emerald-500/15 px-3 text-sm font-bold text-emerald-300">
               <Check className="h-4 w-4" /> {record.record_type === "downtime" ? "Back in service" : "Complete"}
+            </button>
+          ) : null}
+          {record.record_type === "reminder" && record.status === "completed" ? (
+            <button type="button" disabled={busy} onClick={() => void onAction(record, "reopen")} className="min-h-10 rounded-xl border border-[color:var(--theme-border-soft)] px-3 text-sm font-bold">
+              Reopen
             </button>
           ) : null}
         </div>
@@ -285,12 +325,15 @@ export default function FieldMyTruck() {
 
   useEffect(() => { void load(); }, [load]);
 
-  const submit = async (recordType: FieldTruckRecordType, form: FormData) => {
+  const submit = async (
+    recordType: FieldTruckRecordType,
+    form: FormData,
+    operationKey: string,
+  ) => {
     if (busy) return false;
     setBusy(true);
     setError(null);
     try {
-      const operationKey = crypto.randomUUID();
       const file = form.get("file");
       const hasFile = file instanceof File && file.size > 0;
       let response: Response;
@@ -322,7 +365,7 @@ export default function FieldMyTruck() {
     }
   };
 
-  const complete = async (record: FieldTruckRecord) => {
+  const complete = async (record: FieldTruckRecord, action?: "reopen") => {
     setBusy(true);
     setError(null);
     try {
@@ -330,7 +373,12 @@ export default function FieldMyTruck() {
         method: "PATCH",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: record.id, action: record.record_type === "downtime" ? "end_downtime" : "complete" }),
+        body: JSON.stringify({
+          id: record.id,
+          action:
+            action ??
+            (record.record_type === "downtime" ? "end_downtime" : "complete"),
+        }),
       });
       const body = (await response.json().catch(() => null)) as { error?: string } | null;
       if (!response.ok) throw new Error(body?.error ?? "Truck record could not be updated.");
@@ -343,14 +391,21 @@ export default function FieldMyTruck() {
   };
 
   const openFile = async (record: FieldTruckRecord) => {
+    const popup = window.open("", "_blank");
+    if (popup) popup.opener = null;
     setBusy(true);
     setError(null);
     try {
       const response = await fetch(`/api/mobile/service/my-truck/files?id=${encodeURIComponent(record.id)}`, { credentials: "include", cache: "no-store" });
       const body = (await response.json().catch(() => null)) as { url?: string; error?: string } | null;
       if (!response.ok || !body?.url) throw new Error(body?.error ?? "Truck file could not be opened.");
-      window.open(body.url, "_blank", "noopener,noreferrer");
+      if (popup) {
+        popup.location.replace(body.url);
+      } else {
+        window.location.assign(body.url);
+      }
     } catch (cause) {
+      popup?.close();
       setError(cause instanceof Error ? cause.message : "Truck file could not be opened.");
     } finally {
       setBusy(false);
@@ -358,7 +413,7 @@ export default function FieldMyTruck() {
   };
 
   const records = useMemo(() => snapshot.records.slice().sort((a, b) => b.created_at.localeCompare(a.created_at)), [snapshot.records]);
-  const alerts = records.filter((record) => record.status === "open" && ["reminder", "downtime"].includes(record.record_type));
+  const alerts = snapshot.alerts;
 
   if (loading && !snapshot.truck) {
     return <div className="grid min-h-[45vh] place-items-center"><Loader2 className="h-7 w-7 animate-spin text-sky-400" /></div>;
@@ -393,7 +448,15 @@ export default function FieldMyTruck() {
               [Gauge, "Odometer", snapshot.summary.latestOdometer === null ? "Not logged" : `${Number(snapshot.summary.latestOdometer).toLocaleString()} ${snapshot.summary.odometerUnit ?? "km"}`],
               [CalendarClock, "Open reminders", String(snapshot.summary.openReminders)],
               [AlertTriangle, "Active downtime", String(snapshot.summary.activeDowntime)],
-              [Receipt, "Costs this month", money(snapshot.summary.monthCosts, snapshot.summary.currency)],
+              [
+                Receipt,
+                "Costs this month",
+                snapshot.summary.monthCostsByCurrency.length
+                  ? snapshot.summary.monthCostsByCurrency
+                      .map(({ amount, currency }) => money(amount, currency))
+                      .join(" · ")
+                  : money(0, "CAD"),
+              ],
             ].map(([Icon, label, value]) => {
               const CardIcon = Icon as typeof Gauge;
               return <div key={String(label)} className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-card"><CardIcon className="h-5 w-5 text-sky-400" /><div className="mt-3 text-xs font-bold uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">{String(label)}</div><div className="mt-1 text-lg font-black">{String(value)}</div></div>;

--- a/features/mobile/service/FieldMyTruck.tsx
+++ b/features/mobile/service/FieldMyTruck.tsx
@@ -43,6 +43,7 @@ const today = () => {
   const day = String(now.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 };
+const localMonth = () => today().slice(0, 7);
 const localDateTime = () => {
   const now = new Date();
   now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
@@ -306,7 +307,7 @@ export default function FieldMyTruck() {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("/api/mobile/service/my-truck", { credentials: "include", cache: "no-store" });
+      const response = await fetch(`/api/mobile/service/my-truck?month=${localMonth()}`, { credentials: "include", cache: "no-store" });
       const body = (await response.json().catch(() => null)) as SnapshotResponse | { error?: string } | null;
       if (!response.ok || !body || !("truck" in body)) {
         throw new Error(
@@ -346,11 +347,16 @@ export default function FieldMyTruck() {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            recordType,
-            operationKey,
-            ...Object.fromEntries(form.entries()),
-          }),
+          body: JSON.stringify((() => {
+            const payload = Object.fromEntries(form.entries());
+            for (const key of ["startsAt", "endsAt"] as const) {
+              const value = payload[key];
+              if (typeof value === "string" && value) {
+                payload[key] = new Date(value).toISOString();
+              }
+            }
+            return { recordType, operationKey, ...payload };
+          })()),
         });
       }
       const body = (await response.json().catch(() => null)) as { error?: string } | null;

--- a/features/mobile/service/FieldMyTruck.tsx
+++ b/features/mobile/service/FieldMyTruck.tsx
@@ -192,7 +192,13 @@ function RecordForm({
               <input className={inputClass} name="dueOn" type="date" />
             </Field>
             <Field label="Due odometer">
-              <input className={inputClass} name="dueOdometer" type="number" min="0" step="0.1" />
+              <div className="grid grid-cols-[minmax(0,1fr)_5.5rem] gap-2">
+                <input className={inputClass} name="dueOdometer" type="number" min="0" step="0.1" />
+                <select className={inputClass} name="odometerUnit" defaultValue="km">
+                  <option value="km">km</option>
+                  <option value="mi">mi</option>
+                </select>
+              </div>
             </Field>
           </>
         ) : null}
@@ -215,7 +221,7 @@ function RecordForm({
         ) : null}
 
         {isUpload ? (
-          <Field label={type === "expense" ? "Receipt (optional)" : "File"}>
+          <Field label={type === "expense" ? "Receipt (optional, max 4 MB)" : "File (max 4 MB)"}>
             <input
               className={`${inputClass} py-2`}
               name="file"
@@ -271,7 +277,7 @@ function RecordRow({
         {record.amount !== null ? <span>{money(Number(record.amount), record.currency ?? "CAD")}</span> : null}
         {record.vendor ? <span>{record.vendor}</span> : null}
         {record.due_on ? <span>Due {displayDate(record.due_on)}</span> : null}
-        {record.due_odometer !== null ? <span>Due at {Number(record.due_odometer).toLocaleString()}</span> : null}
+        {record.due_odometer !== null ? <span>Due at {Number(record.due_odometer).toLocaleString()} {record.odometer_unit ?? "km"}</span> : null}
         {record.starts_at ? <span>From {new Date(record.starts_at).toLocaleString()}</span> : null}
         {record.ends_at ? <span>To {new Date(record.ends_at).toLocaleString()}</span> : null}
       </div>

--- a/features/mobile/service/FieldMyTruck.tsx
+++ b/features/mobile/service/FieldMyTruck.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import {
+  AlertTriangle,
+  CalendarClock,
+  Check,
+  FileText,
+  Gauge,
+  Loader2,
+  Plus,
+  Receipt,
+  RefreshCw,
+  Truck,
+  Wrench,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type {
+  FieldMyTruckSnapshot,
+  FieldTruckRecord,
+  FieldTruckRecordType,
+} from "./myTruck";
+
+type SnapshotResponse = FieldMyTruckSnapshot & { ok: true };
+
+const EMPTY_SNAPSHOT: FieldMyTruckSnapshot = {
+  truck: null,
+  records: [],
+  summary: {
+    latestOdometer: null,
+    odometerUnit: null,
+    openReminders: 0,
+    activeDowntime: 0,
+    monthCosts: 0,
+    currency: "CAD",
+  },
+};
+
+const today = () => new Date().toISOString().slice(0, 10);
+const localDateTime = () => {
+  const now = new Date();
+  now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
+  return now.toISOString().slice(0, 16);
+};
+
+function money(amount: number, currency: string) {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
+function displayDate(value: string | null) {
+  if (!value) return "—";
+  const parsed = value.length === 10 ? new Date(`${value}T00:00:00`) : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleDateString();
+}
+
+const inputClass =
+  "min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 text-base";
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+      {label}
+      <span className="mt-1 block">{children}</span>
+    </label>
+  );
+}
+
+function RecordForm({
+  type,
+  title,
+  onSubmit,
+  busy,
+}: {
+  type: FieldTruckRecordType;
+  title: string;
+  onSubmit: (type: FieldTruckRecordType, form: FormData) => Promise<boolean>;
+  busy: boolean;
+}) {
+  const isUpload = type === "document" || type === "expense";
+  return (
+    <details className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]">
+      <summary className="flex min-h-14 cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 font-extrabold">
+        <span>{title}</span>
+        <Plus aria-hidden className="h-5 w-5 text-[color:var(--accent-copper)]" />
+      </summary>
+      <form
+        className="grid gap-3 border-t border-[color:var(--theme-border-soft)] p-4 sm:grid-cols-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const form = event.currentTarget;
+          void onSubmit(type, new FormData(form)).then((saved) => {
+            if (saved) form.reset();
+          });
+        }}
+      >
+        <Field label={type === "odometer" ? "Reading label" : "Title"}>
+          <input
+            className={inputClass}
+            name="title"
+            required
+            maxLength={180}
+            defaultValue={type === "odometer" ? "Odometer reading" : ""}
+            placeholder={
+              type === "maintenance"
+                ? "Oil and filter service"
+                : type === "reminder"
+                  ? "Renew registration"
+                  : type === "downtime"
+                    ? "Truck unavailable"
+                    : type === "expense"
+                      ? "Fuel or operating cost"
+                      : "Registration or insurance"
+            }
+          />
+        </Field>
+
+        {type === "odometer" || type === "maintenance" ? (
+          <Field label="Odometer">
+            <div className="grid grid-cols-[minmax(0,1fr)_5.5rem] gap-2">
+              <input className={inputClass} name="odometer" type="number" min="0" step="0.1" required={type === "odometer"} />
+              <select className={inputClass} name="odometerUnit" defaultValue="km">
+                <option value="km">km</option>
+                <option value="mi">mi</option>
+              </select>
+            </div>
+          </Field>
+        ) : null}
+
+        {["odometer", "maintenance", "expense"].includes(type) ? (
+          <Field label="Date">
+            <input className={inputClass} name="occurredOn" type="date" defaultValue={today()} required />
+          </Field>
+        ) : null}
+
+        {type === "maintenance" || type === "expense" ? (
+          <>
+            <Field label="Cost">
+              <div className="grid grid-cols-[minmax(0,1fr)_5.5rem] gap-2">
+                <input className={inputClass} name="amount" type="number" min="0" step="0.01" required={type === "expense"} />
+                <input className={inputClass} name="currency" defaultValue="CAD" maxLength={3} />
+              </div>
+            </Field>
+            <Field label="Vendor">
+              <input className={inputClass} name="vendor" maxLength={180} />
+            </Field>
+          </>
+        ) : null}
+
+        {type === "reminder" ? (
+          <>
+            <Field label="Due date">
+              <input className={inputClass} name="dueOn" type="date" />
+            </Field>
+            <Field label="Due odometer">
+              <input className={inputClass} name="dueOdometer" type="number" min="0" step="0.1" />
+            </Field>
+          </>
+        ) : null}
+
+        {type === "downtime" ? (
+          <>
+            <Field label="Starts">
+              <input className={inputClass} name="startsAt" type="datetime-local" defaultValue={localDateTime()} required />
+            </Field>
+            <Field label="Ended (leave blank while active)">
+              <input className={inputClass} name="endsAt" type="datetime-local" />
+            </Field>
+          </>
+        ) : null}
+
+        {type === "document" ? (
+          <Field label="Expiry date (optional)">
+            <input className={inputClass} name="dueOn" type="date" />
+          </Field>
+        ) : null}
+
+        {isUpload ? (
+          <Field label={type === "expense" ? "Receipt (optional)" : "File"}>
+            <input
+              className={`${inputClass} py-2`}
+              name="file"
+              type="file"
+              required={type === "document"}
+              accept="application/pdf,image/jpeg,image/png,image/webp"
+            />
+          </Field>
+        ) : null}
+
+        <Field label="Notes">
+          <textarea className={`${inputClass} min-h-24 py-2`} name="notes" maxLength={2000} />
+        </Field>
+
+        <button
+          type="submit"
+          disabled={busy}
+          className="min-h-11 rounded-xl bg-sky-500 px-4 font-extrabold text-slate-950 disabled:opacity-60 sm:col-span-2"
+        >
+          {busy ? "Saving…" : `Save ${title.toLowerCase()}`}
+        </button>
+      </form>
+    </details>
+  );
+}
+
+function RecordRow({
+  record,
+  onAction,
+  onOpenFile,
+  busy,
+}: {
+  record: FieldTruckRecord;
+  onAction: (record: FieldTruckRecord) => Promise<void>;
+  onOpenFile: (record: FieldTruckRecord) => Promise<void>;
+  busy: boolean;
+}) {
+  return (
+    <article className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate font-extrabold">{record.title}</div>
+          <div className="mt-0.5 text-xs uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">
+            {record.record_type.replace("_", " ")} · {displayDate(record.occurred_on ?? record.created_at)}
+          </div>
+        </div>
+        {record.status === "open" ? (
+          <span className="rounded-full bg-amber-500/15 px-2 py-1 text-[0.65rem] font-extrabold uppercase text-amber-300">Open</span>
+        ) : null}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-[color:var(--theme-text-secondary)]">
+        {record.odometer !== null ? <span>{Number(record.odometer).toLocaleString()} {record.odometer_unit ?? "km"}</span> : null}
+        {record.amount !== null ? <span>{money(Number(record.amount), record.currency ?? "CAD")}</span> : null}
+        {record.vendor ? <span>{record.vendor}</span> : null}
+        {record.due_on ? <span>Due {displayDate(record.due_on)}</span> : null}
+        {record.due_odometer !== null ? <span>Due at {Number(record.due_odometer).toLocaleString()}</span> : null}
+        {record.starts_at ? <span>From {new Date(record.starts_at).toLocaleString()}</span> : null}
+        {record.ends_at ? <span>To {new Date(record.ends_at).toLocaleString()}</span> : null}
+      </div>
+      {record.notes ? <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">{record.notes}</p> : null}
+      {record.file_path || (record.status === "open" && ["reminder", "downtime"].includes(record.record_type)) ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {record.file_path ? (
+            <button type="button" disabled={busy} onClick={() => void onOpenFile(record)} className="min-h-10 rounded-xl border border-[color:var(--theme-border-soft)] px-3 text-sm font-bold">Open file</button>
+          ) : null}
+          {record.status === "open" && ["reminder", "downtime"].includes(record.record_type) ? (
+            <button type="button" disabled={busy} onClick={() => void onAction(record)} className="inline-flex min-h-10 items-center gap-2 rounded-xl bg-emerald-500/15 px-3 text-sm font-bold text-emerald-300">
+              <Check className="h-4 w-4" /> {record.record_type === "downtime" ? "Back in service" : "Complete"}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+export default function FieldMyTruck() {
+  const [snapshot, setSnapshot] = useState<FieldMyTruckSnapshot>(EMPTY_SNAPSHOT);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/mobile/service/my-truck", { credentials: "include", cache: "no-store" });
+      const body = (await response.json().catch(() => null)) as SnapshotResponse | { error?: string } | null;
+      if (!response.ok || !body || !("truck" in body)) {
+        throw new Error(
+          body && "error" in body
+            ? body.error ?? "My Truck could not be loaded."
+            : "My Truck could not be loaded.",
+        );
+      }
+      setSnapshot(body);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "My Truck could not be loaded.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const submit = async (recordType: FieldTruckRecordType, form: FormData) => {
+    if (busy) return false;
+    setBusy(true);
+    setError(null);
+    try {
+      const operationKey = crypto.randomUUID();
+      const file = form.get("file");
+      const hasFile = file instanceof File && file.size > 0;
+      let response: Response;
+      if (recordType === "document" || (recordType === "expense" && hasFile)) {
+        form.set("recordType", recordType);
+        form.set("operationKey", operationKey);
+        response = await fetch("/api/mobile/service/my-truck/files", { method: "POST", credentials: "include", body: form });
+      } else {
+        response = await fetch("/api/mobile/service/my-truck", {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            recordType,
+            operationKey,
+            ...Object.fromEntries(form.entries()),
+          }),
+        });
+      }
+      const body = (await response.json().catch(() => null)) as { error?: string } | null;
+      if (!response.ok) throw new Error(body?.error ?? "Truck record could not be saved.");
+      await load();
+      return true;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Truck record could not be saved.");
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const complete = async (record: FieldTruckRecord) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/mobile/service/my-truck", {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: record.id, action: record.record_type === "downtime" ? "end_downtime" : "complete" }),
+      });
+      const body = (await response.json().catch(() => null)) as { error?: string } | null;
+      if (!response.ok) throw new Error(body?.error ?? "Truck record could not be updated.");
+      await load();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Truck record could not be updated.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const openFile = async (record: FieldTruckRecord) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/mobile/service/my-truck/files?id=${encodeURIComponent(record.id)}`, { credentials: "include", cache: "no-store" });
+      const body = (await response.json().catch(() => null)) as { url?: string; error?: string } | null;
+      if (!response.ok || !body?.url) throw new Error(body?.error ?? "Truck file could not be opened.");
+      window.open(body.url, "_blank", "noopener,noreferrer");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Truck file could not be opened.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const records = useMemo(() => snapshot.records.slice().sort((a, b) => b.created_at.localeCompare(a.created_at)), [snapshot.records]);
+  const alerts = records.filter((record) => record.status === "open" && ["reminder", "downtime"].includes(record.record_type));
+
+  if (loading && !snapshot.truck) {
+    return <div className="grid min-h-[45vh] place-items-center"><Loader2 className="h-7 w-7 animate-spin text-sky-400" /></div>;
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-6xl space-y-4 px-3 pb-8 pt-3 sm:px-4">
+      <header className="rounded-3xl border border-white/10 bg-slate-950 p-5 text-white shadow-card">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-[0.65rem] font-extrabold uppercase tracking-[0.2em] text-sky-300">Field operations</div>
+            <h1 className="mt-1 text-2xl font-black">{snapshot.truck?.name ?? "My Truck"}</h1>
+            <p className="mt-1 text-sm text-slate-300">{snapshot.truck?.unitNumber ? `Unit ${snapshot.truck.unitNumber} · ` : ""}Maintenance, readiness, records and operating costs.</p>
+          </div>
+          <button type="button" onClick={() => void load()} disabled={loading} aria-label="Refresh My Truck" className="inline-grid h-11 w-11 place-items-center rounded-xl border border-white/15 bg-white/[0.06]">
+            <RefreshCw className={`h-5 w-5 ${loading ? "animate-spin" : ""}`} />
+          </button>
+        </div>
+      </header>
+
+      {error ? <div role="alert" className="rounded-2xl border border-rose-400/30 bg-rose-500/10 p-3 text-sm text-rose-200">{error}</div> : null}
+
+      {!snapshot.truck ? (
+        <section className="rounded-3xl border border-amber-400/30 bg-amber-500/10 p-5 text-amber-100">
+          <div className="flex items-center gap-2 font-extrabold"><AlertTriangle className="h-5 w-5" /> No truck assigned</div>
+          <p className="mt-2 text-sm">An owner or admin must assign this Field profile as the primary operator of an active service vehicle before My Truck records can be accessed.</p>
+        </section>
+      ) : (
+        <>
+          <section className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+            {[
+              [Gauge, "Odometer", snapshot.summary.latestOdometer === null ? "Not logged" : `${Number(snapshot.summary.latestOdometer).toLocaleString()} ${snapshot.summary.odometerUnit ?? "km"}`],
+              [CalendarClock, "Open reminders", String(snapshot.summary.openReminders)],
+              [AlertTriangle, "Active downtime", String(snapshot.summary.activeDowntime)],
+              [Receipt, "Costs this month", money(snapshot.summary.monthCosts, snapshot.summary.currency)],
+            ].map(([Icon, label, value]) => {
+              const CardIcon = Icon as typeof Gauge;
+              return <div key={String(label)} className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-card"><CardIcon className="h-5 w-5 text-sky-400" /><div className="mt-3 text-xs font-bold uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">{String(label)}</div><div className="mt-1 text-lg font-black">{String(value)}</div></div>;
+            })}
+          </section>
+
+          {alerts.length ? (
+            <section className="space-y-2 rounded-3xl border border-amber-400/30 bg-amber-500/10 p-4">
+              <h2 className="flex items-center gap-2 font-black text-amber-200"><AlertTriangle className="h-5 w-5" /> Truck alerts</h2>
+              {alerts.map((record) => <RecordRow key={record.id} record={record} onAction={complete} onOpenFile={openFile} busy={busy} />)}
+            </section>
+          ) : null}
+
+          <section className="space-y-3">
+            <div><h2 className="text-lg font-black">Add truck record</h2><p className="text-sm text-[color:var(--theme-text-secondary)]">Everything stays attached to this assigned Field truck.</p></div>
+            <div className="grid gap-3 lg:grid-cols-2">
+              <RecordForm type="odometer" title="Mileage" onSubmit={submit} busy={busy} />
+              <RecordForm type="maintenance" title="Maintenance" onSubmit={submit} busy={busy} />
+              <RecordForm type="expense" title="Cost or receipt" onSubmit={submit} busy={busy} />
+              <RecordForm type="reminder" title="Reminder" onSubmit={submit} busy={busy} />
+              <RecordForm type="downtime" title="Downtime" onSubmit={submit} busy={busy} />
+              <RecordForm type="document" title="Document" onSubmit={submit} busy={busy} />
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <div className="flex items-center gap-2"><Truck className="h-5 w-5 text-sky-400" /><h2 className="text-lg font-black">Truck history</h2></div>
+            {records.length ? <div className="grid gap-3 lg:grid-cols-2">{records.map((record) => <RecordRow key={record.id} record={record} onAction={complete} onOpenFile={openFile} busy={busy} />)}</div> : <div className="rounded-3xl border border-dashed border-[color:var(--theme-border-soft)] p-8 text-center text-sm text-[color:var(--theme-text-secondary)]"><Wrench className="mx-auto mb-2 h-6 w-6" />No truck records yet.</div>}
+          </section>
+
+          <footer className="flex items-center gap-2 rounded-2xl bg-[color:var(--theme-surface-subtle)] p-3 text-xs text-[color:var(--theme-text-secondary)]"><FileText className="h-4 w-4" />Documents and receipts are private, signed on demand, and scoped to this Field truck.</footer>
+        </>
+      )}
+    </div>
+  );
+}

--- a/features/mobile/service/FieldWorkspaceShell.tsx
+++ b/features/mobile/service/FieldWorkspaceShell.tsx
@@ -14,6 +14,7 @@ import {
   RadioTower,
   ReceiptText,
   Settings2,
+  Truck,
   Wrench,
   X,
   type LucideIcon,
@@ -73,6 +74,11 @@ const WORK_NAV: FieldNavItem[] = [
 
 const OPERATIONS_NAV: FieldNavItem[] = [
   {
+    label: "My Truck",
+    href: "/mobile/service/my-truck",
+    icon: Truck,
+  },
+  {
     label: "Invoices & history",
     href: "/mobile/service/invoices",
     icon: ReceiptText,
@@ -126,6 +132,7 @@ function pageTitle(pathname: string): string {
   if (pathname.startsWith("/mobile/service/truck-inventory")) {
     return "Truck inventory";
   }
+  if (pathname.startsWith("/mobile/service/my-truck")) return "My Truck";
   if (pathname.startsWith("/mobile/service/followup")) return "Follow-ups";
   if (pathname.startsWith("/mobile/service/closeout")) return "Field closeout";
   if (pathname.startsWith("/mobile/appointments")) return "Appointments";

--- a/features/mobile/service/MobileServiceSetup.tsx
+++ b/features/mobile/service/MobileServiceSetup.tsx
@@ -13,6 +13,16 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 type ServiceModel = "shop" | "mobile" | "both";
+type FieldTeamMember = {
+  profileId: string;
+  name: string;
+  vehicleId: string | null;
+};
+type FieldVehicle = {
+  id: string;
+  name: string;
+  unitNumber: string | null;
+};
 
 export default function MobileServiceSetup() {
   const router = useRouter();
@@ -29,6 +39,8 @@ export default function MobileServiceSetup() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [canConfigure, setCanConfigure] = useState(true);
+  const [fieldTeam, setFieldTeam] = useState<FieldTeamMember[]>([]);
+  const [fieldVehicles, setFieldVehicles] = useState<FieldVehicle[]>([]);
 
   useEffect(() => {
     void fetch("/api/mobile/service/settings", {
@@ -50,6 +62,10 @@ export default function MobileServiceSetup() {
           setDefaultVisitMinutes(Number(settings.default_visit_minutes || 60));
         }
         setFieldOperator(Boolean(body.currentActorFieldOperator));
+        setFieldTeam(Array.isArray(body.fieldTeam) ? body.fieldTeam : []);
+        setFieldVehicles(
+          Array.isArray(body.fieldVehicles) ? body.fieldVehicles : [],
+        );
         if (body.serviceVehicle) {
           setTruckName(body.serviceVehicle.name || "Service Truck");
           setUnitNumber(body.serviceVehicle.unit_number || "");
@@ -93,6 +109,37 @@ export default function MobileServiceSetup() {
         cause instanceof Error
           ? cause.message
           : "Field Service setup could not be saved.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function assignTruck(profileId: string, serviceVehicleId: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/mobile/service/settings", {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ profileId, serviceVehicleId }),
+      });
+      const body = (await response.json().catch(() => null)) as {
+        error?: string;
+        fieldTeam?: FieldTeamMember[];
+        fieldVehicles?: FieldVehicle[];
+      } | null;
+      if (!response.ok) {
+        throw new Error(body?.error || "Truck assignment could not be saved.");
+      }
+      setFieldTeam(body?.fieldTeam ?? []);
+      setFieldVehicles(body?.fieldVehicles ?? []);
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Truck assignment could not be saved.",
       );
     } finally {
       setBusy(false);
@@ -256,6 +303,49 @@ export default function MobileServiceSetup() {
           />
         </label>
       </section>
+
+      {canConfigure && fieldTeam.length > 0 && fieldVehicles.length > 0 ? (
+        <section className="space-y-3 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-card">
+          <div className="flex items-center gap-2">
+            <UsersRound className="h-5 w-5" />
+            <h2 className="font-extrabold">Field truck assignments</h2>
+          </div>
+          <p className="text-xs text-[color:var(--theme-text-secondary)]">
+            Assign each enabled Field operator to the truck shown in their My
+            Truck workspace.
+          </p>
+          <div className="space-y-2">
+            {fieldTeam.map((member) => (
+              <label
+                key={member.profileId}
+                className="grid gap-1 rounded-2xl bg-[color:var(--theme-surface-subtle)] p-3 sm:grid-cols-[minmax(0,1fr)_minmax(12rem,1fr)] sm:items-center"
+              >
+                <span className="text-sm font-semibold">{member.name}</span>
+                <select
+                  value={member.vehicleId ?? ""}
+                  disabled={busy}
+                  onChange={(event) => {
+                    if (event.target.value) {
+                      void assignTruck(member.profileId, event.target.value);
+                    }
+                  }}
+                  className="min-h-11 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 text-base"
+                >
+                  <option value="" disabled>
+                    Choose a truck
+                  </option>
+                  {fieldVehicles.map((vehicle) => (
+                    <option key={vehicle.id} value={vehicle.id}>
+                      {vehicle.name}
+                      {vehicle.unitNumber ? ` · ${vehicle.unitNumber}` : ""}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-card">
         <label className="block text-xs text-[color:var(--theme-text-secondary)]">

--- a/features/mobile/service/fieldDashboardLayout.ts
+++ b/features/mobile/service/fieldDashboardLayout.ts
@@ -7,6 +7,7 @@ export const FIELD_DASHBOARD_LEGACY_LAYOUT_CACHE_KEY =
 export const FIELD_DASHBOARD_CARD_IDS = [
   "dispatch_queue",
   "jobs_in_progress",
+  "my_truck",
   "awaiting_approval",
   "parts_required",
   "truck_inventory",

--- a/features/mobile/service/myTruck.ts
+++ b/features/mobile/service/myTruck.ts
@@ -1,0 +1,122 @@
+import type { Database } from "@shared/types/types/supabase";
+
+export const FIELD_TRUCK_RECORD_TYPES = [
+  "odometer",
+  "maintenance",
+  "expense",
+  "reminder",
+  "downtime",
+  "document",
+] as const;
+
+export type FieldTruckRecordType = (typeof FIELD_TRUCK_RECORD_TYPES)[number];
+export type FieldTruckRecord =
+  Database["public"]["Tables"]["field_truck_records"]["Row"];
+
+export type FieldTruckVehicle = {
+  id: string;
+  name: string;
+  unitNumber: string | null;
+};
+
+export type FieldMyTruckSnapshot = {
+  truck: FieldTruckVehicle | null;
+  records: FieldTruckRecord[];
+  summary: {
+    latestOdometer: number | null;
+    odometerUnit: string | null;
+    openReminders: number;
+    activeDowntime: number;
+    monthCosts: number;
+    currency: string;
+  };
+};
+
+export function isFieldTruckRecordType(
+  value: unknown,
+): value is FieldTruckRecordType {
+  return FIELD_TRUCK_RECORD_TYPES.includes(value as FieldTruckRecordType);
+}
+
+export function buildFieldMyTruckSummary(
+  records: FieldTruckRecord[],
+  now = new Date(),
+): FieldMyTruckSnapshot["summary"] {
+  const latestOdometer = records
+    .filter(
+      (record) =>
+        record.odometer !== null &&
+        ["odometer", "maintenance"].includes(record.record_type),
+    )
+    .sort((a, b) => {
+      const aDate = a.occurred_on ?? a.created_at;
+      const bDate = b.occurred_on ?? b.created_at;
+      return bDate.localeCompare(aDate);
+    })[0];
+  const monthKey = now.toISOString().slice(0, 7);
+  const monthCosts = records.reduce((total, record) => {
+    if (
+      record.amount === null ||
+      !["expense", "maintenance"].includes(record.record_type) ||
+      !(record.occurred_on ?? record.created_at).startsWith(monthKey)
+    ) {
+      return total;
+    }
+    return total + Number(record.amount);
+  }, 0);
+  const currency =
+    records.find(
+      (record) =>
+        record.currency &&
+        ["expense", "maintenance"].includes(record.record_type),
+    )?.currency ?? "CAD";
+
+  return {
+    latestOdometer: latestOdometer?.odometer ?? null,
+    odometerUnit: latestOdometer?.odometer_unit ?? null,
+    openReminders: records.filter(
+      (record) => record.record_type === "reminder" && record.status === "open",
+    ).length,
+    activeDowntime: records.filter(
+      (record) =>
+        record.record_type === "downtime" &&
+        record.status === "open" &&
+        record.ends_at === null,
+    ).length,
+    monthCosts,
+    currency,
+  };
+}
+
+export function toNullableText(value: unknown, maxLength = 2000): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized ? normalized.slice(0, maxLength) : null;
+}
+
+export function toNonNegativeNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : null;
+}
+
+export function isDateKey(value: unknown): value is string {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+export function isIsoTimestamp(value: unknown): value is string {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+export function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  );
+}

--- a/features/mobile/service/myTruck.ts
+++ b/features/mobile/service/myTruck.ts
@@ -22,13 +22,13 @@ export type FieldTruckVehicle = {
 export type FieldMyTruckSnapshot = {
   truck: FieldTruckVehicle | null;
   records: FieldTruckRecord[];
+  alerts: FieldTruckRecord[];
   summary: {
     latestOdometer: number | null;
     odometerUnit: string | null;
     openReminders: number;
     activeDowntime: number;
-    monthCosts: number;
-    currency: string;
+    monthCostsByCurrency: Array<{ currency: string; amount: number }>;
   };
 };
 
@@ -54,22 +54,18 @@ export function buildFieldMyTruckSummary(
       return bDate.localeCompare(aDate);
     })[0];
   const monthKey = now.toISOString().slice(0, 7);
-  const monthCosts = records.reduce((total, record) => {
+  const monthCosts = new Map<string, number>();
+  records.forEach((record) => {
     if (
       record.amount === null ||
       !["expense", "maintenance"].includes(record.record_type) ||
       !(record.occurred_on ?? record.created_at).startsWith(monthKey)
     ) {
-      return total;
+      return;
     }
-    return total + Number(record.amount);
-  }, 0);
-  const currency =
-    records.find(
-      (record) =>
-        record.currency &&
-        ["expense", "maintenance"].includes(record.record_type),
-    )?.currency ?? "CAD";
+    const currency = record.currency ?? "CAD";
+    monthCosts.set(currency, (monthCosts.get(currency) ?? 0) + Number(record.amount));
+  });
 
   return {
     latestOdometer: latestOdometer?.odometer ?? null,
@@ -83,8 +79,9 @@ export function buildFieldMyTruckSummary(
         record.status === "open" &&
         record.ends_at === null,
     ).length,
-    monthCosts,
-    currency,
+    monthCostsByCurrency: [...monthCosts.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([currency, amount]) => ({ currency, amount })),
   };
 }
 

--- a/features/mobile/service/myTruck.ts
+++ b/features/mobile/service/myTruck.ts
@@ -106,7 +106,11 @@ export function isDateKey(value: unknown): value is string {
 }
 
 export function isIsoTimestamp(value: unknown): value is string {
-  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+  return (
+    typeof value === "string" &&
+    /T.*(?:Z|[+-]\d{2}:\d{2})$/.test(value) &&
+    !Number.isNaN(Date.parse(value))
+  );
 }
 
 export function isUuid(value: unknown): value is string {

--- a/features/mobile/service/server/myTruck.ts
+++ b/features/mobile/service/server/myTruck.ts
@@ -37,6 +37,7 @@ export async function loadFieldMyTruckSnapshot(input: {
   supabase: Client;
   shopId: string;
   profileId: string;
+  monthKey?: string;
 }): Promise<FieldMyTruckSnapshot> {
   const truck = await resolveAssignedFieldTruck(input);
   if (!truck) {
@@ -79,11 +80,12 @@ export async function loadFieldMyTruckSnapshot(input: {
     }
   };
 
-  const monthStart = new Date();
-  monthStart.setUTCDate(1);
-  monthStart.setUTCHours(0, 0, 0, 0);
-  const nextMonth = new Date(monthStart);
-  nextMonth.setUTCMonth(nextMonth.getUTCMonth() + 1);
+  const monthKey = input.monthKey ?? new Date().toISOString().slice(0, 7);
+  const [monthYear, monthNumber] = monthKey.split("-").map(Number);
+  const monthStart = `${monthKey}-01`;
+  const nextMonth = new Date(Date.UTC(monthYear, monthNumber, 1))
+    .toISOString()
+    .slice(0, 10);
   const [latestResult] = await Promise.all([
     input.supabase
       .from("field_truck_records")
@@ -112,8 +114,8 @@ export async function loadFieldMyTruckSnapshot(input: {
         .eq("shop_id", input.shopId)
         .eq("service_vehicle_id", truck.id)
         .in("record_type", ["expense", "maintenance"])
-        .gte("occurred_on", monthStart.toISOString().slice(0, 10))
-        .lt("occurred_on", nextMonth.toISOString().slice(0, 10))
+        .gte("occurred_on", monthStart)
+        .lt("occurred_on", nextMonth)
         .range(from, to),
     ),
   ]);
@@ -136,7 +138,10 @@ export async function loadFieldMyTruckSnapshot(input: {
           ["reminder", "downtime"].includes(record.record_type),
       )
       .sort((a, b) => b.created_at.localeCompare(a.created_at)),
-    summary: buildFieldMyTruckSummary([...summaryRecords.values()]),
+    summary: buildFieldMyTruckSummary(
+      [...summaryRecords.values()],
+      new Date(`${monthKey}-15T12:00:00.000Z`),
+    ),
   };
 }
 

--- a/features/mobile/service/server/myTruck.ts
+++ b/features/mobile/service/server/myTruck.ts
@@ -19,15 +19,22 @@ export async function resolveAssignedFieldTruck(input: {
   shopId: string;
   profileId: string;
 }) {
+  const { data: assignment, error: assignmentError } = await input.supabase
+    .from("field_service_vehicle_assignments")
+    .select("service_vehicle_id")
+    .eq("shop_id", input.shopId)
+    .eq("profile_id", input.profileId)
+    .maybeSingle<{ service_vehicle_id: string }>();
+  if (assignmentError) throw new Error(assignmentError.message);
+  if (!assignment) return null;
+
   const { data, error } = await input.supabase
     .from("service_vehicles")
     .select("id,name,unit_number")
+    .eq("id", assignment.service_vehicle_id)
     .eq("shop_id", input.shopId)
-    .eq("primary_user_id", input.profileId)
     .eq("active", true)
     .contains("capabilities", { mobile_v1: true })
-    .order("created_at", { ascending: true })
-    .limit(1)
     .maybeSingle<{ id: string; name: string; unit_number: string | null }>();
   if (error) throw new Error(error.message);
   return data ?? null;

--- a/features/mobile/service/server/myTruck.ts
+++ b/features/mobile/service/server/myTruck.ts
@@ -1,0 +1,71 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+
+import {
+  buildFieldMyTruckSummary,
+  type FieldMyTruckSnapshot,
+  type FieldTruckRecord,
+} from "@/features/mobile/service/myTruck";
+
+type Client = SupabaseClient<Database>;
+
+const FIELD_TRUCK_RECORD_SELECT =
+  "id,shop_id,service_vehicle_id,operation_key,record_type,title,occurred_on,odometer,odometer_unit,amount,currency,vendor,due_on,due_odometer,starts_at,ends_at,status,notes,file_bucket,file_path,original_filename,content_type,file_size_bytes,created_by_profile_id,created_at,updated_at";
+
+export async function resolveAssignedFieldTruck(input: {
+  supabase: Client;
+  shopId: string;
+  profileId: string;
+}) {
+  const { data, error } = await input.supabase
+    .from("service_vehicles")
+    .select("id,name,unit_number")
+    .eq("shop_id", input.shopId)
+    .eq("primary_user_id", input.profileId)
+    .eq("active", true)
+    .contains("capabilities", { mobile_v1: true })
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle<{ id: string; name: string; unit_number: string | null }>();
+  if (error) throw new Error(error.message);
+  return data ?? null;
+}
+
+export async function loadFieldMyTruckSnapshot(input: {
+  supabase: Client;
+  shopId: string;
+  profileId: string;
+}): Promise<FieldMyTruckSnapshot> {
+  const truck = await resolveAssignedFieldTruck(input);
+  if (!truck) {
+    return {
+      truck: null,
+      records: [],
+      summary: buildFieldMyTruckSummary([]),
+    };
+  }
+
+  const { data, error } = await input.supabase
+    .from("field_truck_records")
+    .select(FIELD_TRUCK_RECORD_SELECT)
+    .eq("shop_id", input.shopId)
+    .eq("service_vehicle_id", truck.id)
+    .order("created_at", { ascending: false })
+    .limit(250);
+  if (error) throw new Error(error.message);
+  const records = (data ?? []) as FieldTruckRecord[];
+
+  return {
+    truck: {
+      id: truck.id,
+      name: truck.name,
+      unitNumber: truck.unit_number,
+    },
+    records,
+    summary: buildFieldMyTruckSummary(records),
+  };
+}
+
+export { FIELD_TRUCK_RECORD_SELECT };

--- a/features/mobile/service/server/myTruck.ts
+++ b/features/mobile/service/server/myTruck.ts
@@ -43,6 +43,7 @@ export async function loadFieldMyTruckSnapshot(input: {
     return {
       truck: null,
       records: [],
+      alerts: [],
       summary: buildFieldMyTruckSummary([]),
     };
   }
@@ -57,6 +58,70 @@ export async function loadFieldMyTruckSnapshot(input: {
   if (error) throw new Error(error.message);
   const records = (data ?? []) as FieldTruckRecord[];
 
+  const summaryRecords = new Map<string, FieldTruckRecord>();
+  const collectAll = async (
+    loadPage: (from: number, to: number) => PromiseLike<{
+      data: unknown[] | null;
+      error: { message: string } | null;
+    }>,
+  ) => {
+    const pageSize = 500;
+    for (let from = 0; ; from += pageSize) {
+      const { data: page, error: pageError } = await loadPage(
+        from,
+        from + pageSize - 1,
+      );
+      if (pageError) throw new Error(pageError.message);
+      for (const record of (page ?? []) as FieldTruckRecord[]) {
+        summaryRecords.set(record.id, record);
+      }
+      if ((page ?? []).length < pageSize) break;
+    }
+  };
+
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+  const nextMonth = new Date(monthStart);
+  nextMonth.setUTCMonth(nextMonth.getUTCMonth() + 1);
+  const [latestResult] = await Promise.all([
+    input.supabase
+      .from("field_truck_records")
+      .select(FIELD_TRUCK_RECORD_SELECT)
+      .eq("shop_id", input.shopId)
+      .eq("service_vehicle_id", truck.id)
+      .in("record_type", ["odometer", "maintenance"])
+      .not("odometer", "is", null)
+      .order("occurred_on", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .limit(1),
+    collectAll((from, to) =>
+      input.supabase
+        .from("field_truck_records")
+        .select(FIELD_TRUCK_RECORD_SELECT)
+        .eq("shop_id", input.shopId)
+        .eq("service_vehicle_id", truck.id)
+        .in("record_type", ["reminder", "downtime"])
+        .eq("status", "open")
+        .range(from, to),
+    ),
+    collectAll((from, to) =>
+      input.supabase
+        .from("field_truck_records")
+        .select(FIELD_TRUCK_RECORD_SELECT)
+        .eq("shop_id", input.shopId)
+        .eq("service_vehicle_id", truck.id)
+        .in("record_type", ["expense", "maintenance"])
+        .gte("occurred_on", monthStart.toISOString().slice(0, 10))
+        .lt("occurred_on", nextMonth.toISOString().slice(0, 10))
+        .range(from, to),
+    ),
+  ]);
+  if (latestResult.error) throw new Error(latestResult.error.message);
+  for (const record of (latestResult.data ?? []) as FieldTruckRecord[]) {
+    summaryRecords.set(record.id, record);
+  }
+
   return {
     truck: {
       id: truck.id,
@@ -64,7 +129,14 @@ export async function loadFieldMyTruckSnapshot(input: {
       unitNumber: truck.unit_number,
     },
     records,
-    summary: buildFieldMyTruckSummary(records),
+    alerts: [...summaryRecords.values()]
+      .filter(
+        (record) =>
+          record.status === "open" &&
+          ["reminder", "downtime"].includes(record.record_type),
+      )
+      .sort((a, b) => b.created_at.localeCompare(a.created_at)),
+    summary: buildFieldMyTruckSummary([...summaryRecords.values()]),
   };
 }
 

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -4441,6 +4441,13 @@ export type Database = {
             foreignKeyName: "field_service_vehicle_assignments_shop_id_fkey"
             columns: ["shop_id"]
             isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "field_service_vehicle_assignments_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
             referencedRelation: "shops"
             referencedColumns: ["id"]
           },

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -28432,6 +28432,22 @@ export type Database = {
         Args: { p_service_vehicle_id: string; p_shop_id: string }
         Returns: boolean
       }
+      field_assign_service_vehicle: {
+        Args: {
+          p_profile_id: string
+          p_service_vehicle_id: string
+          p_shop_id: string
+        }
+        Returns: Json
+      }
+      field_transition_truck_record: {
+        Args: {
+          p_action: string
+          p_ended_at?: string | null
+          p_record_id: string
+        }
+        Returns: Database["public"]["Tables"]["field_truck_records"]["Row"][]
+      }
       field_receive_po_part_to_truck_atomic: {
         Args: {
           p_actor_user_id: string

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -4397,6 +4397,62 @@ export type Database = {
         }
         Relationships: []
       }
+      field_service_vehicle_assignments: {
+        Row: {
+          assigned_by_profile_id: string | null
+          created_at: string
+          profile_id: string
+          service_vehicle_id: string
+          shop_id: string
+          updated_at: string
+        }
+        Insert: {
+          assigned_by_profile_id?: string | null
+          created_at?: string
+          profile_id: string
+          service_vehicle_id: string
+          shop_id: string
+          updated_at?: string
+        }
+        Update: {
+          assigned_by_profile_id?: string | null
+          created_at?: string
+          profile_id?: string
+          service_vehicle_id?: string
+          shop_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "field_service_vehicle_assignments_assigned_by_profile_id_fkey"
+            columns: ["assigned_by_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "field_service_vehicle_assignments_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "field_service_vehicle_assignments_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "field_service_vehicle_assignments_vehicle_shop_fk"
+            columns: ["shop_id", "service_vehicle_id"]
+            isOneToOne: true
+            referencedRelation: "service_vehicles"
+            referencedColumns: ["shop_id", "id"]
+          },
+        ]
+      }
       field_truck_records: {
         Row: {
           amount: number | null

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -31216,3 +31216,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -28443,10 +28443,10 @@ export type Database = {
       field_transition_truck_record: {
         Args: {
           p_action: string
-          p_ended_at?: string | null
+          p_ended_at?: string
           p_record_id: string
         }
-        Returns: Database["public"]["Tables"]["field_truck_records"]["Row"][]
+        Returns: Json
       }
       field_receive_po_part_to_truck_atomic: {
         Args: {

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -4466,6 +4466,129 @@ export type Database = {
           },
         ]
       }
+      field_truck_records: {
+        Row: {
+          amount: number | null
+          content_type: string | null
+          created_at: string
+          created_by_profile_id: string | null
+          currency: string | null
+          due_odometer: number | null
+          due_on: string | null
+          ends_at: string | null
+          file_bucket: string | null
+          file_path: string | null
+          file_size_bytes: number | null
+          id: string
+          notes: string | null
+          occurred_on: string | null
+          odometer: number | null
+          odometer_unit: string | null
+          operation_key: string
+          original_filename: string | null
+          record_type: string
+          service_vehicle_id: string
+          shop_id: string
+          starts_at: string | null
+          status: string
+          title: string
+          updated_at: string
+          vendor: string | null
+        }
+        Insert: {
+          amount?: number | null
+          content_type?: string | null
+          created_at?: string
+          created_by_profile_id?: string | null
+          currency?: string | null
+          due_odometer?: number | null
+          due_on?: string | null
+          ends_at?: string | null
+          file_bucket?: string | null
+          file_path?: string | null
+          file_size_bytes?: number | null
+          id?: string
+          notes?: string | null
+          occurred_on?: string | null
+          odometer?: number | null
+          odometer_unit?: string | null
+          operation_key: string
+          original_filename?: string | null
+          record_type: string
+          service_vehicle_id: string
+          shop_id: string
+          starts_at?: string | null
+          status?: string
+          title: string
+          updated_at?: string
+          vendor?: string | null
+        }
+        Update: {
+          amount?: number | null
+          content_type?: string | null
+          created_at?: string
+          created_by_profile_id?: string | null
+          currency?: string | null
+          due_odometer?: number | null
+          due_on?: string | null
+          ends_at?: string | null
+          file_bucket?: string | null
+          file_path?: string | null
+          file_size_bytes?: number | null
+          id?: string
+          notes?: string | null
+          occurred_on?: string | null
+          odometer?: number | null
+          odometer_unit?: string | null
+          operation_key?: string
+          original_filename?: string | null
+          record_type?: string
+          service_vehicle_id?: string
+          shop_id?: string
+          starts_at?: string | null
+          status?: string
+          title?: string
+          updated_at?: string
+          vendor?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "field_truck_records_created_by_profile_id_fkey"
+            columns: ["created_by_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "field_truck_records_service_vehicle_id_fkey"
+            columns: ["service_vehicle_id"]
+            isOneToOne: false
+            referencedRelation: "service_vehicles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "field_truck_records_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "field_truck_records_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "field_truck_records_vehicle_shop_fk"
+            columns: ["shop_id", "service_vehicle_id"]
+            isOneToOne: false
+            referencedRelation: "service_vehicles"
+            referencedColumns: ["shop_id", "id"]
+          },
+        ]
+      }
       fleet_defect_clarifications: {
         Row: {
           closed_at: string | null
@@ -28305,6 +28428,10 @@ export type Database = {
         Args: { p_claim_token: string; p_error: string; p_event_id: string }
         Returns: boolean
       }
+      field_actor_can_access_service_vehicle: {
+        Args: { p_service_vehicle_id: string; p_shop_id: string }
+        Returns: boolean
+      }
       field_receive_po_part_to_truck_atomic: {
         Args: {
           p_actor_user_id: string
@@ -28351,6 +28478,7 @@ export type Database = {
         }
         Returns: Json
       }
+      field_storage_path_uuid: { Args: { p_value: string }; Returns: string }
       field_transfer_stock_to_truck_atomic: {
         Args: {
           p_actor_user_id: string
@@ -31076,4 +31204,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -4397,75 +4397,6 @@ export type Database = {
         }
         Relationships: []
       }
-      financial_domain_outbox: {
-        Row: {
-          aggregate_id: string
-          aggregate_type: string
-          attempts: number
-          dedupe_key: string
-          delivered_at: string | null
-          event_type: string
-          id: string
-          last_error: string | null
-          lease_expires_at: string | null
-          lease_owner: string | null
-          next_attempt_at: string
-          occurred_at: string
-          payload: Json
-          processing_at: string | null
-          shop_id: string
-        }
-        Insert: {
-          aggregate_id: string
-          aggregate_type: string
-          attempts?: number
-          dedupe_key: string
-          delivered_at?: string | null
-          event_type: string
-          id?: string
-          last_error?: string | null
-          lease_expires_at?: string | null
-          lease_owner?: string | null
-          next_attempt_at?: string
-          occurred_at?: string
-          payload?: Json
-          processing_at?: string | null
-          shop_id: string
-        }
-        Update: {
-          aggregate_id?: string
-          aggregate_type?: string
-          attempts?: number
-          dedupe_key?: string
-          delivered_at?: string | null
-          event_type?: string
-          id?: string
-          last_error?: string | null
-          lease_expires_at?: string | null
-          lease_owner?: string | null
-          next_attempt_at?: string
-          occurred_at?: string
-          payload?: Json
-          processing_at?: string | null
-          shop_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "financial_domain_outbox_shop_id_fkey"
-            columns: ["shop_id"]
-            isOneToOne: false
-            referencedRelation: "shop_public_profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "financial_domain_outbox_shop_id_fkey"
-            columns: ["shop_id"]
-            isOneToOne: false
-            referencedRelation: "shops"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       field_truck_records: {
         Row: {
           amount: number | null
@@ -4586,6 +4517,75 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "service_vehicles"
             referencedColumns: ["shop_id", "id"]
+          },
+        ]
+      }
+      financial_domain_outbox: {
+        Row: {
+          aggregate_id: string
+          aggregate_type: string
+          attempts: number
+          dedupe_key: string
+          delivered_at: string | null
+          event_type: string
+          id: string
+          last_error: string | null
+          lease_expires_at: string | null
+          lease_owner: string | null
+          next_attempt_at: string
+          occurred_at: string
+          payload: Json
+          processing_at: string | null
+          shop_id: string
+        }
+        Insert: {
+          aggregate_id: string
+          aggregate_type: string
+          attempts?: number
+          dedupe_key: string
+          delivered_at?: string | null
+          event_type: string
+          id?: string
+          last_error?: string | null
+          lease_expires_at?: string | null
+          lease_owner?: string | null
+          next_attempt_at?: string
+          occurred_at?: string
+          payload?: Json
+          processing_at?: string | null
+          shop_id: string
+        }
+        Update: {
+          aggregate_id?: string
+          aggregate_type?: string
+          attempts?: number
+          dedupe_key?: string
+          delivered_at?: string | null
+          event_type?: string
+          id?: string
+          last_error?: string | null
+          lease_expires_at?: string | null
+          lease_owner?: string | null
+          next_attempt_at?: string
+          occurred_at?: string
+          payload?: Json
+          processing_at?: string | null
+          shop_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "financial_domain_outbox_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "financial_domain_outbox_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -28440,14 +28440,6 @@ export type Database = {
         }
         Returns: Json
       }
-      field_transition_truck_record: {
-        Args: {
-          p_action: string
-          p_ended_at?: string
-          p_record_id: string
-        }
-        Returns: Json
-      }
       field_receive_po_part_to_truck_atomic: {
         Args: {
           p_actor_user_id: string
@@ -28517,6 +28509,10 @@ export type Database = {
           p_shop_id: string
           p_source_location_id: string
         }
+        Returns: Json
+      }
+      field_transition_truck_record: {
+        Args: { p_action: string; p_ended_at?: string; p_record_id: string }
         Returns: Json
       }
       field_truck_inventory_activity: {

--- a/supabase/migrations/20260820221500_field_my_truck_foundation.sql
+++ b/supabase/migrations/20260820221500_field_my_truck_foundation.sql
@@ -1,0 +1,267 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '10min';
+set local check_function_bodies = false;
+
+-- Field-owned service-truck operating log. This deliberately extends the
+-- existing service_vehicles aggregate instead of reusing Fleet assets or
+-- exposing Fleet maintenance navigation inside the Field product.
+create table if not exists public.field_truck_records (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  service_vehicle_id uuid not null references public.service_vehicles(id) on delete cascade,
+  operation_key text not null,
+  record_type text not null,
+  title text not null,
+  occurred_on date,
+  odometer numeric(12,1),
+  odometer_unit text,
+  amount numeric(12,2),
+  currency text,
+  vendor text,
+  due_on date,
+  due_odometer numeric(12,1),
+  starts_at timestamptz,
+  ends_at timestamptz,
+  status text not null default 'open',
+  notes text,
+  file_bucket text,
+  file_path text,
+  original_filename text,
+  content_type text,
+  file_size_bytes bigint,
+  created_by_profile_id uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint field_truck_records_type_ck check (
+    record_type in ('odometer','maintenance','expense','reminder','downtime','document')
+  ),
+  constraint field_truck_records_operation_key_ck check (
+    length(trim(operation_key)) between 8 and 160
+  ),
+  constraint field_truck_records_title_ck check (
+    length(trim(title)) between 1 and 180
+  ),
+  constraint field_truck_records_status_ck check (
+    status in ('open','completed','cancelled')
+  ),
+  constraint field_truck_records_odometer_ck check (
+    odometer is null or odometer >= 0
+  ),
+  constraint field_truck_records_due_odometer_ck check (
+    due_odometer is null or due_odometer >= 0
+  ),
+  constraint field_truck_records_amount_ck check (
+    amount is null or amount >= 0
+  ),
+  constraint field_truck_records_file_size_ck check (
+    file_size_bytes is null or file_size_bytes between 1 and 10485760
+  ),
+  constraint field_truck_records_downtime_window_ck check (
+    record_type <> 'downtime'
+    or (starts_at is not null and (ends_at is null or ends_at > starts_at))
+  ),
+  constraint field_truck_records_reminder_due_ck check (
+    record_type <> 'reminder' or due_on is not null or due_odometer is not null
+  ),
+  constraint field_truck_records_document_file_ck check (
+    record_type <> 'document' or file_path is not null
+  ),
+  constraint field_truck_records_file_metadata_ck check (
+    (file_path is null and file_bucket is null and original_filename is null
+      and content_type is null and file_size_bytes is null)
+    or
+    (file_path is not null and file_bucket is not null and original_filename is not null
+      and content_type is not null and file_size_bytes is not null)
+  )
+);
+
+create unique index if not exists service_vehicles_shop_id_id_unique
+  on public.service_vehicles(shop_id, id);
+
+do $do$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.field_truck_records'::regclass
+      and conname = 'field_truck_records_vehicle_shop_fk'
+  ) then
+    alter table public.field_truck_records
+      add constraint field_truck_records_vehicle_shop_fk
+      foreign key (shop_id, service_vehicle_id)
+      references public.service_vehicles(shop_id, id)
+      on delete cascade;
+  end if;
+end
+$do$;
+
+create index if not exists field_truck_records_vehicle_timeline_idx
+  on public.field_truck_records(service_vehicle_id, created_at desc);
+create unique index if not exists field_truck_records_operation_key_unique
+  on public.field_truck_records(shop_id, service_vehicle_id, operation_key);
+create index if not exists field_truck_records_open_alerts_idx
+  on public.field_truck_records(service_vehicle_id, record_type, due_on, due_odometer)
+  where status = 'open' and record_type in ('reminder','downtime');
+create index if not exists field_truck_records_expense_date_idx
+  on public.field_truck_records(service_vehicle_id, occurred_on desc)
+  where record_type in ('expense','maintenance');
+
+create or replace function public.field_truck_records_touch_updated_at()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists field_truck_records_touch_updated_at
+  on public.field_truck_records;
+create trigger field_truck_records_touch_updated_at
+before update on public.field_truck_records
+for each row execute function public.field_truck_records_touch_updated_at();
+
+-- One authenticated Field operator can access only their explicitly assigned,
+-- active service vehicle. A same-shop membership alone is insufficient.
+create or replace function public.field_actor_can_access_service_vehicle(
+  p_shop_id uuid,
+  p_service_vehicle_id uuid
+) returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.profiles profile
+    join public.service_vehicles vehicle
+      on vehicle.shop_id = profile.shop_id
+     and vehicle.primary_user_id = profile.id
+     and vehicle.active
+    where profile.shop_id = p_shop_id
+      and vehicle.id = p_service_vehicle_id
+      and (profile.id = auth.uid() or profile.user_id = auth.uid())
+      and public.mobile_profile_has_field_service_access(profile.shop_id, profile.id)
+  );
+$$;
+
+revoke all on function public.field_actor_can_access_service_vehicle(uuid, uuid)
+  from public, anon;
+grant execute on function public.field_actor_can_access_service_vehicle(uuid, uuid)
+  to authenticated, service_role;
+
+alter table public.field_truck_records enable row level security;
+
+revoke all on table public.field_truck_records from public, anon;
+revoke all on table public.field_truck_records from authenticated;
+grant select, insert on table public.field_truck_records to authenticated;
+grant update (status, ends_at) on table public.field_truck_records to authenticated;
+grant all on table public.field_truck_records to service_role;
+
+drop policy if exists field_truck_records_assigned_select
+  on public.field_truck_records;
+create policy field_truck_records_assigned_select
+on public.field_truck_records for select to authenticated
+using (
+  public.field_actor_can_access_service_vehicle(shop_id, service_vehicle_id)
+);
+
+drop policy if exists field_truck_records_assigned_insert
+  on public.field_truck_records;
+create policy field_truck_records_assigned_insert
+on public.field_truck_records for insert to authenticated
+with check (
+  public.field_actor_can_access_service_vehicle(shop_id, service_vehicle_id)
+  and exists (
+    select 1
+    from public.profiles profile
+    where profile.id = created_by_profile_id
+      and profile.shop_id = shop_id
+      and (profile.id = auth.uid() or profile.user_id = auth.uid())
+  )
+);
+
+drop policy if exists field_truck_records_assigned_update
+  on public.field_truck_records;
+create policy field_truck_records_assigned_update
+on public.field_truck_records for update to authenticated
+using (
+  public.field_actor_can_access_service_vehicle(shop_id, service_vehicle_id)
+)
+with check (
+  public.field_actor_can_access_service_vehicle(shop_id, service_vehicle_id)
+  and exists (
+    select 1
+    from public.profiles profile
+    where profile.id = created_by_profile_id
+      and profile.shop_id = shop_id
+      and (profile.id = auth.uid() or profile.user_id = auth.uid())
+  )
+);
+
+create or replace function public.field_storage_path_uuid(p_value text)
+returns uuid
+language plpgsql
+immutable
+set search_path = public, pg_temp
+as $$
+begin
+  return p_value::uuid;
+exception when invalid_text_representation then
+  return null;
+end;
+$$;
+
+revoke all on function public.field_storage_path_uuid(text) from public, anon;
+grant execute on function public.field_storage_path_uuid(text)
+  to authenticated, service_role;
+
+-- Private Field-only files. Object paths are always:
+--   <shop uuid>/<service vehicle uuid>/<documents|receipts>/<record uuid>/<file>
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'field-truck-files',
+  'field-truck-files',
+  false,
+  10485760,
+  array['application/pdf','image/jpeg','image/png','image/webp']
+)
+on conflict (id) do update
+set public = false,
+    file_size_limit = excluded.file_size_limit,
+    allowed_mime_types = excluded.allowed_mime_types;
+
+drop policy if exists field_truck_files_assigned_select on storage.objects;
+create policy field_truck_files_assigned_select
+on storage.objects for select to authenticated
+using (
+  bucket_id = 'field-truck-files'
+  and public.field_actor_can_access_service_vehicle(
+    public.field_storage_path_uuid((storage.foldername(name))[1]),
+    public.field_storage_path_uuid((storage.foldername(name))[2])
+  )
+);
+
+drop policy if exists field_truck_files_assigned_insert on storage.objects;
+create policy field_truck_files_assigned_insert
+on storage.objects for insert to authenticated
+with check (
+  bucket_id = 'field-truck-files'
+  and (storage.foldername(name))[3] in ('documents','receipts')
+  and public.field_actor_can_access_service_vehicle(
+    public.field_storage_path_uuid((storage.foldername(name))[1]),
+    public.field_storage_path_uuid((storage.foldername(name))[2])
+  )
+);
+
+comment on table public.field_truck_records is
+  'Field-only operating ledger for an assigned service truck: mileage, maintenance, costs, reminders, downtime, documents, and receipt metadata.';
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260820221500_field_my_truck_foundation.sql
+++ b/supabase/migrations/20260820221500_field_my_truck_foundation.sql
@@ -10,7 +10,7 @@ set local check_function_bodies = false;
 create table if not exists public.field_truck_records (
   id uuid primary key default gen_random_uuid(),
   shop_id uuid not null references public.shops(id) on delete cascade,
-  service_vehicle_id uuid not null references public.service_vehicles(id) on delete cascade,
+  service_vehicle_id uuid not null references public.service_vehicles(id) on delete restrict,
   operation_key text not null,
   record_type text not null,
   title text not null,
@@ -57,6 +57,17 @@ create table if not exists public.field_truck_records (
   ),
   constraint field_truck_records_file_size_ck check (
     file_size_bytes is null or file_size_bytes between 1 and 10485760
+  ),
+  constraint field_truck_records_shape_ck check (
+    (record_type = 'odometer' and odometer is not null and status = 'completed')
+    or (record_type = 'maintenance' and status = 'completed')
+    or (record_type = 'expense' and amount is not null and status = 'completed')
+    or (record_type = 'reminder' and status in ('open','completed')
+        and (due_odometer is null or odometer_unit is not null))
+    or (record_type = 'downtime' and starts_at is not null
+        and ((status = 'open' and ends_at is null)
+          or (status = 'completed' and ends_at is not null)))
+    or (record_type = 'document' and status = 'completed')
   ),
   constraint field_truck_records_downtime_window_ck check (
     record_type <> 'downtime'
@@ -107,7 +118,7 @@ begin
       add constraint field_truck_records_vehicle_shop_fk
       foreign key (shop_id, service_vehicle_id)
       references public.service_vehicles(shop_id, id)
-      on delete cascade;
+      on delete restrict;
   end if;
 end
 $do$;

--- a/supabase/migrations/20260820221500_field_my_truck_foundation.sql
+++ b/supabase/migrations/20260820221500_field_my_truck_foundation.sql
@@ -206,13 +206,14 @@ create or replace function public.field_transition_truck_record(
   p_record_id uuid,
   p_action text,
   p_ended_at timestamptz default null
-) returns setof public.field_truck_records
+) returns jsonb
 language plpgsql
 security definer
 set search_path = public, pg_temp
 as $$
 declare
   v_record public.field_truck_records%rowtype;
+  v_updated public.field_truck_records%rowtype;
   v_ended_at timestamptz;
 begin
   select * into v_record
@@ -232,23 +233,21 @@ begin
   if p_action = 'complete'
     and v_record.record_type = 'reminder'
     and v_record.status = 'open' then
-    return query
-      update public.field_truck_records
+    update public.field_truck_records
       set status = 'completed'
       where id = p_record_id
-      returning *;
-    return;
+      returning * into v_updated;
+    return to_jsonb(v_updated);
   end if;
 
   if p_action = 'reopen'
     and v_record.record_type = 'reminder'
     and v_record.status = 'completed' then
-    return query
-      update public.field_truck_records
+    update public.field_truck_records
       set status = 'open'
       where id = p_record_id
-      returning *;
-    return;
+      returning * into v_updated;
+    return to_jsonb(v_updated);
   end if;
 
   if p_action = 'end_downtime'
@@ -260,12 +259,11 @@ begin
       raise exception 'Downtime must end after it starts.'
         using errcode = '22007';
     end if;
-    return query
-      update public.field_truck_records
+    update public.field_truck_records
       set status = 'completed', ends_at = v_ended_at
       where id = p_record_id
-      returning *;
-    return;
+      returning * into v_updated;
+    return to_jsonb(v_updated);
   end if;
 
   raise exception 'Truck record transition is not allowed.'

--- a/supabase/migrations/20260820221500_field_my_truck_foundation.sql
+++ b/supabase/migrations/20260820221500_field_my_truck_foundation.sql
@@ -4,6 +4,22 @@ set local lock_timeout = '5s';
 set local statement_timeout = '10min';
 set local check_function_bodies = false;
 
+-- Compatibility repair for the workspace authorization foundation: the
+-- canonical service role had work-order assignment authority before the
+-- capability presets were introduced and Mobile handoff depends on it.
+insert into public.workspace_role_capability_presets (
+  capability_key,
+  role_key,
+  effect
+) values (
+  'work_order.assignment.manage',
+  'service',
+  'allow'
+)
+on conflict (capability_key, role_key) do update
+set effect = excluded.effect,
+    updated_at = now();
+
 -- Field-owned service-truck operating log. This deliberately extends the
 -- existing service_vehicles aggregate instead of reusing Fleet assets or
 -- exposing Fleet maintenance navigation inside the Field product.
@@ -55,8 +71,12 @@ create table if not exists public.field_truck_records (
   constraint field_truck_records_amount_ck check (
     amount is null or amount >= 0
   ),
+  constraint field_truck_records_currency_ck check (
+    (amount is null and currency is null)
+    or (amount is not null and currency ~ '^[A-Z]{3}$')
+  ),
   constraint field_truck_records_file_size_ck check (
-    file_size_bytes is null or file_size_bytes between 1 and 10485760
+    file_size_bytes is null or file_size_bytes between 1 and 4194304
   ),
   constraint field_truck_records_shape_ck check (
     (record_type = 'odometer' and odometer is not null and status = 'completed')
@@ -106,6 +126,39 @@ create table if not exists public.field_truck_records (
 create unique index if not exists service_vehicles_shop_id_id_unique
   on public.service_vehicles(shop_id, id);
 
+-- My Truck assignments are feature-owned authorization relationships. They do
+-- not trust service_vehicles.primary_user_id, which remains writable by legacy
+-- scheduler roles for unrelated dispatch workflows.
+create table if not exists public.field_service_vehicle_assignments (
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  service_vehicle_id uuid not null,
+  profile_id uuid not null references public.profiles(id) on delete cascade,
+  assigned_by_profile_id uuid references public.profiles(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (shop_id, service_vehicle_id),
+  unique (shop_id, profile_id),
+  constraint field_service_vehicle_assignments_vehicle_shop_fk
+    foreign key (shop_id, service_vehicle_id)
+    references public.service_vehicles(shop_id, id)
+    on delete cascade
+);
+
+insert into public.field_service_vehicle_assignments (
+  shop_id, service_vehicle_id, profile_id, assigned_by_profile_id
+)
+select
+  vehicle.shop_id, vehicle.id, vehicle.primary_user_id, vehicle.primary_user_id
+from public.service_vehicles vehicle
+join public.mobile_field_operators operator
+  on operator.shop_id = vehicle.shop_id
+ and operator.profile_id = vehicle.primary_user_id
+ and operator.enabled
+where vehicle.primary_user_id is not null
+  and vehicle.active
+  and vehicle.capabilities @> '{"mobile_v1":true}'::jsonb
+on conflict do nothing;
+
 do $do$
 begin
   if not exists (
@@ -151,6 +204,12 @@ create trigger field_truck_records_touch_updated_at
 before update on public.field_truck_records
 for each row execute function public.field_truck_records_touch_updated_at();
 
+drop trigger if exists field_service_vehicle_assignments_touch_updated_at
+  on public.field_service_vehicle_assignments;
+create trigger field_service_vehicle_assignments_touch_updated_at
+before update on public.field_service_vehicle_assignments
+for each row execute function public.field_truck_records_touch_updated_at();
+
 -- One authenticated Field operator can access only their explicitly assigned,
 -- active service vehicle. A same-shop membership alone is insufficient.
 create or replace function public.field_actor_can_access_service_vehicle(
@@ -164,13 +223,17 @@ set search_path = public, pg_temp
 as $$
   select exists (
     select 1
-    from public.profiles profile
+    from public.field_service_vehicle_assignments assignment
+    join public.profiles profile
+      on profile.id = assignment.profile_id
+     and profile.shop_id = assignment.shop_id
     join public.service_vehicles vehicle
-      on vehicle.shop_id = profile.shop_id
-     and vehicle.primary_user_id = profile.id
+      on vehicle.id = assignment.service_vehicle_id
+     and vehicle.shop_id = assignment.shop_id
      and vehicle.active
-    where profile.shop_id = p_shop_id
-      and vehicle.id = p_service_vehicle_id
+     and vehicle.capabilities @> '{"mobile_v1":true}'::jsonb
+    where assignment.shop_id = p_shop_id
+      and assignment.service_vehicle_id = p_service_vehicle_id
       and (profile.id = auth.uid() or profile.user_id = auth.uid())
       and public.mobile_profile_has_field_service_access(profile.shop_id, profile.id)
   );
@@ -182,6 +245,28 @@ grant execute on function public.field_actor_can_access_service_vehicle(uuid, uu
   to authenticated, service_role;
 
 alter table public.field_truck_records enable row level security;
+
+alter table public.field_service_vehicle_assignments enable row level security;
+
+revoke all on table public.field_service_vehicle_assignments
+  from public, anon, authenticated;
+grant select on table public.field_service_vehicle_assignments to authenticated;
+grant all on table public.field_service_vehicle_assignments to service_role;
+
+drop policy if exists field_service_vehicle_assignments_self_select
+  on public.field_service_vehicle_assignments;
+create policy field_service_vehicle_assignments_self_select
+on public.field_service_vehicle_assignments for select to authenticated
+using (
+  exists (
+    select 1
+    from public.profiles profile
+    where profile.id = field_service_vehicle_assignments.profile_id
+      and profile.shop_id = field_service_vehicle_assignments.shop_id
+      and (profile.id = auth.uid() or profile.user_id = auth.uid())
+      and public.mobile_profile_has_field_service_access(profile.shop_id, profile.id)
+  )
+);
 
 revoke all on table public.field_truck_records from public, anon;
 revoke all on table public.field_truck_records from authenticated;
@@ -243,6 +328,12 @@ begin
 
   if p_action = 'complete'
     and v_record.record_type = 'reminder'
+    and v_record.status = 'completed' then
+    return to_jsonb(v_record) || jsonb_build_object('replayed', true);
+  end if;
+
+  if p_action = 'complete'
+    and v_record.record_type = 'reminder'
     and v_record.status = 'open' then
     update public.field_truck_records
       set status = 'completed'
@@ -253,12 +344,25 @@ begin
 
   if p_action = 'reopen'
     and v_record.record_type = 'reminder'
+    and v_record.status = 'open' then
+    return to_jsonb(v_record) || jsonb_build_object('replayed', true);
+  end if;
+
+  if p_action = 'reopen'
+    and v_record.record_type = 'reminder'
     and v_record.status = 'completed' then
     update public.field_truck_records
       set status = 'open'
       where id = p_record_id
       returning * into v_updated;
     return to_jsonb(v_updated);
+  end if;
+
+  if p_action = 'end_downtime'
+    and v_record.record_type = 'downtime'
+    and v_record.status = 'completed'
+    and v_record.ends_at is not null then
+    return to_jsonb(v_record) || jsonb_build_object('replayed', true);
   end if;
 
   if p_action = 'end_downtime'
@@ -300,14 +404,18 @@ set search_path = public, pg_temp
 as $$
 declare
   v_vehicle public.service_vehicles%rowtype;
+  v_actor_profile_id uuid;
 begin
-  if not exists (
-    select 1
-    from public.profiles actor
-    where actor.shop_id = p_shop_id
-      and (actor.id = auth.uid() or actor.user_id = auth.uid())
-      and lower(coalesce(actor.role, '')) in ('owner','admin')
-  ) then
+  select actor.id
+    into v_actor_profile_id
+  from public.profiles actor
+  where actor.shop_id = p_shop_id
+    and (actor.id = auth.uid() or actor.user_id = auth.uid())
+    and lower(coalesce(actor.role, '')) in ('owner','admin')
+  order by (actor.id = auth.uid()) desc, actor.id
+  limit 1;
+
+  if v_actor_profile_id is null then
     raise exception 'Field truck assignment requires owner or admin access.'
       using errcode = '42501';
   end if;
@@ -338,17 +446,31 @@ begin
       using errcode = '22023';
   end if;
 
-  update public.service_vehicles
-  set primary_user_id = null, updated_at = now()
-  where shop_id = p_shop_id
-    and id <> p_service_vehicle_id
-    and primary_user_id = p_profile_id
-    and active
-    and capabilities @> '{"mobile_v1":true}'::jsonb;
+  perform pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'field-truck-profile:' || p_shop_id::text || ':' || p_profile_id::text,
+      0
+    )
+  );
+  perform pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'field-truck-vehicle:' || p_shop_id::text || ':' || p_service_vehicle_id::text,
+      0
+    )
+  );
 
-  update public.service_vehicles
-  set primary_user_id = p_profile_id, updated_at = now()
-  where id = p_service_vehicle_id;
+  delete from public.field_service_vehicle_assignments assignment
+  where assignment.shop_id = p_shop_id
+    and (
+      assignment.profile_id = p_profile_id
+      or assignment.service_vehicle_id = p_service_vehicle_id
+    );
+
+  insert into public.field_service_vehicle_assignments (
+    shop_id, service_vehicle_id, profile_id, assigned_by_profile_id
+  ) values (
+    p_shop_id, p_service_vehicle_id, p_profile_id, v_actor_profile_id
+  );
 
   return jsonb_build_object(
     'serviceVehicleId', p_service_vehicle_id,
@@ -386,7 +508,7 @@ values (
   'field-truck-files',
   'field-truck-files',
   false,
-  10485760,
+  4194304,
   array['application/pdf','image/jpeg','image/png','image/webp']
 )
 on conflict (id) do update
@@ -416,6 +538,9 @@ with check (
     public.field_storage_path_uuid((storage.foldername(name))[2])
   )
 );
+
+comment on table public.field_service_vehicle_assignments is
+  'Protected Field-only truck assignment relation used by My Truck authorization.';
 
 comment on table public.field_truck_records is
   'Field-only operating ledger for an assigned service truck: mileage, maintenance, costs, reminders, downtime, documents, and receipt metadata.';

--- a/supabase/migrations/20260820221500_field_my_truck_foundation.sql
+++ b/supabase/migrations/20260820221500_field_my_truck_foundation.sql
@@ -74,6 +74,21 @@ create table if not exists public.field_truck_records (
     or
     (file_path is not null and file_bucket is not null and original_filename is not null
       and content_type is not null and file_size_bytes is not null)
+  ),
+  constraint field_truck_records_file_path_scope_ck check (
+    file_path is null
+    or (
+      file_bucket = 'field-truck-files'
+      and split_part(file_path, '/', 1) = shop_id::text
+      and split_part(file_path, '/', 2) = service_vehicle_id::text
+      and (
+        (record_type = 'document' and split_part(file_path, '/', 3) = 'documents')
+        or (record_type = 'expense' and split_part(file_path, '/', 3) = 'receipts')
+      )
+      and split_part(file_path, '/', 4) = id::text
+      and split_part(file_path, '/', 5) <> ''
+      and split_part(file_path, '/', 6) = ''
+    )
   )
 );
 
@@ -160,7 +175,6 @@ alter table public.field_truck_records enable row level security;
 revoke all on table public.field_truck_records from public, anon;
 revoke all on table public.field_truck_records from authenticated;
 grant select, insert on table public.field_truck_records to authenticated;
-grant update (status, ends_at) on table public.field_truck_records to authenticated;
 grant all on table public.field_truck_records to service_role;
 
 drop policy if exists field_truck_records_assigned_select
@@ -186,23 +200,158 @@ with check (
   )
 );
 
-drop policy if exists field_truck_records_assigned_update
-  on public.field_truck_records;
-create policy field_truck_records_assigned_update
-on public.field_truck_records for update to authenticated
-using (
-  public.field_actor_can_access_service_vehicle(shop_id, service_vehicle_id)
-)
-with check (
-  public.field_actor_can_access_service_vehicle(shop_id, service_vehicle_id)
-  and exists (
+-- State changes are command-owned. Direct table updates stay revoked so an
+-- assigned operator cannot mutate arbitrary record types or transitions.
+create or replace function public.field_transition_truck_record(
+  p_record_id uuid,
+  p_action text,
+  p_ended_at timestamptz default null
+) returns setof public.field_truck_records
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_record public.field_truck_records%rowtype;
+  v_ended_at timestamptz;
+begin
+  select * into v_record
+  from public.field_truck_records
+  where id = p_record_id
+  for update;
+
+  if not found
+    or not public.field_actor_can_access_service_vehicle(
+      v_record.shop_id,
+      v_record.service_vehicle_id
+    ) then
+    raise exception 'Truck record was not found or is not accessible.'
+      using errcode = '42501';
+  end if;
+
+  if p_action = 'complete'
+    and v_record.record_type = 'reminder'
+    and v_record.status = 'open' then
+    return query
+      update public.field_truck_records
+      set status = 'completed'
+      where id = p_record_id
+      returning *;
+    return;
+  end if;
+
+  if p_action = 'reopen'
+    and v_record.record_type = 'reminder'
+    and v_record.status = 'completed' then
+    return query
+      update public.field_truck_records
+      set status = 'open'
+      where id = p_record_id
+      returning *;
+    return;
+  end if;
+
+  if p_action = 'end_downtime'
+    and v_record.record_type = 'downtime'
+    and v_record.status = 'open'
+    and v_record.ends_at is null then
+    v_ended_at := coalesce(p_ended_at, now());
+    if v_record.starts_at is null or v_ended_at <= v_record.starts_at then
+      raise exception 'Downtime must end after it starts.'
+        using errcode = '22007';
+    end if;
+    return query
+      update public.field_truck_records
+      set status = 'completed', ends_at = v_ended_at
+      where id = p_record_id
+      returning *;
+    return;
+  end if;
+
+  raise exception 'Truck record transition is not allowed.'
+    using errcode = '22023';
+end;
+$$;
+
+revoke all on function public.field_transition_truck_record(uuid, text, timestamptz)
+  from public, anon;
+grant execute on function public.field_transition_truck_record(uuid, text, timestamptz)
+  to authenticated, service_role;
+
+-- Field owners/admins can assign one active Field truck to a team operator.
+-- The command stays inside the Field setup surface and never exposes Fleet.
+create or replace function public.field_assign_service_vehicle(
+  p_shop_id uuid,
+  p_service_vehicle_id uuid,
+  p_profile_id uuid
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_vehicle public.service_vehicles%rowtype;
+begin
+  if not exists (
+    select 1
+    from public.profiles actor
+    where actor.shop_id = p_shop_id
+      and (actor.id = auth.uid() or actor.user_id = auth.uid())
+      and lower(coalesce(actor.role, '')) in ('owner','admin')
+  ) then
+    raise exception 'Field truck assignment requires owner or admin access.'
+      using errcode = '42501';
+  end if;
+
+  if not exists (
     select 1
     from public.profiles profile
-    where profile.id = created_by_profile_id
-      and profile.shop_id = shop_id
-      and (profile.id = auth.uid() or profile.user_id = auth.uid())
-  )
-);
+    join public.mobile_field_operators operator
+      on operator.shop_id = profile.shop_id
+     and operator.profile_id = profile.id
+     and operator.enabled
+    where profile.id = p_profile_id
+      and profile.shop_id = p_shop_id
+  ) then
+    raise exception 'The selected profile is not an enabled Field operator.'
+      using errcode = '22023';
+  end if;
+
+  select * into v_vehicle
+  from public.service_vehicles
+  where id = p_service_vehicle_id
+    and shop_id = p_shop_id
+    and active
+    and capabilities @> '{"mobile_v1":true}'::jsonb
+  for update;
+  if not found then
+    raise exception 'The selected Field truck is unavailable.'
+      using errcode = '22023';
+  end if;
+
+  update public.service_vehicles
+  set primary_user_id = null, updated_at = now()
+  where shop_id = p_shop_id
+    and id <> p_service_vehicle_id
+    and primary_user_id = p_profile_id
+    and active
+    and capabilities @> '{"mobile_v1":true}'::jsonb;
+
+  update public.service_vehicles
+  set primary_user_id = p_profile_id, updated_at = now()
+  where id = p_service_vehicle_id;
+
+  return jsonb_build_object(
+    'serviceVehicleId', p_service_vehicle_id,
+    'profileId', p_profile_id
+  );
+end;
+$$;
+
+revoke all on function public.field_assign_service_vehicle(uuid, uuid, uuid)
+  from public, anon;
+grant execute on function public.field_assign_service_vehicle(uuid, uuid, uuid)
+  to authenticated, service_role;
 
 create or replace function public.field_storage_path_uuid(p_value text)
 returns uuid

--- a/tests/field-dashboard-layout.test.ts
+++ b/tests/field-dashboard-layout.test.ts
@@ -27,6 +27,7 @@ describe("Field dashboard layout", () => {
       "followups_due",
       "dispatch_queue",
       "jobs_in_progress",
+      "my_truck",
       "awaiting_approval",
       "parts_required",
       "truck_inventory",

--- a/tests/field-hub-shell.test.ts
+++ b/tests/field-hub-shell.test.ts
@@ -39,6 +39,7 @@ describe("Field Hub workspace", () => {
       "/mobile/service/purchase-orders",
       "/mobile/service/followups",
       "/mobile/service/invoices",
+      "/mobile/service/my-truck",
     ]) {
       expect(`${fieldShell}\n${fieldHub}`).toContain(href);
     }
@@ -123,6 +124,10 @@ describe("Field Hub workspace", () => {
     expect(fieldShell).toContain('label: "Truck inventory"');
     expect(fieldShell.match(/label: "Truck inventory"/g)).toHaveLength(1);
     expect(fieldShell).toContain('label: "Invoices & history"');
+    expect(fieldShell).toContain('label: "My Truck"');
+    expect(fieldHub).toMatch(
+      /id: "my_truck"[\s\S]*?href: "\/mobile\/service\/my-truck"/,
+    );
     expect(fieldHub).toMatch(
       /id: "unpaid_invoices"[\s\S]*?title: "Unpaid invoices"/,
     );

--- a/tests/field-my-truck-foundation.test.ts
+++ b/tests/field-my-truck-foundation.test.ts
@@ -12,7 +12,10 @@ const migration = read(
 );
 const route = read("app/api/mobile/service/my-truck/route.ts");
 const fileRoute = read("app/api/mobile/service/my-truck/files/route.ts");
+const settingsRoute = read("app/api/mobile/service/settings/route.ts");
 const screen = read("features/mobile/service/FieldMyTruck.tsx");
+const settingsScreen = read("features/mobile/service/MobileServiceSetup.tsx");
+const server = read("features/mobile/service/server/myTruck.ts");
 const shell = read("features/mobile/service/FieldWorkspaceShell.tsx");
 const runtime = read("tests/mobile/field-my-truck.runtime.sql");
 const workflow = read(".github/workflows/mobile-v1-validation.yml");
@@ -102,9 +105,37 @@ describe("Field My Truck foundation", () => {
       odometerUnit: "km",
       openReminders: 1,
       activeDowntime: 1,
-      monthCosts: 200.5,
-      currency: "CAD",
+      monthCostsByCurrency: [{ currency: "CAD", amount: 200.5 }],
     });
+  });
+
+  it("keeps monthly operating costs separated by currency", () => {
+    const summary = buildFieldMyTruckSummary(
+      [
+        record({
+          id: "cad-cost",
+          record_type: "expense",
+          title: "Fuel",
+          occurred_on: "2026-08-18",
+          amount: 100,
+          currency: "CAD",
+        }),
+        record({
+          id: "usd-cost",
+          record_type: "expense",
+          title: "Toll",
+          occurred_on: "2026-08-19",
+          amount: 100,
+          currency: "USD",
+        }),
+      ],
+      new Date("2026-08-20T18:00:00.000Z"),
+    );
+
+    expect(summary.monthCostsByCurrency).toEqual([
+      { currency: "CAD", amount: 100 },
+      { currency: "USD", amount: 100 },
+    ]);
   });
 
   it("binds every record to the authenticated operator's active Field truck", () => {
@@ -122,6 +153,8 @@ describe("Field My Truck foundation", () => {
     expect(migration).toContain("field_truck_records_operation_key_unique");
     expect(route).toContain('error.code === "23505"');
     expect(fileRoute).toContain('insertError?.code === "23505"');
+    expect(screen).toContain("pendingSubmission");
+    expect(screen).toContain("submissionFingerprint");
     expect(runtime).toContain("cross-truck insert was accepted");
     expect(runtime).toContain("operator one can read operator two records");
     expect(workflow).toContain("tests/mobile/field-my-truck.runtime.sql");
@@ -133,6 +166,8 @@ describe("Field My Truck foundation", () => {
     expect(migration).toContain("field_truck_files_assigned_select");
     expect(migration).toContain("field_truck_files_assigned_insert");
     expect(fileRoute).toContain("createSignedUrl(record.file_path, 60)");
+    expect(fileRoute).toContain("expectedPrefix");
+    expect(migration).toContain("field_truck_records_file_path_scope_ck");
     expect(fileRoute).toContain("remove([storagePath])");
     expect(fileRoute).toContain("MAX_FILE_BYTES");
   });
@@ -151,6 +186,22 @@ describe("Field My Truck foundation", () => {
     expect(shell).toContain('href: "/mobile/service/my-truck"');
     expect(shell).not.toContain('href: "/fleet/maintenance"');
     expect(screen).not.toContain("Fleet");
+    expect(migration).toContain("field_assign_service_vehicle");
+    expect(migration).toContain("field_transition_truck_record");
+    expect(settingsRoute).toContain("field_assign_service_vehicle");
+    expect(settingsScreen).toContain("Field truck assignments");
+  });
+
+  it("keeps alerts and totals independent of the paginated history surface", () => {
+    expect(server).toContain("const collectAll");
+    expect(server).toContain("alerts: [...summaryRecords.values()]");
+    expect(screen).toContain("const alerts = snapshot.alerts");
+  });
+
+  it("uses local form dates, mobile-safe file opening and reminder reopening", () => {
+    expect(screen).toContain("now.getFullYear()");
+    expect(screen).toContain('window.open("", "_blank")');
+    expect(screen).toContain('onAction(record, "reopen")');
   });
 
   it("uses a forward additive migration without destructive schema operations", () => {

--- a/tests/field-my-truck-foundation.test.ts
+++ b/tests/field-my-truck-foundation.test.ts
@@ -53,6 +53,16 @@ function record(
 }
 
 describe("Field My Truck foundation", () => {
+  it("hardens assignment, ledger shape, retention, and local time boundaries", () => {
+    expect(settingsRoute).toContain("createAdminSupabase()");
+    expect(migration).toContain("on delete restrict");
+    expect(migration).toContain("field_truck_records_shape_ck");
+    expect(route).toContain("dueOdometer === null");
+    expect(screen).toContain("new Date(value).toISOString()");
+    expect(screen).toContain("?month=${localMonth()}");
+    expect(server).toContain("input.monthKey");
+  });
+
   it("summarizes latest mileage, current alerts, downtime and monthly costs", () => {
     const summary = buildFieldMyTruckSummary(
       [

--- a/tests/field-my-truck-foundation.test.ts
+++ b/tests/field-my-truck-foundation.test.ts
@@ -166,7 +166,9 @@ describe("Field My Truck foundation", () => {
 
   it("binds every record to the authenticated operator's active Field truck", () => {
     expect(migration).toContain("field_actor_can_access_service_vehicle");
-    expect(migration).toContain("vehicle.primary_user_id = profile.id");
+    expect(migration).toContain("assignment.profile_id");
+    expect(migration).toContain("field_service_vehicle_assignments");
+    expect(migration).not.toContain("vehicle.primary_user_id = profile.id");
     expect(migration).toContain("mobile_profile_has_field_service_access");
     expect(migration).toContain(
       "foreign key (shop_id, service_vehicle_id)",
@@ -233,6 +235,8 @@ describe("Field My Truck foundation", () => {
   it("uses a forward additive migration without destructive schema operations", () => {
     expect(migration).not.toMatch(/\bdrop\s+(table|column|schema)\b/i);
     expect(migration).not.toMatch(/\btruncate\b/i);
-    expect(migration).not.toMatch(/\bdelete\s+from\b/i);
+    expect(migration).not.toMatch(
+      /\bdelete\s+from\s+public\.(field_truck_records|service_vehicles)\b/i,
+    );
   });
 });

--- a/tests/field-my-truck-foundation.test.ts
+++ b/tests/field-my-truck-foundation.test.ts
@@ -63,6 +63,22 @@ describe("Field My Truck foundation", () => {
     expect(server).toContain("input.monthKey");
   });
 
+  it("keeps My Truck assignment and retries inside the additive boundary", () => {
+    expect(migration).toContain("field_service_vehicle_assignments");
+    expect(migration).toContain("field-truck-profile:");
+    expect(migration).toContain("field-truck-vehicle:");
+    expect(migration).not.toContain("set primary_user_id = p_profile_id");
+    expect(migration).toContain("currency ~ '^[A-Z]{3}$'");
+    expect(migration).toContain("jsonb_build_object('replayed', true)");
+    expect(migration).toContain("'work_order.assignment.manage',\n  'service'");
+    expect(server).toContain('.from("field_service_vehicle_assignments")');
+    expect(screen).toContain('name="odometerUnit"');
+    expect(screen).toContain('record.odometer_unit ?? "km"');
+    expect(fileRoute).toContain("4 * 1024 * 1024");
+    expect(runtime).toContain("mutable scheduler assignment granted ledger access");
+    expect(runtime).toContain("invalid currency was accepted");
+  });
+
   it("summarizes latest mileage, current alerts, downtime and monthly costs", () => {
     const summary = buildFieldMyTruckSummary(
       [

--- a/tests/field-my-truck-foundation.test.ts
+++ b/tests/field-my-truck-foundation.test.ts
@@ -1,0 +1,161 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFieldMyTruckSummary,
+  type FieldTruckRecord,
+} from "@/features/mobile/service/myTruck";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const migration = read(
+  "supabase/migrations/20260820221500_field_my_truck_foundation.sql",
+);
+const route = read("app/api/mobile/service/my-truck/route.ts");
+const fileRoute = read("app/api/mobile/service/my-truck/files/route.ts");
+const screen = read("features/mobile/service/FieldMyTruck.tsx");
+const shell = read("features/mobile/service/FieldWorkspaceShell.tsx");
+const runtime = read("tests/mobile/field-my-truck.runtime.sql");
+const workflow = read(".github/workflows/mobile-v1-validation.yml");
+
+function record(
+  input: Partial<FieldTruckRecord> &
+    Pick<FieldTruckRecord, "id" | "record_type" | "title">,
+): FieldTruckRecord {
+  return {
+    amount: null,
+    content_type: null,
+    created_at: "2026-08-20T12:00:00.000Z",
+    created_by_profile_id: "profile-1",
+    currency: null,
+    due_odometer: null,
+    due_on: null,
+    ends_at: null,
+    file_bucket: null,
+    file_path: null,
+    file_size_bytes: null,
+    notes: null,
+    occurred_on: null,
+    odometer: null,
+    odometer_unit: null,
+    operation_key: input.id,
+    original_filename: null,
+    service_vehicle_id: "truck-1",
+    shop_id: "shop-1",
+    starts_at: null,
+    status: "completed",
+    updated_at: "2026-08-20T12:00:00.000Z",
+    vendor: null,
+    ...input,
+  };
+}
+
+describe("Field My Truck foundation", () => {
+  it("summarizes latest mileage, current alerts, downtime and monthly costs", () => {
+    const summary = buildFieldMyTruckSummary(
+      [
+        record({
+          id: "mileage-old",
+          record_type: "odometer",
+          title: "Reading",
+          occurred_on: "2026-08-01",
+          odometer: 1000,
+          odometer_unit: "km",
+        }),
+        record({
+          id: "mileage-new",
+          record_type: "maintenance",
+          title: "Oil service",
+          occurred_on: "2026-08-19",
+          odometer: 1200,
+          odometer_unit: "km",
+          amount: 125,
+          currency: "CAD",
+        }),
+        record({
+          id: "expense",
+          record_type: "expense",
+          title: "Fuel",
+          occurred_on: "2026-08-18",
+          amount: 75.5,
+          currency: "CAD",
+        }),
+        record({
+          id: "reminder",
+          record_type: "reminder",
+          title: "Registration",
+          status: "open",
+          due_on: "2026-09-01",
+        }),
+        record({
+          id: "downtime",
+          record_type: "downtime",
+          title: "Repair",
+          status: "open",
+          starts_at: "2026-08-20T10:00:00.000Z",
+        }),
+      ],
+      new Date("2026-08-20T18:00:00.000Z"),
+    );
+
+    expect(summary).toEqual({
+      latestOdometer: 1200,
+      odometerUnit: "km",
+      openReminders: 1,
+      activeDowntime: 1,
+      monthCosts: 200.5,
+      currency: "CAD",
+    });
+  });
+
+  it("binds every record to the authenticated operator's active Field truck", () => {
+    expect(migration).toContain("field_actor_can_access_service_vehicle");
+    expect(migration).toContain("vehicle.primary_user_id = profile.id");
+    expect(migration).toContain("mobile_profile_has_field_service_access");
+    expect(migration).toContain(
+      "foreign key (shop_id, service_vehicle_id)",
+    );
+    expect(migration).toContain("enable row level security");
+    expect(migration).toContain("field_truck_records_assigned_insert");
+    expect(route).toContain("resolveAssignedFieldTruck");
+    expect(route).toContain("service_vehicle_id: access.truck.id");
+    expect(route).not.toContain("body.serviceVehicleId");
+    expect(migration).toContain("field_truck_records_operation_key_unique");
+    expect(route).toContain('error.code === "23505"');
+    expect(fileRoute).toContain('insertError?.code === "23505"');
+    expect(runtime).toContain("cross-truck insert was accepted");
+    expect(runtime).toContain("operator one can read operator two records");
+    expect(workflow).toContain("tests/mobile/field-my-truck.runtime.sql");
+  });
+
+  it("keeps files private and cleans storage if metadata persistence fails", () => {
+    expect(migration).toContain("'field-truck-files'");
+    expect(migration).toMatch(/'field-truck-files',[\s\S]*?false,/);
+    expect(migration).toContain("field_truck_files_assigned_select");
+    expect(migration).toContain("field_truck_files_assigned_insert");
+    expect(fileRoute).toContain("createSignedUrl(record.file_path, 60)");
+    expect(fileRoute).toContain("remove([storagePath])");
+    expect(fileRoute).toContain("MAX_FILE_BYTES");
+  });
+
+  it("exposes all requested My Truck record types only inside Field", () => {
+    for (const label of [
+      "Mileage",
+      "Maintenance",
+      "Cost or receipt",
+      "Reminder",
+      "Downtime",
+      "Document",
+    ]) {
+      expect(screen).toContain(`title="${label}"`);
+    }
+    expect(shell).toContain('href: "/mobile/service/my-truck"');
+    expect(shell).not.toContain('href: "/fleet/maintenance"');
+    expect(screen).not.toContain("Fleet");
+  });
+
+  it("uses a forward additive migration without destructive schema operations", () => {
+    expect(migration).not.toMatch(/\bdrop\s+(table|column|schema)\b/i);
+    expect(migration).not.toMatch(/\btruncate\b/i);
+    expect(migration).not.toMatch(/\bdelete\s+from\b/i);
+  });
+});

--- a/tests/mobile/field-my-truck.runtime.sql
+++ b/tests/mobile/field-my-truck.runtime.sql
@@ -169,9 +169,45 @@ begin
     '8f100000-0000-4000-8000-000000000001'
   );
 
-  update public.field_truck_records
-  set status = 'completed'
-  where id = '8f400000-0000-4000-8000-000000000001';
+  begin
+    insert into public.field_truck_records (
+      id, shop_id, service_vehicle_id, operation_key, record_type, title,
+      status, file_bucket, file_path, original_filename, content_type,
+      file_size_bytes, created_by_profile_id
+    ) values (
+      '8f400000-0000-4000-8000-000000000003',
+      '8f200000-0000-4000-8000-000000000001',
+      '8f300000-0000-4000-8000-000000000001',
+      'runtime-forged-file-path',
+      'document',
+      'Forged document path',
+      'completed',
+      'field-truck-files',
+      '8f200000-0000-4000-8000-000000000001/8f300000-0000-4000-8000-000000000002/documents/8f400000-0000-4000-8000-000000000003/secret.pdf',
+      'secret.pdf',
+      'application/pdf',
+      100,
+      '8f100000-0000-4000-8000-000000000001'
+    );
+    raise exception 'My Truck runtime failed: forged file path was accepted';
+  exception when check_violation then
+    null;
+  end;
+
+  begin
+    update public.field_truck_records
+    set status = 'completed'
+    where id = '8f400000-0000-4000-8000-000000000001';
+    raise exception 'My Truck runtime failed: direct status update was accepted';
+  exception when insufficient_privilege then
+    null;
+  end;
+
+  perform public.field_transition_truck_record(
+    '8f400000-0000-4000-8000-000000000001',
+    'complete',
+    null
+  );
   if not exists (
     select 1 from public.field_truck_records
     where id = '8f400000-0000-4000-8000-000000000001'
@@ -179,6 +215,17 @@ begin
   ) then
     raise exception 'My Truck runtime failed: assigned reminder was not completed';
   end if;
+
+  begin
+    perform public.field_transition_truck_record(
+      '8f400000-0000-4000-8000-000000000001',
+      'end_downtime',
+      now()
+    );
+    raise exception 'My Truck runtime failed: invalid record transition was accepted';
+  exception when invalid_parameter_value then
+    null;
+  end;
 
   begin
     update public.field_truck_records

--- a/tests/mobile/field-my-truck.runtime.sql
+++ b/tests/mobile/field-my-truck.runtime.sql
@@ -1,0 +1,195 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values
+  ('8f100000-0000-4000-8000-000000000001', 'field-my-truck-one@example.com', '{}'::jsonb),
+  ('8f100000-0000-4000-8000-000000000002', 'field-my-truck-two@example.com', '{}'::jsonb)
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name, email, shop_id)
+values (
+  '8f100000-0000-4000-8000-000000000001',
+  '8f100000-0000-4000-8000-000000000001',
+  'owner',
+  'Field Truck One',
+  'field-my-truck-one@example.com',
+  null
+)
+on conflict (id) do update set user_id = excluded.user_id, shop_id = null;
+
+insert into public.shops (
+  id, owner_id, business_name, name, user_limit, accepts_online_booking,
+  min_notice_minutes, max_lead_days, location_type, country,
+  billing_entitlement_override, subscription_package
+)
+values (
+  '8f200000-0000-4000-8000-000000000001',
+  '8f100000-0000-4000-8000-000000000001',
+  'Field My Truck Runtime',
+  'Field My Truck Runtime',
+  10,
+  true,
+  0,
+  365,
+  'repair_facility',
+  'CA',
+  'internal_demo',
+  'complete_operations'
+)
+on conflict (id) do nothing;
+
+update public.profiles
+set shop_id = '8f200000-0000-4000-8000-000000000001'
+where id = '8f100000-0000-4000-8000-000000000001';
+
+insert into public.profiles (id, user_id, role, full_name, email, shop_id)
+values (
+  '8f100000-0000-4000-8000-000000000002',
+  '8f100000-0000-4000-8000-000000000002',
+  'mechanic',
+  'Field Truck Two',
+  'field-my-truck-two@example.com',
+  '8f200000-0000-4000-8000-000000000001'
+)
+on conflict (id) do update
+set user_id = excluded.user_id, shop_id = excluded.shop_id;
+
+insert into public.mobile_service_settings (
+  shop_id, service_model, service_vehicles_enabled,
+  onboarding_completed_at, configured_by
+)
+values (
+  '8f200000-0000-4000-8000-000000000001',
+  'mobile',
+  true,
+  now(),
+  '8f100000-0000-4000-8000-000000000001'
+)
+on conflict (shop_id) do update
+set service_model = 'mobile',
+    service_vehicles_enabled = true,
+    onboarding_completed_at = now();
+
+insert into public.mobile_field_operators (shop_id, profile_id, enabled)
+values
+  ('8f200000-0000-4000-8000-000000000001', '8f100000-0000-4000-8000-000000000001', true),
+  ('8f200000-0000-4000-8000-000000000001', '8f100000-0000-4000-8000-000000000002', true)
+on conflict (shop_id, profile_id) do update set enabled = true;
+
+insert into public.service_vehicles (
+  id, shop_id, name, unit_number, primary_user_id, active, capabilities
+)
+values
+  (
+    '8f300000-0000-4000-8000-000000000001',
+    '8f200000-0000-4000-8000-000000000001',
+    'Field Truck One',
+    'FT-1',
+    '8f100000-0000-4000-8000-000000000001',
+    true,
+    '{"mobile_v1":true}'::jsonb
+  ),
+  (
+    '8f300000-0000-4000-8000-000000000002',
+    '8f200000-0000-4000-8000-000000000001',
+    'Field Truck Two',
+    'FT-2',
+    '8f100000-0000-4000-8000-000000000002',
+    true,
+    '{"mobile_v1":true}'::jsonb
+  )
+on conflict (id) do nothing;
+
+insert into public.field_truck_records (
+  id, shop_id, service_vehicle_id, operation_key, record_type, title,
+  due_on, status, created_by_profile_id
+)
+values (
+  '8f400000-0000-4000-8000-000000000002',
+  '8f200000-0000-4000-8000-000000000001',
+  '8f300000-0000-4000-8000-000000000002',
+  'runtime-truck-two-reminder',
+  'reminder',
+  'Truck two reminder',
+  current_date + 5,
+  'open',
+  '8f100000-0000-4000-8000-000000000002'
+);
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', '8f100000-0000-4000-8000-000000000001', true);
+set local role authenticated;
+
+do $$
+declare
+  v_visible integer;
+begin
+  select count(*) into v_visible
+  from public.field_truck_records
+  where service_vehicle_id = '8f300000-0000-4000-8000-000000000002';
+  if v_visible <> 0 then
+    raise exception 'My Truck runtime failed: operator one can read operator two records';
+  end if;
+
+  begin
+    insert into public.field_truck_records (
+      shop_id, service_vehicle_id, operation_key, record_type, title,
+      occurred_on, odometer, odometer_unit, status, created_by_profile_id
+    ) values (
+      '8f200000-0000-4000-8000-000000000001',
+      '8f300000-0000-4000-8000-000000000002',
+      'runtime-forged-reading',
+      'odometer',
+      'Forged truck reading',
+      current_date,
+      123,
+      'km',
+      'completed',
+      '8f100000-0000-4000-8000-000000000001'
+    );
+    raise exception 'My Truck runtime failed: cross-truck insert was accepted';
+  exception when insufficient_privilege then
+    null;
+  end;
+
+  insert into public.field_truck_records (
+    id, shop_id, service_vehicle_id, operation_key, record_type, title,
+    due_on, status, created_by_profile_id
+  ) values (
+    '8f400000-0000-4000-8000-000000000001',
+    '8f200000-0000-4000-8000-000000000001',
+    '8f300000-0000-4000-8000-000000000001',
+    'runtime-truck-one-reminder',
+    'reminder',
+    'Truck one reminder',
+    current_date + 5,
+    'open',
+    '8f100000-0000-4000-8000-000000000001'
+  );
+
+  update public.field_truck_records
+  set status = 'completed'
+  where id = '8f400000-0000-4000-8000-000000000001';
+  if not exists (
+    select 1 from public.field_truck_records
+    where id = '8f400000-0000-4000-8000-000000000001'
+      and status = 'completed'
+  ) then
+    raise exception 'My Truck runtime failed: assigned reminder was not completed';
+  end if;
+
+  begin
+    update public.field_truck_records
+    set title = 'Rewritten audit history'
+    where id = '8f400000-0000-4000-8000-000000000001';
+    raise exception 'My Truck runtime failed: immutable history field was updated';
+  exception when insufficient_privilege then
+    null;
+  end;
+end;
+$$;
+
+reset role;
+rollback;

--- a/tests/mobile/field-my-truck.runtime.sql
+++ b/tests/mobile/field-my-truck.runtime.sql
@@ -292,7 +292,7 @@ begin
     null;
   end;
 end;
-$;
+$$;
 
 reset role;
 
@@ -305,7 +305,7 @@ update public.service_vehicles
 set primary_user_id = '8f100000-0000-4000-8000-000000000002'
 where id = '8f300000-0000-4000-8000-000000000001';
 
-do $
+do $$
 begin
   if exists (
     select 1
@@ -328,7 +328,7 @@ begin
     null;
   end;
 end;
-$;
+$$;
 
 reset role;
 rollback;

--- a/tests/mobile/field-my-truck.runtime.sql
+++ b/tests/mobile/field-my-truck.runtime.sql
@@ -102,6 +102,24 @@ values
   )
 on conflict (id) do nothing;
 
+insert into public.field_service_vehicle_assignments (
+  shop_id, service_vehicle_id, profile_id, assigned_by_profile_id
+)
+values
+  (
+    '8f200000-0000-4000-8000-000000000001',
+    '8f300000-0000-4000-8000-000000000001',
+    '8f100000-0000-4000-8000-000000000001',
+    '8f100000-0000-4000-8000-000000000001'
+  ),
+  (
+    '8f200000-0000-4000-8000-000000000001',
+    '8f300000-0000-4000-8000-000000000002',
+    '8f100000-0000-4000-8000-000000000002',
+    '8f100000-0000-4000-8000-000000000001'
+  )
+on conflict do nothing;
+
 insert into public.field_truck_records (
   id, shop_id, service_vehicle_id, operation_key, record_type, title,
   due_on, status, created_by_profile_id
@@ -195,6 +213,27 @@ begin
   end;
 
   begin
+    insert into public.field_truck_records (
+      shop_id, service_vehicle_id, operation_key, record_type, title,
+      occurred_on, amount, currency, status, created_by_profile_id
+    ) values (
+      '8f200000-0000-4000-8000-000000000001',
+      '8f300000-0000-4000-8000-000000000001',
+      'runtime-invalid-currency',
+      'expense',
+      'Invalid currency',
+      current_date,
+      1,
+      'X',
+      'completed',
+      '8f100000-0000-4000-8000-000000000001'
+    );
+    raise exception 'My Truck runtime failed: invalid currency was accepted';
+  exception when check_violation then
+    null;
+  end;
+
+  begin
     update public.field_truck_records
     set status = 'completed'
     where id = '8f400000-0000-4000-8000-000000000001';
@@ -216,6 +255,23 @@ begin
     raise exception 'My Truck runtime failed: assigned reminder was not completed';
   end if;
 
+  -- Lost HTTP responses must be safe to retry.
+  perform public.field_transition_truck_record(
+    '8f400000-0000-4000-8000-000000000001',
+    'complete',
+    null
+  );
+  perform public.field_transition_truck_record(
+    '8f400000-0000-4000-8000-000000000001',
+    'reopen',
+    null
+  );
+  perform public.field_transition_truck_record(
+    '8f400000-0000-4000-8000-000000000001',
+    'reopen',
+    null
+  );
+
   begin
     perform public.field_transition_truck_record(
       '8f400000-0000-4000-8000-000000000001',
@@ -236,7 +292,43 @@ begin
     null;
   end;
 end;
-$$;
+$;
+
+reset role;
+
+-- Legacy scheduler writes to primary_user_id must not grant My Truck access.
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', '8f100000-0000-4000-8000-000000000002', true);
+set local role authenticated;
+
+update public.service_vehicles
+set primary_user_id = '8f100000-0000-4000-8000-000000000002'
+where id = '8f300000-0000-4000-8000-000000000001';
+
+do $
+begin
+  if exists (
+    select 1
+    from public.field_truck_records
+    where service_vehicle_id = '8f300000-0000-4000-8000-000000000001'
+  ) then
+    raise exception 'My Truck runtime failed: mutable scheduler assignment granted ledger access';
+  end if;
+
+  begin
+    insert into public.field_service_vehicle_assignments (
+      shop_id, service_vehicle_id, profile_id
+    ) values (
+      '8f200000-0000-4000-8000-000000000001',
+      '8f300000-0000-4000-8000-000000000001',
+      '8f100000-0000-4000-8000-000000000002'
+    );
+    raise exception 'My Truck runtime failed: operator self-assignment was accepted';
+  exception when insufficient_privilege then
+    null;
+  end;
+end;
+$;
 
 reset role;
 rollback;


### PR DESCRIPTION
## Summary

Adds the first Field-only **My Truck** operating foundation without exposing Fleet workflows.

- Adds `/mobile/service/my-truck` to the Field shell and dashboard.
- Tracks mileage, maintenance, operating costs, receipts, reminders, downtime, and private truck documents in one service-vehicle ledger.
- Derives the active truck from a dedicated, command-owned Field assignment relation; clients cannot choose a shop or truck ID.
- Keeps uploaded files private and serves them through short-lived signed URLs after revalidating the authorized shop/truck path.
- Uses durable operation keys for retry-safe creation and idempotent reminder/downtime transitions.
- Allows only reminder completion/reopen and downtime completion to mutate existing ledger records.

## Authorization and data boundaries

- Records remain attached to canonical `service_vehicles`, not Fleet assets.
- Ledger and storage access require explicit Field access plus `field_service_vehicle_assignments`; legacy scheduler writes to `service_vehicles.primary_user_id` do not grant My Truck access.
- Owner/admin assignment commands are serialized and database uniqueness enforces one active truck per operator.
- Composite shop/truck foreign keys and storage-path checks prevent cross-tenant attachment and privileged signing.
- Direct inserts are constrained to valid record shapes, currencies, statuses, timestamps, and odometer units.
- Truck-ledger records use restrictive vehicle deletion semantics so vehicle deletion cannot cascade through durable history.
- No QR, Fleet-customer relationship, Field↔Shop conversion, voice, or unrestricted Fleet navigation work is included.

## Validation

- Focused source/contract coverage for dashboard wiring, summary behavior, local dates and offset-bearing timestamps, active alerts independent of paginated history, assignment recovery/concurrency, reminder reopening and units, private file signing, record shape, and idempotency.
- `tests/mobile/field-my-truck.runtime.sql` covers assigned-truck access, cross-truck denial, direct-insert constraints, transition retries, assignment boundaries, and legacy scheduler self-assignment resistance.
- The migration restores the pre-existing service-role work-order assignment capability required by the unchanged Mobile V1 regression flow.

## Database and deployment

Adds forward migration:

- `20260820221500_field_my_truck_foundation.sql`

The migration has **not** been applied to production. Merge only after clean replay, generated-type verification, runtime SQL, application checks, and final review pass.

Vercel preview deployments are not requested or enabled.