### PR TITLE
Add Work Order Workspace foundation

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -18,15 +18,21 @@ export default async function ChatListPage({
   const requested = await searchParams;
   const contextId = requested.contextId?.trim() ?? "";
   const customerId = requested.customerId?.trim() ?? "";
+  const contextType =
+    requested.contextType === "vehicle" ||
+    requested.contextType === "work_order"
+      ? requested.contextType
+      : null;
   const startCustomerCompose =
     requested.compose === "customer" &&
-    requested.contextType === "vehicle" &&
+    contextType !== null &&
     UUID_PATTERN.test(contextId) &&
     UUID_PATTERN.test(customerId);
 
   return (
     <ChatListClient
       startCustomerCompose={startCustomerCompose}
+      contextType={startCustomerCompose ? contextType : null}
       contextId={startCustomerCompose ? contextId : null}
       customerId={startCustomerCompose ? customerId : null}
     />

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -8,7 +8,14 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { format } from "date-fns";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
-import { BrainCircuit, Clock3, ListChecks, Plus, ReceiptText } from "lucide-react";
+import {
+  BrainCircuit,
+  Clock3,
+  ListChecks,
+  MessageSquareText,
+  Plus,
+  ReceiptText,
+} from "lucide-react";
 
 import { supabaseBrowser as supabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
@@ -56,9 +63,19 @@ import {
   createAssignTechnicianOperationKey,
 } from "@/features/work-orders/lib/assignTechnicianClient";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { isCustomerMessagingRole } from "@/features/ai/lib/chat/authorization";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 import { WORKSPACE_CAPABILITIES } from "@/features/workspace/authorization/capabilities";
 import { useWorkspaceCapabilities } from "@/features/workspace/authorization/useWorkspaceCapabilities";
+import { usePublishWorkspaceResourceContext } from "@/features/workspace/context/WorkspaceResourceContext";
+import {
+  WorkOrderWorkspaceCommandBar,
+  WorkOrderWorkspaceModule,
+} from "@/features/work-orders/workspace/WorkOrderWorkspaceFrame";
+import {
+  createWorkOrderWorkspaceResource,
+  workOrderWorkspaceCustomerMessageHref,
+} from "@/features/work-orders/workspace/workOrderWorkspace";
 
 import { prepareSectionsWithCornerGrid } from "@inspections/lib/inspection/prepareSectionsWithCornerGrid";
 
@@ -305,6 +322,24 @@ export default function WorkOrderIdClient(): JSX.Element {
     () => formatWorkOrderHeaderStatus(wo?.status, wo?.payment_status),
     [wo?.payment_status, wo?.status],
   );
+  const workspaceResource = useMemo(
+    () =>
+      createWorkOrderWorkspaceResource({
+        shopId: wo?.shop_id,
+        workOrderId: wo?.id,
+        customerId: customer?.id ?? wo?.customer_id,
+        vehicleId: vehicle?.id ?? wo?.vehicle_id,
+      }),
+    [
+      customer?.id,
+      vehicle?.id,
+      wo?.customer_id,
+      wo?.id,
+      wo?.shop_id,
+      wo?.vehicle_id,
+    ],
+  );
+  usePublishWorkspaceResourceContext(workspaceResource);
 
   useEffect(() => {
     if (!wo?.id || !shouldUseReadOnlyWorkOrderView(wo.payment_status)) return;
@@ -1192,6 +1227,11 @@ export default function WorkOrderIdClient(): JSX.Element {
   const canApprove = currentActor.canAuthorizeQuotes;
   const canRequestParts = currentActor.canManageWorkOrders;
   const canUseInventoryPicker = currentActor.canManageParts;
+  const canMessageCustomer = isCustomerMessagingRole(currentUserRole);
+  const messageCustomerHref = workOrderWorkspaceCustomerMessageHref({
+    workOrderId: wo?.id,
+    customerId: customer?.id ?? wo?.customer_id,
+  });
 
   const canDeleteLine = currentUserRole ? LINE_DELETE_ROLES.has(currentUserRole) : false;
 
@@ -1642,7 +1682,10 @@ export default function WorkOrderIdClient(): JSX.Element {
           <div className="mt-2 text-sm text-red-400">Work order not found.</div>
         ) : (
           <div className={cn("space-y-2", supportFullyCollapsed && "space-y-1.5")}>
-            <section className="overflow-hidden rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 shadow-[0_14px_36px_rgba(15,23,42,0.08)] sm:px-4">
+            <WorkOrderWorkspaceModule
+              module="statusCommand"
+              className="overflow-hidden rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 shadow-[0_14px_36px_rgba(15,23,42,0.08)] sm:px-4"
+            >
               <div className="flex flex-wrap items-center gap-2">
                 <PreviousPageButton />
                 <div className="text-sm font-semibold text-foreground">
@@ -1676,7 +1719,9 @@ export default function WorkOrderIdClient(): JSX.Element {
                   <span className="rounded-full border border-sky-400/30 bg-sky-500/10 px-2 py-0.5 text-sky-200">Approval queue: {approvalPending.length + approvalPendingQuotes.length}</span>
                 ) : null}
               </div>
-              <div className="mt-3 flex flex-wrap items-center gap-1 border-t border-[color:var(--theme-border-soft)] pt-2">
+              <WorkOrderWorkspaceCommandBar
+                className="mt-3 gap-1 border-t border-[color:var(--theme-border-soft)] pt-2"
+              >
                 <button
                   type="button"
                   onClick={() => setShowWoContext((prev) => !prev)}
@@ -1716,12 +1761,22 @@ export default function WorkOrderIdClient(): JSX.Element {
                   <Clock3 className="h-3.5 w-3.5" />
                   Activity
                 </button>
+                {canMessageCustomer && messageCustomerHref ? (
+                  <Link
+                    href={messageCustomerHref}
+                    data-workspace-module-action="communication"
+                    className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--theme-text-secondary)] transition hover:bg-[color:var(--theme-surface-subtle)] hover:text-[color:var(--theme-text-primary)]"
+                  >
+                    <MessageSquareText className="h-3.5 w-3.5" />
+                    Message
+                  </Link>
+                ) : null}
                 <span className="ml-auto inline-flex items-center gap-2 font-mono text-[11px] font-semibold text-[color:var(--theme-text-primary)]">
                   <ListChecks className="h-3.5 w-3.5 text-[color:var(--theme-text-secondary)]" />
                   {sortedLines.length} jobs · {formatCurrency(workOrderTotal)}
                 </span>
-              </div>
-            </section>
+              </WorkOrderWorkspaceCommandBar>
+            </WorkOrderWorkspaceModule>
 
             {loading ? (
               <div className="rounded-lg border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs text-muted-foreground">
@@ -1861,27 +1916,32 @@ export default function WorkOrderIdClient(): JSX.Element {
                       </>
                     )}
                   </div>
-                  <section
-                className={cn(
-                  PANEL_VARIANTS.secondary,
-                  "p-2",
-                  hasAnyApprovalItems ? "cursor-pointer hover:border-sky-400/35" : "",
-                )}
-                onClick={hasAnyApprovalItems ? openQuoteReview : undefined}
-                role={hasAnyApprovalItems ? "button" : undefined}
-                tabIndex={hasAnyApprovalItems ? 0 : undefined}
-                onKeyDown={
-                  hasAnyApprovalItems
-                    ? (e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          openQuoteReview();
-                        }
-                      }
-                    : undefined
-                }
-                aria-label={hasAnyApprovalItems ? "Open quote review" : undefined}
-              >
+                  <WorkOrderWorkspaceModule
+                    module="estimateApproval"
+                    className={cn(
+                      PANEL_VARIANTS.secondary,
+                      "p-2",
+                      hasAnyApprovalItems
+                        ? "cursor-pointer hover:border-sky-400/35"
+                        : "",
+                    )}
+                    onClick={hasAnyApprovalItems ? openQuoteReview : undefined}
+                    role={hasAnyApprovalItems ? "button" : undefined}
+                    tabIndex={hasAnyApprovalItems ? 0 : undefined}
+                    onKeyDown={
+                      hasAnyApprovalItems
+                        ? (e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              openQuoteReview();
+                            }
+                          }
+                        : undefined
+                    }
+                    aria-label={
+                      hasAnyApprovalItems ? "Open quote review" : undefined
+                    }
+                  >
               <div className="mb-2 flex items-center justify-between gap-2">
                 <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                   Approval queue
@@ -2044,8 +2104,11 @@ export default function WorkOrderIdClient(): JSX.Element {
                   {approvalPending.length + approvalPendingQuotes.length} item(s) awaiting decision.
                 </div>
               )}
-                  </section>
-                  <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
+                  </WorkOrderWorkspaceModule>
+                  <WorkOrderWorkspaceModule
+                    module="timeline"
+                    className={cn(PANEL_VARIANTS.secondary, "p-2")}
+                  >
                 <button
                   type="button"
                   className="flex w-full items-center justify-between gap-2 text-left"
@@ -2086,13 +2149,16 @@ export default function WorkOrderIdClient(): JSX.Element {
                     Recent decision history is available when needed.
                   </p>
                 )}
-                  </section>
+                  </WorkOrderWorkspaceModule>
                 </div>
               )}
             </section>
 
           {/* Full-height cockpit: navigate left, work center, act right. */}
-          <section className="grid items-start gap-2 rounded-[24px] border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] p-2 shadow-[0_20px_55px_rgba(15,23,42,0.1)] lg:grid-cols-[17rem_minmax(0,1fr)]">
+          <WorkOrderWorkspaceModule
+            module="repairLines"
+            className="grid items-start gap-2 rounded-[24px] border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] p-2 shadow-[0_20px_55px_rgba(15,23,42,0.1)] lg:grid-cols-[17rem_minmax(0,1fr)]"
+          >
             <aside className="flex min-h-0 flex-col overflow-hidden rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[0_16px_42px_rgba(15,23,42,0.08)]">
               <div className="flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] px-3 py-3">
                 <div>
@@ -2363,7 +2429,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                 </section>
               )}
             </div>
-          </section>
+          </WorkOrderWorkspaceModule>
 
           {latestDecisionEvent ? (
             <button

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1231,6 +1231,9 @@ export default function WorkOrderIdClient(): JSX.Element {
   const messageCustomerHref = workOrderWorkspaceCustomerMessageHref({
     workOrderId: wo?.id,
     customerId: customer?.id ?? wo?.customer_id,
+    customerActive: customer?.active,
+    customerArchivedAt: customer?.archived_at,
+    customerMergedIntoCustomerId: customer?.merged_into_customer_id,
   });
 
   const canDeleteLine = currentUserRole ? LINE_DELETE_ROLES.has(currentUserRole) : false;

--- a/app/work-orders/[id]/page.tsx
+++ b/app/work-orders/[id]/page.tsx
@@ -1,5 +1,6 @@
 // app/work-orders/[id]/page.tsx
 import WorkOrderOperationalTimelineDock from "@/features/operations/components/WorkOrderOperationalTimelineDock";
+import { WorkOrderWorkspaceFrame } from "@/features/work-orders/workspace/WorkOrderWorkspaceFrame";
 import WorkOrderIdClient from "./Client";
 
 export const dynamic = "force-dynamic";
@@ -7,9 +8,9 @@ export const revalidate = 0;
 
 export default function Page() {
   return (
-    <>
+    <WorkOrderWorkspaceFrame>
       <WorkOrderIdClient />
       <WorkOrderOperationalTimelineDock />
-    </>
+    </WorkOrderWorkspaceFrame>
   );
 }

--- a/features/chat/components/ChatListClient.tsx
+++ b/features/chat/components/ChatListClient.tsx
@@ -7,12 +7,14 @@ import PageShell from "@/features/shared/components/PageShell";
 
 type ChatListClientProps = {
   startCustomerCompose: boolean;
+  contextType?: "vehicle" | "work_order" | null;
   contextId: string | null;
   customerId: string | null;
 };
 
 export default function ChatListClient({
   startCustomerCompose,
+  contextType = "vehicle",
   contextId,
   customerId,
 }: ChatListClientProps): JSX.Element {
@@ -21,13 +23,19 @@ export default function ChatListClient({
     () =>
       startCustomerCompose && contextId
         ? {
-            context_type: "vehicle",
+            context_type: contextType ?? "vehicle",
             context_id: contextId,
-            deep_link: `/vehicles/${contextId}`,
-            context_label: "Vehicle workspace",
+            deep_link:
+              contextType === "work_order"
+                ? `/work-orders/${contextId}`
+                : `/vehicles/${contextId}`,
+            context_label:
+              contextType === "work_order"
+                ? "Work order workspace"
+                : "Vehicle workspace",
           }
         : null,
-    [contextId, startCustomerCompose],
+    [contextId, contextType, startCustomerCompose],
   );
 
   return (

--- a/features/operations/components/WorkOrderOperationalTimelineDock.tsx
+++ b/features/operations/components/WorkOrderOperationalTimelineDock.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { getOperationalEventPresentation } from "@/features/operations/lib/eventPresentation";
 import { canonicalizeRole } from "@/features/shared/lib/rbac";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { useWorkspaceResourceContext } from "@/features/workspace/context/WorkspaceResourceContext";
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const ALLOWED_ROLES = new Set(["owner", "admin", "manager"]);
@@ -54,6 +55,11 @@ function severityDot(value: EventItem["severity"]): string {
 export default function WorkOrderOperationalTimelineDock() {
   const params = useParams();
   const routeId = String(params?.id ?? "").trim();
+  const workspaceResource = useWorkspaceResourceContext();
+  const workspaceWorkOrderId =
+    workspaceResource?.kind === "work_order"
+      ? (workspaceResource.workOrderId ?? workspaceResource.resourceId)
+      : null;
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [eligible, setEligible] = useState(false);
   const [workOrderId, setWorkOrderId] = useState<string | null>(null);
@@ -102,6 +108,12 @@ export default function WorkOrderOperationalTimelineDock() {
       cancelled = true;
     };
   }, [routeId, supabase]);
+
+  useEffect(() => {
+    if (workspaceWorkOrderId && UUID_PATTERN.test(workspaceWorkOrderId)) {
+      setWorkOrderId(workspaceWorkOrderId);
+    }
+  }, [workspaceWorkOrderId]);
 
   const load = useCallback(async () => {
     if (!workOrderId) return;

--- a/features/operations/components/WorkOrderOperationalTimelineDock.tsx
+++ b/features/operations/components/WorkOrderOperationalTimelineDock.tsx
@@ -60,9 +60,17 @@ export default function WorkOrderOperationalTimelineDock() {
     workspaceResource?.kind === "work_order"
       ? (workspaceResource.workOrderId ?? workspaceResource.resourceId)
       : null;
+  const canonicalWorkspaceWorkOrderId =
+    workspaceWorkOrderId && UUID_PATTERN.test(workspaceWorkOrderId)
+      ? workspaceWorkOrderId
+      : null;
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [eligible, setEligible] = useState(false);
-  const [workOrderId, setWorkOrderId] = useState<string | null>(null);
+  const [routeResolvedWorkOrderId, setRouteResolvedWorkOrderId] = useState<
+    string | null
+  >(null);
+  const workOrderId =
+    canonicalWorkspaceWorkOrderId ?? routeResolvedWorkOrderId;
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [events, setEvents] = useState<EventItem[]>([]);
@@ -88,12 +96,32 @@ export default function WorkOrderOperationalTimelineDock() {
       const role = canonicalizeRole(profile?.role);
       if (!ALLOWED_ROLES.has(role) || cancelled) return;
       setEligible(true);
+    })();
 
-      if (UUID_PATTERN.test(routeId)) {
-        setWorkOrderId(routeId);
-        return;
-      }
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!eligible || canonicalWorkspaceWorkOrderId) {
+      setRouteResolvedWorkOrderId(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    if (UUID_PATTERN.test(routeId)) {
+      setRouteResolvedWorkOrderId(routeId);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setRouteResolvedWorkOrderId(null);
+    void (async () => {
       const { data: workOrder } = await supabase
         .from("work_orders")
         .select("id")
@@ -101,19 +129,15 @@ export default function WorkOrderOperationalTimelineDock() {
         .limit(1)
         .maybeSingle();
 
-      if (!cancelled) setWorkOrderId(workOrder?.id ?? null);
+      if (!cancelled) {
+        setRouteResolvedWorkOrderId(workOrder?.id ?? null);
+      }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [routeId, supabase]);
-
-  useEffect(() => {
-    if (workspaceWorkOrderId && UUID_PATTERN.test(workspaceWorkOrderId)) {
-      setWorkOrderId(workspaceWorkOrderId);
-    }
-  }, [workspaceWorkOrderId]);
+  }, [canonicalWorkspaceWorkOrderId, eligible, routeId, supabase]);
 
   const load = useCallback(async () => {
     if (!workOrderId) return;

--- a/features/work-orders/workspace/WorkOrderWorkspaceFrame.tsx
+++ b/features/work-orders/workspace/WorkOrderWorkspaceFrame.tsx
@@ -22,9 +22,7 @@ export function WorkOrderWorkspaceFrame({
 
   return (
     <WorkspaceResourceProvider key={routeId}>
-      <WorkspaceShell className="mx-0 max-w-none gap-0 px-0 py-0">
-        {children}
-      </WorkspaceShell>
+      <WorkspaceShell layout="embedded">{children}</WorkspaceShell>
     </WorkspaceResourceProvider>
   );
 }

--- a/features/work-orders/workspace/WorkOrderWorkspaceFrame.tsx
+++ b/features/work-orders/workspace/WorkOrderWorkspaceFrame.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { useParams } from "next/navigation";
+
+import { WorkspaceCommandBar } from "@/features/workspace/components/WorkspaceCommandBar";
+import { WorkspaceShell } from "@/features/workspace/components/WorkspaceShell";
+import { WorkspaceResourceProvider } from "@/features/workspace/context/WorkspaceResourceContext";
+import { cn } from "@/features/shared/lib/utils";
+import {
+  WORK_ORDER_WORKSPACE_MODULES,
+  type WorkOrderWorkspaceModuleKey,
+} from "@/features/work-orders/workspace/workOrderWorkspace";
+
+export function WorkOrderWorkspaceFrame({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const params = useParams<{ id: string }>();
+  const routeId = params?.id ?? "work-order";
+
+  return (
+    <WorkspaceResourceProvider key={routeId}>
+      <WorkspaceShell className="mx-0 max-w-none gap-0 px-0 py-0">
+        {children}
+      </WorkspaceShell>
+    </WorkspaceResourceProvider>
+  );
+}
+
+export type WorkOrderWorkspaceModuleProps = Omit<
+  ComponentPropsWithoutRef<"section">,
+  "id"
+> & {
+  module: WorkOrderWorkspaceModuleKey;
+  id?: string;
+};
+
+export function WorkOrderWorkspaceModule({
+  module,
+  id,
+  "aria-label": ariaLabel,
+  ...props
+}: WorkOrderWorkspaceModuleProps) {
+  const definition = WORK_ORDER_WORKSPACE_MODULES[module];
+  return (
+    <section
+      {...props}
+      id={id ?? definition.anchorId}
+      aria-label={ariaLabel ?? definition.label}
+      data-workspace-module={module}
+    />
+  );
+}
+
+export function WorkOrderWorkspaceCommandBar({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <WorkspaceCommandBar
+      ariaLabel="Work order actions"
+      className={cn("items-center", className)}
+    >
+      {children}
+    </WorkspaceCommandBar>
+  );
+}

--- a/features/work-orders/workspace/workOrderWorkspace.ts
+++ b/features/work-orders/workspace/workOrderWorkspace.ts
@@ -75,13 +75,25 @@ export function createWorkOrderWorkspaceResource({
 export function workOrderWorkspaceCustomerMessageHref({
   workOrderId,
   customerId,
-}: Pick<
-  WorkOrderWorkspaceResourceInput,
-  "workOrderId" | "customerId"
->): string | null {
+  customerActive,
+  customerArchivedAt = null,
+  customerMergedIntoCustomerId = null,
+}: Pick<WorkOrderWorkspaceResourceInput, "workOrderId" | "customerId"> & {
+  customerActive: boolean | null | undefined;
+  customerArchivedAt?: string | null;
+  customerMergedIntoCustomerId?: string | null;
+}): string | null {
   const canonicalWorkOrderId = workOrderId?.trim() ?? "";
   const canonicalCustomerId = customerId?.trim() ?? "";
-  if (!canonicalWorkOrderId || !canonicalCustomerId) return null;
+  if (
+    !canonicalWorkOrderId ||
+    !canonicalCustomerId ||
+    customerActive !== true ||
+    Boolean(customerArchivedAt?.trim()) ||
+    Boolean(customerMergedIntoCustomerId?.trim())
+  ) {
+    return null;
+  }
 
   const handoff = new URLSearchParams({
     compose: "customer",

--- a/features/work-orders/workspace/workOrderWorkspace.ts
+++ b/features/work-orders/workspace/workOrderWorkspace.ts
@@ -1,0 +1,93 @@
+import type { WorkspaceResourceContext } from "@/features/workspace/lib/workspace";
+
+export const WORK_ORDER_WORKSPACE_MODULES = {
+  statusCommand: {
+    anchorId: "work-order-workspace-command",
+    label: "Work order status and commands",
+  },
+  repairLines: {
+    anchorId: "work-order-workspace-repair-lines",
+    label: "Repair lines",
+  },
+  inspection: {
+    anchorId: "work-order-workspace-inspection",
+    label: "Inspection",
+  },
+  parts: {
+    anchorId: "work-order-workspace-parts",
+    label: "Parts",
+  },
+  estimateApproval: {
+    anchorId: "work-order-workspace-estimate-approval",
+    label: "Estimate and approval",
+  },
+  communication: {
+    anchorId: "work-order-workspace-communication",
+    label: "Communication",
+  },
+  documents: {
+    anchorId: "work-order-workspace-documents",
+    label: "Documents",
+  },
+  financials: {
+    anchorId: "work-order-workspace-financials",
+    label: "Financials",
+  },
+  timeline: {
+    anchorId: "work-order-workspace-timeline",
+    label: "Timeline",
+  },
+} as const;
+
+export type WorkOrderWorkspaceModuleKey =
+  keyof typeof WORK_ORDER_WORKSPACE_MODULES;
+
+export type WorkOrderWorkspaceResourceInput = {
+  shopId: string | null | undefined;
+  workOrderId: string | null | undefined;
+  customerId?: string | null;
+  vehicleId?: string | null;
+  locationId?: string | null;
+};
+
+export function createWorkOrderWorkspaceResource({
+  shopId,
+  workOrderId,
+  customerId = null,
+  vehicleId = null,
+  locationId = null,
+}: WorkOrderWorkspaceResourceInput): WorkspaceResourceContext | null {
+  const canonicalShopId = shopId?.trim() ?? "";
+  const canonicalWorkOrderId = workOrderId?.trim() ?? "";
+  if (!canonicalShopId || !canonicalWorkOrderId) return null;
+
+  return {
+    kind: "work_order",
+    shopId: canonicalShopId,
+    resourceId: canonicalWorkOrderId,
+    workOrderId: canonicalWorkOrderId,
+    customerId: customerId?.trim() || null,
+    vehicleId: vehicleId?.trim() || null,
+    locationId: locationId?.trim() || null,
+  };
+}
+
+export function workOrderWorkspaceCustomerMessageHref({
+  workOrderId,
+  customerId,
+}: Pick<
+  WorkOrderWorkspaceResourceInput,
+  "workOrderId" | "customerId"
+>): string | null {
+  const canonicalWorkOrderId = workOrderId?.trim() ?? "";
+  const canonicalCustomerId = customerId?.trim() ?? "";
+  if (!canonicalWorkOrderId || !canonicalCustomerId) return null;
+
+  const handoff = new URLSearchParams({
+    compose: "customer",
+    contextType: "work_order",
+    contextId: canonicalWorkOrderId,
+    customerId: canonicalCustomerId,
+  });
+  return `/chat?${handoff.toString()}`;
+}

--- a/features/workspace/components/WorkspaceShell.tsx
+++ b/features/workspace/components/WorkspaceShell.tsx
@@ -5,16 +5,21 @@ import { cn } from "@/features/shared/lib/utils";
 export type WorkspaceShellProps = {
   children: ReactNode;
   className?: string;
+  layout?: "contained" | "embedded";
 };
 
 export function WorkspaceShell({
   children,
   className,
+  layout = "contained",
 }: WorkspaceShellProps) {
   return (
     <main
       className={cn(
-        "mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 py-4 text-[color:var(--theme-text-primary)] sm:px-6 sm:py-6 lg:px-8",
+        "flex w-full flex-col text-[color:var(--theme-text-primary)]",
+        layout === "contained"
+          ? "mx-auto max-w-7xl gap-5 px-4 py-4 sm:px-6 sm:py-6 lg:px-8"
+          : "mx-0 max-w-none gap-0 p-0",
         className,
       )}
     >

--- a/features/workspace/context/WorkspaceResourceContext.tsx
+++ b/features/workspace/context/WorkspaceResourceContext.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+import type { WorkspaceResourceContext } from "@/features/workspace/lib/workspace";
+
+const WorkspaceResourceValueContext =
+  createContext<WorkspaceResourceContext | null>(null);
+const WorkspaceResourcePublisherContext = createContext<
+  Dispatch<SetStateAction<WorkspaceResourceContext | null>> | null
+>(null);
+
+export type WorkspaceResourceProviderProps = {
+  children: ReactNode;
+  initialResource?: WorkspaceResourceContext | null;
+};
+
+/**
+ * Shares canonical resource identity across independently mounted workspace
+ * modules. Authorization remains owned by the effective capability resolver;
+ * this client context is not a security boundary.
+ */
+export function WorkspaceResourceProvider({
+  children,
+  initialResource = null,
+}: WorkspaceResourceProviderProps) {
+  const [resource, setResource] =
+    useState<WorkspaceResourceContext | null>(initialResource);
+
+  return (
+    <WorkspaceResourcePublisherContext.Provider value={setResource}>
+      <WorkspaceResourceValueContext.Provider value={resource}>
+        {children}
+      </WorkspaceResourceValueContext.Provider>
+    </WorkspaceResourcePublisherContext.Provider>
+  );
+}
+
+export function useWorkspaceResourceContext(): WorkspaceResourceContext | null {
+  return useContext(WorkspaceResourceValueContext);
+}
+
+/**
+ * Publishes the RLS-authorized resource loaded by a workspace screen. It is a
+ * no-op outside a WorkspaceResourceProvider so isolated component previews and
+ * tests keep working.
+ */
+export function usePublishWorkspaceResourceContext(
+  resource: WorkspaceResourceContext | null,
+): void {
+  const publish = useContext(WorkspaceResourcePublisherContext);
+
+  useEffect(() => {
+    publish?.(resource);
+  }, [publish, resource]);
+
+  useEffect(
+    () => () => {
+      publish?.(null);
+    },
+    [publish],
+  );
+}

--- a/tests/work-order-operational-timeline-dock.test.ts
+++ b/tests/work-order-operational-timeline-dock.test.ts
@@ -17,6 +17,16 @@ describe("work-order operational timeline", () => {
     expect(dock).toContain("Latest ${relativeTime(events[0].occurred_at)}");
   });
 
+  it("keeps the canonical Workspace UUID authoritative over route fallback", () => {
+    expect(dock).toContain(
+      "canonicalWorkspaceWorkOrderId ?? routeResolvedWorkOrderId",
+    );
+    expect(dock).toContain(
+      "if (!eligible || canonicalWorkspaceWorkOrderId)",
+    );
+    expect(dock).not.toContain("setWorkOrderId(workOrder?.id ?? null)");
+  });
+
   it("does not discard older events from an explicitly filtered timeline", () => {
     expect(server).toContain("if (!hasOperationalEventFilter(input))");
     expect(server).toContain('eventsQuery = eventsQuery.gte("occurred_at", since7d)');

--- a/tests/work-order-workspace-foundation.test.tsx
+++ b/tests/work-order-workspace-foundation.test.tsx
@@ -13,6 +13,7 @@ import {
   createWorkOrderWorkspaceResource,
   workOrderWorkspaceCustomerMessageHref,
 } from "@/features/work-orders/workspace/workOrderWorkspace";
+import { WorkspaceShell } from "@/features/workspace/components/WorkspaceShell";
 import {
   usePublishWorkspaceResourceContext,
   useWorkspaceResourceContext,
@@ -65,6 +66,23 @@ function ResourceConsumer() {
 }
 
 describe("Work Order Workspace foundation", () => {
+  it("embeds the existing cockpit without contained-shell spacing", () => {
+    render(<WorkspaceShell layout="embedded">Existing cockpit</WorkspaceShell>);
+
+    const shell = screen.getByRole("main");
+    expect(shell).toHaveClass("mx-0", "max-w-none", "gap-0", "p-0");
+    expect(shell).not.toHaveClass(
+      "mx-auto",
+      "max-w-7xl",
+      "gap-5",
+      "px-4",
+      "py-4",
+      "sm:px-6",
+      "sm:py-6",
+      "lg:px-8",
+    );
+  });
+
   it("publishes the canonical Work Order identity to sibling workspace modules", async () => {
     expect(resource).toEqual({
       kind: "work_order",

--- a/tests/work-order-workspace-foundation.test.tsx
+++ b/tests/work-order-workspace-foundation.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import ChatListPage from "@/app/chat/page";
+import ChatListPage from "../app/chat/page";
 import ChatListClient from "@/features/chat/components/ChatListClient";
 import {
   WorkOrderWorkspaceCommandBar,

--- a/tests/work-order-workspace-foundation.test.tsx
+++ b/tests/work-order-workspace-foundation.test.tsx
@@ -1,0 +1,196 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import ChatListPage from "@/app/chat/page";
+import ChatListClient from "@/features/chat/components/ChatListClient";
+import {
+  WorkOrderWorkspaceCommandBar,
+  WorkOrderWorkspaceModule,
+} from "@/features/work-orders/workspace/WorkOrderWorkspaceFrame";
+import {
+  WORK_ORDER_WORKSPACE_MODULES,
+  createWorkOrderWorkspaceResource,
+  workOrderWorkspaceCustomerMessageHref,
+} from "@/features/work-orders/workspace/workOrderWorkspace";
+import {
+  usePublishWorkspaceResourceContext,
+  useWorkspaceResourceContext,
+  WorkspaceResourceProvider,
+} from "@/features/workspace/context/WorkspaceResourceContext";
+import type { WorkspaceResourceContext } from "@/features/workspace/lib/workspace";
+
+vi.mock("@/features/shared/components/PageShell", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/features/chat/components/InboxModal", () => ({
+  default: ({
+    contextOverride,
+  }: {
+    contextOverride: {
+      context_type: string | null;
+      context_id: string | null;
+      deep_link: string | null;
+      context_label: string;
+    } | null;
+  }) => (
+    <output data-testid="compose-context">
+      {contextOverride ? JSON.stringify(contextOverride) : "none"}
+    </output>
+  ),
+}));
+
+afterEach(() => cleanup());
+
+const resource = createWorkOrderWorkspaceResource({
+  shopId: "shop-1",
+  workOrderId: "wo-1",
+  customerId: "customer-1",
+  vehicleId: "vehicle-1",
+});
+
+function ResourcePublisher({
+  value,
+}: {
+  value: WorkspaceResourceContext | null;
+}) {
+  usePublishWorkspaceResourceContext(value);
+  return null;
+}
+
+function ResourceConsumer() {
+  const value = useWorkspaceResourceContext();
+  return <output data-testid="workspace-resource">{value?.resourceId ?? "none"}</output>;
+}
+
+describe("Work Order Workspace foundation", () => {
+  it("publishes the canonical Work Order identity to sibling workspace modules", async () => {
+    expect(resource).toEqual({
+      kind: "work_order",
+      shopId: "shop-1",
+      resourceId: "wo-1",
+      workOrderId: "wo-1",
+      customerId: "customer-1",
+      vehicleId: "vehicle-1",
+      locationId: null,
+    });
+
+    const view = render(
+      <WorkspaceResourceProvider>
+        <ResourcePublisher value={resource} />
+        <ResourceConsumer />
+      </WorkspaceResourceProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("workspace-resource")).toHaveTextContent("wo-1"),
+    );
+
+    view.rerender(
+      <WorkspaceResourceProvider>
+        <ResourcePublisher value={null} />
+        <ResourceConsumer />
+      </WorkspaceResourceProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("workspace-resource")).toHaveTextContent("none"),
+    );
+  });
+
+  it("keeps existing Work Order UI inside semantic module boundaries", () => {
+    render(
+      <WorkOrderWorkspaceModule module="repairLines">
+        <WorkOrderWorkspaceCommandBar>
+          <button type="button">Existing action</button>
+        </WorkOrderWorkspaceCommandBar>
+      </WorkOrderWorkspaceModule>,
+    );
+
+    const module = screen.getByLabelText("Repair lines");
+    expect(module).toHaveAttribute(
+      "id",
+      WORK_ORDER_WORKSPACE_MODULES.repairLines.anchorId,
+    );
+    expect(module).toHaveAttribute("data-workspace-module", "repairLines");
+    expect(screen.getByRole("navigation", { name: "Work order actions" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Existing action" })).toBeVisible();
+  });
+
+  it("builds a customer message handoff anchored to the canonical Work Order", () => {
+    expect(
+      workOrderWorkspaceCustomerMessageHref({
+        workOrderId: "11111111-1111-4111-8111-111111111111",
+        customerId: "22222222-2222-4222-8222-222222222222",
+      }),
+    ).toBe(
+      "/chat?compose=customer&contextType=work_order&contextId=11111111-1111-4111-8111-111111111111&customerId=22222222-2222-4222-8222-222222222222",
+    );
+    expect(
+      workOrderWorkspaceCustomerMessageHref({
+        workOrderId: "11111111-1111-4111-8111-111111111111",
+        customerId: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts the Work Order compose handoff while preserving Vehicle compose", async () => {
+    const workOrderPage = await ChatListPage({
+      searchParams: Promise.resolve({
+        compose: "customer",
+        contextType: "work_order",
+        contextId: "11111111-1111-4111-8111-111111111111",
+        customerId: "22222222-2222-4222-8222-222222222222",
+      }),
+    });
+    expect(workOrderPage.props).toMatchObject({
+      startCustomerCompose: true,
+      contextType: "work_order",
+      contextId: "11111111-1111-4111-8111-111111111111",
+      customerId: "22222222-2222-4222-8222-222222222222",
+    });
+
+    const unsupportedContextPage = await ChatListPage({
+      searchParams: Promise.resolve({
+        compose: "customer",
+        contextType: "inspection",
+        contextId: "11111111-1111-4111-8111-111111111111",
+        customerId: "22222222-2222-4222-8222-222222222222",
+      }),
+    });
+    expect(unsupportedContextPage.props).toMatchObject({
+      startCustomerCompose: false,
+      contextType: null,
+      contextId: null,
+      customerId: null,
+    });
+
+    render(
+      <ChatListClient
+        startCustomerCompose
+        contextType="work_order"
+        contextId="11111111-1111-4111-8111-111111111111"
+        customerId="22222222-2222-4222-8222-222222222222"
+      />,
+    );
+    expect(screen.getByTestId("compose-context")).toHaveTextContent(
+      '"context_type":"work_order"',
+    );
+    expect(screen.getByTestId("compose-context")).toHaveTextContent(
+      '"deep_link":"/work-orders/11111111-1111-4111-8111-111111111111"',
+    );
+
+    cleanup();
+    render(
+      <ChatListClient
+        startCustomerCompose
+        contextId="33333333-3333-4333-8333-333333333333"
+        customerId="22222222-2222-4222-8222-222222222222"
+      />,
+    );
+    expect(screen.getByTestId("compose-context")).toHaveTextContent(
+      '"context_type":"vehicle"',
+    );
+  });
+});

--- a/tests/work-order-workspace-foundation.test.tsx
+++ b/tests/work-order-workspace-foundation.test.tsx
@@ -108,12 +108,15 @@ describe("Work Order Workspace foundation", () => {
       </WorkOrderWorkspaceModule>,
     );
 
-    const module = screen.getByLabelText("Repair lines");
-    expect(module).toHaveAttribute(
+    const moduleBoundary = screen.getByLabelText("Repair lines");
+    expect(moduleBoundary).toHaveAttribute(
       "id",
       WORK_ORDER_WORKSPACE_MODULES.repairLines.anchorId,
     );
-    expect(module).toHaveAttribute("data-workspace-module", "repairLines");
+    expect(moduleBoundary).toHaveAttribute(
+      "data-workspace-module",
+      "repairLines",
+    );
     expect(screen.getByRole("navigation", { name: "Work order actions" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Existing action" })).toBeVisible();
   });

--- a/tests/work-order-workspace-foundation.test.tsx
+++ b/tests/work-order-workspace-foundation.test.tsx
@@ -144,6 +144,7 @@ describe("Work Order Workspace foundation", () => {
       workOrderWorkspaceCustomerMessageHref({
         workOrderId: "11111111-1111-4111-8111-111111111111",
         customerId: "22222222-2222-4222-8222-222222222222",
+        customerActive: true,
       }),
     ).toBe(
       "/chat?compose=customer&contextType=work_order&contextId=11111111-1111-4111-8111-111111111111&customerId=22222222-2222-4222-8222-222222222222",
@@ -152,6 +153,36 @@ describe("Work Order Workspace foundation", () => {
       workOrderWorkspaceCustomerMessageHref({
         workOrderId: "11111111-1111-4111-8111-111111111111",
         customerId: null,
+        customerActive: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("suppresses customer messaging for inactive, archived, or merged accounts", () => {
+    const input = {
+      workOrderId: "11111111-1111-4111-8111-111111111111",
+      customerId: "22222222-2222-4222-8222-222222222222",
+    };
+
+    expect(
+      workOrderWorkspaceCustomerMessageHref({
+        ...input,
+        customerActive: false,
+      }),
+    ).toBeNull();
+    expect(
+      workOrderWorkspaceCustomerMessageHref({
+        ...input,
+        customerActive: true,
+        customerArchivedAt: "2026-08-20T00:00:00.000Z",
+      }),
+    ).toBeNull();
+    expect(
+      workOrderWorkspaceCustomerMessageHref({
+        ...input,
+        customerActive: true,
+        customerMergedIntoCustomerId:
+          "33333333-3333-4333-8333-333333333333",
       }),
     ).toBeNull();
   });


### PR DESCRIPTION
## Summary

Begins Phase 3 by making the existing canonical `/work-orders/[id]` cockpit the second consumer of the shared Workspace Platform without redesigning or replacing its technician workflow.

- adds a route-keyed shared Work Order resource context for sibling Workspace modules
- wraps the existing page in the shared Workspace shell through an explicit spacing-free embedded layout
- adds semantic module boundaries for status/commands, repair lines, estimate/approval, and timeline
- publishes the RLS-loaded canonical shop, work-order, customer, and vehicle identity
- makes that canonical Work Order UUID authoritative over route-alias fallback resolution
- lets the existing operational timeline consume the canonical Work Order identity
- adds a role-gated Message action using the existing `work_order` conversation context
- blocks the Message handoff for unloaded, inactive, archived, or merged customer accounts
- preserves the existing Vehicle compose handoff as the Chat page default
- records the future module registry (inspection, Parts, communication, documents, financials) without duplicating existing operational logic

## Preserved behavior

- `/work-orders/[id]` remains the canonical Work Order screen.
- Existing status, repair-line, inspection, Parts, punch, assignment, approval, focused-job, and timeline handlers are unchanged.
- Existing Work Order ID layout, mobile modal fallback, and desktop cockpit remain intact.
- Existing authorization remains authoritative; the client Workspace context is explicitly not a security boundary.
- Existing contained Workspace shells retain their current spacing; only the embedded Work Order frame is spacing-free.
- Vehicle Workspace messaging continues to resolve to `vehicle` context when no explicit context type is supplied.
- The merged Parts pick hardening files are incorporated from current `main` without overlap.

## Review fixes

- responsive Workspace shell spacing no longer alters the tablet/desktop cockpit
- canonical Workspace UUID cannot be overwritten by a slower route-alias lookup
- inactive, archived, and merged customer accounts cannot start a Work Order message handoff

All three originating Codex threads are outdated on the current head. No review replies or thread-resolution actions were posted.

## Validation

Exact head `0074c334`:
- full-app regression inventory build, summary, and artifact upload passed
- TypeScript passed
- changed-file ESLint passed
- complete test suite passed
- production application build passed
- regression inventory enforcement was skipped because the PR is Draft
- unrelated Mobile Dispatch, Operational Observability, and Universal Scheduler workflows skipped as designed
- `git diff --check` passed locally
- exact updated GitHub blob hashes match the local committed files
- branch is zero commits behind current `main` and mergeable

## Database/deployment

- no migration
- no production database write
- no Vercel configuration change
- non-main preview deployments remain disabled
