### PR TITLE
Fix selected-job chat authorization context

### DIFF
--- a/features/ai/components/chat/NewChatModal.tsx
+++ b/features/ai/components/chat/NewChatModal.tsx
@@ -40,6 +40,19 @@ type MessageRow = {
   recipients?: string[] | null;
 };
 
+type ConversationContextSummary = {
+  conversation: {
+    id: string;
+    context_type: string | null;
+    context_id: string | null;
+    created_at: string | null;
+  };
+  latest_message?: {
+    sent_at: string | null;
+    created_at: string | null;
+  } | null;
+};
+
 type Props = {
   isOpen: boolean;
   onClose: () => void;
@@ -62,6 +75,7 @@ type Props = {
 
 const LOCAL_ACTIVE_KEY = "pfq-chat-last-conversation";
 const LOCAL_RECENT_KEY = "pfq-chat-recent-convos";
+const EMPTY_CONVERSATION_IDS: readonly string[] = [];
 
 function scopedStorageKey(key: string, userId: string): string {
   return `${key}:${userId}`;
@@ -71,15 +85,65 @@ export function resolveInitialChatConversationId({
   forcedConversationId,
   storedConversationId,
   restoreStoredConversation,
+  contextualConversationIds = [],
 }: {
   forcedConversationId: string | null;
   storedConversationId: string | null;
   restoreStoredConversation: boolean;
+  contextualConversationIds?: string[];
 }): string | null {
-  return (
-    forcedConversationId ??
-    (restoreStoredConversation ? storedConversationId : null)
-  );
+  if (forcedConversationId) return forcedConversationId;
+  if (restoreStoredConversation) return storedConversationId;
+  if (
+    storedConversationId &&
+    contextualConversationIds.includes(storedConversationId)
+  ) {
+    return storedConversationId;
+  }
+  return contextualConversationIds[0] ?? null;
+}
+
+export function getContextualChatConversationIds({
+  conversations,
+  recentConversationIds,
+  contextType,
+  contextId,
+}: {
+  conversations: ConversationContextSummary[];
+  recentConversationIds: string[];
+  contextType: string;
+  contextId: string;
+}): string[] {
+  const matches = conversations
+    .filter(
+      ({ conversation }) =>
+        conversation.context_type === contextType &&
+        conversation.context_id === contextId,
+    )
+    .sort((left, right) => {
+      const leftActivity =
+        left.latest_message?.sent_at ??
+        left.latest_message?.created_at ??
+        left.conversation.created_at ??
+        "";
+      const rightActivity =
+        right.latest_message?.sent_at ??
+        right.latest_message?.created_at ??
+        right.conversation.created_at ??
+        "";
+      return rightActivity.localeCompare(leftActivity);
+    })
+    .map(({ conversation }) => conversation.id);
+
+  const matchingIds = new Set(matches);
+  const orderedIds = recentConversationIds.filter((id) => matchingIds.has(id));
+  const orderedIdSet = new Set(orderedIds);
+  for (const id of matches) {
+    if (orderedIdSet.has(id)) continue;
+    orderedIds.push(id);
+    orderedIdSet.add(id);
+  }
+  return orderedIds;
 }
 
 export default function NewChatModal({
@@ -123,6 +187,9 @@ export default function NewChatModal({
   const [recentConversationIds, setRecentConversationIds] = useState<string[]>(
     [],
   );
+  const [contextualConversationIds, setContextualConversationIds] = useState<
+    string[] | null
+  >(null);
   const [recentLabels, setRecentLabels] = useState<Record<string, string>>({});
 
   const bottomRef = useRef<HTMLDivElement | null>(null);
@@ -209,6 +276,26 @@ export default function NewChatModal({
       const recent = loadRecentFromStorage();
       setRecentConversationIds(recent);
 
+      const contextualConversationIdsPromise =
+        !restoreStoredConversation && context_type && context_id
+          ? fetch("/api/chat/my-conversations", {
+              method: "GET",
+              credentials: "include",
+            })
+              .then(async (response) => {
+                if (!response.ok) return [];
+                const payload: unknown = await response.json().catch(() => []);
+                if (!Array.isArray(payload)) return [];
+                return getContextualChatConversationIds({
+                  conversations: payload as ConversationContextSummary[],
+                  recentConversationIds: recent,
+                  contextType: context_type,
+                  contextId: context_id,
+                });
+              })
+              .catch(() => [])
+          : Promise.resolve<string[] | null>(null);
+
       setLoadingUsers(true);
       setApiError(null);
 
@@ -285,10 +372,14 @@ export default function NewChatModal({
             )
           : null;
 
+      const matchingConversationIds = await contextualConversationIdsPromise;
+      setContextualConversationIds(matchingConversationIds);
+
       const initialConversationId = resolveInitialChatConversationId({
         forcedConversationId,
         storedConversationId: stored,
         restoreStoredConversation,
+        contextualConversationIds: matchingConversationIds ?? [],
       });
 
       if (initialConversationId) {
@@ -307,6 +398,8 @@ export default function NewChatModal({
     supabase,
     forcedConversationId,
     restoreStoredConversation,
+    context_type,
+    context_id,
     loadRecentFromStorage,
     upsertRecent,
   ]);
@@ -467,6 +560,7 @@ export default function NewChatModal({
 
   // ⬇️ Selecting recipients starts a NEW conversation (refresh chat area)
   useEffect(() => {
+    if (selectedIds.length === 0) return;
     setActiveConvoId(null);
     setMessages([]);
   }, [selectedIds]);
@@ -523,6 +617,11 @@ export default function NewChatModal({
         }
         onCreated?.(newId);
         upsertRecent(newId);
+        setContextualConversationIds((previous) =>
+          previous
+            ? [newId, ...previous.filter((id) => id !== newId)]
+            : previous,
+        );
         return newId;
       } catch (error) {
         console.error("conversation create failed:", error);
@@ -661,11 +760,17 @@ export default function NewChatModal({
     [currentUserId, recentLabels],
   );
 
+  const usesContextualConversationHistory =
+    !restoreStoredConversation && Boolean(context_type && context_id);
+  const visibleRecentConversationIds = usesContextualConversationHistory
+    ? (contextualConversationIds ?? EMPTY_CONVERSATION_IDS)
+    : recentConversationIds;
+
   useEffect(() => {
-    recentConversationIds.slice(0, 12).forEach((id) => {
+    visibleRecentConversationIds.slice(0, 12).forEach((id) => {
       void buildRecentLabel(id);
     });
-  }, [recentConversationIds, buildRecentLabel]);
+  }, [visibleRecentConversationIds, buildRecentLabel]);
 
   return (
     <ModalShell isOpen={isOpen} onClose={onClose} title="Team chat" size="xl">
@@ -847,12 +952,12 @@ export default function NewChatModal({
           Recent:
         </div>
         <div className="flex flex-wrap gap-2">
-          {recentConversationIds.length === 0 ? (
+          {visibleRecentConversationIds.length === 0 ? (
             <div className="text-[11px] text-[color:var(--theme-text-muted)]">
               No recent threads.
             </div>
           ) : (
-            recentConversationIds.slice(0, 12).map((id) => {
+            visibleRecentConversationIds.slice(0, 12).map((id) => {
               const active = id === activeConvoId;
               const label = recentLabels[id] || id.slice(0, 8);
               return (

--- a/features/ai/components/chat/NewChatModal.tsx
+++ b/features/ai/components/chat/NewChatModal.tsx
@@ -49,6 +49,11 @@ type Props = {
   context_id?: string | null;
   activeConversationId?: string | null;
   /**
+   * Contextual launchers can disable the global last-conversation restore so
+   * a stored thread from another resource does not replace their context.
+   */
+  restoreStoredConversation?: boolean;
+  /**
    * Where the "Open conversation history →" link should go.
    * Desktop can use "/chat"; mobile can pass its own route, e.g. "/mobile/chat".
    */
@@ -62,6 +67,21 @@ function scopedStorageKey(key: string, userId: string): string {
   return `${key}:${userId}`;
 }
 
+export function resolveInitialChatConversationId({
+  forcedConversationId,
+  storedConversationId,
+  restoreStoredConversation,
+}: {
+  forcedConversationId: string | null;
+  storedConversationId: string | null;
+  restoreStoredConversation: boolean;
+}): string | null {
+  return (
+    forcedConversationId ??
+    (restoreStoredConversation ? storedConversationId : null)
+  );
+}
+
 export default function NewChatModal({
   isOpen,
   onClose,
@@ -69,6 +89,7 @@ export default function NewChatModal({
   context_type = null,
   context_id = null,
   activeConversationId: forcedConversationId = null,
+  restoreStoredConversation = true,
   historyHref = "/chat",
 }: Props) {
   const supabase = useMemo(() => createBrowserSupabase(), []);
@@ -264,12 +285,15 @@ export default function NewChatModal({
             )
           : null;
 
-      if (forcedConversationId) {
-        setActiveConvoId(forcedConversationId);
-        upsertRecent(forcedConversationId);
-      } else if (stored) {
-        setActiveConvoId(stored);
-        upsertRecent(stored);
+      const initialConversationId = resolveInitialChatConversationId({
+        forcedConversationId,
+        storedConversationId: stored,
+        restoreStoredConversation,
+      });
+
+      if (initialConversationId) {
+        setActiveConvoId(initialConversationId);
+        upsertRecent(initialConversationId);
       } else {
         setActiveConvoId(null);
       }
@@ -282,6 +306,7 @@ export default function NewChatModal({
     isOpen,
     supabase,
     forcedConversationId,
+    restoreStoredConversation,
     loadRecentFromStorage,
     upsertRecent,
   ]);

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -57,6 +57,7 @@ import {
 import { WorkOrderWorkspaceModule } from "@/features/work-orders/workspace/WorkOrderWorkspaceFrame";
 import {
   getComposedWorkOrderJobWorkspaceTabs,
+  getWorkOrderJobChatContext,
   type WorkOrderJobWorkspaceTabId,
 } from "@/features/work-orders/workspace/workOrderWorkspace";
 import { useWorkOrderPartsRefresh } from "@/features/work-orders/workspace/useWorkOrderPartsRefresh";
@@ -246,6 +247,10 @@ export default function FocusedJobModal(props: {
   const [openAi, setOpenAi] = useState(false);
   const [openDtc, setOpenDtc] = useState(false);
   const [openVehicleHistory, setOpenVehicleHistory] = useState(false);
+  const jobChatWorkOrderId = workOrder?.id ?? line?.work_order_id ?? null;
+  const jobChatContext = jobChatWorkOrderId
+    ? getWorkOrderJobChatContext(jobChatWorkOrderId)
+    : null;
   const [activeWorkspaceTab, setActiveWorkspaceTab] =
     useState<WorkOrderJobWorkspaceTabId>("overview");
   const inspectionAvailable = Boolean(onOpenInspection);
@@ -2037,14 +2042,15 @@ export default function FocusedJobModal(props: {
         />
       ) : null}
 
-      {openChat ? (
+      {openChat && jobChatContext ? (
         <NewChatModal
           isOpen={openChat}
           onClose={() => setOpenChat(false)}
           created_by="system"
           onCreated={() => setOpenChat(false)}
-          context_type="work_order_line"
-          context_id={line?.id ?? null}
+          context_type={jobChatContext.contextType}
+          context_id={jobChatContext.contextId}
+          restoreStoredConversation={jobChatContext.restoreStoredConversation}
         />
       ) : null}
 

--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -37,6 +37,9 @@ import NewChatModal from "@/features/ai/components/chat/NewChatModal";
 import SuggestedQuickAdd from "@work-orders/components/SuggestedQuickAdd";
 import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransitionsClient";
 import {
+  getWorkOrderJobChatContext,
+} from "@/features/work-orders/workspace/workOrderWorkspace";
+import {
   filterAllocationsNotBackedByCanonicalParts,
   getCanonicalPartDescription,
   getCanonicalPartManufacturer,
@@ -193,6 +196,9 @@ export default function MobileFocusedJob(props: {
     () => filterAllocationsNotBackedByCanonicalParts(allocs, requiredParts),
     [allocs, requiredParts],
   );
+  const jobChatContext = workOrder?.id
+    ? getWorkOrderJobChatContext(workOrder.id)
+    : null;
 
   const showErr = (prefix: string, err?: { message?: string } | null) => {
     toast.error(`${prefix}: ${err?.message ?? "Something went wrong."}`);
@@ -1659,14 +1665,15 @@ export default function MobileFocusedJob(props: {
         />
       )}
 
-      {openChat && (
+      {openChat && jobChatContext && (
         <NewChatModal
           isOpen={openChat}
           onClose={() => setOpenChat(false)}
           created_by="system"
           onCreated={() => setOpenChat(false)}
-          context_type="work_order_line"
-          context_id={line?.id ?? null}
+          context_type={jobChatContext.contextType}
+          context_id={jobChatContext.contextId}
+          restoreStoredConversation={jobChatContext.restoreStoredConversation}
         />
       )}
 

--- a/features/work-orders/workspace/workOrderWorkspace.ts
+++ b/features/work-orders/workspace/workOrderWorkspace.ts
@@ -131,6 +131,18 @@ export function getComposedWorkOrderJobWorkspaceTabs(input: {
   ];
 }
 
+export function getWorkOrderJobChatContext(workOrderId: string): {
+  contextType: "work_order";
+  contextId: string;
+  restoreStoredConversation: false;
+} {
+  return {
+    contextType: "work_order",
+    contextId: workOrderId,
+    restoreStoredConversation: false,
+  };
+}
+
 export function canOpenWorkOrderInspectionModule(input: {
   inspectionTemplateId: string | null | undefined;
   canRunInspections: boolean;

--- a/tests/new-chat-modal-context.test.ts
+++ b/tests/new-chat-modal-context.test.ts
@@ -1,7 +1,21 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { resolveInitialChatConversationId } from "@/features/ai/components/chat/NewChatModal";
+import {
+  getContextualChatConversationIds,
+  resolveInitialChatConversationId,
+} from "@/features/ai/components/chat/NewChatModal";
 import { getWorkOrderJobChatContext } from "@/features/work-orders/workspace/workOrderWorkspace";
+
+const mobileFocusedJob = readFileSync(
+  join(process.cwd(), "features/work-orders/mobile/MobileFocusedJob.tsx"),
+  "utf8",
+);
+const newChatModal = readFileSync(
+  join(process.cwd(), "features/ai/components/chat/NewChatModal.tsx"),
+  "utf8",
+);
 
 describe("NewChatModal contextual launch", () => {
   it("anchors selected-job chat to the authorized parent Work Order context", () => {
@@ -32,6 +46,57 @@ describe("NewChatModal contextual launch", () => {
     ).toBeNull();
   });
 
+  it("restores only conversations attached to the requested context", () => {
+    const contextualConversationIds = getContextualChatConversationIds({
+      conversations: [
+        {
+          conversation: {
+            id: "older-match",
+            context_type: "work_order",
+            context_id: "wo-1",
+            created_at: "2026-08-20T12:00:00.000Z",
+          },
+          latest_message: null,
+        },
+        {
+          conversation: {
+            id: "newer-match",
+            context_type: "work_order",
+            context_id: "wo-1",
+            created_at: "2026-08-21T12:00:00.000Z",
+          },
+          latest_message: null,
+        },
+        {
+          conversation: {
+            id: "unrelated",
+            context_type: "work_order",
+            context_id: "wo-2",
+            created_at: "2026-08-21T13:00:00.000Z",
+          },
+          latest_message: null,
+        },
+      ],
+      recentConversationIds: ["older-match", "unrelated"],
+      contextType: "work_order",
+      contextId: "wo-1",
+    });
+
+    expect(contextualConversationIds).toEqual(["older-match", "newer-match"]);
+    expect(
+      resolveInitialChatConversationId({
+        forcedConversationId: null,
+        storedConversationId: "unrelated",
+        restoreStoredConversation: false,
+        contextualConversationIds,
+      }),
+    ).toBe("older-match");
+  });
+
+  it("keeps a recent thread active when its recipient picker is cleared", () => {
+    expect(newChatModal).toContain("if (selectedIds.length === 0) return;");
+  });
+
   it("keeps an explicitly requested conversation authoritative", () => {
     expect(
       resolveInitialChatConversationId({
@@ -40,5 +105,13 @@ describe("NewChatModal contextual launch", () => {
         restoreStoredConversation: false,
       }),
     ).toBe("requested-conversation");
+  });
+
+  it("applies the canonical Work Order context to the mobile launcher", () => {
+    expect(mobileFocusedJob).toContain(
+      "context_type={jobChatContext.contextType}",
+    );
+    expect(mobileFocusedJob).toContain("context_id={jobChatContext.contextId}");
+    expect(mobileFocusedJob).not.toContain('context_type="work_order_line"');
   });
 });

--- a/tests/new-chat-modal-context.test.ts
+++ b/tests/new-chat-modal-context.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveInitialChatConversationId } from "@/features/ai/components/chat/NewChatModal";
+import { getWorkOrderJobChatContext } from "@/features/work-orders/workspace/workOrderWorkspace";
+
+describe("NewChatModal contextual launch", () => {
+  it("anchors selected-job chat to the authorized parent Work Order context", () => {
+    expect(getWorkOrderJobChatContext("wo-1")).toEqual({
+      contextType: "work_order",
+      contextId: "wo-1",
+      restoreStoredConversation: false,
+    });
+  });
+
+  it("preserves the existing global last-conversation restore by default", () => {
+    expect(
+      resolveInitialChatConversationId({
+        forcedConversationId: null,
+        storedConversationId: "stored-conversation",
+        restoreStoredConversation: true,
+      }),
+    ).toBe("stored-conversation");
+  });
+
+  it("does not replace a contextual launch with an unrelated stored conversation", () => {
+    expect(
+      resolveInitialChatConversationId({
+        forcedConversationId: null,
+        storedConversationId: "unrelated-conversation",
+        restoreStoredConversation: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps an explicitly requested conversation authoritative", () => {
+    expect(
+      resolveInitialChatConversationId({
+        forcedConversationId: "requested-conversation",
+        storedConversationId: "unrelated-conversation",
+        restoreStoredConversation: false,
+      }),
+    ).toBe("requested-conversation");
+  });
+});


### PR DESCRIPTION
## Summary

- route selected-job team chat through the already-authorized parent `work_order` context instead of the unsupported `work_order_line` value
- prevent a contextual Work Order launch from automatically restoring an unrelated globally stored conversation
- preserve the canonical `NewChatModal`, start-conversation route, authorization helper, default restore behavior, and every existing test

This is the backward-compatible follow-up for the unresolved Codex P2 on merged PR #1503.

## Change classification

Compatible integration. No API contract, authorization rule, role capability, database object, migration, grant, revoke, or existing test changed.

## Local validation

- final focused Work Order/chat regressions: **3 files, 12 tests passed**
- broader focused authorization/workspace regressions: **6 files, 22 tests passed**
- full Vitest suite: **479 files / 2,813 tests passed**, with 2 expected integration skips
- strict TypeScript: **passed**
- changed-file and full ESLint: **passed** with 0 errors; repository retains 235 existing warnings
- regression inventory: **0 new errors**
- production Next.js build: **passed** with the Agent PR Checks compile-only environment
- `git diff --check`: **passed**

## Security issue tracked separately

This PR does **not** change the six existing SECURITY DEFINER RPC privileges. Revoking anonymous/PUBLIC execution is a separate contract change requiring explicit task-specific approval and a forward migration.

## Deployment

- draft only
- no preview deployment requested
- no database or environment changes
- do not merge until explicitly approved