### PR TITLE
Compose Inspection and Parts in Work Order Workspace

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1650,6 +1650,9 @@ export default function WorkOrderIdClient(): JSX.Element {
   const panelLine = panelLineId
     ? sortedLines.find((line) => line.id === panelLineId) ?? null
     : null;
+  const panelInspectionTemplateId = panelLine
+    ? extractInspectionTemplateId(panelLine)
+    : null;
   const panelPrimaryTech = panelLine?.assigned_tech_id
     ? assignables.find((profile) => profile.id === panelLine.assigned_tech_id) ?? null
     : null;
@@ -2435,6 +2438,18 @@ export default function WorkOrderIdClient(): JSX.Element {
                   canAssignTechnician={canAssign}
                   technicianOptions={assignables}
                   onAssignTechnician={assignLineTechnician}
+                  onOpenInspection={
+                    panelLine?.job_type === "inspection" &&
+                    panelInspectionTemplateId &&
+                    currentActor.canRunInspections
+                      ? () => openInspectionForLine(panelLine)
+                      : undefined
+                  }
+                  onOpenPartsInventory={
+                    canUseInventoryPicker
+                      ? () => setPartsLineId(panelLineId)
+                      : undefined
+                  }
                   onChanged={fetchAll}
                   mode="tech"
                   variant="cockpit"

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -79,9 +79,9 @@ import {
   canOpenWorkOrderInspectionModule,
   createWorkOrderWorkspaceResource,
   resolveWorkOrderWorkspaceResource,
-  workOrderPartsRefreshEventName,
   workOrderWorkspaceCustomerMessageHref,
 } from "@/features/work-orders/workspace/workOrderWorkspace";
+import { notifyWorkOrderPartsRefresh } from "@/features/work-orders/workspace/useWorkOrderPartsRefresh";
 
 import { prepareSectionsWithCornerGrid } from "@inspections/lib/inspection/prepareSectionsWithCornerGrid";
 
@@ -1578,9 +1578,7 @@ export default function WorkOrderIdClient(): JSX.Element {
 
     const handler = () => {
       setPartsLineId(null);
-      window.dispatchEvent(
-        new Event(workOrderPartsRefreshEventName(partsLineId)),
-      );
+      notifyWorkOrderPartsRefresh(partsLineId);
       void fetchAll();
     };
 

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -76,8 +76,10 @@ import {
   WorkOrderWorkspaceModule,
 } from "@/features/work-orders/workspace/WorkOrderWorkspaceFrame";
 import {
+  canOpenWorkOrderInspectionModule,
   createWorkOrderWorkspaceResource,
   resolveWorkOrderWorkspaceResource,
+  workOrderPartsRefreshEventName,
   workOrderWorkspaceCustomerMessageHref,
 } from "@/features/work-orders/workspace/workOrderWorkspace";
 
@@ -1576,6 +1578,9 @@ export default function WorkOrderIdClient(): JSX.Element {
 
     const handler = () => {
       setPartsLineId(null);
+      window.dispatchEvent(
+        new Event(workOrderPartsRefreshEventName(partsLineId)),
+      );
       void fetchAll();
     };
 
@@ -2439,9 +2444,11 @@ export default function WorkOrderIdClient(): JSX.Element {
                   technicianOptions={assignables}
                   onAssignTechnician={assignLineTechnician}
                   onOpenInspection={
-                    panelLine?.job_type === "inspection" &&
-                    panelInspectionTemplateId &&
-                    currentActor.canRunInspections
+                    panelLine &&
+                    canOpenWorkOrderInspectionModule({
+                      inspectionTemplateId: panelInspectionTemplateId,
+                      canRunInspections: currentActor.canRunInspections,
+                    })
                       ? () => openInspectionForLine(panelLine)
                       : undefined
                   }

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -54,6 +54,7 @@ import { WorkOrderWorkspaceModule } from "@/features/work-orders/workspace/WorkO
 import {
   getWorkOrderJobWorkspaceTabs,
   type WorkOrderJobWorkspaceTabId,
+  workOrderPartsRefreshEventName,
 } from "@/features/work-orders/workspace/workOrderWorkspace";
 
 import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
@@ -589,6 +590,13 @@ export default function FocusedJobModal(props: {
     window.addEventListener("wol:refresh", handler);
     return () => window.removeEventListener("wol:refresh", handler);
   }, [refresh]);
+
+  useEffect(() => {
+    const eventName = workOrderPartsRefreshEventName(workOrderLineId);
+    const handlePartsRefresh = () => void loadAllocations();
+    window.addEventListener(eventName, handlePartsRefresh);
+    return () => window.removeEventListener(eventName, handlePartsRefresh);
+  }, [loadAllocations, workOrderLineId]);
 
   useEffect(() => {
     const handleClose = () => setOpenParts(false);

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -50,21 +50,17 @@ import {
 } from "@/features/work-orders/lib/display/workOrderParts";
 import VehicleHistoryModal from "@/features/work-orders/components/workorders/VehicleHistoryModal";
 import DtcSuggestionModal from "@/features/work-orders/components/workorders/DtcSuggestionPopup";
+import { WorkOrderWorkspaceModule } from "@/features/work-orders/workspace/WorkOrderWorkspaceFrame";
+import {
+  getWorkOrderJobWorkspaceTabs,
+  type WorkOrderJobWorkspaceTabId,
+} from "@/features/work-orders/workspace/workOrderWorkspace";
 
 import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 
 type Mode = "tech" | "view";
 type Variant = "modal" | "panel" | "cockpit";
-type WorkspaceTab = "overview" | "story" | "parts" | "evidence" | "details";
-
-const WORKSPACE_TABS: ReadonlyArray<{ id: WorkspaceTab; label: string }> = [
-  { id: "overview", label: "Overview" },
-  { id: "story", label: "Story" },
-  { id: "parts", label: "Parts" },
-  { id: "evidence", label: "Evidence" },
-  { id: "details", label: "Details" },
-];
 
 const statusTextColor: Record<string, string> = {
   in_progress: "text-sky-200",
@@ -197,6 +193,8 @@ export default function FocusedJobModal(props: {
     lineId: string,
     technicianId: string,
   ) => void | Promise<void>;
+  onOpenInspection?: () => void | Promise<void>;
+  onOpenPartsInventory?: () => void;
   onChanged?: () => void | Promise<void>;
   mode?: Mode;
   variant?: Variant;
@@ -211,6 +209,8 @@ export default function FocusedJobModal(props: {
     canAssignTechnician = false,
     technicianOptions = EMPTY_TECHNICIAN_OPTIONS,
     onAssignTechnician,
+    onOpenInspection,
+    onOpenPartsInventory,
     onChanged,
     mode = "tech",
     variant = "modal",
@@ -239,7 +239,13 @@ export default function FocusedJobModal(props: {
   const [openAi, setOpenAi] = useState(false);
   const [openDtc, setOpenDtc] = useState(false);
   const [openVehicleHistory, setOpenVehicleHistory] = useState(false);
-  const [activeWorkspaceTab, setActiveWorkspaceTab] = useState<WorkspaceTab>("overview");
+  const [activeWorkspaceTab, setActiveWorkspaceTab] =
+    useState<WorkOrderJobWorkspaceTabId>("overview");
+  const inspectionAvailable = Boolean(onOpenInspection);
+  const workspaceTabs = useMemo(
+    () => getWorkOrderJobWorkspaceTabs({ inspectionAvailable }),
+    [inspectionAvailable],
+  );
 
   const [prefillCause, setPrefillCause] = useState("");
   const [prefillCorrection, setPrefillCorrection] = useState("");
@@ -301,6 +307,14 @@ export default function FocusedJobModal(props: {
   useEffect(() => {
     setActiveWorkspaceTab("overview");
   }, [workOrderLineId]);
+
+  useEffect(() => {
+    if (
+      !workspaceTabs.some((tab) => tab.id === activeWorkspaceTab)
+    ) {
+      setActiveWorkspaceTab("overview");
+    }
+  }, [activeWorkspaceTab, workspaceTabs]);
 
   useEffect(() => {
     if (lineSnapshot?.id === workOrderLineId) {
@@ -1346,7 +1360,7 @@ export default function FocusedJobModal(props: {
 
   const fullPartsWorkspace = line ? (
     <section>
-      <div className="mb-4 flex items-center justify-between gap-3">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <div>
           <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
             Fulfillment
@@ -1355,17 +1369,29 @@ export default function FocusedJobModal(props: {
             {partsBottleneckDisplay?.heading ?? "Parts used and required"}
           </h3>
         </div>
-        <button
-          type="button"
-          className="rounded-lg border border-sky-400/40 bg-sky-500/10 px-3 py-1.5 text-xs font-semibold text-sky-100 transition hover:bg-sky-500/20"
-          onClick={() => {
-            closeAllSubModals();
-            setOpenParts(true);
-          }}
-          disabled={busy}
-        >
-          Request parts
-        </button>
+        <div className="flex flex-wrap items-center gap-2">
+          {onOpenPartsInventory ? (
+            <button
+              type="button"
+              className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-subtle)]"
+              onClick={onOpenPartsInventory}
+              disabled={busy}
+            >
+              Add from inventory
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="rounded-lg border border-sky-400/40 bg-sky-500/10 px-3 py-1.5 text-xs font-semibold text-sky-100 transition hover:bg-sky-500/20"
+            onClick={() => {
+              closeAllSubModals();
+              setOpenParts(true);
+            }}
+            disabled={busy}
+          >
+            Request parts
+          </button>
+        </div>
       </div>
       {allocsLoading ? (
         <div className="text-sm text-[color:var(--theme-text-secondary)]">Loading…</div>
@@ -1417,6 +1443,37 @@ export default function FocusedJobModal(props: {
     </section>
   ) : null;
 
+  const inspectionWorkspace = line && onOpenInspection ? (
+    <section>
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+            Inspection workflow
+          </div>
+          <h3 className="mt-1 text-base font-semibold text-[color:var(--theme-text-primary)]">
+            Attached inspection
+          </h3>
+        </div>
+        <button
+          type="button"
+          className="rounded-lg border border-sky-400/40 bg-sky-500/10 px-3 py-1.5 text-xs font-semibold text-sky-100 transition hover:bg-sky-500/20"
+          onClick={() => void onOpenInspection()}
+          disabled={busy}
+        >
+          Open inspection
+        </button>
+      </div>
+      <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-4">
+        <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">
+          {lineLabel}
+        </div>
+        <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+          Continue the existing inspection, evidence, autosave, and completion flow for this job.
+        </p>
+      </div>
+    </section>
+  ) : null;
+
   const CockpitBody = (
     <div
       data-work-order-cockpit="true"
@@ -1453,12 +1510,13 @@ export default function FocusedJobModal(props: {
             </div>
           </div>
           <div className="flex gap-1 overflow-x-auto" role="tablist" aria-label="Selected job workspace">
-            {WORKSPACE_TABS.map((tab) => (
+            {workspaceTabs.map((tab) => (
               <button
                 key={tab.id}
                 type="button"
                 role="tab"
                 aria-selected={activeWorkspaceTab === tab.id}
+                data-workspace-module-action={tab.module}
                 onClick={() => setActiveWorkspaceTab(tab.id)}
                 className={cn(
                   "border-b-2 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] transition",
@@ -1516,8 +1574,14 @@ export default function FocusedJobModal(props: {
                 </div>
               </section>
             </div>
+          ) : activeWorkspaceTab === "inspection" ? (
+            <WorkOrderWorkspaceModule module="inspection">
+              {inspectionWorkspace}
+            </WorkOrderWorkspaceModule>
           ) : activeWorkspaceTab === "parts" ? (
-            fullPartsWorkspace
+            <WorkOrderWorkspaceModule module="parts">
+              {fullPartsWorkspace}
+            </WorkOrderWorkspaceModule>
           ) : activeWorkspaceTab === "evidence" ? (
             workOrder?.id ? (
               <WorkOrderMediaGallery

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -54,8 +54,8 @@ import { WorkOrderWorkspaceModule } from "@/features/work-orders/workspace/WorkO
 import {
   getWorkOrderJobWorkspaceTabs,
   type WorkOrderJobWorkspaceTabId,
-  workOrderPartsRefreshEventName,
 } from "@/features/work-orders/workspace/workOrderWorkspace";
+import { useWorkOrderPartsRefresh } from "@/features/work-orders/workspace/useWorkOrderPartsRefresh";
 
 import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
@@ -591,12 +591,7 @@ export default function FocusedJobModal(props: {
     return () => window.removeEventListener("wol:refresh", handler);
   }, [refresh]);
 
-  useEffect(() => {
-    const eventName = workOrderPartsRefreshEventName(workOrderLineId);
-    const handlePartsRefresh = () => void loadAllocations();
-    window.addEventListener(eventName, handlePartsRefresh);
-    return () => window.removeEventListener(eventName, handlePartsRefresh);
-  }, [loadAllocations, workOrderLineId]);
+  useWorkOrderPartsRefresh(workOrderLineId, loadAllocations);
 
   useEffect(() => {
     const handleClose = () => setOpenParts(false);

--- a/features/work-orders/workspace/useWorkOrderPartsRefresh.ts
+++ b/features/work-orders/workspace/useWorkOrderPartsRefresh.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { workOrderPartsRefreshEventName } from "@/features/work-orders/workspace/workOrderWorkspace";
+
+export function notifyWorkOrderPartsRefresh(workOrderLineId: string): void {
+  window.dispatchEvent(
+    new Event(workOrderPartsRefreshEventName(workOrderLineId)),
+  );
+}
+
+export function useWorkOrderPartsRefresh(
+  workOrderLineId: string,
+  refresh: () => void | Promise<void>,
+): void {
+  useEffect(() => {
+    const eventName = workOrderPartsRefreshEventName(workOrderLineId);
+    const handlePartsRefresh = () => void refresh();
+    window.addEventListener(eventName, handlePartsRefresh);
+    return () => window.removeEventListener(eventName, handlePartsRefresh);
+  }, [refresh, workOrderLineId]);
+}

--- a/features/work-orders/workspace/workOrderWorkspace.ts
+++ b/features/work-orders/workspace/workOrderWorkspace.ts
@@ -72,6 +72,39 @@ export const WORK_ORDER_WORKSPACE_MODULES = {
 export type WorkOrderWorkspaceModuleKey =
   keyof typeof WORK_ORDER_WORKSPACE_MODULES;
 
+export type WorkOrderJobWorkspaceTabId =
+  | "overview"
+  | "story"
+  | "inspection"
+  | "parts"
+  | "evidence"
+  | "details";
+
+export type WorkOrderJobWorkspaceTab = {
+  id: WorkOrderJobWorkspaceTabId;
+  label: string;
+  module: WorkOrderWorkspaceModuleKey;
+};
+
+const WORK_ORDER_JOB_WORKSPACE_TABS: readonly WorkOrderJobWorkspaceTab[] = [
+  { id: "overview", label: "Overview", module: "repairLines" },
+  { id: "story", label: "Story", module: "repairLines" },
+  { id: "inspection", label: "Inspection", module: "inspection" },
+  { id: "parts", label: "Parts", module: "parts" },
+  { id: "evidence", label: "Evidence", module: "documents" },
+  { id: "details", label: "Details", module: "repairLines" },
+];
+
+export function getWorkOrderJobWorkspaceTabs(input: {
+  inspectionAvailable: boolean;
+}): readonly WorkOrderJobWorkspaceTab[] {
+  return input.inspectionAvailable
+    ? WORK_ORDER_JOB_WORKSPACE_TABS
+    : WORK_ORDER_JOB_WORKSPACE_TABS.filter(
+        (tab) => tab.id !== "inspection",
+      );
+}
+
 export type WorkOrderWorkspaceResourceInput = {
   shopId: string | null | undefined;
   workOrderId: string | null | undefined;

--- a/features/work-orders/workspace/workOrderWorkspace.ts
+++ b/features/work-orders/workspace/workOrderWorkspace.ts
@@ -105,6 +105,21 @@ export function getWorkOrderJobWorkspaceTabs(input: {
       );
 }
 
+export function canOpenWorkOrderInspectionModule(input: {
+  inspectionTemplateId: string | null | undefined;
+  canRunInspections: boolean;
+}): boolean {
+  return Boolean(
+    input.inspectionTemplateId?.trim() && input.canRunInspections,
+  );
+}
+
+export function workOrderPartsRefreshEventName(
+  workOrderLineId: string,
+): string {
+  return `work-order-workspace:parts-refresh:${workOrderLineId.trim()}`;
+}
+
 export type WorkOrderWorkspaceResourceInput = {
   shopId: string | null | undefined;
   workOrderId: string | null | undefined;

--- a/tests/work-order-workspace-module-composition.test.ts
+++ b/tests/work-order-workspace-module-composition.test.ts
@@ -93,13 +93,10 @@ describe("Work Order Workspace Inspection and Parts composition", () => {
       "work-order-workspace:parts-refresh:line-1",
     );
     expect(workOrderClient).toContain(
-      "new Event(workOrderPartsRefreshEventName(partsLineId))",
+      "notifyWorkOrderPartsRefresh(partsLineId)",
     );
     expect(focusedJob).toContain(
-      "workOrderPartsRefreshEventName(workOrderLineId)",
-    );
-    expect(focusedJob).toContain(
-      "const handlePartsRefresh = () => void loadAllocations()",
+      "useWorkOrderPartsRefresh(workOrderLineId, loadAllocations)",
     );
   });
 });

--- a/tests/work-order-workspace-module-composition.test.ts
+++ b/tests/work-order-workspace-module-composition.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  getWorkOrderJobWorkspaceTabs,
+  WORK_ORDER_WORKSPACE_MODULES,
+} from "@/features/work-orders/workspace/workOrderWorkspace";
+
+const workOrderClient = readFileSync("app/work-orders/[id]/Client.tsx", "utf8");
+const focusedJob = readFileSync(
+  "features/work-orders/components/workorders/FocusedJobModal.tsx",
+  "utf8",
+);
+
+describe("Work Order Workspace Inspection and Parts composition", () => {
+  it("adds Inspection only when the existing inspection action is available", () => {
+    const withoutInspection = getWorkOrderJobWorkspaceTabs({
+      inspectionAvailable: false,
+    });
+    const withInspection = getWorkOrderJobWorkspaceTabs({
+      inspectionAvailable: true,
+    });
+
+    expect(withoutInspection.map((tab) => tab.id)).toEqual([
+      "overview",
+      "story",
+      "parts",
+      "evidence",
+      "details",
+    ]);
+    expect(withInspection.map((tab) => tab.id)).toEqual([
+      "overview",
+      "story",
+      "inspection",
+      "parts",
+      "evidence",
+      "details",
+    ]);
+    expect(withInspection.find((tab) => tab.id === "inspection")?.module).toBe(
+      "inspection",
+    );
+  });
+
+  it("keeps Inspection and Parts on distinct canonical module boundaries", () => {
+    expect(WORK_ORDER_WORKSPACE_MODULES.inspection.anchorId).not.toBe(
+      WORK_ORDER_WORKSPACE_MODULES.parts.anchorId,
+    );
+    expect(focusedJob).toContain('<WorkOrderWorkspaceModule module="inspection">');
+    expect(focusedJob).toContain('<WorkOrderWorkspaceModule module="parts">');
+    expect(focusedJob).toContain("data-workspace-module-action={tab.module}");
+  });
+
+  it("delegates to the existing inspection and inventory handlers", () => {
+    expect(workOrderClient).toContain(
+      "panelInspectionTemplateId &&",
+    );
+    expect(workOrderClient).toContain(
+      "? () => openInspectionForLine(panelLine)",
+    );
+    expect(workOrderClient).toContain("? () => setPartsLineId(panelLineId)");
+    expect(focusedJob).toContain("onClick={() => void onOpenInspection()}");
+    expect(focusedJob).toContain("onClick={onOpenPartsInventory}");
+  });
+});

--- a/tests/work-order-workspace-module-composition.test.ts
+++ b/tests/work-order-workspace-module-composition.test.ts
@@ -78,7 +78,7 @@ describe("Work Order Workspace Inspection and Parts composition", () => {
 
   it("delegates to the existing inspection and inventory handlers", () => {
     expect(workOrderClient).toContain(
-      "panelInspectionTemplateId &&",
+      "inspectionTemplateId: panelInspectionTemplateId",
     );
     expect(workOrderClient).toContain(
       "? () => openInspectionForLine(panelLine)",

--- a/tests/work-order-workspace-module-composition.test.ts
+++ b/tests/work-order-workspace-module-composition.test.ts
@@ -2,8 +2,10 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
+  canOpenWorkOrderInspectionModule,
   getWorkOrderJobWorkspaceTabs,
   WORK_ORDER_WORKSPACE_MODULES,
+  workOrderPartsRefreshEventName,
 } from "@/features/work-orders/workspace/workOrderWorkspace";
 
 const workOrderClient = readFileSync("app/work-orders/[id]/Client.tsx", "utf8");
@@ -41,6 +43,30 @@ describe("Work Order Workspace Inspection and Parts composition", () => {
     );
   });
 
+  it("uses the attached template and capability regardless of repair-line type", () => {
+    expect(
+      canOpenWorkOrderInspectionModule({
+        inspectionTemplateId: "template-1",
+        canRunInspections: true,
+      }),
+    ).toBe(true);
+    expect(
+      canOpenWorkOrderInspectionModule({
+        inspectionTemplateId: null,
+        canRunInspections: true,
+      }),
+    ).toBe(false);
+    expect(
+      canOpenWorkOrderInspectionModule({
+        inspectionTemplateId: "template-1",
+        canRunInspections: false,
+      }),
+    ).toBe(false);
+    expect(workOrderClient).not.toContain(
+      'panelLine?.job_type === "inspection"',
+    );
+  });
+
   it("keeps Inspection and Parts on distinct canonical module boundaries", () => {
     expect(WORK_ORDER_WORKSPACE_MODULES.inspection.anchorId).not.toBe(
       WORK_ORDER_WORKSPACE_MODULES.parts.anchorId,
@@ -60,5 +86,20 @@ describe("Work Order Workspace Inspection and Parts composition", () => {
     expect(workOrderClient).toContain("? () => setPartsLineId(panelLineId)");
     expect(focusedJob).toContain("onClick={() => void onOpenInspection()}");
     expect(focusedJob).toContain("onClick={onOpenPartsInventory}");
+  });
+
+  it("refreshes the focused Parts module after the inventory drawer closes", () => {
+    expect(workOrderPartsRefreshEventName("line-1")).toBe(
+      "work-order-workspace:parts-refresh:line-1",
+    );
+    expect(workOrderClient).toContain(
+      "new Event(workOrderPartsRefreshEventName(partsLineId))",
+    );
+    expect(focusedJob).toContain(
+      "workOrderPartsRefreshEventName(workOrderLineId)",
+    );
+    expect(focusedJob).toContain(
+      "const handlePartsRefresh = () => void loadAllocations()",
+    );
   });
 });

--- a/tests/work-order-workspace-parts-refresh.test.tsx
+++ b/tests/work-order-workspace-parts-refresh.test.tsx
@@ -1,0 +1,48 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  notifyWorkOrderPartsRefresh,
+  useWorkOrderPartsRefresh,
+} from "@/features/work-orders/workspace/useWorkOrderPartsRefresh";
+
+function PartsRefreshHarness({
+  lineId,
+  refresh,
+}: {
+  lineId: string;
+  refresh: () => void | Promise<void>;
+}) {
+  useWorkOrderPartsRefresh(lineId, refresh);
+  return null;
+}
+
+afterEach(() => cleanup());
+
+describe("Work Order Workspace Parts refresh", () => {
+  it("refreshes only the selected line and cleans up when selection changes", () => {
+    const refresh = vi.fn();
+    const view = render(
+      <PartsRefreshHarness lineId="line-1" refresh={refresh} />,
+    );
+
+    act(() => notifyWorkOrderPartsRefresh("line-2"));
+    expect(refresh).not.toHaveBeenCalled();
+
+    act(() => notifyWorkOrderPartsRefresh("line-1"));
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <PartsRefreshHarness lineId="line-2" refresh={refresh} />,
+    );
+    act(() => notifyWorkOrderPartsRefresh("line-1"));
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    act(() => notifyWorkOrderPartsRefresh("line-2"));
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    view.unmount();
+    act(() => notifyWorkOrderPartsRefresh("line-2"));
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- add a dedicated Inspection tab to the selected-job cockpit whenever the line has an attached inspection template and the current role can run inspections, independent of the line's `job_type`
- mark Inspection and Parts as explicit Work Order Workspace module boundaries
- connect the Parts tab to the existing authorized inventory drawer while preserving the existing parts-request modal
- refresh the focused Parts allocations explicitly after the inventory drawer closes, scoped to the active work-order line
- keep the canonical inspection launcher, inventory/parts handlers, evidence flow, job actions, mobile paths, and Work Order route unchanged

## Change classification

Compatible integration. Existing callers, authorization decisions, mutations, statuses, side effects, and passing regressions are preserved.

## Codex review follow-ups

- removed the inspection-only job-type gate; availability now depends on the attached template and inspection capability
- added a line-scoped Parts refresh notification and hook so inventory completion reloads the open focused-job allocations
- added behavior coverage for event scoping, line changes, and listener cleanup

## Validation

- Agent PR Checks run 32491657637 passed on head `72e9c6caf2c6089d365443080a9118b2a5be34d5`: regression inventory setup, typecheck, changed-file lint, 478 test files / 2,805 passing tests, and production build
- Universal Scheduler Validation run 32491657659 passed
- Mobile Dispatch Validation run 32491657583 passed
- `git diff --check` passed
- added `tests/work-order-workspace-module-composition.test.ts`
- added `tests/work-order-workspace-parts-refresh.test.tsx`

## Database / deployment

- no schema, migration, RLS, RPC, trigger, API contract, environment, or Vercel configuration changes
- no preview deployment requested or enabled
