### PR TITLE
Phase 2: bound failing route loaders and expose recovery states

### DIFF
--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -17,6 +17,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { Database } from "@shared/types/types/supabase";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
+import {
+  asRouteLoadFailure,
+  runBoundedRouteLoad,
+  type RouteLoadFailure,
+} from "@/features/shared/lib/route-load";
 import PickOrderTaskModal from "@/features/parts/components/PickOrderTaskModal";
 import MenuItemPartsIntakeModal, {
   type MenuIntakeQueueItem,
@@ -687,6 +693,7 @@ export default function PartsRequestsPage(): JSX.Element {
   >({});
   const [menuItems, setMenuItems] = useState<Record<string, MenuItemLite>>({});
   const [loading, setLoading] = useState(true);
+  const [loadFailure, setLoadFailure] = useState<RouteLoadFailure | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [search, setSearch] = useState("");
   const [tab, setTab] = useState<QueueTab>("active");
@@ -708,140 +715,154 @@ export default function PartsRequestsPage(): JSX.Element {
     else setRefreshing(true);
 
     try {
-      const requestRows: PartRequest[] = [];
-      const requestPageSize = 500;
-      for (let offset = 0; ; offset += requestPageSize) {
-        const { data: requests, error: requestError } = await supabase
-          .from("part_requests")
-          .select("*")
-          .in("status", REQUEST_STATUSES)
-          .order("created_at", { ascending: false })
-          .order("id", { ascending: true })
-          .range(offset, offset + requestPageSize - 1);
-        if (requestError) throw requestError;
-        const requestPage = (requests ?? []) as PartRequest[];
-        requestRows.push(...requestPage);
-        if (requestPage.length < requestPageSize) break;
-      }
-
-      const requestIds = requestRows.map((request) => request.id);
-      const itemRows: QueueItem[] = [];
-
-      if (requestIds.length > 0) {
-        const pageSize = 1000;
-        for (
-          let chunkStart = 0;
-          chunkStart < requestIds.length;
-          chunkStart += 200
-        ) {
-          const requestChunk = requestIds.slice(chunkStart, chunkStart + 200);
-          for (let offset = 0; ; offset += pageSize) {
-            const { data: items, error: itemError } = await supabase
-              .from("part_request_items")
-              .select(
-                "id,request_id,description,part_id,requested_part_number,requested_manufacturer,quoted_price,unit_price,unit_cost,qty,qty_requested,qty_approved,qty_ordered,qty_received,qty_reserved,qty_consumed,qty_returned,status,updated_at",
-              )
-              .in("request_id", requestChunk)
+      setLoadFailure(null);
+      await runBoundedRouteLoad(
+        { route: "/parts/requests", operation: "load parts request queue" },
+        async ({ signal }) => {
+          const requestRows: PartRequest[] = [];
+          const requestPageSize = 500;
+          for (let offset = 0; ; offset += requestPageSize) {
+            const { data: requests, error: requestError } = await supabase
+              .from("part_requests")
+              .select("*")
+              .in("status", REQUEST_STATUSES)
+              .order("created_at", { ascending: false })
               .order("id", { ascending: true })
-              .range(offset, offset + pageSize - 1);
-            if (itemError) throw itemError;
-            const itemPage = (items ?? []) as QueueItem[];
-            itemRows.push(...itemPage);
-            if (itemPage.length < pageSize) break;
+              .abortSignal(signal)
+              .range(offset, offset + requestPageSize - 1);
+            if (requestError) throw requestError;
+            const requestPage = (requests ?? []) as PartRequest[];
+            requestRows.push(...requestPage);
+            if (requestPage.length < requestPageSize) break;
           }
-        }
-      }
 
-      const itemsByRequest = new Map<string, QueueItem[]>();
-      for (const item of itemRows) {
-        itemsByRequest.set(item.request_id, [
-          ...(itemsByRequest.get(item.request_id) ?? []),
-          item,
-        ]);
-      }
+          const requestIds = requestRows.map((request) => request.id);
+          const itemRows: QueueItem[] = [];
 
-      const nextModels = requestRows.map((request) => {
-        const items = itemsByRequest.get(request.id) ?? [];
-        const stageItems = items.map(stageItem);
-        const isMenuIntake =
-          Boolean(request.source_menu_item_id) && !request.work_order_id;
-        return {
-          request,
-          items,
-          stage: isMenuIntake
-            ? toMenuIntakeStage({
-                rawStatus: request.status,
-                items: stageItems,
-              })
-            : toPartsRequestStage({
-                rawStatus: request.status,
-                items: stageItems,
-              }),
-        } satisfies RequestModel;
-      });
-
-      const workOrderIds = [
-        ...new Set(
-          requestRows
-            .map((request) => request.work_order_id)
-            .filter((value): value is string => Boolean(value)),
-        ),
-      ];
-      const nextWorkOrders: Record<string, WorkOrderListRow> = {};
-      if (workOrderIds.length > 0) {
-        for (
-          let chunkStart = 0;
-          chunkStart < workOrderIds.length;
-          chunkStart += 200
-        ) {
-          const { data: rows, error: workOrderError } = await supabase
-            .from("work_orders")
-            .select(
-              "id,custom_id,estimate_number,customers(business_name,first_name,last_name),vehicles(year,make,model,vin,unit_number)",
-            )
-            .in("id", workOrderIds.slice(chunkStart, chunkStart + 200));
-          if (workOrderError) throw workOrderError;
-          for (const row of rows ?? []) {
-            const workOrder = row as WorkOrderListRow;
-            nextWorkOrders[workOrder.id] = workOrder;
+          if (requestIds.length > 0) {
+            const pageSize = 1000;
+            for (
+              let chunkStart = 0;
+              chunkStart < requestIds.length;
+              chunkStart += 200
+            ) {
+              const requestChunk = requestIds.slice(
+                chunkStart,
+                chunkStart + 200,
+              );
+              for (let offset = 0; ; offset += pageSize) {
+                const { data: items, error: itemError } = await supabase
+                  .from("part_request_items")
+                  .select(
+                    "id,request_id,description,part_id,requested_part_number,requested_manufacturer,quoted_price,unit_price,unit_cost,qty,qty_requested,qty_approved,qty_ordered,qty_received,qty_reserved,qty_consumed,qty_returned,status,updated_at",
+                  )
+                  .in("request_id", requestChunk)
+                  .order("id", { ascending: true })
+                  .abortSignal(signal)
+                  .range(offset, offset + pageSize - 1);
+                if (itemError) throw itemError;
+                const itemPage = (items ?? []) as QueueItem[];
+                itemRows.push(...itemPage);
+                if (itemPage.length < pageSize) break;
+              }
+            }
           }
-        }
-      }
 
-      const menuItemIds = [
-        ...new Set(
-          requestRows
-            .map((request) => request.source_menu_item_id ?? null)
-            .filter((value): value is string => Boolean(value)),
-        ),
-      ];
-      const nextMenuItems: Record<string, MenuItemLite> = {};
-      if (menuItemIds.length > 0) {
-        for (
-          let chunkStart = 0;
-          chunkStart < menuItemIds.length;
-          chunkStart += 200
-        ) {
-          const { data: rows, error: menuItemError } = await supabase
-            .from("menu_items")
-            .select("id, name")
-            .in("id", menuItemIds.slice(chunkStart, chunkStart + 200));
-          if (menuItemError) throw menuItemError;
-          for (const row of rows ?? []) {
-            nextMenuItems[row.id] = row;
+          const itemsByRequest = new Map<string, QueueItem[]>();
+          for (const item of itemRows) {
+            itemsByRequest.set(item.request_id, [
+              ...(itemsByRequest.get(item.request_id) ?? []),
+              item,
+            ]);
           }
-        }
-      }
 
-      if (sequence === reloadSequence.current) {
-        setModels(nextModels);
-        setWorkOrders(nextWorkOrders);
-        setMenuItems(nextMenuItems);
-      }
+          const nextModels = requestRows.map((request) => {
+            const items = itemsByRequest.get(request.id) ?? [];
+            const stageItems = items.map(stageItem);
+            const isMenuIntake =
+              Boolean(request.source_menu_item_id) && !request.work_order_id;
+            return {
+              request,
+              items,
+              stage: isMenuIntake
+                ? toMenuIntakeStage({
+                    rawStatus: request.status,
+                    items: stageItems,
+                  })
+                : toPartsRequestStage({
+                    rawStatus: request.status,
+                    items: stageItems,
+                  }),
+            } satisfies RequestModel;
+          });
+
+          const workOrderIds = [
+            ...new Set(
+              requestRows
+                .map((request) => request.work_order_id)
+                .filter((value): value is string => Boolean(value)),
+            ),
+          ];
+          const nextWorkOrders: Record<string, WorkOrderListRow> = {};
+          if (workOrderIds.length > 0) {
+            for (
+              let chunkStart = 0;
+              chunkStart < workOrderIds.length;
+              chunkStart += 200
+            ) {
+              const { data: rows, error: workOrderError } = await supabase
+                .from("work_orders")
+                .select(
+                  "id,custom_id,estimate_number,customers(business_name,first_name,last_name),vehicles(year,make,model,vin,unit_number)",
+                )
+                .abortSignal(signal)
+                .in("id", workOrderIds.slice(chunkStart, chunkStart + 200));
+              if (workOrderError) throw workOrderError;
+              for (const row of rows ?? []) {
+                const workOrder = row as WorkOrderListRow;
+                nextWorkOrders[workOrder.id] = workOrder;
+              }
+            }
+          }
+
+          const menuItemIds = [
+            ...new Set(
+              requestRows
+                .map((request) => request.source_menu_item_id ?? null)
+                .filter((value): value is string => Boolean(value)),
+            ),
+          ];
+          const nextMenuItems: Record<string, MenuItemLite> = {};
+          if (menuItemIds.length > 0) {
+            for (
+              let chunkStart = 0;
+              chunkStart < menuItemIds.length;
+              chunkStart += 200
+            ) {
+              const { data: rows, error: menuItemError } = await supabase
+                .from("menu_items")
+                .select("id, name")
+                .abortSignal(signal)
+                .in("id", menuItemIds.slice(chunkStart, chunkStart + 200));
+              if (menuItemError) throw menuItemError;
+              for (const row of rows ?? []) {
+                nextMenuItems[row.id] = row;
+              }
+            }
+          }
+
+          if (sequence === reloadSequence.current) {
+            setModels(nextModels);
+            setWorkOrders(nextWorkOrders);
+            setMenuItems(nextMenuItems);
+          }
+        },
+      );
     } catch (error) {
       if (sequence === reloadSequence.current) {
-        console.error("[parts/requests] queue load failed", error);
-        toast.error("Unable to load the Parts request queue.");
+        setLoadFailure(
+          asRouteLoadFailure(error, "Unable to load the Parts request queue."),
+        );
       }
     } finally {
       if (sequence === reloadSequence.current) {
@@ -1164,11 +1185,19 @@ export default function PartsRequestsPage(): JSX.Element {
         </div>
       </section>
 
+      {loadFailure ? (
+        <RouteLoadPanel
+          failure={loadFailure}
+          onRetry={() => void reload()}
+          title="Parts request queue unavailable"
+        />
+      ) : null}
+
       {loading ? (
         <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-8 text-center text-sm text-[color:var(--theme-text-secondary)]">
           Loading the live Parts workflow…
         </div>
-      ) : tab === "active" ? (
+      ) : loadFailure && models.length === 0 ? null : tab === "active" ? (
         <div
           className={`grid gap-3 ${stageFilter === "all" ? "md:grid-cols-2 xl:grid-cols-4" : "max-w-xl"}`}
         >

--- a/app/portal/approvals/page.tsx
+++ b/app/portal/approvals/page.tsx
@@ -1,7 +1,7 @@
 // app/portal/approvals/page.tsx
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Toaster, toast } from "sonner";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
@@ -15,6 +15,13 @@ import {
   resolveDecisionStatus,
 } from "@/features/shared/lib/decisionStatus";
 import { deriveEventsFromPortalApproval } from "@/features/shared/lib/decisionEvents";
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
+import {
+  asRouteLoadFailure,
+  routeLoadFailureFromStatus,
+  runBoundedRouteLoad,
+  type RouteLoadFailure,
+} from "@/features/shared/lib/route-load";
 
 const COPPER = "#C57A4A";
 
@@ -106,7 +113,8 @@ async function readJson(res: Response): Promise<unknown> {
 }
 
 function safePayload(v: unknown): ApprovalsPayload {
-  if (!isRecord(v)) return { lines: [], partRequestHeaders: [], quoteApprovals: [] };
+  if (!isRecord(v))
+    return { lines: [], partRequestHeaders: [], quoteApprovals: [] };
 
   const linesRaw = v.lines;
   const headersRaw = v.partRequestHeaders;
@@ -128,41 +136,50 @@ export default function PortalApprovalsPage() {
 
   const [lines, setLines] = useState<ApprovalLine[]>([]);
   const [headers, setHeaders] = useState<PartRequestHeader[]>([]);
-  const [quoteApprovals, setQuoteApprovals] = useState<QuoteApprovalSummary[]>([]);
+  const [quoteApprovals, setQuoteApprovals] = useState<QuoteApprovalSummary[]>(
+    [],
+  );
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<RouteLoadFailure | null>(null);
   const [busyItemId, setBusyItemId] = useState<string | null>(null);
 
-  const fetchApprovals = async (opts?: { silent?: boolean }) => {
+  const fetchApprovals = useCallback(async (opts?: { silent?: boolean }) => {
     const silent = Boolean(opts?.silent);
     if (!silent) setLoading(true);
     else setRefreshing(true);
 
     setError(null);
     try {
-      const res = await fetch("/api/portal/approvals", { method: "GET", cache: "no-store" });
-      const parsed = await readJson(res);
+      const payload = await runBoundedRouteLoad(
+        { route: "/portal/approvals", operation: "load approvals" },
+        async ({ recordStatus, signal }) => {
+          const res = await fetch("/api/portal/approvals", {
+            method: "GET",
+            cache: "no-store",
+            signal,
+          });
+          recordStatus(res.status);
+          const parsed = await readJson(res);
 
-      if (!res.ok) {
-        const msg =
-          (isRecord(parsed) && typeof parsed.error === "string" && parsed.error) ||
-          (typeof parsed === "string" ? parsed : null) ||
-          `Failed to load approvals (status ${res.status})`;
+          if (!res.ok) {
+            const msg =
+              (isRecord(parsed) &&
+                typeof parsed.error === "string" &&
+                parsed.error) ||
+              (typeof parsed === "string" ? parsed : null) ||
+              "Approvals could not be loaded.";
+            throw routeLoadFailureFromStatus(res.status, msg);
+          }
 
-        setError(msg);
-        setLines([]);
-        setHeaders([]);
-        setQuoteApprovals([]);
-        return;
-      }
-
-      const payload = safePayload(parsed);
+          return safePayload(parsed);
+        },
+      );
       setLines(payload.lines);
       setHeaders(payload.partRequestHeaders);
       setQuoteApprovals(payload.quoteApprovals);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : "Failed to load approvals");
+      setError(asRouteLoadFailure(e, "Approvals could not be loaded."));
       setLines([]);
       setHeaders([]);
       setQuoteApprovals([]);
@@ -170,16 +187,20 @@ export default function PortalApprovalsPage() {
       if (!silent) setLoading(false);
       else setRefreshing(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     void fetchApprovals();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [fetchApprovals]);
 
   const flattenedCount = useMemo(() => {
     let n = 0;
-    lines.forEach((ln) => (n += Array.isArray(ln.part_request_items) ? ln.part_request_items.length : 0));
+    lines.forEach(
+      (ln) =>
+        (n += Array.isArray(ln.part_request_items)
+          ? ln.part_request_items.length
+          : 0),
+    );
     quoteApprovals.forEach((quote) => (n += quote.lineCount));
     return n;
   }, [lines, quoteApprovals]);
@@ -203,17 +224,22 @@ export default function PortalApprovalsPage() {
     setBusyItemId(itemId);
 
     try {
-      const res = await fetch(`/api/work-orders/lines/${encodeURIComponent(lineId)}/approval-decision`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        cache: "no-store",
-        body: JSON.stringify({ decision, workOrderId }),
-      });
+      const res = await fetch(
+        `/api/work-orders/lines/${encodeURIComponent(lineId)}/approval-decision`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          cache: "no-store",
+          body: JSON.stringify({ decision, workOrderId }),
+        },
+      );
 
       const parsed = await readJson(res);
       if (!res.ok) {
         const msg =
-          (isRecord(parsed) && typeof parsed.error === "string" && parsed.error) ||
+          (isRecord(parsed) &&
+            typeof parsed.error === "string" &&
+            parsed.error) ||
           (typeof parsed === "string" ? parsed : null) ||
           `${decision === "approve" ? "Approve" : "Decline"} failed (${res.status})`;
 
@@ -237,12 +263,15 @@ export default function PortalApprovalsPage() {
   };
 
   const lineSummary = (ln: ApprovalLine) => {
-    const items = Array.isArray(ln.part_request_items) ? ln.part_request_items : [];
+    const items = Array.isArray(ln.part_request_items)
+      ? ln.part_request_items
+      : [];
     if (items.length === 0) return getDecisionStatusView("recommended");
 
     const approvedCount = items.filter((it) => Boolean(it.approved)).length;
     if (approvedCount === 0) return getDecisionStatusView("awaiting_approval");
-    if (approvedCount === items.length) return getDecisionStatusView("approved");
+    if (approvedCount === items.length)
+      return getDecisionStatusView("approved");
     return getDecisionStatusView("in_progress");
   };
 
@@ -258,16 +287,25 @@ export default function PortalApprovalsPage() {
       <Toaster position="top-center" />
       <div className="mx-auto w-full max-w-5xl px-3 py-4 md:px-6">
         <div className={shell}>
-          <div className={cx(metalHeader, "flex items-start justify-between gap-3")}>
+          <div
+            className={cx(
+              metalHeader,
+              "flex items-start justify-between gap-3",
+            )}
+          >
             <div className="min-w-0">
-              <div className="font-blackops text-[0.9rem] tracking-[0.18em]" style={{ color: COPPER }}>
+              <div
+                className="font-blackops text-[0.9rem] tracking-[0.18em]"
+                style={{ color: COPPER }}
+              >
                 APPROVALS
               </div>
               <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
                 Review estimates and approve work waiting for your confirmation.
               </div>
               <div className="mt-2 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
-                When all items on a job are approved, the job automatically moves forward.
+                When all items on a job are approved, the job automatically
+                moves forward.
               </div>
             </div>
 
@@ -302,18 +340,11 @@ export default function PortalApprovalsPage() {
           </div>
 
           {error ? (
-            <div className="mt-4 rounded-2xl border border-red-400/40 bg-red-500/10 p-4">
-              <div className="text-sm font-semibold text-red-100">Error</div>
-              <div className="mt-1 whitespace-pre-wrap text-xs text-red-200">{error}</div>
-              <div className="mt-3 flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => void fetchApprovals()}
-                  className="inline-flex items-center rounded-full border border-red-400/40 bg-[color:var(--theme-surface-inset)] px-4 py-2 text-xs font-semibold text-red-100 hover:bg-[color:var(--theme-surface-overlay)]"
-                >
-                  Try again
-                </button>
-              </div>
+            <div className="mt-4">
+              <RouteLoadPanel
+                failure={error}
+                onRetry={() => void fetchApprovals()}
+              />
             </div>
           ) : null}
 
@@ -335,10 +366,14 @@ export default function PortalApprovalsPage() {
                         <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
                           Estimate {quote.reference}
                         </div>
-                        <StatusBadge variant="warning">Awaiting approval</StatusBadge>
+                        <StatusBadge variant="warning">
+                          Awaiting approval
+                        </StatusBadge>
                       </div>
                       <div className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
-                        {quote.lineCount} quote item{quote.lineCount === 1 ? "" : "s"} ready for your decision
+                        {quote.lineCount} quote item
+                        {quote.lineCount === 1 ? "" : "s"} ready for your
+                        decision
                         {quote.total > 0 ? ` · ${fmtMoney(quote.total)}` : ""}.
                       </div>
                       <div className="mt-1 text-[0.7rem] text-[color:var(--theme-text-muted)]">
@@ -347,7 +382,9 @@ export default function PortalApprovalsPage() {
                     </div>
                     <button
                       type="button"
-                      onClick={() => router.push(`/portal/quotes/${quote.workOrderId}`)}
+                      onClick={() =>
+                        router.push(`/portal/quotes/${quote.workOrderId}`)
+                      }
                       className="inline-flex min-h-10 items-center rounded-full border border-[var(--accent-copper)] bg-[color:color-mix(in_srgb,var(--accent-copper)_14%,transparent)] px-4 py-2 text-xs font-semibold text-[var(--accent-copper-light)]"
                     >
                       Review estimate
@@ -358,9 +395,14 @@ export default function PortalApprovalsPage() {
             </div>
           ) : null}
 
-          {!loading && !error && lines.length === 0 && quoteApprovals.length === 0 ? (
+          {!loading &&
+          !error &&
+          lines.length === 0 &&
+          quoteApprovals.length === 0 ? (
             <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-6 text-center">
-              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">Nothing to approve</div>
+              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                Nothing to approve
+              </div>
               <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
                 You don’t have any jobs waiting for approval right now.
               </div>
@@ -388,14 +430,24 @@ export default function PortalApprovalsPage() {
               {lines.map((ln) => {
                 const title = (ln.description ?? ln.complaint ?? "Job").trim();
                 const summary = lineSummary(ln);
-                const items = Array.isArray(ln.part_request_items) ? ln.part_request_items : [];
+                const items = Array.isArray(ln.part_request_items)
+                  ? ln.part_request_items
+                  : [];
                 const lineDecisionStatus = formatDecisionStatus({
                   approvalState: ln.approval_state,
                   workStatus: ln.status,
                 });
                 const timelineStages: DecisionTimelineStage[] = [
-                  { key: "inspection", label: "Inspection completed", state: "past" },
-                  { key: "recommendation", label: "Recommendation issued", state: "past" },
+                  {
+                    key: "inspection",
+                    label: "Inspection completed",
+                    state: "past",
+                  },
+                  {
+                    key: "recommendation",
+                    label: "Recommendation issued",
+                    state: "past",
+                  },
                   {
                     key: "approval",
                     label: "Awaiting approval",
@@ -447,11 +499,16 @@ export default function PortalApprovalsPage() {
                     <div className="flex flex-wrap items-start justify-between gap-3 border-b border-[color:var(--theme-border-soft)] px-4 py-4">
                       <div className="min-w-0">
                         <div className="flex flex-wrap items-center gap-2">
-                          <div className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">{title}</div>
-                          <StatusBadge variant={summary.variant}>{summary.label}</StatusBadge>
+                          <div className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                            {title}
+                          </div>
+                          <StatusBadge variant={summary.variant}>
+                            {summary.label}
+                          </StatusBadge>
                         </div>
                         <div className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
-                          Decision needed: approve required parts so this work order can continue.
+                          Decision needed: approve required parts so this work
+                          order can continue.
                         </div>
 
                         <div className="mt-1 flex flex-wrap items-center gap-2 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
@@ -459,7 +516,12 @@ export default function PortalApprovalsPage() {
                             Work: {lineDecisionStatus.label}
                           </span>
                           <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5">
-                            Approval: {formatDecisionStatus({ approvalState: ln.approval_state }).label}
+                            Approval:{" "}
+                            {
+                              formatDecisionStatus({
+                                approvalState: ln.approval_state,
+                              }).label
+                            }
                           </span>
                           {ln.hold_reason ? (
                             <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5">
@@ -483,19 +545,32 @@ export default function PortalApprovalsPage() {
                     </div>
 
                     <div className="px-4 py-4">
-                      <DecisionTimeline stages={timelineStages} orientation="vertical" className="mb-3" />
-                      <DecisionEventFeed events={decisionEvents} compact className="mb-3" maxVisible={4} />
+                      <DecisionTimeline
+                        stages={timelineStages}
+                        orientation="vertical"
+                        className="mb-3"
+                      />
+                      <DecisionEventFeed
+                        events={decisionEvents}
+                        compact
+                        className="mb-3"
+                        maxVisible={4}
+                      />
                       <div className="mb-2 grid gap-2 sm:grid-cols-[1fr_auto] sm:items-center">
                         <div>
                           <div className="text-[0.75rem] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
                             Evidence-backed recommendation
                           </div>
                           <div className="text-[0.7rem] text-[color:var(--theme-text-muted)]">
-                            Review pricing and approve each required part. This is the action step for this job.
+                            Review pricing and approve each required part. This
+                            is the action step for this job.
                           </div>
                         </div>
                         <div className="text-[0.68rem] text-[color:var(--theme-text-secondary)]">
-                          Primary action: <span className="text-[color:var(--theme-text-primary)]">Approve</span>
+                          Primary action:{" "}
+                          <span className="text-[color:var(--theme-text-primary)]">
+                            Approve
+                          </span>
                         </div>
                       </div>
 
@@ -519,7 +594,10 @@ export default function PortalApprovalsPage() {
                               const isBusy = busyItemId === it.id;
 
                               return (
-                                <div key={it.id} className="grid grid-cols-12 gap-2 px-3 py-3">
+                                <div
+                                  key={it.id}
+                                  className="grid grid-cols-12 gap-2 px-3 py-3"
+                                >
                                   <div className="col-span-6 min-w-0">
                                     <div className="truncate text-sm text-[color:var(--theme-text-primary)]">
                                       {it.description ?? "—"}
@@ -533,7 +611,9 @@ export default function PortalApprovalsPage() {
                                             : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-secondary)]",
                                         )}
                                       >
-                                        {approved ? "Approved" : "Awaiting approval"}
+                                        {approved
+                                          ? "Approved"
+                                          : "Awaiting approval"}
                                       </span>
                                     </div>
                                   </div>
@@ -595,8 +675,12 @@ export default function PortalApprovalsPage() {
                       </div>
 
                       <div className="mt-3 text-[0.7rem] text-[color:var(--theme-text-muted)]">
-                        If every item on this job is approved, the job will automatically move to{" "}
-                        <span className="text-[color:var(--theme-text-secondary)]">Queued</span>.
+                        If every item on this job is approved, the job will
+                        automatically move to{" "}
+                        <span className="text-[color:var(--theme-text-secondary)]">
+                          Queued
+                        </span>
+                        .
                       </div>
                     </div>
                   </div>
@@ -609,7 +693,10 @@ export default function PortalApprovalsPage() {
             <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
               <div className="text-xs text-[color:var(--theme-text-secondary)]">
                 If approvals never appear, confirm the portal user is linked by{" "}
-                <span className="font-mono text-[color:var(--theme-text-primary)]">customers.user_id = auth.uid()</span>.
+                <span className="font-mono text-[color:var(--theme-text-primary)]">
+                  customers.user_id = auth.uid()
+                </span>
+                .
               </div>
             </div>
           ) : null}

--- a/app/portal/quotes/error.tsx
+++ b/app/portal/quotes/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
+import { asRouteLoadFailure } from "@/features/shared/lib/route-load";
+
+export default function PortalQuotesError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}): JSX.Element {
+  useEffect(() => {
+    console.error("[portal/quotes] route boundary", {
+      digest: error.digest,
+      name: error.name,
+      message: error.message,
+    });
+  }, [error]);
+
+  const failure = useMemo(
+    () => asRouteLoadFailure(error, "Quotes could not be loaded."),
+    [error],
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-10">
+      <RouteLoadPanel failure={failure} onRetry={reset} />
+    </div>
+  );
+}

--- a/app/portal/quotes/loading.tsx
+++ b/app/portal/quotes/loading.tsx
@@ -1,0 +1,11 @@
+export default function PortalQuotesLoading(): JSX.Element {
+  return (
+    <div className="mx-auto w-full max-w-4xl space-y-4 px-3 py-4">
+      <div className="h-24 animate-pulse rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]" />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="h-44 animate-pulse rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]" />
+        <div className="h-44 animate-pulse rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]" />
+      </div>
+    </div>
+  );
+}

--- a/app/portal/quotes/page.tsx
+++ b/app/portal/quotes/page.tsx
@@ -6,6 +6,7 @@ import {
   PortalPageHeader,
   PortalEmptyState,
 } from "@/features/portal/components/PortalUi";
+import { runBoundedRouteLoad } from "@/features/shared/lib/route-load";
 
 export const dynamic = "force-dynamic";
 
@@ -51,17 +52,28 @@ export default async function PortalQuotesPage() {
   const actor = await requirePortalCustomerActor(supabase);
   const shopId = actor.customer.shop_id;
 
-  const { data: workOrders, error } = shopId
-    ? await supabase
-        .from("work_orders")
-        .select(
-          "id,vehicle_id,created_at,scheduled_at,invoice_sent_at,estimate_number,work_order_quote_lines(id,description,status,stage,approved_at,work_order_line_id,sent_to_customer_at,metadata)",
-        )
-        .eq("shop_id", shopId)
-        .eq("customer_id", actor.customer.id)
-        .or("external_id.like.portal_quote:%,estimate_number.not.is.null")
-        .order("created_at", { ascending: false })
-    : { data: [], error: null };
+  const { data: workOrders, error } = await runBoundedRouteLoad(
+    {
+      route: "/portal/quotes",
+      operation: "load customer quotes",
+      tenantId: shopId,
+      actorId: actor.userId,
+      role: "customer",
+    },
+    async ({ signal }) =>
+      shopId
+        ? await supabase
+            .from("work_orders")
+            .select(
+              "id,vehicle_id,created_at,scheduled_at,invoice_sent_at,estimate_number,work_order_quote_lines(id,description,status,stage,approved_at,work_order_line_id,sent_to_customer_at,metadata)",
+            )
+            .eq("shop_id", shopId)
+            .eq("customer_id", actor.customer.id)
+            .or("external_id.like.portal_quote:%,estimate_number.not.is.null")
+            .order("created_at", { ascending: false })
+            .abortSignal(signal)
+        : { data: [], error: null },
+  );
 
   if (error) throw new Error(error.message);
   const rows = (workOrders ?? [])

--- a/features/dashboard/app/dashboard/admin/ShopsClient.tsx
+++ b/features/dashboard/app/dashboard/admin/ShopsClient.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
+import {
+  asRouteLoadFailure,
+  runBoundedRouteLoad,
+  type RouteLoadFailure,
+} from "@/features/shared/lib/route-load";
 import {
   AdminBadge,
   AdminEmptyState,
@@ -32,34 +38,56 @@ type ShopRow = Pick<
 >;
 
 function healthLabel(shop: ShopRow): "Complete" | "Needs profile" {
-  return shop.email && shop.phone_number && shop.timezone ? "Complete" : "Needs profile";
+  return shop.email && shop.phone_number && shop.timezone
+    ? "Complete"
+    : "Needs profile";
 }
 
 export default function AdminShopsClient() {
   const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [rows, setRows] = useState<ShopRow[] | null>(null);
-  const [err, setErr] = useState<string | null>(null);
+  const [loadFailure, setLoadFailure] = useState<RouteLoadFailure | null>(null);
   const [search, setSearch] = useState("");
-  const [healthFilter, setHealthFilter] = useState<"all" | "Complete" | "Needs profile">("all");
+  const [healthFilter, setHealthFilter] = useState<
+    "all" | "Complete" | "Needs profile"
+  >("all");
+
+  const load = useCallback(async () => {
+    setLoadFailure(null);
+    try {
+      const nextRows = await runBoundedRouteLoad(
+        { route: "/dashboard/admin/shops", operation: "load shop directory" },
+        async ({ signal }) => {
+          const { data, error } = await supabase
+            .from("shops")
+            .select(
+              "id, name, city, province, email, phone_number, timezone, plan, owner_id, created_at",
+            )
+            .order("name", { ascending: true })
+            .abortSignal(signal)
+            .limit(200);
+          if (error) throw error;
+          return (data as ShopRow[]) ?? [];
+        },
+      );
+      setRows(nextRows);
+    } catch (error) {
+      setLoadFailure(
+        asRouteLoadFailure(error, "The shop directory could not be loaded."),
+      );
+    }
+  }, [supabase]);
 
   useEffect(() => {
-    (async () => {
-      const { data, error } = await supabase
-        .from("shops")
-        .select("id, name, city, province, email, phone_number, timezone, plan, owner_id, created_at")
-        .order("name", { ascending: true })
-        .limit(200);
-
-      if (error) setErr(error.message);
-      setRows((data as ShopRow[]) ?? []);
-    })();
-  }, [supabase]);
+    void load();
+  }, [load]);
 
   const filteredRows = useMemo(() => {
     const query = search.trim().toLowerCase();
     return (rows ?? []).filter((row) => {
-      const matchesHealth = healthFilter === "all" ? true : healthLabel(row) === healthFilter;
+      const matchesHealth =
+        healthFilter === "all" ? true : healthLabel(row) === healthFilter;
       const matchesSearch =
         !query ||
         row.name?.toLowerCase().includes(query) ||
@@ -71,7 +99,9 @@ export default function AdminShopsClient() {
 
   const summary = useMemo(() => {
     const allRows = rows ?? [];
-    const needsProfile = allRows.filter((row) => healthLabel(row) === "Needs profile").length;
+    const needsProfile = allRows.filter(
+      (row) => healthLabel(row) === "Needs profile",
+    ).length;
     const withOwner = allRows.filter((row) => !!row.owner_id).length;
 
     return {
@@ -91,12 +121,25 @@ export default function AdminShopsClient() {
       />
 
       <AdminPanel>
-        <AdminPanelTitle title="Shop Governance Summary" description="Highlights for fast oversight triage." />
+        <AdminPanelTitle
+          title="Shop Governance Summary"
+          description="Highlights for fast oversight triage."
+        />
         <AdminStatGrid>
-          <AdminStatCard label="Shops" value={summary.total} />
-          <AdminStatCard label="Needs profile follow-up" value={summary.needsProfile} hint="Missing email, phone, or timezone" />
-          <AdminStatCard label="Has owner assigned" value={summary.withOwner} />
-          <AdminStatCard label="Visible rows" value={summary.visible} />
+          <AdminStatCard label="Shops" value={rows ? summary.total : "—"} />
+          <AdminStatCard
+            label="Needs profile follow-up"
+            value={rows ? summary.needsProfile : "—"}
+            hint="Missing email, phone, or timezone"
+          />
+          <AdminStatCard
+            label="Has owner assigned"
+            value={rows ? summary.withOwner : "—"}
+          />
+          <AdminStatCard
+            label="Visible rows"
+            value={rows ? summary.visible : "—"}
+          />
         </AdminStatGrid>
       </AdminPanel>
 
@@ -118,7 +161,11 @@ export default function AdminShopsClient() {
             <select
               className="w-full rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none focus:border-orange-400/70"
               value={healthFilter}
-              onChange={(event) => setHealthFilter(event.target.value as "all" | "Complete" | "Needs profile")}
+              onChange={(event) =>
+                setHealthFilter(
+                  event.target.value as "all" | "Complete" | "Needs profile",
+                )
+              }
             >
               <option value="all">All shops</option>
               <option value="Complete">Complete profile</option>
@@ -127,7 +174,15 @@ export default function AdminShopsClient() {
           </AdminField>
         </AdminToolbar>
 
-        {err ? <p className="px-4 pb-3 text-xs text-red-300">Shop query failed: {err}</p> : null}
+        {loadFailure ? (
+          <div className="px-4 pb-4">
+            <RouteLoadPanel
+              failure={loadFailure}
+              onRetry={() => void load()}
+              title="Shop directory unavailable"
+            />
+          </div>
+        ) : null}
       </AdminPanel>
 
       <AdminPanel>
@@ -135,16 +190,25 @@ export default function AdminShopsClient() {
           title="Shop Directory"
           description="Review key metadata and governance posture before taking follow-up action."
           action={
-            <Link href="/dashboard/workforce/people" className="text-xs font-medium text-[color:var(--theme-accent-text)]">
+            <Link
+              href="/dashboard/workforce/people"
+              className="text-xs font-medium text-[color:var(--theme-accent-text)]"
+            >
               Validate owner/staff posture →
             </Link>
           }
         />
 
-        {!rows ? (
-          <AdminEmptyState title="Loading shops" body="Reading tenant shop records." />
-        ) : filteredRows.length === 0 ? (
-          <AdminEmptyState title="No shops found" body="Adjust filters or confirm shop records are available." />
+        {!rows && !loadFailure ? (
+          <AdminEmptyState
+            title="Loading shops"
+            body="Reading tenant shop records."
+          />
+        ) : !rows ? null : filteredRows.length === 0 ? (
+          <AdminEmptyState
+            title="No shops found"
+            body="Adjust filters or confirm shop records are available."
+          />
         ) : (
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
@@ -161,22 +225,33 @@ export default function AdminShopsClient() {
               </thead>
               <tbody className="divide-y divide-[color:var(--theme-border-soft)]">
                 {filteredRows.map((s) => (
-                  <tr key={s.id} className="text-[color:var(--theme-text-primary)]">
-                    <td className="px-4 py-2.5 font-medium text-[color:var(--theme-text-primary)]">{s.name ?? s.id}</td>
-                    <td className="px-4 py-2.5">{[s.city, s.province].filter(Boolean).join(", ") || "—"}</td>
+                  <tr
+                    key={s.id}
+                    className="text-[color:var(--theme-text-primary)]"
+                  >
+                    <td className="px-4 py-2.5 font-medium text-[color:var(--theme-text-primary)]">
+                      {s.name ?? s.id}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      {[s.city, s.province].filter(Boolean).join(", ") || "—"}
+                    </td>
                     <td className="px-4 py-2.5 text-xs text-[color:var(--theme-text-secondary)]">
                       <p>{s.email ?? "No email"}</p>
                       <p>{s.phone_number ?? "No phone"}</p>
                     </td>
                     <td className="px-4 py-2.5">{s.plan ?? "—"}</td>
                     <td className="px-4 py-2.5">
-                      <AdminBadge>{s.owner_id ? "Assigned" : "Missing owner"}</AdminBadge>
+                      <AdminBadge>
+                        {s.owner_id ? "Assigned" : "Missing owner"}
+                      </AdminBadge>
                     </td>
                     <td className="px-4 py-2.5">
                       <AdminBadge>{healthLabel(s)}</AdminBadge>
                     </td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-[color:var(--theme-text-secondary)]">
-                      {s.created_at ? new Date(s.created_at).toLocaleDateString() : "—"}
+                      {s.created_at
+                        ? new Date(s.created_at).toLocaleDateString()
+                        : "—"}
                     </td>
                   </tr>
                 ))}

--- a/features/mobile/service/MobileFieldServiceRouteGate.tsx
+++ b/features/mobile/service/MobileFieldServiceRouteGate.tsx
@@ -19,6 +19,14 @@ import {
   writeFieldServiceOfflineAccess,
   type FieldServiceAccessPayload,
 } from "./fieldOfflineAccess";
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
+import {
+  asRouteLoadFailure,
+  RouteLoadFailure,
+  routeLoadFailureFromStatus,
+  runBoundedRouteLoad,
+  type RouteLoadFailure as RouteLoadFailureState,
+} from "@/features/shared/lib/route-load";
 
 export default function MobileFieldServiceRouteGate({
   children,
@@ -28,82 +36,126 @@ export default function MobileFieldServiceRouteGate({
   const pathname = usePathname();
   const router = useRouter();
   const [allowed, setAllowed] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+  const [loadFailure, setLoadFailure] = useState<RouteLoadFailureState | null>(
+    null,
+  );
 
   useEffect(() => {
     let active = true;
+    setAllowed(false);
+    setLoadFailure(null);
 
-    void (async () => {
-      const supabase = createBrowserSupabase();
-      const [sessionResult, response] = await Promise.all([
-        supabase.auth.getSession(),
-        fetch("/api/mobile/field-service/access", {
-          credentials: "include",
-          cache: "no-store",
-        }).catch(() => null),
-      ]);
-      const authUserId = sessionResult.data.session?.user.id?.trim() ?? "";
-      const cachedScope = getOfflineMutationScope();
-      const operatorScope =
-        cachedScope?.userId === authUserId ? cachedScope : null;
-      const cachedAccess = operatorScope
-        ? readFieldServiceOfflineAccess(operatorScope)
-        : null;
-      const responseAccess = (await response
-        ?.json()
-        .catch(() => null)) as FieldServiceAccessPayload | null;
-      if (!active) return;
+    void runBoundedRouteLoad(
+      { route: pathname, operation: "verify field service route access" },
+      async ({ recordStatus, signal }) => {
+        const supabase = createBrowserSupabase();
+        const [sessionResult, response] = await Promise.all([
+          supabase.auth.getSession(),
+          fetch("/api/mobile/field-service/access", {
+            credentials: "include",
+            cache: "no-store",
+            signal,
+          }).catch(() => null),
+        ]);
+        if (response) recordStatus(response.status);
+        const authUserId = sessionResult.data.session?.user.id?.trim() ?? "";
+        const cachedScope = getOfflineMutationScope();
+        const operatorScope =
+          cachedScope?.userId === authUserId ? cachedScope : null;
+        const cachedAccess = operatorScope
+          ? readFieldServiceOfflineAccess(operatorScope)
+          : null;
+        const responseAccess = (await response
+          ?.json()
+          .catch(() => null)) as FieldServiceAccessPayload | null;
+        if (!active) return;
 
-      let access: FieldExistingSessionAccess | null = null;
-      if (response?.ok && responseAccess) {
-        const verifiedScope = resolveFieldServiceAccessScope(
-          responseAccess,
-          authUserId,
-        );
-        if (verifiedScope) {
-          access = responseAccess;
+        if (!authUserId) {
+          throw routeLoadFailureFromStatus(
+            401,
+            "Sign in to open Field Service.",
+          );
         }
-        if (verifiedScope && responseAccess.canAccessFieldService === true) {
-          setOfflineMutationScope(verifiedScope);
-          writeFieldServiceOfflineAccess(verifiedScope, responseAccess);
-        } else if (verifiedScope) {
-          clearFieldServiceOfflineAccess(verifiedScope);
+
+        let access: FieldExistingSessionAccess | null = null;
+        if (response?.ok && responseAccess) {
+          const verifiedScope = resolveFieldServiceAccessScope(
+            responseAccess,
+            authUserId,
+          );
+          if (verifiedScope) {
+            access = responseAccess;
+          }
+          if (verifiedScope && responseAccess.canAccessFieldService === true) {
+            setOfflineMutationScope(verifiedScope);
+            writeFieldServiceOfflineAccess(verifiedScope, responseAccess);
+          } else if (verifiedScope) {
+            clearFieldServiceOfflineAccess(verifiedScope);
+          } else if (operatorScope) {
+            clearFieldServiceOfflineAccess(operatorScope);
+          }
+        } else if (
+          (!response ||
+            response.status >= 500 ||
+            isRetryableOfflineStatus(response.status)) &&
+          cachedAccess
+        ) {
+          access = cachedAccess;
+        } else if (!response) {
+          throw new RouteLoadFailure({
+            kind: "network",
+            message: "Field Service access could not be verified.",
+          });
+        } else if (!response.ok) {
+          throw routeLoadFailureFromStatus(
+            response.status,
+            response.status === 403
+              ? "Your account does not have access to Field Service."
+              : "Field Service access could not be verified.",
+          );
         } else if (operatorScope) {
           clearFieldServiceOfflineAccess(operatorScope);
         }
-      } else if (
-        (!response ||
-          response.status >= 500 ||
-          isRetryableOfflineStatus(response.status)) &&
-        cachedAccess
-      ) {
-        access = cachedAccess;
-      } else if (operatorScope) {
-        clearFieldServiceOfflineAccess(operatorScope);
+
+        const destination = access
+          ? resolveFieldExistingSessionHref(access, pathname)
+          : null;
+
+        if (destination === pathname) {
+          setAllowed(true);
+          return;
+        }
+
+        router.replace(destination ?? "/mobile");
+      },
+    ).catch((error) => {
+      if (active) {
+        setLoadFailure(
+          asRouteLoadFailure(
+            error,
+            "Field Service access could not be verified.",
+          ),
+        );
       }
-
-      const destination = access
-        ? resolveFieldExistingSessionHref(access, pathname)
-        : null;
-
-      if (destination === pathname) {
-        setAllowed(true);
-        return;
-      }
-
-      router.replace(destination ?? "/mobile");
-    })().catch(() => {
-      if (active) router.replace("/mobile");
     });
 
     return () => {
       active = false;
     };
-  }, [pathname, router]);
+  }, [attempt, pathname, router]);
 
   if (!allowed) {
     return (
       <main className="mx-auto w-full max-w-3xl px-3 py-4 sm:px-4">
-        <div className="h-32 animate-pulse rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]" />
+        {loadFailure ? (
+          <RouteLoadPanel
+            failure={loadFailure}
+            onRetry={() => setAttempt((value) => value + 1)}
+          />
+        ) : (
+          <div className="h-32 animate-pulse rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]" />
+        )}
       </main>
     );
   }

--- a/features/mobile/service/MobileFieldServiceRouteGate.tsx
+++ b/features/mobile/service/MobileFieldServiceRouteGate.tsx
@@ -72,10 +72,8 @@ export default function MobileFieldServiceRouteGate({
         if (!active) return;
 
         if (!authUserId) {
-          throw routeLoadFailureFromStatus(
-            401,
-            "Sign in to open Field Service.",
-          );
+          router.replace("/mobile");
+          return;
         }
 
         let access: FieldExistingSessionAccess | null = null;

--- a/features/mobile/service/MobileServiceScopeGate.tsx
+++ b/features/mobile/service/MobileServiceScopeGate.tsx
@@ -23,6 +23,14 @@ import {
   writeFieldServiceOfflineAccess,
   type FieldServiceAccessPayload,
 } from "./fieldOfflineAccess";
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
+import {
+  asRouteLoadFailure,
+  RouteLoadFailure,
+  routeLoadFailureFromStatus,
+  runBoundedRouteLoad,
+  type RouteLoadFailure as RouteLoadFailureState,
+} from "@/features/shared/lib/route-load";
 
 const SNAPSHOT_CACHE_KEY = "profixiq:mobile-service:active:v1";
 const SNAPSHOT_SCOPE_KEY = "profixiq:mobile-service:active-scope:v1";
@@ -79,103 +87,143 @@ export default function MobileServiceScopeGate() {
   const [scope, setScope] = useState<OfflineMutationScope | null>(null);
   const [workspaceCapabilities, setWorkspaceCapabilities] =
     useState<FieldWorkspaceCapabilities>(EMPTY_FIELD_WORKSPACE_CAPABILITIES);
+  const [attempt, setAttempt] = useState(0);
+  const [loadFailure, setLoadFailure] = useState<RouteLoadFailureState | null>(
+    null,
+  );
   const router = useRouter();
 
   useEffect(() => {
     let active = true;
+    setReady(false);
+    setLoadFailure(null);
 
-    void (async () => {
-      const supabase = createBrowserSupabase();
-      const [sessionResult, fieldAccessResponse] = await Promise.all([
-        supabase.auth.getSession(),
-        fetch("/api/mobile/field-service/access", {
-          credentials: "include",
-          cache: "no-store",
-        }).catch(() => null),
-      ]);
-      const session = sessionResult.data.session;
-      const authUserId = session?.user?.id?.trim() ?? "";
+    void runBoundedRouteLoad(
+      { route: "/mobile/service", operation: "load field service scope" },
+      async ({ recordStatus, signal }) => {
+        const supabase = createBrowserSupabase();
+        const [sessionResult, fieldAccessResponse] = await Promise.all([
+          supabase.auth.getSession(),
+          fetch("/api/mobile/field-service/access", {
+            credentials: "include",
+            cache: "no-store",
+            signal,
+          }).catch(() => null),
+        ]);
+        if (fieldAccessResponse) recordStatus(fieldAccessResponse.status);
+        const session = sessionResult.data.session;
+        const authUserId = session?.user?.id?.trim() ?? "";
 
-      if (!authUserId) {
+        if (!authUserId) {
+          throw routeLoadFailureFromStatus(
+            401,
+            "Sign in to open Field Service.",
+          );
+        }
+
+        const fieldAccess = (await fieldAccessResponse
+          ?.json()
+          .catch(() => null)) as FieldServiceAccessPayload | null;
         if (!active) return;
-        protectSnapshot(null);
-        router.replace("/mobile");
-        return;
-      }
 
-      const fieldAccess = (await fieldAccessResponse
-        ?.json()
-        .catch(() => null)) as FieldServiceAccessPayload | null;
-      if (!active) return;
+        const cached = getOfflineMutationScope();
+        const cachedScope = cached?.userId === authUserId ? cached : null;
 
-      const cached = getOfflineMutationScope();
-      const cachedScope = cached?.userId === authUserId ? cached : null;
+        if (fieldAccessResponse?.ok && fieldAccess?.canAccessFieldService) {
+          const verifiedScope = resolveFieldServiceAccessScope(
+            fieldAccess,
+            authUserId,
+          );
+          if (!verifiedScope) {
+            if (cachedScope) clearFieldServiceOfflineAccess(cachedScope);
+            protectSnapshot(null);
+            router.replace("/mobile");
+            return;
+          }
 
-      if (fieldAccessResponse?.ok && fieldAccess?.canAccessFieldService) {
-        const verifiedScope = resolveFieldServiceAccessScope(
-          fieldAccess,
-          authUserId,
-        );
-        if (!verifiedScope) {
-          if (cachedScope) clearFieldServiceOfflineAccess(cachedScope);
-          protectSnapshot(null);
-          router.replace("/mobile");
+          setOfflineMutationScope(verifiedScope);
+          writeFieldServiceOfflineAccess(verifiedScope, fieldAccess);
+          setWorkspaceCapabilities(
+            normalizeFieldWorkspaceCapabilities(
+              fieldAccess.workspaceCapabilities,
+            ),
+          );
+          setScope(verifiedScope);
+          protectSnapshot(verifiedScope);
+          setReady(true);
           return;
         }
 
-        setOfflineMutationScope(verifiedScope);
-        writeFieldServiceOfflineAccess(verifiedScope, fieldAccess);
-        setWorkspaceCapabilities(
-          normalizeFieldWorkspaceCapabilities(
-            fieldAccess.workspaceCapabilities,
+        const verificationUnavailable =
+          !fieldAccessResponse ||
+          fieldAccessResponse.status >= 500 ||
+          isRetryableOfflineStatus(fieldAccessResponse.status);
+        const offlineAccess =
+          verificationUnavailable && cachedScope
+            ? readFieldServiceOfflineAccess(cachedScope)
+            : null;
+        if (offlineAccess) {
+          setWorkspaceCapabilities(offlineAccess.workspaceCapabilities);
+          setScope(cachedScope);
+          protectSnapshot(cachedScope);
+          setReady(true);
+          return;
+        }
+
+        if (!fieldAccessResponse) {
+          throw new RouteLoadFailure({
+            kind: "network",
+            message: "Field Service access could not be verified.",
+          });
+        }
+
+        if (!fieldAccessResponse.ok) {
+          throw routeLoadFailureFromStatus(
+            fieldAccessResponse.status,
+            fieldAccessResponse.status === 403
+              ? "Your account does not have access to Field Service."
+              : "Field Service access could not be verified.",
+          );
+        }
+
+        if (cachedScope && !verificationUnavailable) {
+          clearFieldServiceOfflineAccess(cachedScope);
+        }
+        if (!fieldAccessResponse?.ok || !fieldAccess?.canAccessFieldService) {
+          protectSnapshot(null);
+          router.replace(
+            fieldAccess?.canConfigure ? "/mobile/service/setup" : "/mobile",
+          );
+          return;
+        }
+      },
+    ).catch((error) => {
+      if (active) {
+        setLoadFailure(
+          asRouteLoadFailure(
+            error,
+            "Field Service access could not be verified.",
           ),
         );
-        setScope(verifiedScope);
-        protectSnapshot(verifiedScope);
-        setReady(true);
-        return;
       }
-
-      const verificationUnavailable =
-        !fieldAccessResponse ||
-        fieldAccessResponse.status >= 500 ||
-        isRetryableOfflineStatus(fieldAccessResponse.status);
-      const offlineAccess =
-        verificationUnavailable && cachedScope
-          ? readFieldServiceOfflineAccess(cachedScope)
-          : null;
-      if (offlineAccess) {
-        setWorkspaceCapabilities(offlineAccess.workspaceCapabilities);
-        setScope(cachedScope);
-        protectSnapshot(cachedScope);
-        setReady(true);
-        return;
-      }
-
-      if (cachedScope && !verificationUnavailable) {
-        clearFieldServiceOfflineAccess(cachedScope);
-      }
-      if (!fieldAccessResponse?.ok || !fieldAccess?.canAccessFieldService) {
-        protectSnapshot(null);
-        router.replace(
-          fieldAccess?.canConfigure ? "/mobile/service/setup" : "/mobile",
-        );
-        return;
-      }
-    })().catch(() => {
-      if (!active) return;
-      router.replace("/mobile");
     });
 
     return () => {
       active = false;
     };
-  }, [router]);
+  }, [attempt, router]);
 
   if (!ready) {
     return (
       <main className="mx-auto w-full max-w-3xl px-3 py-4 sm:px-4">
-        <div className="h-32 animate-pulse rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]" />
+        {loadFailure ? (
+          <RouteLoadPanel
+            failure={loadFailure}
+            onRetry={() => setAttempt((value) => value + 1)}
+          />
+        ) : (
+          <div className="h-32 animate-pulse rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]" />
+        )}
       </main>
     );
   }

--- a/features/mobile/service/MobileServiceScopeGate.tsx
+++ b/features/mobile/service/MobileServiceScopeGate.tsx
@@ -115,10 +115,10 @@ export default function MobileServiceScopeGate() {
         const authUserId = session?.user?.id?.trim() ?? "";
 
         if (!authUserId) {
-          throw routeLoadFailureFromStatus(
-            401,
-            "Sign in to open Field Service.",
-          );
+          if (!active) return;
+          protectSnapshot(null);
+          router.replace("/mobile");
+          return;
         }
 
         const fieldAccess = (await fieldAccessResponse

--- a/features/mobile/service/MobileTruckInventory.tsx
+++ b/features/mobile/service/MobileTruckInventory.tsx
@@ -7,6 +7,7 @@ import { useTruckInventorySnapshot } from "./useTruckInventorySnapshot";
 import { useTruckInventoryStocking } from "./useTruckInventoryStocking";
 import { useTruckInventoryUsage } from "./useTruckInventoryUsage";
 import type { TruckInventoryView } from "./truckInventoryUi";
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
 
 export default function MobileTruckInventory() {
   const [view, setView] = useState<TruckInventoryView>("stock");
@@ -34,6 +35,18 @@ export default function MobileTruckInventory() {
     stocking.setSelectedReceiptId("");
     state.handleTruckChange(truckId);
   };
+
+  if (state.loadFailure && !state.snapshot) {
+    return (
+      <main className="mx-auto w-full max-w-5xl px-3 py-4 sm:px-4">
+        <RouteLoadPanel
+          failure={state.loadFailure}
+          onRetry={() => void state.load()}
+          title="Truck inventory unavailable"
+        />
+      </main>
+    );
+  }
 
   return (
     <MobileTruckInventoryScreen

--- a/features/mobile/service/RapidServiceIntake.tsx
+++ b/features/mobile/service/RapidServiceIntake.tsx
@@ -11,7 +11,14 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
+import {
+  asRouteLoadFailure,
+  routeLoadFailureFromStatus,
+  runBoundedRouteLoad,
+  type RouteLoadFailure,
+} from "@/features/shared/lib/route-load";
 
 function key(): string {
   return typeof crypto !== "undefined" && "randomUUID" in crypto
@@ -88,24 +95,54 @@ export default function RapidServiceIntake() {
   const [suggestions, setSuggestions] = useState<SuggestedCustomer[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [settingsLoading, setSettingsLoading] = useState(true);
+  const [settingsFailure, setSettingsFailure] =
+    useState<RouteLoadFailure | null>(null);
+
+  const loadSettings = useCallback(async () => {
+    setSettingsLoading(true);
+    setSettingsFailure(null);
+    try {
+      const body = await runBoundedRouteLoad(
+        { route: "/mobile/service/new", operation: "load service settings" },
+        async ({ recordStatus, signal }) => {
+          const response = await fetch("/api/mobile/service/settings", {
+            credentials: "include",
+            cache: "no-store",
+            signal,
+          });
+          recordStatus(response.status);
+          if (!response.ok) {
+            throw routeLoadFailureFromStatus(
+              response.status,
+              "Field Service settings could not be loaded.",
+            );
+          }
+          return response.json();
+        },
+      );
+      const value = Number(body?.settings?.default_visit_minutes);
+      if (Number.isFinite(value) && value >= 5) setDurationMinutes(value);
+      const model = body?.settings?.service_model;
+      if (model === "shop" || model === "mobile" || model === "both") {
+        setConfiguredServiceModel(model);
+        if (model !== "both") setServiceMode(model);
+      }
+    } catch (loadError) {
+      setSettingsFailure(
+        asRouteLoadFailure(
+          loadError,
+          "Field Service settings could not be loaded.",
+        ),
+      );
+    } finally {
+      setSettingsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    void fetch("/api/mobile/service/settings", {
-      credentials: "include",
-      cache: "no-store",
-    })
-      .then((response) => (response.ok ? response.json() : null))
-      .then((body) => {
-        const value = Number(body?.settings?.default_visit_minutes);
-        if (Number.isFinite(value) && value >= 5) setDurationMinutes(value);
-        const model = body?.settings?.service_model;
-        if (model === "shop" || model === "mobile" || model === "both") {
-          setConfiguredServiceModel(model);
-          if (model !== "both") setServiceMode(model);
-        }
-      })
-      .catch(() => undefined);
-  }, []);
+    void loadSettings();
+  }, [loadSettings]);
 
   const searchValue = (phone.trim() || customerName.trim()).slice(0, 80);
   useEffect(() => {
@@ -123,13 +160,9 @@ export default function RapidServiceIntake() {
           signal: controller.signal,
         },
       )
-        .then((response) =>
-          response.ok ? response.json() : { customers: [] },
-        )
+        .then((response) => (response.ok ? response.json() : { customers: [] }))
         .then((body) =>
-          setSuggestions(
-            Array.isArray(body?.customers) ? body.customers : [],
-          ),
+          setSuggestions(Array.isArray(body?.customers) ? body.customers : []),
         )
         .catch(() => undefined);
     }, 220);
@@ -214,9 +247,9 @@ export default function RapidServiceIntake() {
           operationKey: operationKey.current,
         }),
       });
-      const body = (await response.json().catch(() => null)) as
-        | IntakeResult
-        | null;
+      const body = (await response
+        .json()
+        .catch(() => null)) as IntakeResult | null;
       if (!response.ok) {
         throw new Error(body?.error || "Service call could not be saved.");
       }
@@ -242,6 +275,26 @@ export default function RapidServiceIntake() {
     } finally {
       setBusy(false);
     }
+  }
+
+  if (settingsLoading) {
+    return (
+      <main className="mx-auto w-full max-w-3xl px-3 py-4 sm:px-4">
+        <div className="h-32 animate-pulse rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]" />
+      </main>
+    );
+  }
+
+  if (settingsFailure) {
+    return (
+      <main className="mx-auto w-full max-w-3xl px-3 py-4 sm:px-4">
+        <RouteLoadPanel
+          failure={settingsFailure}
+          onRetry={() => void loadSettings()}
+          title="Service intake unavailable"
+        />
+      </main>
+    );
   }
 
   return (
@@ -383,45 +436,46 @@ export default function RapidServiceIntake() {
 
       {serviceMode === "mobile" ? (
         <section className="space-y-3 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-card">
-        <div className="flex items-center gap-2 text-xs font-extrabold uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
-          <MapPin className="h-4 w-4" /> Where
-        </div>
-        <input
-          value={address}
-          onChange={(event) => setAddress(event.target.value)}
-          placeholder="Service address"
-          autoComplete="street-address"
-          className="min-h-12 w-full rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 text-base"
-        />
-        <div className="grid grid-cols-3 gap-2">
+          <div className="flex items-center gap-2 text-xs font-extrabold uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
+            <MapPin className="h-4 w-4" /> Where
+          </div>
           <input
-            value={city}
-            onChange={(event) => setCity(event.target.value)}
-            placeholder="City"
-            className="min-h-11 min-w-0 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 text-sm"
+            value={address}
+            onChange={(event) => setAddress(event.target.value)}
+            placeholder="Service address"
+            autoComplete="street-address"
+            className="min-h-12 w-full rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 text-base"
           />
-          <input
-            value={province}
-            onChange={(event) => setProvince(event.target.value)}
-            placeholder="Province / State"
-            className="min-h-11 min-w-0 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 text-sm"
-          />
-          <input
-            value={postal}
-            onChange={(event) => setPostal(event.target.value)}
-            placeholder="Postal / ZIP"
-            autoCapitalize="characters"
-            className="min-h-11 min-w-0 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 text-sm"
-          />
-        </div>
-      </section>
+          <div className="grid grid-cols-3 gap-2">
+            <input
+              value={city}
+              onChange={(event) => setCity(event.target.value)}
+              placeholder="City"
+              className="min-h-11 min-w-0 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 text-sm"
+            />
+            <input
+              value={province}
+              onChange={(event) => setProvince(event.target.value)}
+              placeholder="Province / State"
+              className="min-h-11 min-w-0 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 text-sm"
+            />
+            <input
+              value={postal}
+              onChange={(event) => setPostal(event.target.value)}
+              placeholder="Postal / ZIP"
+              autoCapitalize="characters"
+              className="min-h-11 min-w-0 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 text-sm"
+            />
+          </div>
+        </section>
       ) : (
         <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-card">
           <div className="flex items-center gap-2 text-xs font-extrabold uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
             <MapPin className="h-4 w-4" /> At the shop
           </div>
           <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
-            This call uses shop scheduling/capacity. No customer service address is required.
+            This call uses shop scheduling/capacity. No customer service address
+            is required.
           </p>
         </section>
       )}
@@ -468,7 +522,9 @@ export default function RapidServiceIntake() {
             Time allowed
             <select
               value={durationMinutes}
-              onChange={(event) => setDurationMinutes(Number(event.target.value))}
+              onChange={(event) =>
+                setDurationMinutes(Number(event.target.value))
+              }
               className="mt-1 min-h-12 w-full rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 text-base"
             >
               {[30, 45, 60, 90, 120, 180].map((value) => (

--- a/features/mobile/service/RapidServiceIntake.tsx
+++ b/features/mobile/service/RapidServiceIntake.tsx
@@ -285,18 +285,6 @@ export default function RapidServiceIntake() {
     );
   }
 
-  if (settingsFailure) {
-    return (
-      <main className="mx-auto w-full max-w-3xl px-3 py-4 sm:px-4">
-        <RouteLoadPanel
-          failure={settingsFailure}
-          onRetry={() => void loadSettings()}
-          title="Service intake unavailable"
-        />
-      </main>
-    );
-  }
-
   return (
     <main className="mx-auto w-full max-w-2xl space-y-3 px-3 pb-28 pt-3 text-[color:var(--theme-text-primary)] sm:px-4">
       <header className="flex items-center gap-3 rounded-3xl border border-white/10 bg-slate-950 p-4 text-white shadow-card">
@@ -317,6 +305,14 @@ export default function RapidServiceIntake() {
           </p>
         </div>
       </header>
+
+      {settingsFailure ? (
+        <RouteLoadPanel
+          failure={settingsFailure}
+          onRetry={() => void loadSettings()}
+          title="Using default service settings"
+        />
+      ) : null}
 
       <section className="relative space-y-3 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-card">
         <div className="flex items-center gap-2 text-xs font-extrabold uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">

--- a/features/mobile/service/truckInventoryClient.ts
+++ b/features/mobile/service/truckInventoryClient.ts
@@ -39,7 +39,9 @@ export function localPartByCode(
     all.find((part) =>
       [part.partNumber, part.sku, ...part.barcodes]
         .filter(Boolean)
-        .some((identity) => String(identity).trim().toLowerCase() === normalized),
+        .some(
+          (identity) => String(identity).trim().toLowerCase() === normalized,
+        ),
     ) ?? null
   );
 }
@@ -47,18 +49,22 @@ export function localPartByCode(
 export async function fetchTruckInventorySnapshot(args: {
   search?: string;
   serviceVehicleId?: string;
+  signal?: AbortSignal;
 }): Promise<FieldTruckInventorySnapshot> {
   const params = new URLSearchParams();
   if (args.search?.trim()) params.set("query", args.search.trim());
-  if (args.serviceVehicleId) params.set("serviceVehicleId", args.serviceVehicleId);
+  if (args.serviceVehicleId)
+    params.set("serviceVehicleId", args.serviceVehicleId);
   const response = await fetch(
     `/api/mobile/service/truck-inventory?${params.toString()}`,
-    { credentials: "include", cache: "no-store" },
+    { credentials: "include", cache: "no-store", signal: args.signal },
   );
   return responseJson<FieldTruckInventorySnapshot>(response);
 }
 
-export async function resolveTruckPartCode(code: string): Promise<FieldPartIdentityResult> {
+export async function resolveTruckPartCode(
+  code: string,
+): Promise<FieldPartIdentityResult> {
   const response = await fetch("/api/mobile/service/truck-inventory/resolve", {
     method: "POST",
     credentials: "include",

--- a/features/mobile/service/useTruckInventorySnapshot.ts
+++ b/features/mobile/service/useTruckInventorySnapshot.ts
@@ -14,15 +14,23 @@ import {
 import { fetchTruckInventorySnapshot } from "./truckInventoryClient";
 import type { FieldTruckInventorySnapshot } from "./truckInventoryContracts";
 import { isActionableFieldWorkOrderLine } from "./truckInventoryContracts";
+import {
+  asRouteLoadFailure,
+  runBoundedRouteLoad,
+  type RouteLoadFailure,
+} from "@/features/shared/lib/route-load";
 
 export function useTruckInventorySnapshot() {
-  const [snapshot, setSnapshot] = useState<FieldTruckInventorySnapshot | null>(null);
+  const [snapshot, setSnapshot] = useState<FieldTruckInventorySnapshot | null>(
+    null,
+  );
   const [scope, setScope] = useState<OfflineMutationScope | null>(null);
   const [online, setOnline] = useState(
     () => typeof navigator === "undefined" || navigator.onLine,
   );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [loadFailure, setLoadFailure] = useState<RouteLoadFailure | null>(null);
   const [query, setQuery] = useState("");
   const selectedTruckIdRef = useRef("");
   const [selectedTruckId, setSelectedTruckId] = useState("");
@@ -32,25 +40,33 @@ export function useTruckInventorySnapshot() {
     async (search = "", serviceVehicleId = selectedTruckIdRef.current) => {
       setLoading(true);
       setError(null);
+      setLoadFailure(null);
       try {
         if (!online) throw new Error("offline");
-        const next = await fetchTruckInventorySnapshot({ search, serviceVehicleId });
+        const next = await runBoundedRouteLoad(
+          {
+            route: "/mobile/service/truck-inventory",
+            operation: "load truck inventory",
+          },
+          ({ signal }) =>
+            fetchTruckInventorySnapshot({ search, serviceVehicleId, signal }),
+        );
         setSnapshot(next);
         const resolvedTruckId = next.truck?.id ?? serviceVehicleId ?? "";
         selectedTruckIdRef.current = resolvedTruckId;
         setSelectedTruckId(resolvedTruckId);
-        setSelectedLineId(
-          (current) => {
-            const actionable = next.workOrderLines.filter(
-              isActionableFieldWorkOrderLine,
-            );
-            return actionable.some((line) => line.id === current)
-              ? current
-              : actionable[0]?.id || "";
-          },
-        );
+        setSelectedLineId((current) => {
+          const actionable = next.workOrderLines.filter(
+            isActionableFieldWorkOrderLine,
+          );
+          return actionable.some((line) => line.id === current)
+            ? current
+            : actionable[0]?.id || "";
+        });
         const resolvedScope =
-          scope ?? getOfflineMutationScope() ?? (await resolveOfflineMutationScope({}));
+          scope ??
+          getOfflineMutationScope() ??
+          (await resolveOfflineMutationScope({}));
         if (resolvedScope) {
           setScope(resolvedScope);
           await cacheFieldTruckInventorySnapshot({
@@ -61,34 +77,39 @@ export function useTruckInventorySnapshot() {
       } catch (loadError) {
         const resolvedScope = scope ?? getOfflineMutationScope();
         const cached = resolvedScope
-          ? await loadCachedFieldTruckInventorySnapshot({ scope: resolvedScope })
+          ? await loadCachedFieldTruckInventorySnapshot({
+              scope: resolvedScope,
+            })
           : null;
         if (cached) {
           setSnapshot(cached);
           const cachedTruckId = cached.truck?.id ?? serviceVehicleId ?? "";
           selectedTruckIdRef.current = cachedTruckId;
           setSelectedTruckId(cachedTruckId);
-          setSelectedLineId(
-            (current) => {
-              const actionable = cached.workOrderLines.filter(
-                isActionableFieldWorkOrderLine,
-              );
-              return actionable.some((line) => line.id === current)
-                ? current
-                : actionable[0]?.id || "";
-            },
-          );
+          setSelectedLineId((current) => {
+            const actionable = cached.workOrderLines.filter(
+              isActionableFieldWorkOrderLine,
+            );
+            return actionable.some((line) => line.id === current)
+              ? current
+              : actionable[0]?.id || "";
+          });
           setError(
             online
               ? "Live truck inventory could not load. Showing the last cached snapshot."
               : "Offline — showing the last cached truck snapshot.",
           );
         } else {
-          setError(
-            loadError instanceof Error && loadError.message !== "offline"
-              ? loadError.message
-              : "This device has no cached truck inventory yet.",
-          );
+          if (loadError instanceof Error && loadError.message === "offline") {
+            setError("This device has no cached truck inventory yet.");
+          } else {
+            setLoadFailure(
+              asRouteLoadFailure(
+                loadError,
+                "Live truck inventory could not be loaded.",
+              ),
+            );
+          }
         }
       } finally {
         setLoading(false);
@@ -132,6 +153,7 @@ export function useTruckInventorySnapshot() {
     online,
     loading,
     error,
+    loadFailure,
     query,
     setQuery,
     selectedTruckId,

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -645,8 +645,7 @@ export default function QuotePageClient(): JSX.Element {
               const lineStatus = safeTrim(line.line_status).toLowerCase();
               const approvalState = safeTrim(line.approval_state).toLowerCase();
               return (
-                (approvalState === "pending" &&
-                  status === "awaiting_approval") ||
+                (approvalState === "pending" && status === "awaiting_approval") ||
                 approvalState === "approved" ||
                 approvalState === "declined" ||
                 approvalState === "deferred" ||

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -28,6 +28,13 @@ import {
   type WorkOrderEvidenceItem,
 } from "@/features/work-orders/lib/evidence/workOrderEvidence";
 import { selectCustomerVisibleQuoteParts } from "@/features/portal/lib/customerVisibleQuoteParts";
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
+import {
+  asRouteLoadFailure,
+  routeLoadFailureFromStatus,
+  runBoundedRouteLoad,
+  type RouteLoadFailure,
+} from "@/features/shared/lib/route-load";
 
 const COPPER = "#C57A4A";
 const CUSTOMER_VISIBLE_QUOTE_STATUSES = new Set([
@@ -358,342 +365,405 @@ export default function QuotePageClient(): JSX.Element {
   const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
+  const [loadFailure, setLoadFailure] = useState<RouteLoadFailure | null>(null);
   const [workOrder, setWorkOrder] = useState<WorkOrderRow | null>(null);
   const [shop, setShop] = useState<ShopRow | null>(null);
   const [lines, setLines] = useState<LineView[]>([]);
 
   const load = useCallback(async () => {
     if (!workOrderId) {
-      router.replace("/portal");
-      return;
-    }
-
-    setLoading(true);
-
-    const {
-      data: { user },
-      error: userErr,
-    } = await supabase.auth.getUser();
-
-    if (userErr || !user) {
-      router.replace("/customer/sign-in");
-      return;
-    }
-
-    const { data: customer, error: custErr } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("user_id", user.id)
-      .maybeSingle();
-
-    if (custErr || !customer?.id) {
-      router.replace("/portal");
-      return;
-    }
-
-    const { data: wo, error: woErr } = await supabase
-      .from("work_orders")
-      .select("*")
-      .eq("id", workOrderId)
-      .eq("customer_id", customer.id)
-      .maybeSingle();
-
-    if (woErr || !wo?.id || !wo.shop_id) {
-      router.replace("/portal");
-      return;
-    }
-
-    setWorkOrder(wo as WorkOrderRow);
-
-    let shopRow: ShopRow | null = null;
-    let laborRate = 0;
-
-    const { data: shopData } = await supabase
-      .from("shops")
-      .select("*")
-      .eq("id", wo.shop_id)
-      .maybeSingle();
-    shopRow = (shopData ?? null) as ShopRow | null;
-    laborRate = asNumber(
-      (shopData as { labor_rate?: unknown } | null)?.labor_rate,
-    );
-    setShop(shopRow);
-
-    const [quoteResult, directLineResult, directPartResult] = await Promise.all([
-      supabase
-        .from("work_order_quote_lines")
-        .select(
-          "id, description, ai_complaint, ai_cause, ai_correction, notes, job_type, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, tax_total, grand_total, status, stage, sent_to_customer_at, approved_at, declined_at, work_order_line_id, metadata, created_at, updated_at",
-        )
-        .eq("work_order_id", workOrderId)
-        .eq("shop_id", wo.shop_id)
-        .order("created_at", { ascending: true }),
-      supabase
-        .from("work_order_lines")
-        .select(
-          "id,line_no,description,complaint,cause,correction,notes,technician_notes,labor_time,price_estimate,status,line_status,approval_state,approval_at,quoted_at,created_at,updated_at,voided_at",
-        )
-        .eq("work_order_id", workOrderId)
-        .eq("shop_id", wo.shop_id)
-        .order("line_no", { ascending: true }),
-      supabase
-        .from("work_order_parts")
-        .select(
-          "id,work_order_line_id,description_snapshot,part_number_snapshot,manufacturer_snapshot,quantity,unit_price,total_price,is_active",
-        )
-        .eq("work_order_id", workOrderId)
-        .eq("shop_id", wo.shop_id)
-        .eq("is_active", true),
-    ]);
-    const { data: quoteRowsRaw, error: quoteErr } = quoteResult;
-    const { data: directRowsRaw, error: directLineErr } = directLineResult;
-    const { data: directPartsRaw, error: directPartErr } = directPartResult;
-
-    if (quoteErr || directLineErr || directPartErr) {
-      setLines([]);
+      setLoadFailure(
+        routeLoadFailureFromStatus(404, "The quote link is incomplete."),
+      );
       setLoading(false);
       return;
     }
 
-    let inspectionPhotos: Array<
-      Pick<InspectionPhotoRow, "image_url" | "item_name">
-    > = [];
-    const inspectionId = safeTrim(
-      (wo as { inspection_id?: unknown } | null)?.inspection_id,
-    );
-    if (inspectionId) {
-      const { data: photos } = await supabase
-        .from("inspection_photos")
-        .select("image_url,item_name")
-        .eq("inspection_id", inspectionId)
-        .order("created_at", { ascending: false })
-        .limit(100);
-      inspectionPhotos = (photos ?? []) as Array<
-        Pick<InspectionPhotoRow, "image_url" | "item_name">
-      >;
-    }
+    setLoading(true);
+    setLoadFailure(null);
 
-    const evidenceResponse = await fetch(
-      `/api/work-orders/${workOrderId}/media?scope=all`,
-      { cache: "no-store" },
-    );
-    const evidenceBody = (await evidenceResponse.json().catch(() => null)) as {
-      items?: WorkOrderEvidenceItem[];
-    } | null;
-    const canonicalEvidence = evidenceResponse.ok
-      ? (evidenceBody?.items ?? [])
-      : [];
+    try {
+      await runBoundedRouteLoad(
+        {
+          route: `/portal/quotes/${workOrderId}`,
+          operation: "load customer quote",
+        },
+        async ({ recordStatus, signal }) => {
+          const {
+            data: { user },
+            error: userErr,
+          } = await supabase.auth.getUser();
 
-    const mappedQuoteLines: LineView[] = ((quoteRowsRaw ?? []) as QuoteLineRow[])
-      .filter(isCustomerVisibleQuoteLine)
-      .map((line, index) => {
-        const parts = getQuoteParts(line, Boolean(wo.estimate_number));
-        const metadata = quoteMetadata(line);
-        const customerLineNotes = wo.estimate_number
-          ? ""
-          : safeTrim(line.notes);
-        const requestKind = safeTrim(metadata.request_kind);
-        const fulfillment = safeTrim(metadata.fulfillment);
-        const laborHours =
-          nullableNumber(line.labor_hours) ??
-          nullableNumber(line.est_labor_hours) ??
-          0;
-        const computedLabor =
-          laborHours * (nullableNumber(metadata.labor_rate) ?? laborRate);
-        const partsAmount =
-          nullableNumber(line.parts_total) ??
-          parts.reduce((sum, part) => sum + (part.total ?? 0), 0);
-        const laborAmount = nullableNumber(line.labor_total) ?? computedLabor;
-        const subtotalAmount =
-          nullableNumber(line.subtotal) ?? laborAmount + partsAmount;
-        const taxAmount = nullableNumber(line.tax_total) ?? 0;
-        const totalAmount =
-          nullableNumber(line.grand_total) ?? subtotalAmount + taxAmount;
+          if (userErr || !user) {
+            throw routeLoadFailureFromStatus(
+              401,
+              "Sign in to view this quote.",
+            );
+          }
 
-        const linkedEvidence = canonicalEvidence.filter(
-          (item) =>
-            item.quoteLineId === line.id ||
-            (line.work_order_line_id != null &&
-              item.workOrderLineId === line.work_order_line_id),
-        );
-        const fallbackEvidence: WorkOrderEvidenceItem[] =
-          linkedEvidence.length > 0
-            ? []
-            : getEvidencePhotos(line, inspectionPhotos).map(
-                (url, photoIndex) => ({
-                  id: `${line.id}-legacy-${photoIndex}`,
-                  workOrderId,
-                  workOrderLineId: line.work_order_line_id,
-                  quoteLineId: line.id,
-                  kind: "photo",
-                  source: "inspection_finding",
-                  visibility: "customer",
-                  fileName: null,
-                  contentType: "image/jpeg",
-                  fileSize: null,
-                  createdAt: null,
-                  displayUrl: url,
-                  annotation: null,
-                }),
+          const { data: customer, error: custErr } = await supabase
+            .from("customers")
+            .select("id")
+            .eq("user_id", user.id)
+            .abortSignal(signal)
+            .maybeSingle();
+
+          if (custErr) throw custErr;
+          if (!customer?.id) {
+            throw routeLoadFailureFromStatus(
+              403,
+              "This account is not linked to a customer portal profile.",
+            );
+          }
+
+          const { data: wo, error: woErr } = await supabase
+            .from("work_orders")
+            .select("*")
+            .eq("id", workOrderId)
+            .eq("customer_id", customer.id)
+            .abortSignal(signal)
+            .maybeSingle();
+
+          if (woErr) throw woErr;
+          if (!wo?.id || !wo.shop_id) {
+            throw routeLoadFailureFromStatus(
+              404,
+              "This quote is unavailable or does not belong to this account.",
+            );
+          }
+
+          setWorkOrder(wo as WorkOrderRow);
+
+          let shopRow: ShopRow | null = null;
+          let laborRate = 0;
+
+          const { data: shopData, error: shopError } = await supabase
+            .from("shops")
+            .select("*")
+            .eq("id", wo.shop_id)
+            .abortSignal(signal)
+            .maybeSingle();
+          if (shopError) throw shopError;
+          shopRow = (shopData ?? null) as ShopRow | null;
+          laborRate = asNumber(
+            (shopData as { labor_rate?: unknown } | null)?.labor_rate,
+          );
+          setShop(shopRow);
+
+          const [quoteResult, directLineResult, directPartResult] =
+            await Promise.all([
+              supabase
+                .from("work_order_quote_lines")
+                .select(
+                  "id, description, ai_complaint, ai_cause, ai_correction, notes, job_type, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, tax_total, grand_total, status, stage, sent_to_customer_at, approved_at, declined_at, work_order_line_id, metadata, created_at, updated_at",
+                )
+                .eq("work_order_id", workOrderId)
+                .eq("shop_id", wo.shop_id)
+                .order("created_at", { ascending: true })
+                .abortSignal(signal),
+              supabase
+                .from("work_order_lines")
+                .select(
+                  "id,line_no,description,complaint,cause,correction,notes,technician_notes,labor_time,price_estimate,status,line_status,approval_state,approval_at,quoted_at,created_at,updated_at,voided_at",
+                )
+                .eq("work_order_id", workOrderId)
+                .eq("shop_id", wo.shop_id)
+                .order("line_no", { ascending: true })
+                .abortSignal(signal),
+              supabase
+                .from("work_order_parts")
+                .select(
+                  "id,work_order_line_id,description_snapshot,part_number_snapshot,manufacturer_snapshot,quantity,unit_price,total_price,is_active",
+                )
+                .eq("work_order_id", workOrderId)
+                .eq("shop_id", wo.shop_id)
+                .eq("is_active", true)
+                .abortSignal(signal),
+            ]);
+          const { data: quoteRowsRaw, error: quoteErr } = quoteResult;
+          const { data: directRowsRaw, error: directLineErr } =
+            directLineResult;
+          const { data: directPartsRaw, error: directPartErr } =
+            directPartResult;
+
+          if (quoteErr || directLineErr || directPartErr) {
+            throw quoteErr ?? directLineErr ?? directPartErr;
+          }
+
+          let inspectionPhotos: Array<
+            Pick<InspectionPhotoRow, "image_url" | "item_name">
+          > = [];
+          const inspectionId = safeTrim(
+            (wo as { inspection_id?: unknown } | null)?.inspection_id,
+          );
+          if (inspectionId) {
+            const { data: photos, error: photosError } = await supabase
+              .from("inspection_photos")
+              .select("image_url,item_name")
+              .eq("inspection_id", inspectionId)
+              .order("created_at", { ascending: false })
+              .abortSignal(signal)
+              .limit(100);
+            if (photosError) throw photosError;
+            inspectionPhotos = (photos ?? []) as Array<
+              Pick<InspectionPhotoRow, "image_url" | "item_name">
+            >;
+          }
+
+          const evidenceResponse = await fetch(
+            `/api/work-orders/${workOrderId}/media?scope=all`,
+            { cache: "no-store", signal },
+          );
+          recordStatus(evidenceResponse.status);
+          const evidenceBody = (await evidenceResponse
+            .json()
+            .catch(() => null)) as {
+            items?: WorkOrderEvidenceItem[];
+          } | null;
+          if (!evidenceResponse.ok) {
+            throw routeLoadFailureFromStatus(
+              evidenceResponse.status,
+              "Quote evidence could not be loaded.",
+            );
+          }
+          const canonicalEvidence = evidenceBody?.items ?? [];
+
+          const mappedQuoteLines: LineView[] = (
+            (quoteRowsRaw ?? []) as QuoteLineRow[]
+          )
+            .filter(isCustomerVisibleQuoteLine)
+            .map((line, index) => {
+              const parts = getQuoteParts(line, Boolean(wo.estimate_number));
+              const metadata = quoteMetadata(line);
+              const customerLineNotes = wo.estimate_number
+                ? ""
+                : safeTrim(line.notes);
+              const requestKind = safeTrim(metadata.request_kind);
+              const fulfillment = safeTrim(metadata.fulfillment);
+              const laborHours =
+                nullableNumber(line.labor_hours) ??
+                nullableNumber(line.est_labor_hours) ??
+                0;
+              const computedLabor =
+                laborHours * (nullableNumber(metadata.labor_rate) ?? laborRate);
+              const partsAmount =
+                nullableNumber(line.parts_total) ??
+                parts.reduce((sum, part) => sum + (part.total ?? 0), 0);
+              const laborAmount =
+                nullableNumber(line.labor_total) ?? computedLabor;
+              const subtotalAmount =
+                nullableNumber(line.subtotal) ?? laborAmount + partsAmount;
+              const taxAmount = nullableNumber(line.tax_total) ?? 0;
+              const totalAmount =
+                nullableNumber(line.grand_total) ?? subtotalAmount + taxAmount;
+
+              const linkedEvidence = canonicalEvidence.filter(
+                (item) =>
+                  item.quoteLineId === line.id ||
+                  (line.work_order_line_id != null &&
+                    item.workOrderLineId === line.work_order_line_id),
               );
+              const fallbackEvidence: WorkOrderEvidenceItem[] =
+                linkedEvidence.length > 0
+                  ? []
+                  : getEvidencePhotos(line, inspectionPhotos).map(
+                      (url, photoIndex) => ({
+                        id: `${line.id}-legacy-${photoIndex}`,
+                        workOrderId,
+                        workOrderLineId: line.work_order_line_id,
+                        quoteLineId: line.id,
+                        kind: "photo",
+                        source: "inspection_finding",
+                        visibility: "customer",
+                        fileName: null,
+                        contentType: "image/jpeg",
+                        fileSize: null,
+                        createdAt: null,
+                        displayUrl: url,
+                        annotation: null,
+                      }),
+                    );
 
-        return {
-          id: line.id,
-          source: "quote" as const,
-          lineNo: index + 1,
-          title:
-            safeTrim(line.description) ||
-            safeTrim(line.ai_complaint) ||
-            "Quote line",
-          complaint: safeTrim(line.ai_complaint) || customerLineNotes || null,
-          cause: safeTrim(line.ai_cause) || null,
-          correction: safeTrim(line.ai_correction) || null,
-          notes: customerLineNotes || null,
-          laborHours,
-          laborAmount,
-          partsAmount,
-          subtotalAmount,
-          taxAmount,
-          totalAmount,
-          approvalState: quoteApprovalState(line),
-          status: line.status,
-          stage: line.stage,
-          sentAt: line.sent_to_customer_at ?? null,
-          approvedAt: line.approved_at ?? null,
-          declinedAt: line.declined_at ?? null,
-          convertedWorkOrderLineId: line.work_order_line_id ?? null,
-          createdAt: line.created_at ?? null,
-          updatedAt: line.updated_at ?? null,
-          parts,
-          evidence:
-            linkedEvidence.length > 0 ? linkedEvidence : fallbackEvidence,
-          requestKind:
-            requestKind === "parts_only"
-              ? "parts_only"
-              : requestKind === "repair"
-                ? "repair"
-                : null,
-          fulfillment:
-            fulfillment === "pickup"
-              ? "pickup"
-              : fulfillment === "appointment"
-                ? "appointment"
-                : null,
-        };
-      });
+              return {
+                id: line.id,
+                source: "quote" as const,
+                lineNo: index + 1,
+                title:
+                  safeTrim(line.description) ||
+                  safeTrim(line.ai_complaint) ||
+                  "Quote line",
+                complaint:
+                  safeTrim(line.ai_complaint) || customerLineNotes || null,
+                cause: safeTrim(line.ai_cause) || null,
+                correction: safeTrim(line.ai_correction) || null,
+                notes: customerLineNotes || null,
+                laborHours,
+                laborAmount,
+                partsAmount,
+                subtotalAmount,
+                taxAmount,
+                totalAmount,
+                approvalState: quoteApprovalState(line),
+                status: line.status,
+                stage: line.stage,
+                sentAt: line.sent_to_customer_at ?? null,
+                approvedAt: line.approved_at ?? null,
+                declinedAt: line.declined_at ?? null,
+                convertedWorkOrderLineId: line.work_order_line_id ?? null,
+                createdAt: line.created_at ?? null,
+                updatedAt: line.updated_at ?? null,
+                parts,
+                evidence:
+                  linkedEvidence.length > 0 ? linkedEvidence : fallbackEvidence,
+                requestKind:
+                  requestKind === "parts_only"
+                    ? "parts_only"
+                    : requestKind === "repair"
+                      ? "repair"
+                      : null,
+                fulfillment:
+                  fulfillment === "pickup"
+                    ? "pickup"
+                    : fulfillment === "appointment"
+                      ? "appointment"
+                      : null,
+              };
+            });
 
-    const linkedWorkOrderLineIds = new Set(
-      mappedQuoteLines
-        .map((line) => line.convertedWorkOrderLineId)
-        .filter((id): id is string => Boolean(id)),
-    );
-    const mappedDirectLines: LineView[] = (
-      (directRowsRaw ?? []) as DirectLineRow[]
-    )
-      .filter((line) => {
-        if (line.voided_at || linkedWorkOrderLineIds.has(line.id)) return false;
-        const status = safeTrim(line.status).toLowerCase();
-        const lineStatus = safeTrim(line.line_status).toLowerCase();
-        const approvalState = safeTrim(line.approval_state).toLowerCase();
-        return (
-          (approvalState === "pending" && status === "awaiting_approval") ||
-          approvalState === "approved" ||
-          approvalState === "declined" ||
-          approvalState === "deferred" ||
-          lineStatus === "authorized" ||
-          Boolean(line.approval_at) ||
-          ["completed", "ready_to_invoice", "invoiced"].includes(status)
-        );
-      })
-      .map((line, index) => {
-        const laborHours = asNumber(line.labor_time);
-        const computedLabor = laborHours * laborRate;
-        const laborAmount = nullableNumber(line.price_estimate) ?? computedLabor;
-        const directParts: QuotePartView[] = (
-          (directPartsRaw ?? []) as DirectPartRow[]
-        )
-          .filter((part) => part.work_order_line_id === line.id)
-          .map((part) => {
-            const qty = asNumber(part.quantity);
-            const unitPrice = asNumber(part.unit_price);
-            return {
-              name: safeTrim(part.description_snapshot) || "Part",
-              qty,
-              unitPrice,
-              total: nullableNumber(part.total_price) ?? qty * unitPrice,
-              pricingUnavailable: false,
-              meta:
-                [
-                  safeTrim(part.manufacturer_snapshot),
-                  safeTrim(part.part_number_snapshot),
-                ]
-                  .filter(Boolean)
-                  .join(" • ") || null,
-            };
-          });
-        const partsAmount = directParts.reduce(
-          (sum, part) => sum + (part.total ?? 0),
-          0,
-        );
-        const totalAmount = laborAmount + partsAmount;
-        const linkedEvidence = canonicalEvidence.filter(
-          (item) => item.workOrderLineId === line.id,
-        );
-        const normalizedApprovalState = safeTrim(
-          line.approval_state,
-        ).toLowerCase();
-        const approvalState: LineView["approvalState"] = [
-          "pending",
-          "approved",
-          "declined",
-          "deferred",
-        ].includes(normalizedApprovalState)
-          ? (normalizedApprovalState as Exclude<
-              LineView["approvalState"],
-              null
-            >)
-          : ["completed", "ready_to_invoice", "invoiced"].includes(
-                safeTrim(line.status).toLowerCase(),
-              ) || safeTrim(line.line_status).toLowerCase() === "authorized"
-            ? "approved"
-            : null;
-        return {
-          id: line.id,
-          source: "work_order" as const,
-          lineNo: line.line_no ?? index + 1,
-          title:
-            safeTrim(line.description) ||
-            safeTrim(line.complaint) ||
-            "Authorized work",
-          complaint: safeTrim(line.complaint) || null,
-          cause: safeTrim(line.cause) || null,
-          correction: safeTrim(line.correction) || null,
-          notes:
-            safeTrim(line.technician_notes) || safeTrim(line.notes) || null,
-          laborHours,
-          laborAmount,
-          partsAmount,
-          subtotalAmount: totalAmount,
-          taxAmount: 0,
-          totalAmount,
-          approvalState,
-          status: line.status,
-          stage: null,
-          sentAt: line.quoted_at ?? null,
-          approvedAt: line.approval_at ?? null,
-          declinedAt: null,
-          convertedWorkOrderLineId: line.id,
-          createdAt: line.created_at ?? null,
-          updatedAt: line.updated_at ?? null,
-          parts: directParts,
-          evidence: linkedEvidence,
-          requestKind: null,
-          fulfillment: null,
-        };
-      });
+          const linkedWorkOrderLineIds = new Set(
+            mappedQuoteLines
+              .map((line) => line.convertedWorkOrderLineId)
+              .filter((id): id is string => Boolean(id)),
+          );
+          const mappedDirectLines: LineView[] = (
+            (directRowsRaw ?? []) as DirectLineRow[]
+          )
+            .filter((line) => {
+              if (line.voided_at || linkedWorkOrderLineIds.has(line.id))
+                return false;
+              const status = safeTrim(line.status).toLowerCase();
+              const lineStatus = safeTrim(line.line_status).toLowerCase();
+              const approvalState = safeTrim(line.approval_state).toLowerCase();
+              return (
+                (approvalState === "pending" &&
+                  status === "awaiting_approval") ||
+                approvalState === "approved" ||
+                approvalState === "declined" ||
+                approvalState === "deferred" ||
+                lineStatus === "authorized" ||
+                Boolean(line.approval_at) ||
+                ["completed", "ready_to_invoice", "invoiced"].includes(status)
+              );
+            })
+            .map((line, index) => {
+              const laborHours = asNumber(line.labor_time);
+              const computedLabor = laborHours * laborRate;
+              const laborAmount =
+                nullableNumber(line.price_estimate) ?? computedLabor;
+              const directParts: QuotePartView[] = (
+                (directPartsRaw ?? []) as DirectPartRow[]
+              )
+                .filter((part) => part.work_order_line_id === line.id)
+                .map((part) => {
+                  const qty = asNumber(part.quantity);
+                  const unitPrice = asNumber(part.unit_price);
+                  return {
+                    name: safeTrim(part.description_snapshot) || "Part",
+                    qty,
+                    unitPrice,
+                    total: nullableNumber(part.total_price) ?? qty * unitPrice,
+                    pricingUnavailable: false,
+                    meta:
+                      [
+                        safeTrim(part.manufacturer_snapshot),
+                        safeTrim(part.part_number_snapshot),
+                      ]
+                        .filter(Boolean)
+                        .join(" • ") || null,
+                  };
+                });
+              const partsAmount = directParts.reduce(
+                (sum, part) => sum + (part.total ?? 0),
+                0,
+              );
+              const totalAmount = laborAmount + partsAmount;
+              const linkedEvidence = canonicalEvidence.filter(
+                (item) => item.workOrderLineId === line.id,
+              );
+              const normalizedApprovalState = safeTrim(
+                line.approval_state,
+              ).toLowerCase();
+              const approvalState: LineView["approvalState"] = [
+                "pending",
+                "approved",
+                "declined",
+                "deferred",
+              ].includes(normalizedApprovalState)
+                ? (normalizedApprovalState as Exclude<
+                    LineView["approvalState"],
+                    null
+                  >)
+                : ["completed", "ready_to_invoice", "invoiced"].includes(
+                      safeTrim(line.status).toLowerCase(),
+                    ) ||
+                    safeTrim(line.line_status).toLowerCase() === "authorized"
+                  ? "approved"
+                  : null;
+              return {
+                id: line.id,
+                source: "work_order" as const,
+                lineNo: line.line_no ?? index + 1,
+                title:
+                  safeTrim(line.description) ||
+                  safeTrim(line.complaint) ||
+                  "Authorized work",
+                complaint: safeTrim(line.complaint) || null,
+                cause: safeTrim(line.cause) || null,
+                correction: safeTrim(line.correction) || null,
+                notes:
+                  safeTrim(line.technician_notes) ||
+                  safeTrim(line.notes) ||
+                  null,
+                laborHours,
+                laborAmount,
+                partsAmount,
+                subtotalAmount: totalAmount,
+                taxAmount: 0,
+                totalAmount,
+                approvalState,
+                status: line.status,
+                stage: null,
+                sentAt: line.quoted_at ?? null,
+                approvedAt: line.approval_at ?? null,
+                declinedAt: null,
+                convertedWorkOrderLineId: line.id,
+                createdAt: line.created_at ?? null,
+                updatedAt: line.updated_at ?? null,
+                parts: directParts,
+                evidence: linkedEvidence,
+                requestKind: null,
+                fulfillment: null,
+              };
+            });
 
-    setLines([...mappedQuoteLines, ...mappedDirectLines]);
-    setLoading(false);
+          setLines([...mappedQuoteLines, ...mappedDirectLines]);
+        },
+      );
+    } catch (error) {
+      const failure = asRouteLoadFailure(
+        error,
+        "This quote could not be loaded.",
+      );
+      setLoadFailure(failure);
+      setWorkOrder(null);
+      setShop(null);
+      setLines([]);
+      if (failure.kind === "unauthenticated") {
+        router.replace("/customer/sign-in");
+      }
+    } finally {
+      setLoading(false);
+    }
   }, [router, supabase, workOrderId]);
 
   useEffect(() => {
@@ -708,10 +778,27 @@ export default function QuotePageClient(): JSX.Element {
     );
   }
 
-  if (loading || !workOrder) {
+  if (loading) {
     return (
       <div className="min-h-screen px-4 py-10 flex items-center justify-center text-[color:var(--theme-text-secondary)]">
         Loading quote...
+      </div>
+    );
+  }
+
+  if (loadFailure || !workOrder) {
+    const failure =
+      loadFailure ??
+      routeLoadFailureFromStatus(404, "This quote is unavailable.");
+    return (
+      <div className="mx-auto min-h-screen w-full max-w-2xl px-4 py-10">
+        <RouteLoadPanel failure={failure} onRetry={() => void load()} />
+        <Link
+          href="/portal"
+          className="mt-4 inline-flex min-h-10 items-center text-sm font-semibold text-[var(--accent-copper-light)]"
+        >
+          Back to portal
+        </Link>
       </div>
     );
   }

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -28,6 +28,7 @@ import {
   type WorkOrderEvidenceItem,
 } from "@/features/work-orders/lib/evidence/workOrderEvidence";
 import { selectCustomerVisibleQuoteParts } from "@/features/portal/lib/customerVisibleQuoteParts";
+import { loadOptionalQuoteEvidence } from "@/features/portal/lib/loadOptionalQuoteEvidence";
 import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
 import {
   asRouteLoadFailure,
@@ -366,6 +367,8 @@ export default function QuotePageClient(): JSX.Element {
 
   const [loading, setLoading] = useState(true);
   const [loadFailure, setLoadFailure] = useState<RouteLoadFailure | null>(null);
+  const [evidenceWarning, setEvidenceWarning] =
+    useState<RouteLoadFailure | null>(null);
   const [workOrder, setWorkOrder] = useState<WorkOrderRow | null>(null);
   const [shop, setShop] = useState<ShopRow | null>(null);
   const [lines, setLines] = useState<LineView[]>([]);
@@ -381,6 +384,7 @@ export default function QuotePageClient(): JSX.Element {
 
     setLoading(true);
     setLoadFailure(null);
+    setEvidenceWarning(null);
 
     try {
       await runBoundedRouteLoad(
@@ -493,6 +497,7 @@ export default function QuotePageClient(): JSX.Element {
           let inspectionPhotos: Array<
             Pick<InspectionPhotoRow, "image_url" | "item_name">
           > = [];
+          let evidenceWarningCandidate: RouteLoadFailure | null = null;
           const inspectionId = safeTrim(
             (wo as { inspection_id?: unknown } | null)?.inspection_id,
           );
@@ -504,29 +509,26 @@ export default function QuotePageClient(): JSX.Element {
               .order("created_at", { ascending: false })
               .abortSignal(signal)
               .limit(100);
-            if (photosError) throw photosError;
-            inspectionPhotos = (photos ?? []) as Array<
-              Pick<InspectionPhotoRow, "image_url" | "item_name">
-            >;
+            if (photosError) {
+              if (signal.aborted) throw photosError;
+              evidenceWarningCandidate = asRouteLoadFailure(
+                photosError,
+                "Some quote evidence could not be loaded.",
+              );
+            } else {
+              inspectionPhotos = (photos ?? []) as Array<
+                Pick<InspectionPhotoRow, "image_url" | "item_name">
+              >;
+            }
           }
 
-          const evidenceResponse = await fetch(
-            `/api/work-orders/${workOrderId}/media?scope=all`,
-            { cache: "no-store", signal },
-          );
-          recordStatus(evidenceResponse.status);
-          const evidenceBody = (await evidenceResponse
-            .json()
-            .catch(() => null)) as {
-            items?: WorkOrderEvidenceItem[];
-          } | null;
-          if (!evidenceResponse.ok) {
-            throw routeLoadFailureFromStatus(
-              evidenceResponse.status,
-              "Quote evidence could not be loaded.",
-            );
-          }
-          const canonicalEvidence = evidenceBody?.items ?? [];
+          const evidenceResult = await loadOptionalQuoteEvidence({
+            workOrderId,
+            signal,
+            recordStatus,
+          });
+          const canonicalEvidence = evidenceResult.items;
+          evidenceWarningCandidate ??= evidenceResult.warning;
 
           const mappedQuoteLines: LineView[] = (
             (quoteRowsRaw ?? []) as QuoteLineRow[]
@@ -745,6 +747,7 @@ export default function QuotePageClient(): JSX.Element {
               };
             });
 
+          setEvidenceWarning(evidenceWarningCandidate);
           setLines([...mappedQuoteLines, ...mappedDirectLines]);
         },
       );
@@ -891,6 +894,36 @@ export default function QuotePageClient(): JSX.Element {
               Quote
             </div>
           </div>
+
+          {evidenceWarning ? (
+            <section
+              aria-live="polite"
+              className="mb-5 rounded-2xl border border-amber-400/40 bg-amber-500/10 p-4 text-amber-100"
+              role="status"
+            >
+              <h2 className="text-sm font-semibold">
+                Some evidence is temporarily unavailable
+              </h2>
+              <p className="mt-1 text-xs text-amber-100/90">
+                The quote details and approval actions are still available.
+              </p>
+              {evidenceWarning.requestId ? (
+                <p className="mt-2 text-[0.7rem] text-amber-100/70">
+                  Reference:{" "}
+                  <span className="font-mono">{evidenceWarning.requestId}</span>
+                </p>
+              ) : null}
+              {evidenceWarning.retryable ? (
+                <button
+                  type="button"
+                  onClick={() => void load()}
+                  className="mt-3 inline-flex min-h-10 items-center justify-center rounded-full border border-amber-300/50 bg-[color:var(--theme-surface-inset)] px-4 py-2 text-xs font-semibold text-amber-100 transition hover:bg-[color:var(--theme-surface-overlay)]"
+                >
+                  Retry evidence
+                </button>
+              ) : null}
+            </section>
+          ) : null}
 
           <div className="mb-6 space-y-1">
             <h1

--- a/features/portal/lib/loadOptionalQuoteEvidence.ts
+++ b/features/portal/lib/loadOptionalQuoteEvidence.ts
@@ -1,0 +1,57 @@
+import type { WorkOrderEvidenceItem } from "@/features/work-orders/lib/evidence/workOrderEvidence";
+import {
+  asRouteLoadFailure,
+  routeLoadFailureFromStatus,
+  type RouteLoadFailure,
+} from "@/features/shared/lib/route-load";
+
+type LoadOptionalQuoteEvidenceArgs = {
+  workOrderId: string;
+  signal: AbortSignal;
+  recordStatus: (status: number) => void;
+  request?: typeof fetch;
+};
+
+export type OptionalQuoteEvidenceResult = {
+  items: WorkOrderEvidenceItem[];
+  warning: RouteLoadFailure | null;
+};
+
+export async function loadOptionalQuoteEvidence({
+  workOrderId,
+  signal,
+  recordStatus,
+  request = fetch,
+}: LoadOptionalQuoteEvidenceArgs): Promise<OptionalQuoteEvidenceResult> {
+  try {
+    const response = await request(
+      `/api/work-orders/${workOrderId}/media?scope=all`,
+      { cache: "no-store", signal },
+    );
+    recordStatus(response.status);
+    const body = (await response.json().catch(() => null)) as {
+      items?: WorkOrderEvidenceItem[];
+    } | null;
+
+    if (response.ok) {
+      return { items: body?.items ?? [], warning: null };
+    }
+
+    return {
+      items: [],
+      warning: routeLoadFailureFromStatus(
+        response.status,
+        "Some quote evidence could not be loaded.",
+      ),
+    };
+  } catch (error) {
+    if (signal.aborted) throw error;
+    return {
+      items: [],
+      warning: asRouteLoadFailure(
+        error,
+        "Some quote evidence could not be loaded.",
+      ),
+    };
+  }
+}

--- a/features/shared/components/ui/RouteLoadPanel.tsx
+++ b/features/shared/components/ui/RouteLoadPanel.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import type { RouteLoadFailure } from "@/features/shared/lib/route-load";
+
+function titleForFailure(failure: RouteLoadFailure): string {
+  switch (failure.kind) {
+    case "unauthenticated":
+      return "Sign in required";
+    case "forbidden":
+      return "Access denied";
+    case "not-found":
+      return "Record not found";
+    case "timeout":
+      return "Still waiting for data";
+    default:
+      return "Unable to load this screen";
+  }
+}
+
+export default function RouteLoadPanel({
+  failure,
+  onRetry,
+  title,
+}: {
+  failure: RouteLoadFailure;
+  onRetry?: () => void;
+  title?: string;
+}): JSX.Element {
+  return (
+    <section
+      aria-live="polite"
+      className="rounded-2xl border border-red-400/40 bg-red-500/10 p-4 text-red-100"
+      role="alert"
+    >
+      <h2 className="text-sm font-semibold">
+        {title ?? titleForFailure(failure)}
+      </h2>
+      <p className="mt-1 text-xs text-red-100/90">{failure.message}</p>
+      {failure.requestId ? (
+        <p className="mt-2 text-[0.7rem] text-red-100/70">
+          Reference: <span className="font-mono">{failure.requestId}</span>
+        </p>
+      ) : null}
+      {failure.retryable && onRetry ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 inline-flex min-h-10 items-center justify-center rounded-full border border-red-300/50 bg-[color:var(--theme-surface-inset)] px-4 py-2 text-xs font-semibold text-red-100 transition hover:bg-[color:var(--theme-surface-overlay)]"
+        >
+          Try again
+        </button>
+      ) : null}
+    </section>
+  );
+}

--- a/features/shared/lib/route-load.ts
+++ b/features/shared/lib/route-load.ts
@@ -1,0 +1,192 @@
+export type RouteLoadFailureKind =
+  | "timeout"
+  | "unauthenticated"
+  | "forbidden"
+  | "not-found"
+  | "network"
+  | "error";
+
+export type RouteLoadContext = {
+  route: string;
+  operation: string;
+  tenantId?: string | null;
+  actorId?: string | null;
+  role?: string | null;
+};
+
+export type RouteLoadOperationContext = {
+  requestId: string;
+  recordStatus: (status: number) => void;
+  signal: AbortSignal;
+};
+
+type RouteLoadFailureOptions = {
+  kind: RouteLoadFailureKind;
+  message: string;
+  requestId?: string;
+  status?: number;
+  retryable?: boolean;
+  cause?: unknown;
+};
+
+export class RouteLoadFailure extends Error {
+  readonly kind: RouteLoadFailureKind;
+  readonly requestId: string | null;
+  readonly retryable: boolean;
+  readonly status: number | null;
+
+  constructor(options: RouteLoadFailureOptions) {
+    super(options.message, { cause: options.cause });
+    this.name = "RouteLoadFailure";
+    this.kind = options.kind;
+    this.requestId = options.requestId ?? null;
+    this.retryable =
+      options.retryable ??
+      !["unauthenticated", "forbidden", "not-found"].includes(options.kind);
+    this.status = options.status ?? null;
+  }
+}
+
+const DEFAULT_TIMEOUT_MS = 12_000;
+
+function createRequestId(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `route-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function looksLikeNetworkFailure(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const value = `${error.name} ${error.message}`.toLowerCase();
+  return (
+    value.includes("failed to fetch") ||
+    value.includes("network") ||
+    value.includes("load failed") ||
+    value.includes("connection")
+  );
+}
+
+export function asRouteLoadFailure(
+  error: unknown,
+  fallbackMessage = "This screen could not be loaded.",
+): RouteLoadFailure {
+  if (error instanceof RouteLoadFailure) return error;
+  return new RouteLoadFailure({
+    kind: looksLikeNetworkFailure(error) ? "network" : "error",
+    message: fallbackMessage,
+    cause: error,
+  });
+}
+
+export function routeLoadFailureFromStatus(
+  status: number,
+  message: string,
+): RouteLoadFailure {
+  if (status === 401) {
+    return new RouteLoadFailure({
+      kind: "unauthenticated",
+      message,
+      status,
+      retryable: false,
+    });
+  }
+  if (status === 403) {
+    return new RouteLoadFailure({
+      kind: "forbidden",
+      message,
+      status,
+      retryable: false,
+    });
+  }
+  if (status === 404) {
+    return new RouteLoadFailure({
+      kind: "not-found",
+      message,
+      status,
+      retryable: false,
+    });
+  }
+  return new RouteLoadFailure({
+    kind: status >= 500 ? "network" : "error",
+    message,
+    status,
+  });
+}
+
+export async function runBoundedRouteLoad<T>(
+  context: RouteLoadContext,
+  operation: (operationContext: RouteLoadOperationContext) => Promise<T>,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<T> {
+  const requestId = createRequestId();
+  const controller = new AbortController();
+  const startedAt = Date.now();
+  let responseStatus: number | null = null;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(
+      () => {
+        controller.abort();
+        reject(
+          new RouteLoadFailure({
+            kind: "timeout",
+            message: "This screen took too long to load. Try again.",
+            requestId,
+          }),
+        );
+      },
+      Math.max(1, timeoutMs),
+    );
+  });
+
+  try {
+    const result = await Promise.race([
+      operation({
+        requestId,
+        recordStatus: (status) => {
+          if (Number.isInteger(status) && status >= 100 && status <= 599) {
+            responseStatus = status;
+          }
+        },
+        signal: controller.signal,
+      }),
+      timeoutPromise,
+    ]);
+    console.info("[route-load] complete", {
+      ...context,
+      requestId,
+      durationMs: Date.now() - startedAt,
+      status: responseStatus ?? "success",
+    });
+    return result;
+  } catch (error) {
+    const failure = asRouteLoadFailure(error);
+    const normalized = failure.requestId
+      ? failure
+      : new RouteLoadFailure({
+          kind: failure.kind,
+          message: failure.message,
+          requestId,
+          retryable: failure.retryable,
+          status: failure.status ?? undefined,
+          cause: failure.cause,
+        });
+    console.error("[route-load] failed", {
+      ...context,
+      requestId,
+      durationMs: Date.now() - startedAt,
+      failureKind: normalized.kind,
+      retryable: normalized.retryable,
+      status: normalized.status ?? responseStatus,
+      cause:
+        error instanceof Error
+          ? { name: error.name, message: error.message }
+          : String(error),
+    });
+    throw normalized;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}

--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -54,6 +54,13 @@ import {
   type MobileWorkOrderSnapshot,
 } from "@/features/work-orders/mobile/technicianOfflineExecution";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
+import {
+  asRouteLoadFailure,
+  routeLoadFailureFromStatus,
+  runBoundedRouteLoad,
+  type RouteLoadFailure,
+} from "@/features/shared/lib/route-load";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -255,8 +262,9 @@ export default function MobileWorkOrderClient({
     null,
   );
 
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const [viewError, setViewError] = useState<string | null>(null);
+  const [loadFailure, setLoadFailure] = useState<RouteLoadFailure | null>(null);
 
   const [techNamesById, setTechNamesById] = useState<Record<string, string>>(
     {},
@@ -298,58 +306,85 @@ export default function MobileWorkOrderClient({
     let mounted = true;
 
     const waitForSession = async () => {
-      let {
-        data: { session },
-      } = await supabase.auth.getSession();
+      setLoading(true);
+      setLoadFailure(null);
+      try {
+        await runBoundedRouteLoad(
+          {
+            route: `/mobile/work-orders/${routeId}`,
+            operation: "resolve mobile work order actor",
+          },
+          async ({ signal }) => {
+            let {
+              data: { session },
+            } = await supabase.auth.getSession();
 
-      if (!session) {
-        for (let i = 0; i < 8; i++) {
-          await new Promise((r) => setTimeout(r, 150 * (i + 1)));
-          const res = await supabase.auth.getSession();
-          session = res.data.session;
-          if (session) break;
-        }
-      }
+            if (!session) {
+              for (let i = 0; i < 8; i++) {
+                await new Promise((resolve) =>
+                  setTimeout(resolve, 150 * (i + 1)),
+                );
+                if (signal.aborted) return;
+                const result = await supabase.auth.getSession();
+                session = result.data.session;
+                if (session) break;
+              }
+            }
 
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
+            const {
+              data: { user },
+            } = await supabase.auth.getUser();
+            if (!mounted || signal.aborted) return;
 
-      if (!mounted) return;
+            const uid = user?.id ?? session?.user.id ?? null;
+            if (!uid) {
+              throw routeLoadFailureFromStatus(
+                401,
+                "Sign in to view this work order.",
+              );
+            }
 
-      const uid = user?.id ?? session?.user.id ?? null;
-      setCurrentUserId(uid);
-      setUserId(uid);
+            setCurrentUserId(uid);
+            setUserId(uid);
 
-      if (uid) {
-        const cachedScope = getOfflineMutationScope();
-        if (!navigator.onLine && cachedScope?.userId === uid) {
-          setCurrentUserRole(session?.user.user_metadata?.role ?? null);
-          setShopId(cachedScope.shopId);
-          setLoading(false);
-          return;
-        }
-        const { data: prof, error: profErr } = await supabase
-          .from("profiles")
-          .select("role, shop_id")
-          .eq("id", uid)
-          .maybeSingle();
+            const cachedScope = getOfflineMutationScope();
+            if (!navigator.onLine && cachedScope?.userId === uid) {
+              setCurrentUserRole(session?.user.user_metadata?.role ?? null);
+              setShopId(cachedScope.shopId);
+              setLoading(false);
+              return;
+            }
 
-        if (!profErr) {
-          setCurrentUserRole(prof?.role ?? null);
-          setShopId((prof?.shop_id as string | null) ?? null);
-          if (prof?.shop_id)
-            setOfflineMutationScope({ userId: uid, shopId: prof.shop_id });
-        } else {
-          setCurrentUserRole(null);
-          setShopId(null);
-        }
-      } else {
+            const { data: prof, error: profErr } = await supabase
+              .from("profiles")
+              .select("role, shop_id")
+              .eq("id", uid)
+              .abortSignal(signal)
+              .maybeSingle();
+            if (profErr) throw profErr;
+            if (!mounted || signal.aborted) return;
+
+            setCurrentUserRole(prof?.role ?? null);
+            setShopId((prof?.shop_id as string | null) ?? null);
+            if (prof?.shop_id) {
+              setOfflineMutationScope({ userId: uid, shopId: prof.shop_id });
+            }
+          },
+        );
+      } catch (error) {
+        if (!mounted) return;
+        setCurrentUserId(null);
+        setUserId(null);
         setCurrentUserRole(null);
         setShopId(null);
+        setLoadFailure(
+          asRouteLoadFailure(
+            error,
+            "The signed-in user could not be verified.",
+          ),
+        );
+        setLoading(false);
       }
-
-      if (!uid) setLoading(false);
     };
 
     void waitForSession();
@@ -382,6 +417,7 @@ export default function MobileWorkOrderClient({
       if (!routeId) return;
       setLoading(true);
       setViewError(null);
+      setLoadFailure(null);
 
       const scope =
         currentUserId && shopId ? { userId: currentUserId, shopId } : null;
@@ -414,250 +450,281 @@ export default function MobileWorkOrderClient({
       }
 
       try {
-        let woRow: WorkOrder | null = null;
+        await runBoundedRouteLoad(
+          {
+            route: `/mobile/work-orders/${routeId}`,
+            operation: "load mobile work order",
+            tenantId: shopId,
+            actorId: currentUserId,
+            role: currentUserRole,
+          },
+          async ({ signal }) => {
+            let woRow: WorkOrder | null = null;
 
-        // 1) by UUID
-        if (looksLikeUuid(routeId)) {
-          const { data, error } = await supabase
-            .from("work_orders")
-            .select("*")
-            .eq("id", routeId)
-            .maybeSingle();
-          if (!error) woRow = (data as WorkOrder | null) ?? null;
-        }
-
-        // 2) by custom_id (NOW SHOP-SCOPED when we have shopId)
-        if (!woRow) {
-          // exact match
-          const eqQuery = supabase
-            .from("work_orders")
-            .select("*")
-            .eq("custom_id", routeId);
-
-          const eqRes = shopId
-            ? await eqQuery.eq("shop_id", shopId).maybeSingle()
-            : await eqQuery.maybeSingle();
-
-          woRow = (eqRes.data as WorkOrder | null) ?? null;
-
-          // ilike match
-          if (!woRow) {
-            const ilikeQuery = supabase
-              .from("work_orders")
-              .select("*")
-              .ilike("custom_id", routeId.toUpperCase());
-
-            const ilikeRes = shopId
-              ? await ilikeQuery.eq("shop_id", shopId).maybeSingle()
-              : await ilikeQuery.maybeSingle();
-
-            woRow = (ilikeRes.data as WorkOrder | null) ?? null;
-          }
-
-          // prefix + number normalization fallback
-          if (!woRow) {
-            const { prefix, n } = splitCustomId(routeId);
-            if (n !== null) {
-              const candQuery = supabase
+            // 1) by UUID
+            if (looksLikeUuid(routeId)) {
+              const { data, error } = await supabase
                 .from("work_orders")
                 .select("*")
-                .ilike("custom_id", `${prefix}%`)
-                .limit(50);
-
-              const { data: cands } = shopId
-                ? await candQuery.eq("shop_id", shopId)
-                : await candQuery;
-
-              const wanted = `${prefix}${n}`;
-              const match = (cands ?? []).find(
-                (r) =>
-                  (r.custom_id ?? "")
-                    .toUpperCase()
-                    .replace(/^([A-Z]+)0+/, "$1") === wanted,
-              );
-              if (match) woRow = match as WorkOrder;
+                .eq("id", routeId)
+                .abortSignal(signal)
+                .maybeSingle();
+              if (!error) woRow = (data as WorkOrder | null) ?? null;
             }
-          }
-        }
 
-        if (!woRow) {
-          if (retry < 2) {
-            await new Promise((r) => setTimeout(r, 200 * Math.pow(2, retry)));
-            return fetchAll(retry + 1);
-          }
-          setViewError("Work order not visible / not found.");
-          setWo(null);
-          setLines([]);
-          setQuoteLines([]);
-          setVehicle(null);
-          setCustomer(null);
-          setLineContext(emptyCanonicalWorkOrderLineContext());
-          setShopLaborRate(null);
-          setLoading(false);
-          return;
-        }
+            // 2) by custom_id (NOW SHOP-SCOPED when we have shopId)
+            if (!woRow) {
+              // exact match
+              const eqQuery = supabase
+                .from("work_orders")
+                .select("*")
+                .eq("custom_id", routeId);
 
-        if (!warnedMissing && (!woRow.vehicle_id || !woRow.customer_id)) {
-          toast.error(
-            "This work order is missing vehicle and/or customer. Open the Create form to set them.",
-          );
-          setWarnedMissing(true);
-        }
+              const eqRes = shopId
+                ? await eqQuery
+                    .eq("shop_id", shopId)
+                    .abortSignal(signal)
+                    .maybeSingle()
+                : await eqQuery.abortSignal(signal).maybeSingle();
 
-        const [linesRes, vehRes, custRes, quotesRes, shopRes] =
-          await Promise.all([
-            supabase
-              .from("work_order_lines")
-              .select("*")
-              .eq("work_order_id", woRow.id)
-              .order("created_at", { ascending: true }),
-            woRow.vehicle_id
-              ? supabase
-                  .from("vehicles")
+              woRow = (eqRes.data as WorkOrder | null) ?? null;
+
+              // ilike match
+              if (!woRow) {
+                const ilikeQuery = supabase
+                  .from("work_orders")
                   .select("*")
-                  .eq("id", woRow.vehicle_id)
-                  .maybeSingle()
-              : Promise.resolve({ data: null, error: null } as const),
-            woRow.customer_id
-              ? supabase
-                  .from("customers")
+                  .ilike("custom_id", routeId.toUpperCase());
+
+                const ilikeRes = shopId
+                  ? await ilikeQuery
+                      .eq("shop_id", shopId)
+                      .abortSignal(signal)
+                      .maybeSingle()
+                  : await ilikeQuery.abortSignal(signal).maybeSingle();
+
+                woRow = (ilikeRes.data as WorkOrder | null) ?? null;
+              }
+
+              // prefix + number normalization fallback
+              if (!woRow) {
+                const { prefix, n } = splitCustomId(routeId);
+                if (n !== null) {
+                  const candQuery = supabase
+                    .from("work_orders")
+                    .select("*")
+                    .ilike("custom_id", `${prefix}%`)
+                    .limit(50);
+
+                  const { data: cands } = shopId
+                    ? await candQuery.eq("shop_id", shopId).abortSignal(signal)
+                    : await candQuery.abortSignal(signal);
+
+                  const wanted = `${prefix}${n}`;
+                  const match = (cands ?? []).find(
+                    (r) =>
+                      (r.custom_id ?? "")
+                        .toUpperCase()
+                        .replace(/^([A-Z]+)0+/, "$1") === wanted,
+                  );
+                  if (match) woRow = match as WorkOrder;
+                }
+              }
+            }
+
+            if (!woRow) {
+              if (retry < 2) {
+                await new Promise((r) =>
+                  setTimeout(r, 200 * Math.pow(2, retry)),
+                );
+                return fetchAll(retry + 1);
+              }
+              setViewError("Work order not visible / not found.");
+              setWo(null);
+              setLines([]);
+              setQuoteLines([]);
+              setVehicle(null);
+              setCustomer(null);
+              setLineContext(emptyCanonicalWorkOrderLineContext());
+              setShopLaborRate(null);
+              throw routeLoadFailureFromStatus(
+                404,
+                "Work order not visible or not found.",
+              );
+            }
+
+            if (!warnedMissing && (!woRow.vehicle_id || !woRow.customer_id)) {
+              toast.error(
+                "This work order is missing vehicle and/or customer. Open the Create form to set them.",
+              );
+              setWarnedMissing(true);
+            }
+
+            const [linesRes, vehRes, custRes, quotesRes, shopRes] =
+              await Promise.all([
+                supabase
+                  .from("work_order_lines")
                   .select("*")
-                  .eq("id", woRow.customer_id)
-                  .maybeSingle()
-              : Promise.resolve({ data: null, error: null } as const),
-            supabase
-              .from("work_order_quote_lines")
-              .select("*")
-              .eq("work_order_id", woRow.id)
-              .order("created_at", { ascending: true }),
-            supabase
-              .from("shops")
-              .select("labor_rate")
-              .eq("id", woRow.shop_id)
-              .maybeSingle<{ labor_rate: number | null }>(),
-          ]);
+                  .eq("work_order_id", woRow.id)
+                  .order("created_at", { ascending: true })
+                  .abortSignal(signal),
+                woRow.vehicle_id
+                  ? supabase
+                      .from("vehicles")
+                      .select("*")
+                      .eq("id", woRow.vehicle_id)
+                      .abortSignal(signal)
+                      .maybeSingle()
+                  : Promise.resolve({ data: null, error: null } as const),
+                woRow.customer_id
+                  ? supabase
+                      .from("customers")
+                      .select("*")
+                      .eq("id", woRow.customer_id)
+                      .abortSignal(signal)
+                      .maybeSingle()
+                  : Promise.resolve({ data: null, error: null } as const),
+                supabase
+                  .from("work_order_quote_lines")
+                  .select("*")
+                  .eq("work_order_id", woRow.id)
+                  .order("created_at", { ascending: true })
+                  .abortSignal(signal),
+                supabase
+                  .from("shops")
+                  .select("labor_rate")
+                  .eq("id", woRow.shop_id)
+                  .abortSignal(signal)
+                  .maybeSingle<{ labor_rate: number | null }>(),
+              ]);
 
-        if (linesRes.error) throw linesRes.error;
-        const lineRows = (linesRes.data ?? []) as WorkOrderLine[];
-        const freshCore = applyFetchedMobileDetailSnapshot({
-          cachedWorkOrder: null,
-          cachedLines: [],
-          fetchedWorkOrder: woRow,
-          fetchedLines: lineRows,
-        });
-        setWo(freshCore.workOrder);
-        setLines(freshCore.lines);
-
-        const freshLineContext = await loadCanonicalWorkOrderLineContext({
-          supabase,
-          workOrderId: woRow.id,
-          shopId: woRow.shop_id,
-          lineIds: lineRows.map((line) => line.id),
-        });
-        setLineContext(freshLineContext);
-        if (shopRes.error) throw shopRes.error;
-        const freshShopLaborRate =
-          typeof shopRes.data?.labor_rate === "number"
-            ? shopRes.data.labor_rate
-            : null;
-        setShopLaborRate(freshShopLaborRate);
-
-        // Populate names for every visible primary or shared assignment.
-        const techIds = collectTechnicianIdsForLineContexts(
-          [freshLineContext],
-          lineRows.map((line) => line.assigned_tech_id),
-        );
-
-        const techMap: Record<string, string> = {};
-        if (techIds.length > 0) {
-          const { data: techProfiles, error: techErr } = await supabase
-            .from("profiles")
-            .select("id, full_name")
-            .in("id", techIds);
-
-          if (!techErr && techProfiles) {
-            techProfiles.forEach((p) => {
-              techMap[p.id] = p.full_name ?? "Technician";
+            if (linesRes.error) throw linesRes.error;
+            const lineRows = (linesRes.data ?? []) as WorkOrderLine[];
+            const freshCore = applyFetchedMobileDetailSnapshot({
+              cachedWorkOrder: null,
+              cachedLines: [],
+              fetchedWorkOrder: woRow,
+              fetchedLines: lineRows,
             });
-            setTechNamesById(techMap);
-          } else {
-            setTechNamesById({});
-          }
-        } else {
-          setTechNamesById({});
-        }
+            setWo(freshCore.workOrder);
+            setLines(freshCore.lines);
 
-        const freshQuoteLines = quotesRes.error
-          ? []
-          : ((quotesRes.data as WorkOrderQuoteLine[] | null) ?? []);
-        const freshVehicle = vehRes?.error
-          ? null
-          : ((vehRes?.data as Vehicle | null) ?? null);
-        const freshCustomer = custRes?.error
-          ? null
-          : ((custRes?.data as Customer | null) ?? null);
+            const freshLineContext = await loadCanonicalWorkOrderLineContext({
+              supabase,
+              workOrderId: woRow.id,
+              shopId: woRow.shop_id,
+              lineIds: lineRows.map((line) => line.id),
+            });
+            setLineContext(freshLineContext);
+            if (shopRes.error) throw shopRes.error;
+            const freshShopLaborRate =
+              typeof shopRes.data?.labor_rate === "number"
+                ? shopRes.data.labor_rate
+                : null;
+            setShopLaborRate(freshShopLaborRate);
 
-        if (quotesRes.error) {
-          setQuoteLines([]);
-          console.error(
-            "[Mobile WO id page] quote lines load error:",
-            quotesRes.error,
-          );
-        } else {
-          setQuoteLines((quotesRes.data as WorkOrderQuoteLine[] | null) ?? []);
-        }
+            // Populate names for every visible primary or shared assignment.
+            const techIds = collectTechnicianIdsForLineContexts(
+              [freshLineContext],
+              lineRows.map((line) => line.assigned_tech_id),
+            );
 
-        if (vehRes?.error) {
-          setVehicle(null);
-          console.error(
-            "[Mobile WO id page] vehicle load error:",
-            vehRes.error,
-          );
-        } else {
-          setVehicle((vehRes?.data as Vehicle | null) ?? null);
-        }
+            const techMap: Record<string, string> = {};
+            if (techIds.length > 0) {
+              const { data: techProfiles, error: techErr } = await supabase
+                .from("profiles")
+                .select("id, full_name")
+                .abortSignal(signal)
+                .in("id", techIds);
 
-        if (custRes?.error) {
-          setCustomer(null);
-          console.error(
-            "[Mobile WO id page] customer load error:",
-            custRes.error,
-          );
-        } else {
-          setCustomer((custRes?.data as Customer | null) ?? null);
-        }
-        if (scope) {
-          const snapshot: MobileWorkOrderSnapshot = {
-            workOrder: freshCore.workOrder,
-            lines: freshCore.lines,
-            quoteLines: freshQuoteLines,
-            vehicle: freshVehicle,
-            customer: freshCustomer,
-            techNamesById: techMap,
-            lineContext: freshLineContext,
-            shopLaborRate: freshShopLaborRate,
-          };
-          await Promise.all([
-            saveOfflineSnapshot({
-              scope,
-              kind: "mobile-work-order-detail",
-              entityId: routeId,
-              data: snapshot,
-            }),
-            saveOfflineSnapshot({
-              scope,
-              kind: "mobile-work-order-detail",
-              entityId: woRow.id,
-              data: snapshot,
-            }),
-          ]);
-        }
+              if (!techErr && techProfiles) {
+                techProfiles.forEach((p) => {
+                  techMap[p.id] = p.full_name ?? "Technician";
+                });
+                setTechNamesById(techMap);
+              } else {
+                setTechNamesById({});
+              }
+            } else {
+              setTechNamesById({});
+            }
+
+            const freshQuoteLines = quotesRes.error
+              ? []
+              : ((quotesRes.data as WorkOrderQuoteLine[] | null) ?? []);
+            const freshVehicle = vehRes?.error
+              ? null
+              : ((vehRes?.data as Vehicle | null) ?? null);
+            const freshCustomer = custRes?.error
+              ? null
+              : ((custRes?.data as Customer | null) ?? null);
+
+            if (quotesRes.error) {
+              setQuoteLines([]);
+              console.error(
+                "[Mobile WO id page] quote lines load error:",
+                quotesRes.error,
+              );
+            } else {
+              setQuoteLines(
+                (quotesRes.data as WorkOrderQuoteLine[] | null) ?? [],
+              );
+            }
+
+            if (vehRes?.error) {
+              setVehicle(null);
+              console.error(
+                "[Mobile WO id page] vehicle load error:",
+                vehRes.error,
+              );
+            } else {
+              setVehicle((vehRes?.data as Vehicle | null) ?? null);
+            }
+
+            if (custRes?.error) {
+              setCustomer(null);
+              console.error(
+                "[Mobile WO id page] customer load error:",
+                custRes.error,
+              );
+            } else {
+              setCustomer((custRes?.data as Customer | null) ?? null);
+            }
+            if (scope) {
+              const snapshot: MobileWorkOrderSnapshot = {
+                workOrder: freshCore.workOrder,
+                lines: freshCore.lines,
+                quoteLines: freshQuoteLines,
+                vehicle: freshVehicle,
+                customer: freshCustomer,
+                techNamesById: techMap,
+                lineContext: freshLineContext,
+                shopLaborRate: freshShopLaborRate,
+              };
+              await Promise.all([
+                saveOfflineSnapshot({
+                  scope,
+                  kind: "mobile-work-order-detail",
+                  entityId: routeId,
+                  data: snapshot,
+                }),
+                saveOfflineSnapshot({
+                  scope,
+                  kind: "mobile-work-order-detail",
+                  entityId: woRow.id,
+                  data: snapshot,
+                }),
+              ]);
+            }
+          },
+        );
       } catch (e: unknown) {
-        const msg =
-          e instanceof Error ? e.message : "Failed to load work order.";
-        setViewError(msg);
-        await loadCached();
-        // eslint-disable-next-line no-console
+        const usedCache = await loadCached();
+        if (!usedCache) {
+          setLoadFailure(
+            asRouteLoadFailure(e, "The work order could not be loaded."),
+          );
+        }
         console.error("[Mobile WO id page] load error:", e);
       } finally {
         setLoading(false);
@@ -667,6 +734,7 @@ export default function MobileWorkOrderClient({
       routeId,
       shopId,
       currentUserId,
+      currentUserRole,
       warnedMissing,
       setWo,
       setLines,
@@ -1421,6 +1489,13 @@ export default function MobileWorkOrderClient({
           {viewError}
         </div>
       )}
+      {loadFailure ? (
+        <RouteLoadPanel
+          failure={loadFailure}
+          onRetry={() => void fetchAll()}
+          title="Work order unavailable"
+        />
+      ) : null}
       {(offlineSummary.queued > 0 ||
         offlineSummary.syncing > 0 ||
         offlineSummary.failed > 0 ||
@@ -1438,7 +1513,7 @@ export default function MobileWorkOrderClient({
           <Skeleton className="h-32" />
           <Skeleton className="h-40" />
         </div>
-      ) : !wo ? (
+      ) : loadFailure && !wo ? null : !wo ? (
         <div className="text-sm text-red-300">Work order not found.</div>
       ) : (
         <div className="space-y-5">

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -28,6 +28,13 @@ import {
 } from "./partsModel";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 import { PricingQuarantineRemediation } from "./PricingQuarantineRemediation";
+import RouteLoadPanel from "@/features/shared/components/ui/RouteLoadPanel";
+import {
+  asRouteLoadFailure,
+  routeLoadFailureFromStatus,
+  runBoundedRouteLoad,
+  type RouteLoadFailure,
+} from "@/features/shared/lib/route-load";
 
 const COPPER = "#C57A4A";
 const SEND_READY_STAGES = new Set(["advisor_pending", "ready_to_send"]);
@@ -90,7 +97,6 @@ const inputCls = `${inputBase} ${inputFocus}`;
 function safeTrim(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
-
 function asNumber(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) return value;
   if (typeof value === "string") {
@@ -479,6 +485,7 @@ export default function QuoteReviewView(props: {
   const { updateActiveTab } = useTabs();
 
   const [loading, setLoading] = useState(true);
+  const [loadFailure, setLoadFailure] = useState<RouteLoadFailure | null>(null);
   const [loadedOnce, setLoadedOnce] = useState(false);
   const loadedOnceRef = useRef(false);
   const [wo, setWo] = useState<WorkOrder | null>(null);
@@ -541,15 +548,215 @@ export default function QuoteReviewView(props: {
   const reload = useCallback(async () => {
     if (!woId) return;
     setLoading(true);
+    setLoadFailure(null);
 
-    const { data: woRow, error: woErr } = await supabase
-      .from("work_orders")
-      .select("*")
-      .eq("id", woId)
-      .maybeSingle();
+    try {
+      await runBoundedRouteLoad(
+        { route: `/quote-review/${woId}`, operation: "load quote review" },
+        async ({ signal }) => {
+          const { data: woRow, error: woErr } = await supabase
+            .from("work_orders")
+            .select("*")
+            .eq("id", woId)
+            .abortSignal(signal)
+            .maybeSingle();
 
-    if (woErr) {
-      toast.error(woErr.message);
+          if (woErr) throw woErr;
+          if (!woRow) {
+            throw routeLoadFailureFromStatus(404, "Work order not found.");
+          }
+
+          setWo(woRow);
+          const loadedSuppliesEnabled = (
+            woRow as { shop_supplies_enabled_override?: unknown }
+          ).shop_supplies_enabled_override;
+          setSuppliesEnabledDraft(
+            typeof loadedSuppliesEnabled === "boolean"
+              ? loadedSuppliesEnabled
+              : null,
+          );
+          const loadedSuppliesAmount = (
+            woRow as { shop_supplies_amount_override?: unknown }
+          ).shop_supplies_amount_override;
+          setSuppliesAmountDraft(
+            typeof loadedSuppliesAmount === "number"
+              ? String(loadedSuppliesAmount)
+              : "",
+          );
+          const shopId = woRow.shop_id ?? null;
+
+          if (shopId) {
+            const pricingResponse = await fetch(
+              `/api/work-orders/${woId}/customer-pricing`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ quoteLineIds: [] }),
+                signal,
+              },
+            );
+            if (!pricingResponse.ok && pricingResponse.status !== 403) {
+              const pricingPayload = (await pricingResponse
+                .json()
+                .catch(() => null)) as { error?: string } | null;
+              throw routeLoadFailureFromStatus(
+                pricingResponse.status,
+                pricingPayload?.error ??
+                  "Customer pricing could not be resolved.",
+              );
+            }
+
+            const [
+              { data: shopRow, error: shopErr },
+              { data: qRows, error: qErr },
+              { data: wlRows, error: wlErr },
+            ] = await Promise.all([
+              supabase
+                .from("shops")
+                .select("*")
+                .eq("id", shopId)
+                .abortSignal(signal)
+                .maybeSingle(),
+              supabase
+                .from("work_order_quote_lines")
+                .select("*")
+                .eq("shop_id", shopId)
+                .eq("work_order_id", woId)
+                .order("created_at", { ascending: true })
+                .abortSignal(signal),
+              supabase
+                .from("work_order_lines")
+                .select("*")
+                .eq("shop_id", shopId)
+                .eq("work_order_id", woId)
+                .order("line_no", { ascending: true })
+                .abortSignal(signal),
+            ]);
+
+            if (shopErr) throw shopErr;
+            if (qErr) throw qErr;
+            if (wlErr) throw wlErr;
+            setShop(shopRow ?? null);
+            const loadedQuoteLines = ((qRows ?? []) as QuoteLine[]).map(
+              (line) => ({
+                ...line,
+                _dirty: false,
+                _laborRateDraft: jsonNumber(quoteMetadata(line).labor_rate),
+              }),
+            );
+            const quoteLineIds = loadedQuoteLines
+              .map((line) => line.id)
+              .filter(Boolean);
+            let liveRequests: PartRequest[] = [];
+            let liveItems: PartRequestItem[] = [];
+            let selectedParts = new Map<string, CatalogPart>();
+
+            if (quoteLineIds.length > 0) {
+              const [
+                { data: requestRows, error: requestErr },
+                { data: itemRows, error: itemErr },
+              ] = await Promise.all([
+                supabase
+                  .from("part_requests")
+                  .select("*")
+                  .eq("shop_id", shopId)
+                  .eq("work_order_id", woId)
+                  .in("quote_line_id", quoteLineIds)
+                  .abortSignal(signal),
+                supabase
+                  .from("part_request_items")
+                  .select("*")
+                  .eq("shop_id", shopId)
+                  .eq("work_order_id", woId)
+                  .in("quote_line_id", quoteLineIds)
+                  .order("created_at", { ascending: true })
+                  .abortSignal(signal),
+              ]);
+              if (requestErr) throw requestErr;
+              if (itemErr) throw itemErr;
+              liveRequests = (requestRows ?? []) as PartRequest[];
+              liveItems = (itemRows ?? []) as PartRequestItem[];
+
+              const selectedPartIds = [
+                ...new Set(
+                  liveItems
+                    .map((item) => safeTrim(item.part_id ?? ""))
+                    .filter(Boolean),
+                ),
+              ];
+              if (selectedPartIds.length > 0) {
+                const { data: partRows, error: partErr } = await supabase
+                  .from("parts")
+                  .select(
+                    "id,name,sku,part_number,supplier,cost,default_cost,price,default_price",
+                  )
+                  .eq("shop_id", shopId)
+                  .in("id", selectedPartIds)
+                  .abortSignal(signal);
+                if (partErr) throw partErr;
+                selectedParts = new Map(
+                  ((partRows ?? []) as CatalogPart[]).map((part) => [
+                    part.id,
+                    part,
+                  ]),
+                );
+              }
+            }
+
+            const nextPartsByLine: PartsByQuoteLine = {};
+            const nextRequestsByLine: RequestByQuoteLine = {};
+            for (const line of loadedQuoteLines) {
+              nextPartsByLine[line.id] = resolveQuoteLineParts({
+                line,
+                liveItems,
+                requests: liveRequests,
+                selectedParts,
+              });
+              nextRequestsByLine[line.id] = liveRequests.filter(
+                (request) => request.quote_line_id === line.id,
+              );
+            }
+
+            setQuoteLines(loadedQuoteLines);
+            setPartsByQuoteLine(nextPartsByLine);
+            setRequestsByQuoteLine(nextRequestsByLine);
+            setWorkLines(
+              ((wlRows ?? []) as WorkOrderLine[]).filter(activeWorkLine),
+            );
+          } else {
+            setShop(null);
+            setQuoteLines([]);
+            setPartsByQuoteLine({});
+            setRequestsByQuoteLine({});
+            setWorkLines([]);
+          }
+
+          if (woRow.customer_id) {
+            const { data: custRow, error: custErr } = await supabase
+              .from("customers")
+              .select("*")
+              .eq("id", woRow.customer_id)
+              .abortSignal(signal)
+              .maybeSingle();
+            if (custErr) throw custErr;
+            setCustomer((custRow as Customer | null) ?? null);
+            setPendingCustomerEmail(safeTrim(custRow?.email ?? ""));
+          } else {
+            setCustomer(null);
+            setPendingCustomerEmail("");
+          }
+        },
+      );
+
+      loadedOnceRef.current = true;
+      setLoadedOnce(true);
+      void loadHistoryInsights();
+    } catch (error) {
+      const failure = asRouteLoadFailure(
+        error,
+        "The quote review could not be loaded.",
+      );
+      setLoadFailure(failure);
       if (!loadedOnceRef.current) {
         setWo(null);
         setShop(null);
@@ -559,136 +766,9 @@ export default function QuoteReviewView(props: {
         setRequestsByQuoteLine({});
         setWorkLines([]);
       }
+    } finally {
       setLoading(false);
-      return;
     }
-
-    setWo(woRow ?? null);
-    const loadedSuppliesEnabled = (woRow as { shop_supplies_enabled_override?: unknown } | null)?.shop_supplies_enabled_override;
-    setSuppliesEnabledDraft(typeof loadedSuppliesEnabled === "boolean" ? loadedSuppliesEnabled : null);
-    const loadedSuppliesAmount = (woRow as { shop_supplies_amount_override?: unknown } | null)?.shop_supplies_amount_override;
-    setSuppliesAmountDraft(typeof loadedSuppliesAmount === "number" ? String(loadedSuppliesAmount) : "");
-    const shopId = woRow?.shop_id ?? null;
-
-    if (shopId) {
-      const pricingResponse = await fetch(
-        `/api/work-orders/${woId}/customer-pricing`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ quoteLineIds: [] }),
-        },
-      );
-      if (!pricingResponse.ok && pricingResponse.status !== 403) {
-        const pricingPayload = (await pricingResponse
-          .json()
-          .catch(() => null)) as { error?: string } | null;
-        toast.error(
-          pricingPayload?.error ?? "Customer pricing could not be resolved.",
-        );
-      }
-
-      const [{ data: shopRow, error: shopErr }, { data: qRows, error: qErr }, { data: wlRows, error: wlErr }] = await Promise.all([
-        supabase.from("shops").select("*").eq("id", shopId).maybeSingle(),
-        supabase
-          .from("work_order_quote_lines")
-          .select("*")
-          .eq("shop_id", shopId)
-          .eq("work_order_id", woId)
-          .order("created_at", { ascending: true }),
-        supabase
-          .from("work_order_lines")
-          .select("*")
-          .eq("shop_id", shopId)
-          .eq("work_order_id", woId)
-          .order("line_no", { ascending: true }),
-      ]);
-
-      if (shopErr) toast.error(shopErr.message);
-      if (qErr) toast.error(qErr.message);
-      if (wlErr) toast.error(wlErr.message);
-      setShop(shopRow ?? null);
-      const loadedQuoteLines = ((qRows ?? []) as QuoteLine[]).map((line) => ({ ...line, _dirty: false, _laborRateDraft: jsonNumber(quoteMetadata(line).labor_rate) }));
-      const quoteLineIds = loadedQuoteLines.map((line) => line.id).filter(Boolean);
-      let liveRequests: PartRequest[] = [];
-      let liveItems: PartRequestItem[] = [];
-      let selectedParts = new Map<string, CatalogPart>();
-
-      if (quoteLineIds.length > 0) {
-        const [{ data: requestRows, error: requestErr }, { data: itemRows, error: itemErr }] = await Promise.all([
-          supabase
-            .from("part_requests")
-            .select("*")
-            .eq("shop_id", shopId)
-            .eq("work_order_id", woId)
-            .in("quote_line_id", quoteLineIds),
-          supabase
-            .from("part_request_items")
-            .select("*")
-            .eq("shop_id", shopId)
-            .eq("work_order_id", woId)
-            .in("quote_line_id", quoteLineIds)
-            .order("created_at", { ascending: true }),
-        ]);
-        if (requestErr) toast.error(requestErr.message);
-        if (itemErr) toast.error(itemErr.message);
-        liveRequests = (requestRows ?? []) as PartRequest[];
-        liveItems = (itemRows ?? []) as PartRequestItem[];
-
-        const selectedPartIds = [...new Set(liveItems.map((item) => safeTrim(item.part_id ?? "")).filter(Boolean))];
-        if (selectedPartIds.length > 0) {
-          const { data: partRows, error: partErr } = await supabase
-            .from("parts")
-            .select("id,name,sku,part_number,supplier,cost,default_cost,price,default_price")
-            .eq("shop_id", shopId)
-            .in("id", selectedPartIds);
-          if (partErr) toast.error(partErr.message);
-          selectedParts = new Map(((partRows ?? []) as CatalogPart[]).map((part) => [part.id, part]));
-        }
-      }
-
-      const nextPartsByLine: PartsByQuoteLine = {};
-      const nextRequestsByLine: RequestByQuoteLine = {};
-      for (const line of loadedQuoteLines) {
-        nextPartsByLine[line.id] = resolveQuoteLineParts({ line, liveItems, requests: liveRequests, selectedParts });
-        nextRequestsByLine[line.id] = liveRequests.filter((request) => request.quote_line_id === line.id);
-      }
-
-      setQuoteLines(loadedQuoteLines);
-      setPartsByQuoteLine(nextPartsByLine);
-      setRequestsByQuoteLine(nextRequestsByLine);
-      setWorkLines(((wlRows ?? []) as WorkOrderLine[]).filter(activeWorkLine));
-    } else {
-      setShop(null);
-      setQuoteLines([]);
-      setPartsByQuoteLine({});
-      setRequestsByQuoteLine({});
-      setWorkLines([]);
-    }
-
-    if (woRow?.customer_id) {
-      const { data: custRow, error: custErr } = await supabase
-        .from("customers")
-        .select("*")
-        .eq("id", woRow.customer_id)
-        .maybeSingle();
-      if (custErr) {
-        toast.error(custErr.message);
-        setCustomer(null);
-        setPendingCustomerEmail("");
-      } else {
-        setCustomer((custRow as Customer | null) ?? null);
-        setPendingCustomerEmail(safeTrim(custRow?.email ?? ""));
-      }
-    } else {
-      setCustomer(null);
-      setPendingCustomerEmail("");
-    }
-
-    setLoading(false);
-    loadedOnceRef.current = true;
-    setLoadedOnce(true);
-    void loadHistoryInsights();
   }, [loadHistoryInsights, supabase, woId]);
 
   useEffect(() => {
@@ -995,6 +1075,13 @@ export default function QuoteReviewView(props: {
 
   if (!woId) return <div className="p-6 text-red-300">Missing work order id.</div>;
   if (loading && !loadedOnce) return <div className="p-6 text-[color:var(--theme-text-secondary)]">Loading…</div>;
+  if (loadFailure && !loadedOnce) {
+    return (
+      <div className="mx-auto max-w-2xl p-6">
+        <RouteLoadPanel failure={loadFailure} onRetry={() => void reload()} />
+      </div>
+    );
+  }
   if (!wo) return <div className="p-6 text-red-300">Work order not found.</div>;
 
   const outerCls = embedded ? "min-h-full w-full px-0 py-0 text-foreground" : "min-h-screen px-4 py-6 text-foreground";
@@ -1008,6 +1095,15 @@ export default function QuoteReviewView(props: {
   return (
     <div className={outerCls} style={{ ["--copper" as never]: COPPER }}>
       <div className={containerCls}>
+        {loadFailure ? (
+          <div className="mb-3">
+            <RouteLoadPanel
+              failure={loadFailure}
+              onRetry={() => void reload()}
+              title="Quote refresh failed"
+            />
+          </div>
+        ) : null}
         {loading ? (
           <div className="mb-2 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">
             Refreshing canonical quote lines…

--- a/tests/route-load-state.test.ts
+++ b/tests/route-load-state.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  RouteLoadFailure,
+  asRouteLoadFailure,
+  routeLoadFailureFromStatus,
+  runBoundedRouteLoad,
+} from "@/features/shared/lib/route-load";
+
+describe("bounded route loading", () => {
+  it("returns successful data without changing the payload", async () => {
+    const payload = { id: "fixture", rows: [1, 2] };
+    await expect(
+      runBoundedRouteLoad(
+        { route: "/fixture", operation: "load" },
+        async ({ recordStatus }) => {
+          recordStatus(200);
+          return payload;
+        },
+        100,
+      ),
+    ).resolves.toBe(payload);
+  });
+
+  it("turns a hanging request into a retryable timeout", async () => {
+    vi.useFakeTimers();
+    const result = runBoundedRouteLoad(
+      { route: "/fixture", operation: "load" },
+      async () => new Promise<never>(() => undefined),
+      25,
+    );
+    const expectation = expect(result).rejects.toMatchObject({
+      kind: "timeout",
+      retryable: true,
+      requestId: expect.any(String),
+    });
+    await vi.advanceTimersByTimeAsync(25);
+    await expectation;
+    vi.useRealTimers();
+  });
+
+  it.each([
+    [401, "unauthenticated"],
+    [403, "forbidden"],
+    [404, "not-found"],
+    [503, "network"],
+  ] as const)("classifies HTTP %s", (status, kind) => {
+    expect(routeLoadFailureFromStatus(status, "failed")).toMatchObject({
+      kind,
+      status,
+    });
+  });
+
+  it("preserves an explicit route failure", () => {
+    const failure = new RouteLoadFailure({
+      kind: "forbidden",
+      message: "Access denied.",
+    });
+    expect(asRouteLoadFailure(failure)).toBe(failure);
+  });
+});

--- a/tests/route-loader-integration-contract.test.ts
+++ b/tests/route-loader-integration-contract.test.ts
@@ -63,6 +63,48 @@ describe("failing route loader integration", () => {
     }
   });
 
+  it("keeps quote approval available when optional evidence is degraded", () => {
+    const source = read(
+      "features/portal/app/quotes/[id]/QuotePageClient.tsx",
+    );
+    expect(source).toContain("loadOptionalQuoteEvidence");
+    expect(source).toContain("setEvidenceWarning(evidenceWarningCandidate)");
+    expect(source).toContain(
+      "The quote details and approval actions are still available.",
+    );
+    expect(source).not.toContain("evidenceResponse");
+  });
+
+  it("keeps rapid intake usable with its defaults when settings are unavailable", () => {
+    const source = read("features/mobile/service/RapidServiceIntake.tsx");
+    expect(source).toContain(
+      "const [durationMinutes, setDurationMinutes] = useState(60)",
+    );
+    expect(source).toContain('title="Using default service settings"');
+    expect(source).not.toMatch(/if \(settingsFailure\)\s*\{\s*return/);
+  });
+
+  it("clears the protected Field snapshot and redirects signed-out users", () => {
+    const scopeGate = read(
+      "features/mobile/service/MobileServiceScopeGate.tsx",
+    );
+    const signedOutScope = scopeGate.match(
+      /if \(!authUserId\)\s*\{([\s\S]*?)\n\s*\}/,
+    )?.[1];
+    expect(signedOutScope).toContain("protectSnapshot(null)");
+    expect(signedOutScope).toContain('router.replace("/mobile")');
+    expect(signedOutScope).not.toContain("throw routeLoadFailureFromStatus");
+
+    const routeGate = read(
+      "features/mobile/service/MobileFieldServiceRouteGate.tsx",
+    );
+    const signedOutRoute = routeGate.match(
+      /if \(!authUserId\)\s*\{([\s\S]*?)\n\s*\}/,
+    )?.[1];
+    expect(signedOutRoute).toContain('router.replace("/mobile")');
+    expect(signedOutRoute).not.toContain("throw routeLoadFailureFromStatus");
+  });
+
   it("does not show zero owner-governance metrics while shops are loading", () => {
     const source = read(
       "features/dashboard/app/dashboard/admin/ShopsClient.tsx",

--- a/tests/route-loader-integration-contract.test.ts
+++ b/tests/route-loader-integration-contract.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+const boundedClientLoaders = [
+  "features/work-orders/quote-review/QuoteReviewView.tsx",
+  "features/portal/app/quotes/[id]/QuotePageClient.tsx",
+  "app/portal/approvals/page.tsx",
+  "features/work-orders/mobile/MobileWorkOrderClient.tsx",
+  "app/parts/requests/page.tsx",
+  "features/mobile/service/MobileFieldServiceRouteGate.tsx",
+  "features/mobile/service/MobileServiceScopeGate.tsx",
+  "features/mobile/service/RapidServiceIntake.tsx",
+  "features/mobile/service/useTruckInventorySnapshot.ts",
+  "features/dashboard/app/dashboard/admin/ShopsClient.tsx",
+];
+
+describe("failing route loader integration", () => {
+  it.each(boundedClientLoaders)("%s uses the shared bounded loader", (path) => {
+    const source = read(path);
+    expect(source).toContain("runBoundedRouteLoad");
+    expect(source).toContain("asRouteLoadFailure");
+  });
+
+  it.each([
+    "features/work-orders/quote-review/QuoteReviewView.tsx",
+    "features/portal/app/quotes/[id]/QuotePageClient.tsx",
+    "app/portal/approvals/page.tsx",
+    "features/work-orders/mobile/MobileWorkOrderClient.tsx",
+    "app/parts/requests/page.tsx",
+    "features/mobile/service/MobileFieldServiceRouteGate.tsx",
+    "features/mobile/service/MobileServiceScopeGate.tsx",
+    "features/mobile/service/RapidServiceIntake.tsx",
+    "features/mobile/service/MobileTruckInventory.tsx",
+    "features/dashboard/app/dashboard/admin/ShopsClient.tsx",
+  ])("%s renders an actionable route failure", (path) => {
+    expect(read(path)).toContain("RouteLoadPanel");
+  });
+
+  it("bounds the server-rendered customer quote list", () => {
+    const page = read("app/portal/quotes/page.tsx");
+    expect(page).toContain("runBoundedRouteLoad");
+    expect(page).toContain(".abortSignal(signal)");
+    expect(read("app/portal/quotes/loading.tsx")).toContain(
+      "PortalQuotesLoading",
+    );
+    expect(read("app/portal/quotes/error.tsx")).toContain("RouteLoadPanel");
+  });
+
+  it("does not silently redirect Field network failures", () => {
+    for (const path of [
+      "features/mobile/service/MobileFieldServiceRouteGate.tsx",
+      "features/mobile/service/MobileServiceScopeGate.tsx",
+    ]) {
+      const source = read(path);
+      expect(source).toContain("Field Service access could not be verified.");
+      expect(source).not.toContain(
+        '.catch(() => {\n      if (active) router.replace("/mobile");',
+      );
+    }
+  });
+
+  it("does not show zero owner-governance metrics while shops are loading", () => {
+    const source = read(
+      "features/dashboard/app/dashboard/admin/ShopsClient.tsx",
+    );
+    expect(source).toContain('value={rows ? summary.total : "—"}');
+    expect(source).toContain("Shop directory unavailable");
+  });
+});

--- a/tests/route-loader-recovery.test.tsx
+++ b/tests/route-loader-recovery.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import MobileServiceScopeGate from "@/features/mobile/service/MobileServiceScopeGate";
+import RapidServiceIntake from "@/features/mobile/service/RapidServiceIntake";
+import { loadOptionalQuoteEvidence } from "@/features/portal/lib/loadOptionalQuoteEvidence";
+import type { WorkOrderEvidenceItem } from "@/features/work-orders/lib/evidence/workOrderEvidence";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  replace: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: ComponentProps<"a">) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/features/shared/lib/supabase/client", () => ({
+  createBrowserSupabase: () => ({
+    auth: { getSession: mocks.getSession },
+  }),
+}));
+
+vi.mock("@/features/mobile/service/FieldHub", () => ({
+  default: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+function response(body: unknown, status: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  mocks.getSession.mockResolvedValue({ data: { session: null } });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("route loader recovery behavior", () => {
+  it("returns quote lines without evidence when the media endpoint is unavailable", async () => {
+    const request = vi.fn().mockResolvedValue(response({ error: "down" }, 503));
+    const recordStatus = vi.fn();
+
+    const result = await loadOptionalQuoteEvidence({
+      workOrderId: "wo-1",
+      signal: new AbortController().signal,
+      recordStatus,
+      request: request as typeof fetch,
+    });
+
+    expect(result.items).toEqual([]);
+    expect(result.warning).toMatchObject({
+      kind: "network",
+      retryable: true,
+      status: 503,
+    });
+    expect(recordStatus).toHaveBeenCalledWith(503);
+  });
+
+  it("returns canonical quote evidence when the media endpoint succeeds", async () => {
+    const item = { id: "evidence-1" } as WorkOrderEvidenceItem;
+    const request = vi.fn().mockResolvedValue(response({ items: [item] }, 200));
+
+    const result = await loadOptionalQuoteEvidence({
+      workOrderId: "wo-1",
+      signal: new AbortController().signal,
+      recordStatus: vi.fn(),
+      request: request as typeof fetch,
+    });
+
+    expect(result).toEqual({ items: [item], warning: null });
+  });
+
+  it("keeps rapid intake usable with defaults after settings fail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(response({ error: "unavailable" }, 503)),
+    );
+
+    render(<RapidServiceIntake />);
+
+    expect(
+      await screen.findByText("Using default service settings"),
+    ).toBeVisible();
+    expect(screen.getByRole("heading", { name: "New service call" })).toBeVisible();
+    expect(screen.getByLabelText("Time allowed")).toHaveValue("60");
+    expect(
+      screen.getByRole("button", { name: "Save call · ETA 30 min" }),
+    ).toBeVisible();
+  });
+
+  it("clears protected snapshots and redirects signed-out Field users", async () => {
+    window.localStorage.setItem(
+      "profixiq:mobile-service:active:v1",
+      JSON.stringify({ visits: ["stale"] }),
+    );
+    window.localStorage.setItem(
+      "profixiq:mobile-service:active-scope:v1",
+      JSON.stringify({ userId: "former-user", shopId: "shop-1" }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(response({ error: "unauthenticated" }, 401)),
+    );
+
+    render(<MobileServiceScopeGate />);
+
+    await waitFor(() => expect(mocks.replace).toHaveBeenCalledWith("/mobile"));
+    expect(
+      window.localStorage.getItem("profixiq:mobile-service:active:v1"),
+    ).toBeNull();
+    expect(
+      window.localStorage.getItem(
+        "profixiq:mobile-service:active-scope:v1",
+      ),
+    ).toBeNull();
+    expect(screen.queryByText("Sign in required")).not.toBeInTheDocument();
+  });
+});

--- a/tests/work-order-line-evidence.test.ts
+++ b/tests/work-order-line-evidence.test.ts
@@ -430,6 +430,10 @@ describe("premium work-order evidence UI contract", () => {
     "features/portal/app/quotes/[id]/QuotePageClient.tsx",
     "utf8",
   );
+  const optionalQuoteEvidence = readFileSync(
+    "features/portal/lib/loadOptionalQuoteEvidence.ts",
+    "utf8",
+  );
   const focusedJob = readFileSync(
     "features/work-orders/components/workorders/FocusedJobModal.tsx",
     "utf8",
@@ -465,7 +469,10 @@ describe("premium work-order evidence UI contract", () => {
   });
 
   it("shows canonical line evidence in customer and fleet portal experiences", () => {
-    expect(quote).toContain("/api/work-orders/${workOrderId}/media?scope=all");
+    expect(quote).toContain("loadOptionalQuoteEvidence");
+    expect(optionalQuoteEvidence).toContain(
+      "/api/work-orders/${workOrderId}/media?scope=all",
+    );
     expect(quote).toContain("item.quoteLineId === line.id");
     expect(quote).toContain("EvidenceImage");
     expect(


### PR DESCRIPTION
## Summary

- add one shared, 12-second bounded route-load contract with request IDs, safe structured diagnostics, HTTP/error classification, cancellation, and retryability
- add a reusable accessible loader failure panel with explicit Retry behavior
- apply the contract only to the identified failing boundaries across quote review, customer quotes/approvals, parts requests, admin shops, Field access/intake/truck inventory, and mobile work-order detail
- preserve successful payload shapes, existing offline cache fallbacks, tenant filters, role gates, and product-specific authentication redirects
- add server-route loading/error boundaries for the customer quotes list

## Validation

- `pnpm typecheck` — passed
- focused ESLint for all changed files — passed
- focused Phase 2 regression suite — 58/58 passed
- `pnpm build` with the repository's CI placeholder environment — passed
- `pnpm regression:inventory:check` — passed with 0 new errors
- local Browser pass — all touched protected routes retained the correct Shop, Customer, Field, Admin, or Mobile sign-in boundary and exact redirect target while the backend was unavailable

## Known environment gaps

- Authenticated success/empty/forbidden browser states could not be exercised locally because this checkout has no live Supabase test session. The bounded state transitions and route wiring are covered by focused tests.
- `pnpm check` completes typecheck and lint, then the full suite reports 52 failures / 2,812 passes. The failures are existing Windows CRLF-sensitive source/migration string contracts; the focused Phase 2 tests pass and no failed full-suite test targets the new loader implementation.

## Data/deployment

- no schema or migration changes
- no API response-shape changes
- no destructive data operations