### PR TITLE
Fix Shop sign-in shell initialization

### DIFF
--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
 import AuthShell from "@/features/auth/components/AuthShell";
 import AuthStatus from "@/features/auth/components/AuthStatus";
@@ -11,6 +11,7 @@ import {
   acquisitionOnboardingHref,
 } from "@/features/auth/lib/acquisitionSurfaceRouting";
 import { resolvePostAuthDestination } from "@/features/auth/lib/postAuthRouting";
+import { navigateAfterAuthentication } from "@/features/auth/lib/postAuthNavigation";
 import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
 import { signInWithIdentifier } from "@/features/auth/lib/signInClient";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
@@ -100,7 +101,6 @@ const VERIFYING_TRIAL_COPY = {
 };
 
 export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const isAcquisitionFlow = searchParams.get("flow")?.trim() === "acquisition";
@@ -268,12 +268,12 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
             }
           : {}),
       });
-      router.replace(destination);
+      navigateAfterAuthentication(destination);
     })();
     return () => {
       cancelled = true;
     };
-  }, [router, searchParams, supabase]);
+  }, [searchParams, supabase]);
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -315,16 +315,14 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
             defaultDashboardHref: acquisitionHomeHref(claim.surface),
             unassignedAccountHref: acquisitionOnboardingHref(claim.surface),
           });
-          router.replace(destination);
-          router.refresh();
+          navigateAfterAuthentication(destination);
           return;
         }
         const requested = safeInternalRedirect(
           searchParams.get("redirect"),
           result.destination,
         );
-        router.replace(requested);
-        router.refresh();
+        navigateAfterAuthentication(requested);
         return;
       }
 
@@ -377,7 +375,7 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
               unassignedAccountHref: "/onboarding",
             }),
       });
-      router.replace(destination);
+      navigateAfterAuthentication(destination);
     } finally {
       setLoading(false);
     }

--- a/features/auth/lib/postAuthNavigation.ts
+++ b/features/auth/lib/postAuthNavigation.ts
@@ -1,0 +1,11 @@
+type ReplaceDocument = (destination: string) => void;
+
+/** Rebuild the root layout when authentication crosses into the protected app. */
+export function navigateAfterAuthentication(
+  destination: string,
+  replaceDocument: ReplaceDocument = window.location.replace.bind(
+    window.location,
+  ),
+): void {
+  replaceDocument(destination);
+}

--- a/tests/sign-in-shell-transition.test.tsx
+++ b/tests/sign-in-shell-transition.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AuthPage from "@/features/auth/components/SignIn";
+
+const mocks = vi.hoisted(() => ({
+  claimAcquisition: vi.fn(),
+  getUser: vi.fn(),
+  navigateAfterAuthentication: vi.fn(),
+  signInWithIdentifier: vi.fn(),
+}));
+
+const searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: ComponentProps<"a">) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/features/auth/components/AuthShell", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/features/auth/lib/signInClient", () => ({
+  signInWithIdentifier: mocks.signInWithIdentifier,
+}));
+
+vi.mock("@/features/auth/lib/postAuthNavigation", () => ({
+  navigateAfterAuthentication: mocks.navigateAfterAuthentication,
+}));
+
+vi.mock("@/features/stripe/lib/client/claim-acquisition", () => ({
+  claimStripeAcquisitionAfterAuth: mocks.claimAcquisition,
+}));
+
+vi.mock("@/features/shared/lib/supabase/client", () => ({
+  createBrowserSupabase: () => ({
+    auth: {
+      getUser: mocks.getUser,
+      resend: vi.fn(),
+      signInWithOAuth: vi.fn(),
+      signUp: vi.fn(),
+    },
+  }),
+}));
+
+describe("Shop sign-in shell transition", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchParams.forEach((_value, key) => searchParams.delete(key));
+    mocks.getUser.mockResolvedValue({ data: { user: null } });
+    mocks.claimAcquisition.mockResolvedValue({ linked: true });
+    mocks.signInWithIdentifier.mockResolvedValue({
+      ok: true,
+      destination: "/dashboard/operations",
+    });
+  });
+
+  it("performs a document navigation after a successful sign-in", async () => {
+    const user = userEvent.setup();
+    render(<AuthPage />);
+
+    await user.type(screen.getByLabelText("Email or username"), "owner");
+    await user.type(screen.getByLabelText("Password"), "password123");
+    await user.click(
+      screen.getByRole("button", { name: "Sign in to ProFixIQ Shop" }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.navigateAfterAuthentication).toHaveBeenCalledWith(
+        "/dashboard/operations",
+      );
+    });
+    expect(mocks.signInWithIdentifier).toHaveBeenCalledWith({
+      identifier: "owner",
+      password: "password123",
+      surface: "shop",
+      acquisitionSessionId: undefined,
+    });
+  });
+
+  it("uses location replacement to rebuild the protected root layout", async () => {
+    const { navigateAfterAuthentication } = await vi.importActual<
+      typeof import("@/features/auth/lib/postAuthNavigation")
+    >("@/features/auth/lib/postAuthNavigation");
+    const replaceDocument = vi.fn();
+
+    navigateAfterAuthentication("/dashboard/operations", replaceDocument);
+
+    expect(replaceDocument).toHaveBeenCalledOnce();
+    expect(replaceDocument).toHaveBeenCalledWith("/dashboard/operations");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the Shop sign-in transition so the authenticated desktop shell appears immediately without requiring a manual refresh.

- replaces client-only routing after successful Shop authentication with a document replacement
- preserves the existing resolved destination, safe redirect handling, and browser-history replacement semantics
- covers both standard sign-in and the existing acquisition/sign-up paths owned by the same Shop auth component
- adds focused interaction coverage for the successful submit path and the document-replacement adapter

## Root cause

The Shop sign-in route is rendered as a standalone public root-layout state. A client-side `router.replace()` changed the page content after authentication, but the persistent Next.js root layout was not rebuilt, so `AppShell` remained absent until a manual browser refresh. A document replacement rebuilds the root layout with the authenticated pathname and session.

## Scope

Changed only:

- `features/auth/components/SignIn.tsx`
- `features/auth/lib/postAuthNavigation.ts`
- `tests/sign-in-shell-transition.test.tsx`

No dashboard UI, shell component, authorization, database, migration, or unrelated product behavior was changed. Open PRs #1492 and #1494 do not overlap these files.

## Validation

Exact head: `d10e82a284784dbe8b3c029354d9313797e49cc7`

- `git diff --check` — passed
- Agent PR Checks — passed
  - typecheck — passed
  - changed-file lint — passed
  - complete test suite — passed
  - production build — passed
- P0-006 Stripe Identity Validation — passed
- unrelated draft-only domain workflows — skipped as expected

## Database and deployment

- migrations: none
- environment changes: none
- preview deployment requested: no
