### PR TITLE
Bootstrap trusted Work Order workspace context

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -67,13 +67,17 @@ import { isCustomerMessagingRole } from "@/features/ai/lib/chat/authorization";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 import { WORKSPACE_CAPABILITIES } from "@/features/workspace/authorization/capabilities";
 import { useWorkspaceCapabilities } from "@/features/workspace/authorization/useWorkspaceCapabilities";
-import { usePublishWorkspaceResourceContext } from "@/features/workspace/context/WorkspaceResourceContext";
+import {
+  usePublishWorkspaceResourceContext,
+  useWorkspaceResourceContext,
+} from "@/features/workspace/context/WorkspaceResourceContext";
 import {
   WorkOrderWorkspaceCommandBar,
   WorkOrderWorkspaceModule,
 } from "@/features/work-orders/workspace/WorkOrderWorkspaceFrame";
 import {
   createWorkOrderWorkspaceResource,
+  resolveWorkOrderWorkspaceResource,
   workOrderWorkspaceCustomerMessageHref,
 } from "@/features/work-orders/workspace/workOrderWorkspace";
 
@@ -322,7 +326,7 @@ export default function WorkOrderIdClient(): JSX.Element {
     () => formatWorkOrderHeaderStatus(wo?.status, wo?.payment_status),
     [wo?.payment_status, wo?.status],
   );
-  const workspaceResource = useMemo(
+  const loadedWorkspaceResource = useMemo(
     () =>
       createWorkOrderWorkspaceResource({
         shopId: wo?.shop_id,
@@ -338,6 +342,15 @@ export default function WorkOrderIdClient(): JSX.Element {
       wo?.shop_id,
       wo?.vehicle_id,
     ],
+  );
+  const initialWorkspaceResource = useWorkspaceResourceContext();
+  const workspaceResource = useMemo(
+    () =>
+      resolveWorkOrderWorkspaceResource({
+        initialResource: initialWorkspaceResource,
+        loadedResource: loadedWorkspaceResource,
+      }),
+    [initialWorkspaceResource, loadedWorkspaceResource],
   );
   usePublishWorkspaceResourceContext(workspaceResource);
 

--- a/app/work-orders/[id]/page.tsx
+++ b/app/work-orders/[id]/page.tsx
@@ -1,14 +1,23 @@
 // app/work-orders/[id]/page.tsx
 import WorkOrderOperationalTimelineDock from "@/features/operations/components/WorkOrderOperationalTimelineDock";
 import { WorkOrderWorkspaceFrame } from "@/features/work-orders/workspace/WorkOrderWorkspaceFrame";
+import { loadCurrentWorkOrderWorkspaceSnapshot } from "@/features/work-orders/workspace/server/loadWorkOrderWorkspaceSnapshot";
 import WorkOrderIdClient from "./Client";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-export default function Page() {
+type WorkOrderWorkspacePageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function Page({ params }: WorkOrderWorkspacePageProps) {
+  const { id } = await params;
+  const initialWorkspaceSnapshot =
+    await loadCurrentWorkOrderWorkspaceSnapshot({ routeId: id });
+
   return (
-    <WorkOrderWorkspaceFrame>
+    <WorkOrderWorkspaceFrame initialResource={initialWorkspaceSnapshot?.resource}>
       <WorkOrderIdClient />
       <WorkOrderOperationalTimelineDock />
     </WorkOrderWorkspaceFrame>

--- a/features/work-orders/workspace/WorkOrderWorkspaceFrame.tsx
+++ b/features/work-orders/workspace/WorkOrderWorkspaceFrame.tsx
@@ -11,17 +11,20 @@ import {
   WORK_ORDER_WORKSPACE_MODULES,
   type WorkOrderWorkspaceModuleKey,
 } from "@/features/work-orders/workspace/workOrderWorkspace";
+import type { WorkspaceResourceContext } from "@/features/workspace/lib/workspace";
 
 export function WorkOrderWorkspaceFrame({
   children,
+  initialResource = null,
 }: {
   children: ReactNode;
+  initialResource?: WorkspaceResourceContext | null;
 }) {
   const params = useParams<{ id: string }>();
   const routeId = params?.id ?? "work-order";
 
   return (
-    <WorkspaceResourceProvider key={routeId}>
+    <WorkspaceResourceProvider key={routeId} initialResource={initialResource}>
       <WorkspaceShell layout="embedded">{children}</WorkspaceShell>
     </WorkspaceResourceProvider>
   );

--- a/features/work-orders/workspace/server/loadWorkOrderWorkspaceSnapshot.ts
+++ b/features/work-orders/workspace/server/loadWorkOrderWorkspaceSnapshot.ts
@@ -1,0 +1,246 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@shared/types/types/supabase";
+import {
+  getActorCapabilities,
+  type CanonicalRole,
+} from "@/features/shared/lib/rbac";
+import { resolveAuthenticatedStaffProfile } from "@/features/shared/lib/server/admin-access";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import {
+  createWorkOrderWorkspaceResource,
+  type WorkOrderWorkspaceServerSnapshot,
+} from "@/features/work-orders/workspace/workOrderWorkspace";
+
+type WorkOrderRow = Database["public"]["Tables"]["work_orders"]["Row"];
+
+type WorkspaceWorkOrderRow = Pick<
+  WorkOrderRow,
+  | "id"
+  | "shop_id"
+  | "customer_id"
+  | "vehicle_id"
+  | "custom_id"
+  | "status"
+  | "payment_status"
+  | "approval_state"
+  | "record_type"
+>;
+
+type WorkspaceWorkOrderColumn = "id" | "custom_id";
+
+const WORK_ORDER_WORKSPACE_SELECT =
+  "id,shop_id,customer_id,vehicle_id,custom_id,status,payment_status,approval_state,record_type";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const WORK_ORDER_WORKSPACE_READER_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "service",
+  "parts",
+  "mechanic",
+  "lead_hand",
+  "foreman",
+] as const satisfies readonly CanonicalRole[];
+
+function normalizedCustomIdReference(value: string | null | undefined):
+  | { prefix: string; numericValue: number }
+  | null {
+  const match = String(value ?? "")
+    .trim()
+    .toUpperCase()
+    .match(/^([A-Z]+)\s*0*(\d+)$/);
+  if (!match) return null;
+
+  const numericValue = Number.parseInt(match[2], 10);
+  if (!Number.isSafeInteger(numericValue)) return null;
+  return { prefix: match[1], numericValue };
+}
+
+function customIdReferencesMatch(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): boolean {
+  const normalizedLeft = normalizedCustomIdReference(left);
+  const normalizedRight = normalizedCustomIdReference(right);
+  return (
+    normalizedLeft !== null &&
+    normalizedRight !== null &&
+    normalizedLeft.prefix === normalizedRight.prefix &&
+    normalizedLeft.numericValue === normalizedRight.numericValue
+  );
+}
+
+function throwQueryError(
+  error: { message: string } | null,
+  context: string,
+): void {
+  if (error) throw new Error(`${context}: ${error.message}`);
+}
+
+async function loadExactWorkOrder(
+  supabase: SupabaseClient<Database>,
+  shopId: string,
+  column: WorkspaceWorkOrderColumn,
+  value: string,
+): Promise<WorkspaceWorkOrderRow | null> {
+  const result = await supabase
+    .from("work_orders")
+    .select(WORK_ORDER_WORKSPACE_SELECT)
+    .eq("shop_id", shopId)
+    .eq(column, value)
+    .maybeSingle();
+  throwQueryError(result.error, "Unable to load Work Order workspace identity");
+  return (result.data as WorkspaceWorkOrderRow | null) ?? null;
+}
+
+async function resolveVisibleWorkOrder(
+  supabase: SupabaseClient<Database>,
+  shopId: string,
+  routeId: string,
+): Promise<WorkspaceWorkOrderRow | null> {
+  if (UUID_PATTERN.test(routeId)) {
+    const byId = await loadExactWorkOrder(supabase, shopId, "id", routeId);
+    if (byId) return byId;
+  }
+
+  const byExactCustomId = await loadExactWorkOrder(
+    supabase,
+    shopId,
+    "custom_id",
+    routeId,
+  );
+  if (byExactCustomId) return byExactCustomId;
+
+  // Keep this bootstrap additive to the existing client resolver. It supports
+  // the same common case-insensitive alias while leaving the current client
+  // loader authoritative if no unique server match can be proven.
+  if (!routeId.includes("%") && !routeId.includes("_")) {
+    const caseInsensitiveResult = await supabase
+      .from("work_orders")
+      .select(WORK_ORDER_WORKSPACE_SELECT)
+      .eq("shop_id", shopId)
+      .ilike("custom_id", routeId.toUpperCase())
+      .limit(2);
+    throwQueryError(
+      caseInsensitiveResult.error,
+      "Unable to resolve Work Order workspace alias",
+    );
+    const caseInsensitiveRows = (caseInsensitiveResult.data ?? []) as WorkspaceWorkOrderRow[];
+    if (caseInsensitiveRows.length === 1) return caseInsensitiveRows[0];
+    if (caseInsensitiveRows.length > 1) return null;
+  }
+
+  const normalizedRoute = normalizedCustomIdReference(routeId);
+  if (!normalizedRoute) return null;
+
+  const candidatesResult = await supabase
+    .from("work_orders")
+    .select(WORK_ORDER_WORKSPACE_SELECT)
+    .eq("shop_id", shopId)
+    .ilike("custom_id", `${normalizedRoute.prefix}%`)
+    .limit(50);
+  throwQueryError(
+    candidatesResult.error,
+    "Unable to resolve normalized Work Order workspace alias",
+  );
+
+  const matches = ((candidatesResult.data ?? []) as WorkspaceWorkOrderRow[]).filter(
+    (row) => customIdReferencesMatch(row.custom_id, routeId),
+  );
+  return matches.length === 1 ? matches[0] : null;
+}
+
+/**
+ * Loads only the trusted identity needed to bootstrap sibling Work Order
+ * workspace modules. The authenticated RLS client remains the visibility
+ * boundary; the existing client cockpit still owns operational reads and all
+ * mutations in this compatible-integration slice.
+ */
+export async function loadWorkOrderWorkspaceSnapshot(input: {
+  supabase: SupabaseClient<Database>;
+  shopId: string;
+  routeId: string;
+}): Promise<WorkOrderWorkspaceServerSnapshot | null> {
+  const shopId = input.shopId.trim();
+  const routeId = input.routeId.trim();
+  if (!shopId || !routeId) return null;
+
+  const workOrder = await resolveVisibleWorkOrder(
+    input.supabase,
+    shopId,
+    routeId,
+  );
+  if (!workOrder || workOrder.shop_id !== shopId) return null;
+
+  const resource = createWorkOrderWorkspaceResource({
+    shopId: workOrder.shop_id,
+    workOrderId: workOrder.id,
+    customerId: workOrder.customer_id,
+    vehicleId: workOrder.vehicle_id,
+  });
+  if (!resource) return null;
+
+  return {
+    routeId,
+    resource,
+    workOrder: {
+      id: workOrder.id,
+      shopId: workOrder.shop_id,
+      customerId: workOrder.customer_id,
+      vehicleId: workOrder.vehicle_id,
+      customId: workOrder.custom_id,
+      status: workOrder.status,
+      paymentStatus: workOrder.payment_status,
+      approvalState: workOrder.approval_state,
+      recordType: workOrder.record_type,
+    },
+  };
+}
+
+/**
+ * Best-effort server bootstrap for the existing Work Order screen. Returning
+ * null preserves its current client-side authentication, retry, and not-found
+ * behavior when the server snapshot is unavailable.
+ */
+export async function loadCurrentWorkOrderWorkspaceSnapshot(input: {
+  routeId: string;
+}): Promise<WorkOrderWorkspaceServerSnapshot | null> {
+  try {
+    const supabase = createServerSupabaseRSC();
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+    if (userError || !user) return null;
+
+    const { profile, error: profileError } =
+      await resolveAuthenticatedStaffProfile(supabase, user.id);
+    const actor = getActorCapabilities({ role: profile?.role });
+    if (
+      profileError ||
+      !profile?.shop_id ||
+      !actor.isKnownRole ||
+      !(WORK_ORDER_WORKSPACE_READER_ROLES as readonly CanonicalRole[]).includes(
+        actor.canonicalRole,
+      )
+    ) {
+      return null;
+    }
+
+    return loadWorkOrderWorkspaceSnapshot({
+      supabase,
+      shopId: profile.shop_id,
+      routeId: input.routeId,
+    });
+  } catch (error) {
+    console.error("[Work Order Workspace] server bootstrap failed", error);
+    return null;
+  }
+}

--- a/features/work-orders/workspace/workOrderWorkspace.ts
+++ b/features/work-orders/workspace/workOrderWorkspace.ts
@@ -1,5 +1,35 @@
 import type { WorkspaceResourceContext } from "@/features/workspace/lib/workspace";
 
+export type WorkOrderWorkspaceServerSnapshot = {
+  routeId: string;
+  resource: WorkspaceResourceContext;
+  workOrder: {
+    id: string;
+    shopId: string;
+    customerId: string | null;
+    vehicleId: string | null;
+    customId: string | null;
+    status: string | null;
+    paymentStatus: string | null;
+    approvalState: string | null;
+    recordType: string | null;
+  };
+};
+
+export function resolveWorkOrderWorkspaceResource(input: {
+  initialResource?: WorkspaceResourceContext | null;
+  loadedResource?: WorkspaceResourceContext | null;
+}): WorkspaceResourceContext | null {
+  const serverWorkOrderId = input.initialResource?.workOrderId ?? null;
+  if (
+    serverWorkOrderId &&
+    input.loadedResource?.workOrderId !== serverWorkOrderId
+  ) {
+    return input.initialResource ?? null;
+  }
+  return input.loadedResource ?? input.initialResource ?? null;
+}
+
 export const WORK_ORDER_WORKSPACE_MODULES = {
   statusCommand: {
     anchorId: "work-order-workspace-command",

--- a/tests/work-order-workspace-server-snapshot.test.ts
+++ b/tests/work-order-workspace-server-snapshot.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import type { WorkspaceResourceContext } from "@/features/workspace/lib/workspace";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  resolveAuthenticatedStaffProfile: vi.fn(),
+}));
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createServerSupabaseRSC: vi.fn(),
+}));
+
+import { loadWorkOrderWorkspaceSnapshot } from "@/features/work-orders/workspace/server/loadWorkOrderWorkspaceSnapshot";
+import {
+  resolveWorkOrderWorkspaceResource,
+  type WorkOrderWorkspaceServerSnapshot,
+} from "@/features/work-orders/workspace/workOrderWorkspace";
+
+type QueryResult = {
+  data: unknown;
+  error: { message: string } | null;
+};
+
+type QueryCall = {
+  operation: string;
+  args: unknown[];
+};
+
+type QueryBuilder = {
+  select: (...args: unknown[]) => QueryBuilder;
+  eq: (...args: unknown[]) => QueryBuilder;
+  ilike: (...args: unknown[]) => QueryBuilder;
+  limit: (...args: unknown[]) => QueryBuilder;
+  maybeSingle: (...args: unknown[]) => QueryBuilder;
+  then<TResult1 = QueryResult, TResult2 = never>(
+    onfulfilled?:
+      | ((value: QueryResult) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?:
+      | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+      | null,
+  ): Promise<TResult1 | TResult2>;
+};
+
+function createSupabaseFixture(results: QueryResult[]): {
+  client: SupabaseClient<Database>;
+  calls: QueryCall[];
+} {
+  const calls: QueryCall[] = [];
+  let queryIndex = 0;
+
+  const client = {
+    from(table: string) {
+      expect(table).toBe("work_orders");
+      const result = results[queryIndex++];
+      if (!result) throw new Error(`Missing result for query ${queryIndex}`);
+
+      const query: QueryBuilder = {
+        select(...args) {
+          calls.push({ operation: "select", args });
+          return query;
+        },
+        eq(...args) {
+          calls.push({ operation: "eq", args });
+          return query;
+        },
+        ilike(...args) {
+          calls.push({ operation: "ilike", args });
+          return query;
+        },
+        limit(...args) {
+          calls.push({ operation: "limit", args });
+          return query;
+        },
+        maybeSingle(...args) {
+          calls.push({ operation: "maybeSingle", args });
+          return query;
+        },
+        then(onfulfilled, onrejected) {
+          return Promise.resolve(result).then(onfulfilled, onrejected);
+        },
+      };
+      return query;
+    },
+  };
+
+  return {
+    client: client as unknown as SupabaseClient<Database>,
+    calls,
+  };
+}
+
+function workOrderRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    shop_id: "shop-1",
+    customer_id: "customer-1",
+    vehicle_id: "vehicle-1",
+    custom_id: "WO0001",
+    status: "in_progress",
+    payment_status: null,
+    approval_state: "approved",
+    record_type: "work_order",
+    ...overrides,
+  };
+}
+
+describe("Work Order Workspace server snapshot", () => {
+  it("keeps the server-authorized identity until the client loads that Work Order", () => {
+    const serverSnapshot: WorkOrderWorkspaceServerSnapshot = {
+      routeId: "WO1",
+      resource: {
+        kind: "work_order",
+        shopId: "shop-1",
+        resourceId: "wo-1",
+        workOrderId: "wo-1",
+        customerId: "customer-1",
+        vehicleId: "vehicle-1",
+        locationId: null,
+      },
+      workOrder: {
+        id: "wo-1",
+        shopId: "shop-1",
+        customerId: "customer-1",
+        vehicleId: "vehicle-1",
+        customId: "WO0001",
+        status: "in_progress",
+        paymentStatus: null,
+        approvalState: "approved",
+        recordType: "work_order",
+      },
+    };
+    const matchingClientResource: WorkspaceResourceContext = {
+      ...serverSnapshot.resource,
+    };
+    const staleClientResource: WorkspaceResourceContext = {
+      kind: "work_order",
+      shopId: "shop-1",
+      resourceId: "wo-stale",
+      workOrderId: "wo-stale",
+    };
+
+    expect(
+      resolveWorkOrderWorkspaceResource({
+        initialResource: serverSnapshot.resource,
+        loadedResource: null,
+      }),
+    ).toEqual(serverSnapshot.resource);
+    expect(
+      resolveWorkOrderWorkspaceResource({
+        initialResource: serverSnapshot.resource,
+        loadedResource: staleClientResource,
+      }),
+    ).toEqual(serverSnapshot.resource);
+    expect(
+      resolveWorkOrderWorkspaceResource({
+        initialResource: serverSnapshot.resource,
+        loadedResource: matchingClientResource,
+      }),
+    ).toEqual(matchingClientResource);
+  });
+
+  it("bootstraps the canonical RLS-visible Work Order UUID and scopes by shop", async () => {
+    const fixture = createSupabaseFixture([
+      { data: workOrderRow(), error: null },
+    ]);
+
+    const snapshot = await loadWorkOrderWorkspaceSnapshot({
+      supabase: fixture.client,
+      shopId: "shop-1",
+      routeId: "11111111-1111-4111-8111-111111111111",
+    });
+
+    expect(snapshot).toMatchObject({
+      routeId: "11111111-1111-4111-8111-111111111111",
+      resource: {
+        kind: "work_order",
+        shopId: "shop-1",
+        resourceId: "11111111-1111-4111-8111-111111111111",
+        workOrderId: "11111111-1111-4111-8111-111111111111",
+        customerId: "customer-1",
+        vehicleId: "vehicle-1",
+      },
+      workOrder: {
+        customId: "WO0001",
+        status: "in_progress",
+        approvalState: "approved",
+      },
+    });
+    expect(fixture.calls).toContainEqual({
+      operation: "eq",
+      args: ["shop_id", "shop-1"],
+    });
+    expect(fixture.calls).toContainEqual({
+      operation: "eq",
+      args: ["id", "11111111-1111-4111-8111-111111111111"],
+    });
+  });
+
+  it("resolves an exact custom Work Order number", async () => {
+    const fixture = createSupabaseFixture([
+      { data: workOrderRow(), error: null },
+    ]);
+
+    const snapshot = await loadWorkOrderWorkspaceSnapshot({
+      supabase: fixture.client,
+      shopId: "shop-1",
+      routeId: "WO0001",
+    });
+
+    expect(snapshot?.workOrder.id).toBe(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    expect(fixture.calls).toContainEqual({
+      operation: "eq",
+      args: ["custom_id", "WO0001"],
+    });
+  });
+
+  it("resolves a unique normalized alias without choosing an ambiguous Work Order", async () => {
+    const uniqueFixture = createSupabaseFixture([
+      { data: null, error: null },
+      { data: [], error: null },
+      { data: [workOrderRow()], error: null },
+    ]);
+    const uniqueSnapshot = await loadWorkOrderWorkspaceSnapshot({
+      supabase: uniqueFixture.client,
+      shopId: "shop-1",
+      routeId: "WO1",
+    });
+    expect(uniqueSnapshot?.workOrder.customId).toBe("WO0001");
+
+    const ambiguousFixture = createSupabaseFixture([
+      { data: null, error: null },
+      { data: [], error: null },
+      {
+        data: [
+          workOrderRow(),
+          workOrderRow({
+            id: "22222222-2222-4222-8222-222222222222",
+            custom_id: "WO01",
+          }),
+        ],
+        error: null,
+      },
+    ]);
+    const ambiguousSnapshot = await loadWorkOrderWorkspaceSnapshot({
+      supabase: ambiguousFixture.client,
+      shopId: "shop-1",
+      routeId: "WO1",
+    });
+    expect(ambiguousSnapshot).toBeNull();
+  });
+
+  it("does not publish a cross-shop row even if a malformed fixture returns it", async () => {
+    const fixture = createSupabaseFixture([
+      { data: workOrderRow({ shop_id: "shop-2" }), error: null },
+    ]);
+
+    await expect(
+      loadWorkOrderWorkspaceSnapshot({
+        supabase: fixture.client,
+        shopId: "shop-1",
+        routeId: "WO0001",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("surfaces query failures to the best-effort current-actor boundary", async () => {
+    const fixture = createSupabaseFixture([
+      { data: null, error: { message: "database unavailable" } },
+    ]);
+
+    await expect(
+      loadWorkOrderWorkspaceSnapshot({
+        supabase: fixture.client,
+        shopId: "shop-1",
+        routeId: "WO0001",
+      }),
+    ).rejects.toThrow(
+      "Unable to load Work Order workspace identity: database unavailable",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues Phase 3 after #1499 by adding the first server-loaded Work Order Workspace snapshot alongside the existing canonical `/work-orders/[id]` cockpit.

- resolves the authenticated, RLS-visible Work Order from UUID, exact Work Order number, case-insensitive alias, or one uniquely normalized alias
- scopes every bootstrap query to the actor's canonical Shop
- seeds the shared Workspace resource provider with canonical Work Order, Shop, customer, and vehicle identity before client reads finish
- keeps that server-authorized identity authoritative over stale tab state until the client loads the same Work Order
- fails closed on ambiguous normalized Work Order numbers
- keeps the bootstrap best-effort so the existing client authentication, retry, not-found, realtime, and operational flow remains the compatibility fallback

## Change classification

Compatible integration.

No existing Work Order mutation, status transition, assignment, inspection, Parts, punch, approval, messaging, timeline, or focused-job handler is replaced or redefined.

## Preserved behavior

- `/work-orders/[id]` remains the canonical Work Order screen.
- The existing `<WorkOrderIdClient />` and operational timeline mounts are preserved.
- The one-view technician cockpit and its mobile modal fallback are unchanged.
- Existing client reads and realtime refresh remain active and authoritative for operational data.
- Existing RLS remains the data-visibility boundary; no service-role Work Order read is introduced.
- Existing tests were not changed.
- The merged Parts work is not touched.

## Validation

Exact head `788637a21f4e91f20695e55e31ca4ad1f380bd0b`:

- Agent PR Checks: success — run `32444625226`
- full-app regression inventory build, summary, and artifact upload passed
- TypeScript passed
- changed-file ESLint passed
- complete test suite passed
- production application build passed
- regression inventory enforcement skipped because the PR remains Draft
- unrelated Operational Observability, Mobile Dispatch, and Universal Scheduler workflows skipped as designed
- local TypeScript syntax stripping and `git diff --check` passed
- source-contract audit confirmed the existing Work Order client, timeline, assignment, Parts request, and inspection handlers remain mounted
- no review threads or findings are present on the exact head

## Database / deployment

- no migration
- no production database write
- Supabase preview correctly skipped because there is no `supabase/` diff
- no Vercel configuration change
- non-main preview deployments remain disabled
