### PR TITLE
Compose Work Order communication and documents modules

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -2455,6 +2455,9 @@ export default function WorkOrderIdClient(): JSX.Element {
                       ? () => setPartsLineId(panelLineId)
                       : undefined
                   }
+                  customerMessageHref={
+                    canMessageCustomer ? messageCustomerHref : null
+                  }
                   onChanged={fetchAll}
                   mode="tech"
                   variant="cockpit"

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -50,9 +50,13 @@ import {
 } from "@/features/work-orders/lib/display/workOrderParts";
 import VehicleHistoryModal from "@/features/work-orders/components/workorders/VehicleHistoryModal";
 import DtcSuggestionModal from "@/features/work-orders/components/workorders/DtcSuggestionPopup";
+import {
+  WorkOrderJobCommunicationWorkspace,
+  WorkOrderJobDocumentsWorkspace,
+} from "@/features/work-orders/workspace/WorkOrderJobWorkspaceSurfaces";
 import { WorkOrderWorkspaceModule } from "@/features/work-orders/workspace/WorkOrderWorkspaceFrame";
 import {
-  getWorkOrderJobWorkspaceTabs,
+  getComposedWorkOrderJobWorkspaceTabs,
   type WorkOrderJobWorkspaceTabId,
 } from "@/features/work-orders/workspace/workOrderWorkspace";
 import { useWorkOrderPartsRefresh } from "@/features/work-orders/workspace/useWorkOrderPartsRefresh";
@@ -196,6 +200,7 @@ export default function FocusedJobModal(props: {
   ) => void | Promise<void>;
   onOpenInspection?: () => void | Promise<void>;
   onOpenPartsInventory?: () => void;
+  customerMessageHref?: string | null;
   onChanged?: () => void | Promise<void>;
   mode?: Mode;
   variant?: Variant;
@@ -212,6 +217,7 @@ export default function FocusedJobModal(props: {
     onAssignTechnician,
     onOpenInspection,
     onOpenPartsInventory,
+    customerMessageHref = null,
     onChanged,
     mode = "tech",
     variant = "modal",
@@ -244,7 +250,11 @@ export default function FocusedJobModal(props: {
     useState<WorkOrderJobWorkspaceTabId>("overview");
   const inspectionAvailable = Boolean(onOpenInspection);
   const workspaceTabs = useMemo(
-    () => getWorkOrderJobWorkspaceTabs({ inspectionAvailable }),
+    () =>
+      getComposedWorkOrderJobWorkspaceTabs({
+        inspectionAvailable,
+        communicationAvailable: true,
+      }),
     [inspectionAvailable],
   );
 
@@ -1585,13 +1595,32 @@ export default function FocusedJobModal(props: {
             <WorkOrderWorkspaceModule module="parts">
               {fullPartsWorkspace}
             </WorkOrderWorkspaceModule>
+          ) : activeWorkspaceTab === "communication" ? (
+            <WorkOrderWorkspaceModule module="communication">
+              <WorkOrderJobCommunicationWorkspace
+                jobLabel={lineLabel}
+                customerMessageHref={customerMessageHref}
+                onOpenJobChat={() => {
+                  closeAllSubModals();
+                  setOpenChat(true);
+                }}
+                disabled={busy}
+              />
+            </WorkOrderWorkspaceModule>
           ) : activeWorkspaceTab === "evidence" ? (
             workOrder?.id ? (
-              <WorkOrderMediaGallery
-                workOrderId={workOrder.id}
-                workOrderLineId={workOrderLineId}
-                refreshKey={mediaRefreshKey}
-              />
+              <WorkOrderWorkspaceModule module="documents">
+                <WorkOrderJobDocumentsWorkspace
+                  workOrderId={workOrder.id}
+                  workOrderLineId={workOrderLineId}
+                  refreshKey={mediaRefreshKey}
+                  onAddMedia={() => {
+                    closeAllSubModals();
+                    setOpenPhoto(true);
+                  }}
+                  disabled={busy}
+                />
+              </WorkOrderWorkspaceModule>
             ) : null
           ) : (
             <div className="space-y-6">

--- a/features/work-orders/workspace/WorkOrderJobWorkspaceSurfaces.tsx
+++ b/features/work-orders/workspace/WorkOrderJobWorkspaceSurfaces.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import Link from "next/link";
+import { Camera, MessageSquare, MessageSquareText } from "lucide-react";
+
+import WorkOrderMediaGallery from "@/features/work-orders/components/workorders/extras/WorkOrderMediaGallery";
+
+const actionClassName =
+  "inline-flex items-center justify-center gap-1.5 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-subtle)] disabled:cursor-not-allowed disabled:opacity-60";
+
+export function WorkOrderJobCommunicationWorkspace({
+  jobLabel,
+  customerMessageHref = null,
+  onOpenJobChat,
+  disabled = false,
+}: {
+  jobLabel: string;
+  customerMessageHref?: string | null;
+  onOpenJobChat: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <section>
+      <div className="mb-4">
+        <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+          Communication
+        </div>
+        <h3 className="mt-1 text-base font-semibold text-[color:var(--theme-text-primary)]">
+          Keep this job in context
+        </h3>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <article className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
+          <MessageSquare className="h-5 w-5 text-sky-300" aria-hidden="true" />
+          <h4 className="mt-3 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+            Job conversation
+          </h4>
+          <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+            Start or continue an internal conversation anchored to {jobLabel}.
+          </p>
+          <button
+            type="button"
+            className={`${actionClassName} mt-4`}
+            onClick={onOpenJobChat}
+            disabled={disabled}
+          >
+            <MessageSquare className="h-3.5 w-3.5" aria-hidden="true" />
+            Open job chat
+          </button>
+        </article>
+
+        <article className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
+          <MessageSquareText
+            className="h-5 w-5 text-[color:var(--brand-primary)]"
+            aria-hidden="true"
+          />
+          <h4 className="mt-3 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+            Customer update
+          </h4>
+          <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+            {customerMessageHref
+              ? "Open the existing customer conversation with this Work Order attached."
+              : "Customer messaging is not available for this job or role."}
+          </p>
+          {customerMessageHref ? (
+            <Link
+              href={customerMessageHref}
+              className={`${actionClassName} mt-4`}
+            >
+              <MessageSquareText className="h-3.5 w-3.5" aria-hidden="true" />
+              Message customer
+            </Link>
+          ) : null}
+        </article>
+      </div>
+    </section>
+  );
+}
+
+export function WorkOrderJobDocumentsWorkspace({
+  workOrderId,
+  workOrderLineId,
+  refreshKey,
+  onAddMedia,
+  disabled = false,
+}: {
+  workOrderId: string;
+  workOrderLineId: string;
+  refreshKey: number;
+  onAddMedia: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <section>
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+            Documents &amp; evidence
+          </div>
+          <h3 className="mt-1 text-base font-semibold text-[color:var(--theme-text-primary)]">
+            Job photos, videos, and markup
+          </h3>
+        </div>
+        <button
+          type="button"
+          className={actionClassName}
+          onClick={onAddMedia}
+          disabled={disabled}
+        >
+          <Camera className="h-3.5 w-3.5" aria-hidden="true" />
+          Add photo or video
+        </button>
+      </div>
+
+      <WorkOrderMediaGallery
+        workOrderId={workOrderId}
+        workOrderLineId={workOrderLineId}
+        refreshKey={refreshKey}
+      />
+    </section>
+  );
+}

--- a/features/work-orders/workspace/workOrderWorkspace.ts
+++ b/features/work-orders/workspace/workOrderWorkspace.ts
@@ -77,6 +77,7 @@ export type WorkOrderJobWorkspaceTabId =
   | "story"
   | "inspection"
   | "parts"
+  | "communication"
   | "evidence"
   | "details";
 
@@ -103,6 +104,31 @@ export function getWorkOrderJobWorkspaceTabs(input: {
     : WORK_ORDER_JOB_WORKSPACE_TABS.filter(
         (tab) => tab.id !== "inspection",
       );
+}
+
+const WORK_ORDER_JOB_COMMUNICATION_TAB: WorkOrderJobWorkspaceTab = {
+  id: "communication",
+  label: "Messages",
+  module: "communication",
+};
+
+export function getComposedWorkOrderJobWorkspaceTabs(input: {
+  inspectionAvailable: boolean;
+  communicationAvailable: boolean;
+}): readonly WorkOrderJobWorkspaceTab[] {
+  const existingTabs = getWorkOrderJobWorkspaceTabs(input);
+  if (!input.communicationAvailable) return existingTabs;
+
+  const evidenceIndex = existingTabs.findIndex((tab) => tab.id === "evidence");
+  if (evidenceIndex < 0) {
+    return [...existingTabs, WORK_ORDER_JOB_COMMUNICATION_TAB];
+  }
+
+  return [
+    ...existingTabs.slice(0, evidenceIndex),
+    WORK_ORDER_JOB_COMMUNICATION_TAB,
+    ...existingTabs.slice(evidenceIndex),
+  ];
 }
 
 export function canOpenWorkOrderInspectionModule(input: {

--- a/tests/work-order-workspace-communication-documents.test.tsx
+++ b/tests/work-order-workspace-communication-documents.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  WorkOrderJobCommunicationWorkspace,
+  WorkOrderJobDocumentsWorkspace,
+} from "@/features/work-orders/workspace/WorkOrderJobWorkspaceSurfaces";
+import { WorkOrderWorkspaceModule } from "@/features/work-orders/workspace/WorkOrderWorkspaceFrame";
+import {
+  getComposedWorkOrderJobWorkspaceTabs,
+  getWorkOrderJobWorkspaceTabs,
+} from "@/features/work-orders/workspace/workOrderWorkspace";
+
+vi.mock(
+  "@/features/work-orders/components/workorders/extras/WorkOrderMediaGallery",
+  () => ({
+    default: ({
+      workOrderId,
+      workOrderLineId,
+      refreshKey,
+    }: {
+      workOrderId: string;
+      workOrderLineId: string;
+      refreshKey: number;
+    }) => (
+      <output
+        data-testid="media-gallery"
+        data-work-order-id={workOrderId}
+        data-work-order-line-id={workOrderLineId}
+        data-refresh-key={refreshKey}
+      >
+        Existing media gallery
+      </output>
+    ),
+  }),
+);
+
+afterEach(() => cleanup());
+
+describe("Work Order Workspace Communication and Documents composition", () => {
+  it("adds Messages through a composed adapter without changing the existing tab contract", () => {
+    expect(
+      getWorkOrderJobWorkspaceTabs({ inspectionAvailable: false }).map(
+        (tab) => tab.id,
+      ),
+    ).toEqual(["overview", "story", "parts", "evidence", "details"]);
+
+    expect(
+      getComposedWorkOrderJobWorkspaceTabs({
+        inspectionAvailable: true,
+        communicationAvailable: true,
+      }).map((tab) => [tab.id, tab.module]),
+    ).toEqual([
+      ["overview", "repairLines"],
+      ["story", "repairLines"],
+      ["inspection", "inspection"],
+      ["parts", "parts"],
+      ["communication", "communication"],
+      ["evidence", "documents"],
+      ["details", "repairLines"],
+    ]);
+  });
+
+  it("delegates job and customer messages to the existing authorized entry points", () => {
+    const onOpenJobChat = vi.fn();
+    render(
+      <WorkOrderWorkspaceModule module="communication">
+        <WorkOrderJobCommunicationWorkspace
+          jobLabel="Brake inspection"
+          customerMessageHref="/chat?compose=customer&contextType=work_order&contextId=wo-1&customerId=customer-1"
+          onOpenJobChat={onOpenJobChat}
+        />
+      </WorkOrderWorkspaceModule>,
+    );
+
+    expect(screen.getByLabelText("Communication")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Open job chat" }));
+    expect(onOpenJobChat).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole("link", { name: "Message customer" }),
+    ).toHaveAttribute(
+      "href",
+      "/chat?compose=customer&contextType=work_order&contextId=wo-1&customerId=customer-1",
+    );
+  });
+
+  it("does not manufacture a customer action when the role-shaped handoff is unavailable", () => {
+    render(
+      <WorkOrderJobCommunicationWorkspace
+        jobLabel="Brake inspection"
+        onOpenJobChat={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByRole("link", { name: "Message customer" })).toBeNull();
+    expect(
+      screen.getByText(
+        "Customer messaging is not available for this job or role.",
+      ),
+    ).toBeVisible();
+  });
+
+  it("keeps evidence loading and media capture on their existing handlers", () => {
+    const onAddMedia = vi.fn();
+    render(
+      <WorkOrderWorkspaceModule module="documents">
+        <WorkOrderJobDocumentsWorkspace
+          workOrderId="wo-1"
+          workOrderLineId="line-1"
+          refreshKey={4}
+          onAddMedia={onAddMedia}
+        />
+      </WorkOrderWorkspaceModule>,
+    );
+
+    expect(screen.getByLabelText("Documents")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Add photo or video" }));
+    expect(onAddMedia).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("media-gallery")).toHaveAttribute(
+      "data-work-order-id",
+      "wo-1",
+    );
+    expect(screen.getByTestId("media-gallery")).toHaveAttribute(
+      "data-work-order-line-id",
+      "line-1",
+    );
+    expect(screen.getByTestId("media-gallery")).toHaveAttribute(
+      "data-refresh-key",
+      "4",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a selected-job **Messages** workspace tab using the existing Work Order line chat and the existing role-shaped customer messaging handoff
- compose **Evidence** as the Work Order **Documents** module while preserving the existing photo/video capture modal and media gallery
- keep the original tab helper contract intact through an additive composition adapter
- preserve the prior inspection-template availability and explicit parts-refresh fixes already merged on `main`

## Change classification

Compatible integration. No routes, API contracts, authorization rules, database schema, migrations, or realtime publications changed.

## Validation

- focused Work Order/chat/evidence regression suites: **7 files, 37 tests passed**
- strict TypeScript: **passed**
- changed-file ESLint: **passed**
- full ESLint: **passed** with existing repository warnings only
- full Vitest suite: **478 files / 2,809 tests passed**, with the repository's 2 expected integration skips
- regression inventory: **0 new errors**; advisory warnings are all in untouched files
- production Next.js build: **passed** using the exact compile-only placeholder environment from Agent PR Checks
- `git diff --check`: **passed**

## Deployment / data

- no preview deployment requested
- no database or environment changes
- draft only; do not merge until explicitly approved