### PR TITLE
Polish Vehicle Workspace operational labels

### DIFF
--- a/features/vehicles/components/VehicleWorkspace.tsx
+++ b/features/vehicles/components/VehicleWorkspace.tsx
@@ -153,7 +153,7 @@ function ActiveWorkCard({
         <StatusPill value={item.status} />
       </div>
       {item.detail ? (
-        <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+        <p className="mt-2 line-clamp-3 text-sm text-[color:var(--theme-text-secondary)]">
           {item.detail}
         </p>
       ) : null}

--- a/features/vehicles/server/loadVehicleWorkspaceSnapshot.ts
+++ b/features/vehicles/server/loadVehicleWorkspaceSnapshot.ts
@@ -455,12 +455,16 @@ function workOrderLabel(row: WorkspaceWorkOrderRow): string {
   return row.custom_id ? `WO-${row.custom_id.replace(/^wo-?/i, "")}` : `WO ${row.id.slice(0, 8)}`;
 }
 
+function estimateTitle(row: WorkspaceWorkOrderRow): string {
+  return text(row.estimate_number) ?? `Estimate ${row.id.slice(0, 8)}`;
+}
+
 function workOrderReference(row: WorkspaceWorkOrderRow): VehicleWorkspaceReference {
   const isEstimate = workOrderIsEstimate(row);
   const sourceLabel = isEstimate
     ? row.estimate_number
       ? `Estimate ${row.estimate_number}`
-      : `Estimate ${row.id.slice(0, 8)}`
+      : estimateTitle(row)
     : workOrderLabel(row);
   return {
     sourceType: "work_order",
@@ -522,11 +526,25 @@ function installedPartQuantity(row: WorkspaceWorkOrderPartRow): number {
   return Number(row.quantity_consumed ?? 0) - Number(row.quantity_returned ?? 0);
 }
 
-function inspectionReference(row: WorkspaceInspectionRow): VehicleWorkspaceReference {
+function inspectionLabel(
+  row: WorkspaceInspectionRow,
+  workOrder: WorkspaceWorkOrderRow | null = null,
+): string {
+  const inspectionType = text(row.inspection_type);
+  if (inspectionType) return inspectionType;
+  return workOrder
+    ? `Inspection for ${workOrderLabel(workOrder)}`
+    : `Inspection ${row.id.slice(0, 8)}`;
+}
+
+function inspectionReference(
+  row: WorkspaceInspectionRow,
+  workOrder: WorkspaceWorkOrderRow | null = null,
+): VehicleWorkspaceReference {
   return {
     sourceType: "inspection",
     sourceId: row.id,
-    sourceLabel: row.inspection_type?.trim() || `Inspection ${row.id.slice(0, 8)}`,
+    sourceLabel: inspectionLabel(row, workOrder),
     href: `/inspections/${row.id}`,
   };
 }
@@ -694,11 +712,15 @@ function buildAttentionItems(input: {
   }
 
   for (const inspection of input.inspections) {
+    const workOrder = inspection.work_order_id
+      ? input.workOrdersById.get(inspection.work_order_id)
+      : null;
+    const reference = inspectionReference(inspection, workOrder ?? null);
     for (const finding of extractInspectionFindings(inspection.summary)) {
       const detail = [
         finding.measurement,
         finding.note,
-        `recorded during ${inspectionReference(inspection).sourceLabel}`,
+        `recorded during ${reference.sourceLabel}`,
       ]
         .filter(Boolean)
         .join(" · ");
@@ -712,7 +734,7 @@ function buildAttentionItems(input: {
           inspection.updated_at,
           inspection.created_at,
         ),
-        reference: inspectionReference(inspection),
+        reference,
       });
     }
   }
@@ -765,6 +787,7 @@ function buildTimeline(input: {
 }): VehicleTimelineEvent[] {
   const events: VehicleTimelineEvent[] = [];
   const workOrderIds = new Set(input.workOrders.map((row) => row.id));
+  const workOrdersById = new Map(input.workOrders.map((row) => [row.id, row]));
 
   for (const row of input.workOrders) {
     const isEstimate = workOrderIsEstimate(row);
@@ -774,9 +797,7 @@ function buildTimeline(input: {
       kind: isEstimate ? "estimate" : "work_order",
       title:
         isEstimate
-          ? row.estimate_number
-            ? `Estimate ${row.estimate_number}`
-            : `Estimate ${row.id.slice(0, 8)}`
+          ? estimateTitle(row)
           : workOrderLabel(row),
       detail:
         [
@@ -815,12 +836,16 @@ function buildTimeline(input: {
   }
 
   for (const row of input.inspections) {
+    const reference = inspectionReference(
+      row,
+      row.work_order_id ? workOrdersById.get(row.work_order_id) ?? null : null,
+    );
     events.push({
       kind: "inspection",
-      title: inspectionReference(row).sourceLabel,
+      title: reference.sourceLabel,
       detail: row.status ? formatOperationalLabel(row.status) : null,
       occurredAt: dateValue(row.finalized_at, row.updated_at, row.started_at, row.created_at),
-      reference: inspectionReference(row),
+      reference,
     });
   }
 
@@ -1001,7 +1026,12 @@ function buildDocumentSummary(input: {
           href: `/work-orders/${newestWorkOrderMedia.work_order_id}`,
         }
       : reports[0]
-        ? inspectionReference(reports[0])
+        ? inspectionReference(
+            reports[0],
+            reports[0].work_order_id
+              ? input.workOrdersById.get(reports[0].work_order_id) ?? null
+              : null,
+          )
         : null,
   };
 }
@@ -1593,9 +1623,7 @@ export async function loadVehicleWorkspaceSnapshot(input: {
     activeWork.push({
       kind: isEstimate ? "estimate" : "work_order",
       title: isEstimate
-        ? row.estimate_number
-          ? `Estimate ${row.estimate_number}`
-          : `Estimate ${row.id.slice(0, 8)}`
+        ? estimateTitle(row)
         : workOrderLabel(row),
       status: isEstimate ? row.estimate_status ?? row.status : row.status,
       detail: row.approval_state,
@@ -1606,13 +1634,17 @@ export async function loadVehicleWorkspaceSnapshot(input: {
   for (const row of inspections) {
     const status = normalizedOperationalState(row.status);
     if (row.completed || !OPEN_INSPECTION_STATUSES.has(status)) continue;
+    const reference = inspectionReference(
+      row,
+      row.work_order_id ? workOrdersById.get(row.work_order_id) ?? null : null,
+    );
     activeWork.push({
       kind: "inspection",
-      title: inspectionReference(row).sourceLabel,
+      title: reference.sourceLabel,
       status: row.status,
       detail: null,
       occurredAt: row.updated_at ?? row.created_at,
-      reference: inspectionReference(row),
+      reference,
     });
   }
   for (const row of invoices) {
@@ -1644,10 +1676,9 @@ export async function loadVehicleWorkspaceSnapshot(input: {
     activeWork.push({
       kind: "part_request",
       title:
-        requestSummary ??
-        (workOrder ? `Parts for ${workOrderLabel(workOrder)}` : "Parts request"),
+        workOrder ? `Parts for ${workOrderLabel(workOrder)}` : "Parts request",
       status: row.status,
-      detail: workOrder ? `Requested for ${workOrderLabel(workOrder)}` : null,
+      detail: requestSummary,
       occurredAt: row.created_at,
       reference: {
         sourceType: "part_request",

--- a/tests/vehicle-workspace-contract.test.ts
+++ b/tests/vehicle-workspace-contract.test.ts
@@ -807,6 +807,96 @@ describe("Shop Vehicle Workspace contract", () => {
     );
   });
 
+  it("uses operational labels instead of raw identifiers in Active now", async () => {
+    const fixture = workspaceFixture({
+      additionalWorkOrders: [
+        {
+          id: "estimate-1",
+          customer_id: "customer-1",
+          vehicle_id: "vehicle-1",
+          custom_id: null,
+          status: "draft",
+          record_type: "estimate",
+          approval_state: "pending",
+          estimate_number: "EST-2001",
+          estimate_status: "waiting_for_parts",
+          scheduled_at: null,
+          odometer_km: null,
+          created_at: "2026-01-05T10:00:00.000Z",
+          updated_at: "2026-01-05T11:00:00.000Z",
+        },
+      ],
+      inspections: [
+        {
+          id: "inspection-open",
+          work_order_id: "wo-1",
+          work_order_line_id: null,
+          inspection_type: null,
+          status: "draft",
+          completed: false,
+          summary: { items: [] },
+          created_at: "2026-01-06T10:00:00.000Z",
+          started_at: null,
+          finalized_at: null,
+          updated_at: "2026-01-06T10:00:00.000Z",
+          pdf_url: null,
+          pdf_storage_path: null,
+        },
+      ],
+      partRequests: [
+        {
+          id: "part-request-1",
+          work_order_id: "wo-1",
+          status: "requested",
+          notes: "Estimate EST-2001 · Rebuild front differential.\nInternal note",
+          created_at: "2026-01-07T10:00:00.000Z",
+        },
+      ],
+    });
+
+    const snapshot = await loadVehicleWorkspaceSnapshot({
+      supabase: fixture.client as never,
+      shopId: "shop-a",
+      role: "owner",
+      vehicleId: "vehicle-1",
+    });
+
+    expect(snapshot?.activeWork).toContainEqual(
+      expect.objectContaining({
+        kind: "estimate",
+        title: "EST-2001",
+        reference: expect.objectContaining({
+          sourceId: "estimate-1",
+          sourceLabel: "Estimate EST-2001",
+        }),
+      }),
+    );
+    expect(snapshot?.activeWork).toContainEqual(
+      expect.objectContaining({
+        kind: "inspection",
+        title: "Inspection for WO-1048",
+        reference: expect.objectContaining({
+          sourceId: "inspection-open",
+          sourceLabel: "Inspection for WO-1048",
+        }),
+      }),
+    );
+    expect(snapshot?.activeWork).toContainEqual(
+      expect.objectContaining({
+        kind: "part_request",
+        title: "Parts for WO-1048",
+        detail: "Estimate EST-2001 · Rebuild front differential.",
+        reference: expect.objectContaining({ sourceId: "part-request-1" }),
+      }),
+    );
+    expect(snapshot?.recentTimeline).toContainEqual(
+      expect.objectContaining({
+        kind: "estimate",
+        title: "EST-2001",
+      }),
+    );
+  });
+
   it("does not let rescheduling an older work order replace newer odometer evidence", async () => {
     const fixture = workspaceFixture({
       additionalWorkOrders: [
@@ -1409,9 +1499,9 @@ describe("Shop Vehicle Workspace contract", () => {
       partsSnapshot?.activeWork.filter((item) => item.kind === "part_request"),
     ).toEqual([
       expect.objectContaining({
-        title: "Brake pads needed",
+        title: "Parts for WO-1048",
         status: "requested",
-        detail: "Requested for WO-1048",
+        detail: "Brake pads needed",
         reference: expect.objectContaining({
           sourceType: "part_request",
           sourceId: "request-open",


### PR DESCRIPTION
## Summary

Completes the remaining Vehicle Workspace presentation polish identified during Phase 2 UI review.

- show estimate numbers without repeating the module label
- identify unnamed inspections by their canonical linked work order instead of a raw UUID
- lead Parts request cards with the canonical work order and move request notes into supporting text
- cap long Active now supporting text at three lines
- add behavioral coverage for the operational labels and retain canonical source IDs and routes

## Why

The authoritative read model and handoffs are working, but opaque or duplicated labels make Active now harder to scan on an iPad. This keeps the existing Workspace layout and canonical routes while improving at-a-glance operational clarity.

## Scope and safety

- no schema migration
- no changes to work-order mutation logic
- no changes to Parts pick/punch/notification files in PR #1492
- no changes to `vercel.json`; non-main preview deployments remain disabled
- source IDs, tenant authorization, permissions, and canonical links are unchanged

## Validation

- Node TypeScript syntax checks passed for the loader and focused contract test
- `git diff --check` passed
- remote comparison confirms one commit and exactly three changed files
- full Vitest, type-check, lint, and production build are pending exact-head GitHub CI because the disposable local worktree has no dependency cache
