### PR TITLE
Fix mobile focused-job action dock overlap

### DIFF
--- a/app/mobile/mobile-command-overrides.css
+++ b/app/mobile/mobile-command-overrides.css
@@ -25,3 +25,19 @@
   .mobile-command-main {
   padding-bottom: 0;
 }
+
+/*
+ * The focused-job action dock is fixed to the visual viewport. A backdrop
+ * filter on its current-state panel creates a fixed-position containing block
+ * in WebKit, pinning the dock inside the panel and covering the top of the
+ * job screen. Keep the shared blur everywhere else, but neutralize it on the
+ * one panel that owns the viewport-fixed dock.
+ */
+.profixiq-mobile-command
+  .app-shell
+  main.mobile-tech-page
+  > div
+  > .mobile-tech-panel:first-of-type {
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+}

--- a/tests/mobile-focused-job-layout.test.ts
+++ b/tests/mobile-focused-job-layout.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const mobileLayout = readFileSync("app/mobile/layout.tsx", "utf8");
+const mobileCommandCss = readFileSync("app/mobile/mobile-command.css", "utf8");
+const mobileCommandOverridesCss = readFileSync(
+  "app/mobile/mobile-command-overrides.css",
+  "utf8",
+);
+const mobileWorkCommandCss = readFileSync(
+  "app/mobile/mobile-work-command.css",
+  "utf8",
+);
+
+function normalizeCss(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function ruleBody(source: string, selector: string): string {
+  const normalized = normalizeCss(source);
+  const marker = `${selector} {`;
+  const start = normalized.indexOf(marker);
+  expect(start, `missing CSS rule: ${selector}`).toBeGreaterThanOrEqual(0);
+  const bodyStart = start + marker.length;
+  const end = normalized.indexOf("}", bodyStart);
+  expect(end, `unterminated CSS rule: ${selector}`).toBeGreaterThan(bodyStart);
+  return normalized.slice(bodyStart, end).trim();
+}
+
+describe("mobile focused-job viewport layout", () => {
+  const currentStatePanelSelector =
+    ".profixiq-mobile-command .app-shell main.mobile-tech-page > div > .mobile-tech-panel:first-of-type";
+  const actionDockSelector =
+    `${currentStatePanelSelector} > .flex.flex-col.gap-2`;
+
+  it("keeps the primary job actions fixed to the visual viewport", () => {
+    const dock = ruleBody(mobileWorkCommandCss, actionDockSelector);
+
+    expect(dock).toContain("position: fixed;");
+    expect(dock).toContain("bottom: calc(0.7rem + env(safe-area-inset-bottom, 0px));");
+  });
+
+  it("prevents the current-state panel from becoming the WebKit fixed-position containing block", () => {
+    const sharedPanelRule = ruleBody(
+      mobileCommandCss,
+      ".profixiq-mobile-command .metal-panel, .profixiq-mobile-command .metal-card, .profixiq-mobile-command .mobile-tech-panel, .profixiq-mobile-command .mobile-tech-subpanel, .profixiq-mobile-command .mobile-command-panel, .profixiq-mobile-command .mobile-command-row",
+    );
+    expect(sharedPanelRule).toContain("backdrop-filter: blur(18px);");
+
+    const focusedPanelOverride = ruleBody(
+      mobileCommandOverridesCss,
+      currentStatePanelSelector,
+    );
+    expect(focusedPanelOverride).toContain(
+      "-webkit-backdrop-filter: none !important;",
+    );
+    expect(focusedPanelOverride).toContain("backdrop-filter: none !important;");
+  });
+
+  it("loads the focused-job containment override after the shared mobile surface styles", () => {
+    const baseIndex = mobileLayout.indexOf('import "./mobile-command.css";');
+    const overrideIndex = mobileLayout.indexOf(
+      'import "./mobile-command-overrides.css";',
+    );
+
+    expect(baseIndex).toBeGreaterThanOrEqual(0);
+    expect(overrideIndex).toBeGreaterThan(baseIndex);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent the focused-job current-state panel from becoming WebKit's containing block for the viewport-fixed primary action dock
- keep the existing shared glass/blur treatment everywhere else
- add a regression contract covering the viewport-fixed dock, iOS/WebKit backdrop-filter override, and stylesheet ordering

## Root cause
The primary action group in `MobileFocusedJob` is `position: fixed`, but its ancestor `.mobile-tech-panel` receives `backdrop-filter: blur(18px)`. WebKit treats that filtered ancestor as the containing block for fixed descendants, so the action dock is positioned inside the current-job panel and overlays/cuts off the top of the mobile work-order screen.

## Scope
CSS-only presentation correction plus regression test. No work-order data, lifecycle, permissions, RPCs, or desktop behavior changed.